### PR TITLE
chore: format baseline

### DIFF
--- a/.cursor/commands/5-ship-working-tree.md
+++ b/.cursor/commands/5-ship-working-tree.md
@@ -11,6 +11,7 @@
 ## Rules
 
 - **Never lose work.**
+
 ---
 
 ## Known hiccups and how this command avoids them
@@ -20,7 +21,7 @@
 - **Build gate fails locally due missing env vars:** offer a decision; recommended is temporarily exporting from root `.env.local` without printing/committing secrets.
 - **CODEOWNERS resolves only to PR author:** GitHub blocks self-review; prompt for a fallback reviewer/team.
 - **Cleanup ran without user choice:** hard rule to wait for `1/2/3` before running cleanup commands.
- Create a patch backup before any branch switching or stashing.
+  Create a patch backup before any branch switching or stashing.
 - **PR base must be explicit.** The command must list remote branches and choose a base (default: `epic` if present, else the repo default branch).
 - **Branch name must be derived from a summary of changes.**
   - Format: `<ticket?>-<kebab-summary>` (ticket optional, e.g. `al-123-...`)
@@ -79,6 +80,7 @@ git ls-files --others --exclude-standard
 ```
 
 Record:
+
 - staged/unstaged counts
 - untracked file list
 - file change list + diff stats (for summary generation)
@@ -108,6 +110,7 @@ fi
 ### 2) Remote + auth checks (GitHub + branch list)
 
 **Important (common hiccup):** If `GITHUB_TOKEN` is set in the environment, GitHub CLI (`gh`) will prefer it over its stored login and can produce `HTTP 401: Bad credentials`.
+
 - If `echo $GITHUB_TOKEN` is non-empty, the command must run all `gh ...` calls as: `env -u GITHUB_TOKEN gh ...`
 
 Fetch and list branches:
@@ -126,6 +129,7 @@ gh repo view --json defaultBranchRef,nameWithOwner -q '.defaultBranchRef.name'
 ```
 
 The command must show the user a **short list of candidate PR base branches**:
+
 - If `origin/epic` exists → include `epic` and default to it
 - Else default to the repo’s default branch (from `gh repo view`)
 - Also include common alternatives if they exist: `develop`, `main`
@@ -135,10 +139,11 @@ The command must show the user a **short list of candidate PR base branches**:
 ### 3) Choose PR base branch (explicit) + update it
 
 Choose base branch using this priority:
-1) user-specified base (if valid on origin)  
-2) `epic` if it exists on origin  
-3) repo default branch (from GitHub)  
-4) otherwise: current branch (last resort) **with warning**
+
+1. user-specified base (if valid on origin)
+2. `epic` if it exists on origin
+3. repo default branch (from GitHub)
+4. otherwise: current branch (last resort) **with warning**
 
 Update base cleanly (ff-only). Because there are local changes, stash first:
 
@@ -149,11 +154,12 @@ git pull --ff-only origin <base>
 ```
 
 **If `git stash pop` later fails with** `error: could not restore untracked files from stash`:
+
 - This usually means an “untracked” file became **tracked on `<base>`** before restore.
 - Recovery order (use the autoship backups, not stash internals):
-  1) Confirm the file(s) exist on `<base>`: `git ls-tree -r HEAD --name-only | rg '<path>'`
-  2) Restore your local version from `.git/autoship/untracked.tgz` (preferred) or `working-tree.patch`.
-  3) Continue the flow once `git status` shows your intended modifications.
+  1. Confirm the file(s) exist on `<base>`: `git ls-tree -r HEAD --name-only | rg '<path>'`
+  2. Restore your local version from `.git/autoship/untracked.tgz` (preferred) or `working-tree.patch`.
+  3. Continue the flow once `git status` shows your intended modifications.
 
 After a successful stash pop and `git status` is clean (no conflicts), **drop the autoship stash** to avoid leaving stray stashes:
 
@@ -174,6 +180,7 @@ git stash pop
 ```
 
 If `stash pop` results in conflicts:
+
 - Stop and notify the user.
 - Do **not** proceed to commit/PR creation until conflicts are resolved.
 
@@ -182,26 +189,31 @@ If `stash pop` results in conflicts:
 ### 4) Generate a high-quality summary (branch name + PR title)
 
 The command must generate:
+
 - **Short summary** (5–10 words) describing intent
 - **Kebab slug** derived from the short summary
 - Optional ticket prefix (if `AL-###` was provided or detected)
 
 Inputs for summarization:
+
 - `git diff --stat`
 - `git diff` (limit to a manageable amount if huge)
 - file paths changed (high signal)
 
 Rules:
+
 - Keep slug under ~40 chars if possible.
 - Avoid generic titles like “updates” or “changes”.
 - Prefer action verbs (add/fix/refactor/remove/improve).
 
 Examples:
+
 - `al-123-fix-auth-redirect-loop`
 - `add-admin-user-search-filters`
 - `refactor-api-client-retry-logic`
 
 PR title rules:
+
 - If ticket present: `AL-123: <short summary>`
 - Else: `<short summary>`
 
@@ -212,6 +224,7 @@ PR title rules:
 Before staging and again before committing, scan for likely secrets and accidental sensitive files.
 
 Minimum checks:
+
 - Blocklist filenames (unless user explicitly overrides):
   - `.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa*`, `*.p12`, `*.pfx`, `credentials.*`
 - Grep common secret patterns in the diff (heuristic):
@@ -228,6 +241,7 @@ git diff | rg -n "BEGIN (RSA|OPENSSH) PRIVATE KEY|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-
 ```
 
 If anything matches:
+
 - Print what matched (redact most of the value).
 - Stop and ask for explicit permission to continue.
 
@@ -244,6 +258,7 @@ git diff --staged --stat
 ```
 
 If the staged set is extremely large (e.g., lockfile churn + generated files):
+
 - Warn that review will be hard.
 - Suggest splitting or excluding specific paths.
 
@@ -259,21 +274,21 @@ bun run format:check && bun run lint && bun run typecheck && bun run build && bu
 
 #### If `format:check` fails
 
-1) Collect a **failure inventory** (for scope classification):
+1. Collect a **failure inventory** (for scope classification):
 
 ```bash
 git diff --name-only --staged > /tmp/autoship_staged_files.txt
 bun run format:check
 ```
 
-2) Attempt a **safe formatting remediation**:
+2. Attempt a **safe formatting remediation**:
 
 ```bash
 bun run format
 bun run format:check
 ```
 
-3) Classify the result:
+3. Classify the result:
 
 - **Case A — fixed and diff is reasonable** (mostly within your staged/expected files):
   - Continue to lint/typecheck/build/unit.
@@ -286,13 +301,13 @@ bun run format:check
 
 If any gate fails (including `format:check`), the command must print a concise summary and offer **three** options:
 
-1) **Abort now**  
+1. **Abort now**  
    Keep branch + changes intact. No PR is created.
 
-2) **Proceed anyway**  
+2. **Proceed anyway**  
    Create a **Draft PR** with the current changes and watch CI. Expect red checks.
 
-3) **Troubleshoot & fix now (recommended)**  
+3. **Troubleshoot & fix now (recommended)**  
    The command enters **Troubleshooting Mode** for the failing category, attempts minimal fixes, re-runs the relevant gate(s), and only continues if they pass.
 
 Default should be: **stop and wait for the user to choose 1/2/3**.
@@ -303,9 +318,9 @@ Default should be: **stop and wait for the user to choose 1/2/3**.
 
 If the gate chain fails at `build` with missing env vars (example: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`), the command must **stop** and offer a decision:
 
-1) **Load from root `.env.local` and retry build** *(recommended if `.env.local` exists)*  
-2) **Manually provide env vars for this session and retry build**  
-3) **Proceed anyway (Draft PR) and let CI validate**
+1. **Load from root `.env.local` and retry build** _(recommended if `.env.local` exists)_
+2. **Manually provide env vars for this session and retry build**
+3. **Proceed anyway (Draft PR) and let CI validate**
 
 Implementation for option 1 (never print secrets; never commit env files):
 
@@ -318,7 +333,6 @@ bun run build
 
 Then rerun the remaining gates (at minimum `test:unit`) in the same env-loaded shell session.
 
-
 ### 7A) Troubleshooting Mode: formatting drift (repo-wide)
 
 This mode exists specifically for the case you reported: `format:check` fails because **many pre-existing files** are not formatted, even if you didn’t touch them.
@@ -329,23 +343,24 @@ The command must offer two remediation strategies:
 
 - Warn that this may create a large diff and make review harder.
 - If user chooses this:
-  1) Run `bun run format` (already done above, repeat only if needed).
-  2) Show `git diff --stat` and top changed paths.
-  3) Stage and commit formatting changes in a **separate commit**:
+  1. Run `bun run format` (already done above, repeat only if needed).
+  2. Show `git diff --stat` and top changed paths.
+  3. Stage and commit formatting changes in a **separate commit**:
 
 ```bash
 git add -A
 git commit -m "chore: format baseline" -m "ref autoship"
 ```
 
-  4) Re-run the full gate chain. If it passes, continue to PR creation.
+4. Re-run the full gate chain. If it passes, continue to PR creation.
 
 #### Strategy 2 — Split formatting into a dedicated PR (best practice)
 
 Recommended when formatting drift is repo-wide. Keeps your feature PR focused.
 
 If user chooses this:
-1) Create a **format baseline branch** off the chosen PR base:
+
+1. Create a **format baseline branch** off the chosen PR base:
 
 ```bash
 git stash push -u -m "autoship: before format baseline split"
@@ -357,10 +372,11 @@ git stash pop
 
 > If you stashed feature work, immediately stash it again after switching branches to avoid mixing. The goal is: **baseline PR contains only formatting**.
 
-2) Ensure the branch contains **only formatting** changes:
+2. Ensure the branch contains **only formatting** changes:
+
 - Reset any non-format changes (if present) and keep only the formatter output.
 
-3) Run:
+3. Run:
 
 ```bash
 bun run format
@@ -371,7 +387,7 @@ bun run build
 bun run test:unit
 ```
 
-4) Commit + push:
+4. Commit + push:
 
 ```bash
 git add -A
@@ -379,15 +395,16 @@ git commit -m "chore: format baseline" -m "ref autoship"
 git push -u origin chore-format-baseline-YYYYMMDD
 ```
 
-5) Create a **Draft PR** for the baseline:
+5. Create a **Draft PR** for the baseline:
 
 ```bash
 gh pr create --base <base> --head chore-format-baseline-YYYYMMDD --title "chore: format baseline" --body "Repo-wide formatting drift fix." --draft
 ```
 
-6) Request CODEOWNERS reviewers (same process as Step 11) and watch checks.
+6. Request CODEOWNERS reviewers (same process as Step 11) and watch checks.
 
-7) After the baseline PR is merged:
+7. After the baseline PR is merged:
+
 - Return to your feature branch and rebase onto updated base:
 
 ```bash
@@ -400,16 +417,17 @@ git rebase origin/<base>
 
 > If you have permission and prefer automation, optionally enable auto-merge on the baseline PR once checks pass. Otherwise, prompt the user to merge it manually.
 
-
 ---
 
 ### 8) Commit (message quality + traceability)
 
 Commit message format:
+
 - If ticket present: `AL-123: <short summary>`
 - Else: `<short summary>`
 
 Include a body line for traceability:
+
 - If ticket present: `ref AL-123`
 - Else: `ref autoship`
 
@@ -449,6 +467,7 @@ gh pr create \
 ```
 
 PR body must include:
+
 - Summary
 - Why
 - How to test (include the exact local commands you ran)
@@ -457,6 +476,7 @@ PR body must include:
   - `fixes AL-123`
 
 Optional but recommended:
+
 - Add labels like `autoship` or `needs-review` (if your repo uses labels).
 
 ---
@@ -466,16 +486,17 @@ Optional but recommended:
 **Important:** CODEOWNERS does not always auto-request reviews unless repo settings/branch protection require it. Always explicitly request reviewers.
 
 Steps:
-1) Locate CODEOWNERS file (first found wins):
+
+1. Locate CODEOWNERS file (first found wins):
    - `.github/CODEOWNERS`
    - `CODEOWNERS`
    - `docs/CODEOWNERS`
-2) Determine changed files:
+2. Determine changed files:
    - `git diff --name-only origin/<base>...HEAD`
-3) Resolve owners:
+3. Resolve owners:
    - Apply CODEOWNERS pattern matching in order (last matching pattern wins, per GitHub behavior).
    - Owners can be `@user` or `@org/team`.
-4) Build a reviewer set:
+4. Build a reviewer set:
    - Prefer owners for the most files changed.
    - De-duplicate.
    - If result is empty → fall back to:
@@ -489,6 +510,7 @@ env -u GITHUB_TOKEN gh pr edit --add-reviewer "<owner1>" --add-reviewer "<owner2
 ```
 
 **If GitHub rejects a review request because the only resolved owner is the PR author** (`HTTP 422: Review cannot be requested from pull request author.`):
+
 - The command must **not** treat this as success.
 - Prompt the user for a fallback reviewer/team handle (e.g., `@org/team` or `@username`) and request that instead.
 
@@ -509,6 +531,7 @@ gh pr checks --watch
 ```
 
 On **success**:
+
 - Convert draft → ready:
 
 ```bash
@@ -516,12 +539,14 @@ gh pr ready
 ```
 
 Then report to the user:
+
 - PR URL
 - base + head branches
 - reviewers requested
 - checks passed
 
 On **failure**:
+
 - Print a concise failure summary:
   - which checks failed
   - link(s) to failing runs
@@ -537,16 +562,16 @@ Do not start troubleshooting unless the user explicitly approves.
 
 When approved, the command should:
 
-1) Pull failing check details:
+1. Pull failing check details:
    - `gh pr checks`
    - (optional) `gh run list --branch <new-branch> --limit 5`
-2) Map failing check → local command:
+2. Map failing check → local command:
    - lint → `bun run lint`
    - typecheck → `bun run typecheck`
    - build → `bun run build`
    - unit → `bun run test:unit`
    - format → `bun run format && bun run format:check`
-3) Attempt minimal fixes, then:
+3. Attempt minimal fixes, then:
    - re-run the relevant local gate
    - commit with message `AL-123: fix CI <category>` (or `fix CI <category>`)
    - push
@@ -555,7 +580,6 @@ When approved, the command should:
 Stop after a reasonable number of attempts and ask the user before continuing if failures persist.
 
 ---
-
 
 ## Post-Ship: Local cleanup (required prompt)
 
@@ -573,17 +597,20 @@ If not clean: stop and ask whether to stash or skip cleanup.
 
 ### Step PS2) Offer exactly 3 options (Option 1 is recommended)
 
-1) **Keep working on this PR branch** *(recommended)*  
-2) **Switch to `<base>`**  
-3) **Switch to `<base>` + delete local feature branch**
+1. **Keep working on this PR branch** _(recommended)_
+2. **Switch to `<base>`**
+3. **Switch to `<base>` + delete local feature branch**
 
 ### Step PS3) Implement the chosen option
 
 #### Option 1 — Keep working
+
 No action. Print:
+
 - “Staying on `<new-branch>` (updates to this branch update the same PR).”
 
 #### Option 2 — Switch to base
+
 ```bash
 git fetch origin --prune
 git switch <base>
@@ -591,6 +618,7 @@ git pull --ff-only origin <base>
 ```
 
 #### Option 3 — Switch + delete local branch (safe)
+
 ```bash
 git fetch origin --prune
 git switch <base>
@@ -599,8 +627,10 @@ git branch -d <new-branch>
 ```
 
 If `git branch -d` refuses (not merged): **stop** and ask:
+
 - keep branch, or
 - force delete with:
+
 ```bash
 git branch -D <new-branch>
 ```
@@ -608,4 +638,5 @@ git branch -D <new-branch>
 ### Step PS4) Remote branch cleanup (never automatic)
 
 Never delete the remote branch automatically. You may print:
+
 - “After merge, delete the remote branch in GitHub UI or `git push origin --delete <new-branch>`, then `git fetch --prune`.”


### PR DESCRIPTION
## Summary
- Apply formatting baseline changes produced by `bun run format`.
- Keep this PR focused on formatting-only cleanup before feature shipping.

## Why
- `format:check` failed during autoship due formatting drift.
- Splitting baseline formatting keeps feature PRs focused and lower-risk.

## How to test
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build` (with `.env.local` loaded for required env vars)
- `bun run test:unit`

## Risk / rollout notes
- Formatting-only changes.
- No runtime logic changes intended.
