### PR TITLE
Enable CI checks on epic branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, epic]
   push:
-    branches: [main]
+    branches: [main, develop, epic]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- run the CI workflow on pull requests targeting `epic`
- run the CI workflow on pushes to `develop` and `epic` in addition to `main`
- make required check contexts visible/selectable for `epic` branch protection

## Test plan
- [x] Review workflow diff in `.github/workflows/ci.yml`
- [ ] Open PR and confirm `CI` workflow triggers for base branch `epic`
- [ ] Verify required check contexts (`format`, `lint`, `typecheck`, `build`, `test-unit`) appear in branch protection UI for `epic`

Made with [Cursor](https://cursor.com)