### PR TITLE
Fix missionary layout dynamic config for cacheComponents

### DIFF
--- a/apps/missionary/app/donors/layout.tsx
+++ b/apps/missionary/app/donors/layout.tsx
@@ -1,11 +1,16 @@
+import { connection } from "next/server";
+
 import type { ReactNode } from "react";
 
 /**
- * Intentionally keep this segment dynamic while cacheComponents is enabled globally.
- * Remove this override only after /donors can render without build-time Supabase env access.
+ * Keep this segment request-bound while cacheComponents is enabled globally.
+ * `dynamic = "force-dynamic"` is not supported with cacheComponents in Next.js 16.
  */
-export const dynamic = "force-dynamic";
-
-export default function DonorsLayout({ children }: { children: ReactNode }) {
+export default async function DonorsLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  await connection();
   return children;
 }

--- a/apps/missionary/app/tasks/layout.tsx
+++ b/apps/missionary/app/tasks/layout.tsx
@@ -1,11 +1,16 @@
 /**
- * Intentionally keep this segment dynamic while cacheComponents is enabled globally.
- * Remove this override only after /tasks can render without build-time Supabase env access.
+ * Keep this segment request-bound while cacheComponents is enabled globally.
+ * `dynamic = "force-dynamic"` is not supported with cacheComponents in Next.js 16.
  */
-export const dynamic = "force-dynamic";
+import { connection } from "next/server";
 
 import type { ReactNode } from "react";
 
-export default function TasksLayout({ children }: { children: ReactNode }) {
+export default async function TasksLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  await connection();
   return children;
 }


### PR DESCRIPTION
## Summary
- Replace unsupported `dynamic = \"force-dynamic\"` segment config in missionary `/donors` and `/tasks` layouts.
- Use `await connection()` from `next/server` so both segments stay request-bound under Next.js 16 `cacheComponents`.
- Unblock Vercel/Turbopack builds that fail on route segment config incompatibility.

## Test plan
- [x] `bunx turbo run build --filter=@asym/missionary-app` with required Supabase env vars set.
- [x] Confirm Next build no longer errors on `Route segment config \"dynamic\" is not compatible with nextConfig.cacheComponents`.
- [ ] Verify Vercel deployment succeeds on branch after env variables are present in Vercel project settings.

Made with [Cursor](https://cursor.com)