### PR TITLE
chore: upgrade turbo to 2.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,7 @@
         "eslint-config-next": "^16.1.0",
         "prettier": "^3.6.2",
         "tailwindcss": "^4",
-        "turbo": "^2.7.5",
+        "turbo": "^2.8.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "5.9.3",
         "vitest": "^2.1.5",
@@ -2563,19 +2563,19 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.7.5", "", { "optionalDependencies": { "turbo-darwin-64": "2.7.5", "turbo-darwin-arm64": "2.7.5", "turbo-linux-64": "2.7.5", "turbo-linux-arm64": "2.7.5", "turbo-windows-64": "2.7.5", "turbo-windows-arm64": "2.7.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-7Imdmg37joOloTnj+DPrab9hIaQcDdJ5RwSzcauo/wMOSAgO+A/I/8b3hsGGs6PWQz70m/jkPgdqWsfNKtwwDQ=="],
+    "turbo": ["turbo@2.8.1", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.1", "turbo-darwin-arm64": "2.8.1", "turbo-linux-64": "2.8.1", "turbo-linux-arm64": "2.8.1", "turbo-windows-64": "2.8.1", "turbo-windows-arm64": "2.8.1" }, "bin": { "turbo": "bin/turbo" } }, "sha512-pbSMlRflA0RAuk/0jnAt8pzOYh1+sKaT8nVtcs75OFGVWD0evleQRmKtHJJV42QOhaC3Hx9mUUSOom/irasbjA=="],
 
-    "turbo-darwin-64": ["turbo-darwin-64@2.7.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-nN3wfLLj4OES/7awYyyM7fkU8U8sAFxsXau2bYJwAWi6T09jd87DgHD8N31zXaJ7LcpyppHWPRI2Ov9MuZEwnQ=="],
+    "turbo-darwin-64": ["turbo-darwin-64@2.8.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-FQ6Uqxty/H1Nvn1dpBe8KUlMRclTuiyNSc1PCeDL/ad7M9ykpWutB51YpMpf9ibTA32M6wLdIRf+D96W6hDAtQ=="],
 
-    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.7.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wCoDHMiTf3FgLAbZHDDx/unNNonSGhsF5AbbYODbxnpYyoKDpEYacUEPjZD895vDhNvYCH0Nnk24YsP4n/cD6g=="],
+    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.8.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4bCcEpGP2/aSXmeN2gl5SuAmS1q5ykjubnFvSoXjQoCKtDOV+vc4CTl/DduZzUUutCVUWXjl8OyfIQ+DGCaV4A=="],
 
-    "turbo-linux-64": ["turbo-linux-64@2.7.5", "", { "os": "linux", "cpu": "x64" }, "sha512-KKPvhOmJMmzWj/yjeO4LywkQ85vOJyhru7AZk/+c4B6OUh/odQ++SiIJBSbTG2lm1CuV5gV5vXZnf/2AMlu3Zg=="],
+    "turbo-linux-64": ["turbo-linux-64@2.8.1", "", { "os": "linux", "cpu": "x64" }, "sha512-m99JRlWlEgXPR7mkThAbKh6jbTmWSOXM/c6rt8yd4Uxh0+wjq7+DYcQbead6aoOqmCP9akswZ8EXIv1ogKBblg=="],
 
-    "turbo-linux-arm64": ["turbo-linux-arm64@2.7.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-8PIva4L6BQhiPikUTds9lSFSHXVDAsEvV6QUlgwPsXrtXVQMVi6Sv9p+IxtlWQFvGkdYJUgX9GnK2rC030Xcmw=="],
+    "turbo-linux-arm64": ["turbo-linux-arm64@2.8.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-AsPlza3AsavJdl2o7FE67qyv0aLfmT1XwFQGzvwpoAO6Bj7S4a03tpUchZKNuGjNAkKVProQRFnB7PgUAScFXA=="],
 
-    "turbo-windows-64": ["turbo-windows-64@2.7.5", "", { "os": "win32", "cpu": "x64" }, "sha512-rupskv/mkIUgQXzX/wUiK00mKMorQcK8yzhGFha/D5lm05FEnLx8dsip6rWzMcVpvh+4GUMA56PgtnOgpel2AA=="],
+    "turbo-windows-64": ["turbo-windows-64@2.8.1", "", { "os": "win32", "cpu": "x64" }, "sha512-GdqNO6bYShRsr79B+2G/2ssjLEp9uBTvLBJSWRtRCiac/SEmv8T6RYv9hu+h5oGbFALtnKNp6BQBw78RJURsPw=="],
 
-    "turbo-windows-arm64": ["turbo-windows-arm64@2.7.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-G377Gxn6P42RnCzfMyDvsqQV7j69kVHKlhz9J4RhtJOB5+DyY4yYh/w0oTIxZQ4JRMmhjwLu3w9zncMoQ6nNDw=="],
+    "turbo-windows-arm64": ["turbo-windows-arm64@2.8.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-n40E6IpkzrShRo3yMdRpgnn1/sAbGC6tZXwyNu8fe9RsufeD7KBiaoRSvw8xLyqV3pd2yoTL2rdCXq24MnTCWA=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "eslint-config-next": "^16.1.0",
     "prettier": "^3.6.2",
     "tailwindcss": "^4",
-    "turbo": "^2.7.5",
+    "turbo": "^2.8.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "5.9.3",
     "vitest": "^2.1.5"

--- a/turbo.json
+++ b/turbo.json
@@ -1,59 +1,74 @@
 {
-  "$schema": "https://turborepo.org/schema.json",
+  "$schema": "https://v2-8-1.turborepo.dev/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "description": "Builds the Next.js app for production",
       "outputs": [".next/**", "!.next/cache/**"],
       "env": [
         "NODE_ENV",
         "NEXT_PUBLIC_*",
         "GOOGLE_SITE_VERIFICATION",
         "BING_SITE_VERIFICATION"
-      ]
+      ],
+      "inputs": ["$TURBO_DEFAULT$", ".env", ".env.*", "!.env.example"]
     },
     "lint": {
+      "description": "Runs ESLint with cache",
       "outputs": [".next/cache/eslint/**"]
     },
     "typecheck": {
+      "description": "Runs TypeScript typecheck (incremental)",
       "outputs": ["tsconfig.tsbuildinfo"]
     },
     "dev": {
+      "description": "Runs Next.js dev server",
       "cache": false,
       "persistent": true
     },
     "test:e2e": {
+      "description": "Runs Playwright E2E tests",
       "cache": false
     },
     "test:e2e:ui": {
+      "description": "Runs Playwright in UI mode",
       "cache": false,
       "persistent": true
     },
     "test:a11y": {
+      "description": "Runs Playwright accessibility tests",
       "cache": false
     },
     "test:perf": {
+      "description": "Runs Playwright performance tests",
       "cache": false
     },
     "lighthouse": {
+      "description": "Runs Lighthouse CI",
       "cache": false
     },
     "verify": {
+      "description": "Runs repo verification script",
       "cache": false
     },
     "verify:e2e": {
+      "description": "Runs E2E verification script",
       "cache": false
     },
     "verify:e2e:loop": {
+      "description": "Runs E2E verification loop",
       "cache": false,
       "persistent": true
     },
     "generate:icons": {
+      "description": "Generates icon assets",
       "cache": false
     },
     "setup": {
+      "description": "Runs repo setup",
       "cache": false
     },
     "setup:verify": {
+      "description": "Validates setup",
       "cache": false
     }
   }


### PR DESCRIPTION
## Summary
- upgrade Turbo to 2.8.1 and update the versioned schema URL
- add task descriptions and build inputs for .env.* cache correctness
- remove ^build dependsOn for single-package clarity

## Evidence
- Turbo version: 2.7.5 → 2.8.1
- Cache hit: second `bunx turbo run build` shows `cache hit, replaying logs`
- .env.local change: `NEXT_PUBLIC_TURBO_CACHE_TEST` 1 → 2 produced a cache miss
- Worktree: `bunx turbo run build` reported `Remote caching disabled, using shared worktree cache` (build failed there due to missing Supabase env)

## Test Plan
- `bunx turbo run lint typecheck build` (fails due to linting `playwright-report/trace/*.js`)
- `bunx turbo run build` (cache miss, then hit)
- `bunx turbo run build --dry`
- `bunx turbo run build --summarize`

Made with [Cursor](https://cursor.com)