### PR TITLE
Fix Vercel deploy root resolution in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,6 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DONOR }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      APP_DIR: apps/donor
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -179,11 +178,11 @@ jobs:
             echo "prod_flag=" >> "$GITHUB_OUTPUT"
           fi
       - name: Pull Vercel project settings
-        run: vercel --cwd="${{ env.APP_DIR }}" pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ env.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ env.VERCEL_TOKEN }}
       - name: Build Vercel artifacts
-        run: vercel --cwd="${{ env.APP_DIR }}" build --token=${{ env.VERCEL_TOKEN }}
+        run: vercel build --token=${{ env.VERCEL_TOKEN }}
       - name: Deploy to Vercel
-        run: vercel --cwd="${{ env.APP_DIR }}" deploy --prebuilt ${{ steps.target.outputs.prod_flag }} --token=${{ env.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt ${{ steps.target.outputs.prod_flag }} --token=${{ env.VERCEL_TOKEN }}
 
   deploy-vercel-admin:
     name: Deploy admin to Vercel
@@ -196,7 +195,6 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ADMIN }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      APP_DIR: apps/admin
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -219,11 +217,11 @@ jobs:
             echo "prod_flag=" >> "$GITHUB_OUTPUT"
           fi
       - name: Pull Vercel project settings
-        run: vercel --cwd="${{ env.APP_DIR }}" pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ env.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ env.VERCEL_TOKEN }}
       - name: Build Vercel artifacts
-        run: vercel --cwd="${{ env.APP_DIR }}" build --token=${{ env.VERCEL_TOKEN }}
+        run: vercel build --token=${{ env.VERCEL_TOKEN }}
       - name: Deploy to Vercel
-        run: vercel --cwd="${{ env.APP_DIR }}" deploy --prebuilt ${{ steps.target.outputs.prod_flag }} --token=${{ env.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt ${{ steps.target.outputs.prod_flag }} --token=${{ env.VERCEL_TOKEN }}
 
   deploy-vercel-missionary:
     name: Deploy missionary to Vercel
@@ -236,7 +234,6 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_MISSIONARY }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      APP_DIR: apps/missionary
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -259,8 +256,8 @@ jobs:
             echo "prod_flag=" >> "$GITHUB_OUTPUT"
           fi
       - name: Pull Vercel project settings
-        run: vercel --cwd="${{ env.APP_DIR }}" pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ env.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ env.VERCEL_TOKEN }}
       - name: Build Vercel artifacts
-        run: vercel --cwd="${{ env.APP_DIR }}" build --token=${{ env.VERCEL_TOKEN }}
+        run: vercel build --token=${{ env.VERCEL_TOKEN }}
       - name: Deploy to Vercel
-        run: vercel --cwd="${{ env.APP_DIR }}" deploy --prebuilt ${{ steps.target.outputs.prod_flag }} --token=${{ env.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt ${{ steps.target.outputs.prod_flag }} --token=${{ env.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- remove `--cwd` from Vercel CLI pull/build/deploy steps in all deploy jobs
- rely on each Vercel project's configured Root Directory to prevent duplicate `apps/<app>/apps/<app>` path resolution
- drop now-unused `APP_DIR` env entries from deploy jobs

## Test plan
- [x] Verified local diff only updates `.github/workflows/ci.yml`
- [ ] Confirm Vercel dashboard Root Directory is set per project (`apps/admin`, `apps/donor`, `apps/missionary`)
- [ ] Verify next push to `epic` runs deploy jobs without ENOENT/spawn errors

Made with [Cursor](https://cursor.com)