### PR TITLE
Add reviewers config and Greptile informer workflow

### DIFF
--- a/.cursor/commands/5-ship-working-tree.md
+++ b/.cursor/commands/5-ship-working-tree.md
@@ -1,7 +1,7 @@
 # 5-ship-working-tree
 
 **Name:** `5-ship-working-tree`  
-**Purpose:** Turn **local, uncommitted changes** into a clean feature branch + (draft) PR, request the correct CODEOWNERS reviewers, push to GitHub, and **watch CI checks** until pass/fail—then notify the user and offer troubleshooting on failures.
+**Purpose:** Turn **local, uncommitted changes** into a clean feature branch + (draft) PR, request the correct **CODEOWNERS reviewer(s) + 1 additional best-fit reviewer** (from `.github/reviewers.yml`), push to GitHub, and **watch CI checks** until pass/fail—then notify the user and offer troubleshooting on failures.
 
 **Applies when:** You have meaningful local changes (staged/unstaged/untracked) that you want shipped via PR.  
 **Do not use when:** You are mid-rebase/merge, you suspect secrets are present, or you need a multi-commit / multi-PR breakdown.
@@ -481,11 +481,16 @@ Optional but recommended:
 
 ---
 
-### 11) Resolve CODEOWNERS → request review in GitHub
+### 11) Resolve CODEOWNERS + reviewers.yml → request review in GitHub
 
 **Important:** CODEOWNERS does not always auto-request reviews unless repo settings/branch protection require it. Always explicitly request reviewers.
 
-Steps:
+**Goal:** Request exactly:
+
+- the relevant **CODEOWNER(s)** (prefer individuals), **and**
+- **1 additional reviewer** chosen from `.github/reviewers.yml` based on PR difficulty.
+
+#### 11.1) Resolve CODEOWNERS (source-of-truth)
 
 1. Locate CODEOWNERS file (first found wins):
    - `.github/CODEOWNERS`
@@ -494,30 +499,139 @@ Steps:
 2. Determine changed files:
    - `git diff --name-only origin/<base>...HEAD`
 3. Resolve owners:
-   - Apply CODEOWNERS pattern matching in order (last matching pattern wins, per GitHub behavior).
+   - Apply CODEOWNERS pattern matching in order (**last matching pattern wins**, per GitHub behavior).
    - Owners can be `@user` or `@org/team`.
-4. Build a reviewer set:
-   - Prefer owners for the most files changed.
-   - De-duplicate.
-   - If result is empty → fall back to:
-     - repo default owner, or
-     - prompt user for a reviewer.
 
-Then request reviews (run with `GITHUB_TOKEN` unset):
+Build a **codeowner reviewer set**:
+
+- De-duplicate.
+- If result is empty → fall back to:
+  - repo default owner, or
+  - prompt user for a reviewer.
+
+> If CODEOWNERS returns only teams (e.g. `@org/team`) but you prefer individuals, you may try to expand a team into members via the GitHub API (requires your token to have `read:org`). If expansion fails, request the team as-is.
+
+#### 11.2) Compute PR difficulty (low/medium/high) from `.github/reviewers.yml`
+
+Difficulty evaluation (defaults shown; prefer config if present):
+
+- If **any changed file** matches `difficulty_heuristics.high.high_risk_paths` → `high`.
+- Else:
+  - `files_changed` = count of changed files in `git diff --name-only origin/<base>...HEAD`
+  - `lines_changed` = (additions + deletions) from `git diff --numstat origin/<base>...HEAD`
+  - If within `low` thresholds → `low` (default: `<= 8 files` and `<= 300 lines`)
+  - Else if within `medium` thresholds → `medium` (default: `<= 25 files` and `<= 1500 lines`)
+  - Else → `high`
+
+#### 11.3) Pick the 1 additional reviewer from `.github/reviewers.yml`
+
+Candidates:
+
+- `people[]` where `difficulty` is included in `can_primary_for_difficulty`.
+
+Exclude:
+
+- PR author
+- any CODEOWNER(s) already requested
+- anyone already requested as a reviewer (if you have that info)
+
+**Selection priority (your preferences):**
+
+- **low:** pick the **lowest level** candidate first (prefer interns / junior reviewers).
+- **medium:** pick the candidate **closest to level 3** first (prefer `3`, then `2`, then `4`, then `1`).
+- **high:** pick the **highest level** candidate first (prefer seniors; e.g., pick level 4 over level 3).
+
+If no eligible candidate remains after exclusions → prompt user for a fallback additional reviewer.
+
+#### 11.4) Request reviews via GitHub (explicit)
+
+Run all `gh` commands with `GITHUB_TOKEN` unset if it exists:
 
 ```bash
-env -u GITHUB_TOKEN gh pr edit --add-reviewer "<owner1>" --add-reviewer "<owner2>"
+env -u GITHUB_TOKEN gh --version >/dev/null 2>&1 || true
+```
+
+Request CODEOWNERS first:
+
+```bash
+env -u GITHUB_TOKEN gh pr edit --add-reviewer "<codeowner1>" --add-reviewer "<codeowner2>"
+```
+
+Then request the 1 additional reviewer (if found):
+
+```bash
+env -u GITHUB_TOKEN gh pr edit --add-reviewer "<additional-reviewer>"
 ```
 
 **If GitHub rejects a review request because the only resolved owner is the PR author** (`HTTP 422: Review cannot be requested from pull request author.`):
 
-- The command must **not** treat this as success.
-- Prompt the user for a fallback reviewer/team handle (e.g., `@org/team` or `@username`) and request that instead.
+- Treat it as a failure.
+- Remove the author from the codeowner set, then retry.
+- If the set becomes empty, prompt the user for a fallback reviewer and request that instead.
 
 Also set PR assignee to the author:
 
 ```bash
-gh pr edit --add-assignee "@me"
+env -u GITHUB_TOKEN gh pr edit --add-assignee "@me"
+```
+
+#### 11.5) (Recommended helper) One-shot difficulty + reviewer picker
+
+If you want an automated picker that matches the policy above, you can run this after PR creation (replace `<base>`):
+
+```bash
+BASE="<base>" python3 - <<'PY'
+import os, fnmatch, subprocess, yaml
+
+base = os.environ["BASE"]
+cfg = yaml.safe_load(open(".github/reviewers.yml", "r", encoding="utf-8"))
+
+def sh(cmd: str) -> str:
+    return subprocess.check_output(cmd, shell=True, text=True).strip()
+
+paths = [p for p in sh(f"git diff --name-only origin/{base}...HEAD").splitlines() if p.strip()]
+files_changed = len(paths)
+
+adds = dels = 0
+for line in sh(f"git diff --numstat origin/{base}...HEAD").splitlines():
+    a, d, _ = line.split("	", 2)
+    if a.isdigit(): adds += int(a)
+    if d.isdigit(): dels += int(d)
+lines_changed = adds + dels
+
+high_risk = cfg.get("difficulty_heuristics", {}).get("high", {}).get("high_risk_paths", []) or []
+touches_high_risk = any(any(fnmatch.fnmatch(p, pat) for pat in high_risk) for p in paths)
+
+low = cfg.get("difficulty_heuristics", {}).get("low", {})
+med = cfg.get("difficulty_heuristics", {}).get("medium", {})
+
+if touches_high_risk:
+    difficulty = "high"
+elif files_changed <= int(low.get("max_files_changed", 8)) and lines_changed <= int(low.get("max_lines_changed", 300)):
+    difficulty = "low"
+elif files_changed <= int(med.get("max_files_changed", 25)) and lines_changed <= int(med.get("max_lines_changed", 1500)):
+    difficulty = "medium"
+else:
+    difficulty = "high"
+
+people = cfg.get("people", [])
+candidates = [p for p in people if difficulty in (p.get("can_primary_for_difficulty") or [])]
+
+def sort_key(p):
+    lvl = int(p.get("level", 0))
+    if difficulty == "low":
+        return (lvl,)          # lowest first
+    if difficulty == "high":
+        return (-lvl,)         # highest first
+    return (abs(lvl - 3), lvl) # medium: 3,2,4,1
+
+candidates.sort(key=sort_key)
+
+print("difficulty=", difficulty)
+print("files_changed=", files_changed, "lines_changed=", lines_changed)
+print("candidates=", [f"{c['handle']}(L{c['level']})" for c in candidates])
+print("pick=", candidates[0]["handle"] if candidates else "")
+PY
 ```
 
 ---
@@ -528,6 +642,16 @@ Watch checks:
 
 ```bash
 gh pr checks --watch
+```
+
+Greptile (async reviewer signal):
+
+- **Do not block/wait** for Greptile.
+- If Greptile is installed and you have a workflow like `.github/workflows/greptile-informer.yml`, GitHub will post a 🦜 comment later with key findings + a **suggested** additional reviewer (info only).
+- Optionally check once (no waiting loop):
+
+```bash
+gh pr view --comments | rg -n "greptile|🦜|Issue Found|Confidence Score|Important Files Changed" || true
 ```
 
 On **success**:

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,53 @@
+version: 1
+
+people:
+  - handle: "@loclv94"
+    name: "Loc"
+    level: 4
+    skills: [fullstack]
+    can_primary_for_difficulty: [medium, high]
+
+  - handle: "@musab03"
+    name: "Musab"
+    level: 3
+    skills: [fullstack]
+    can_primary_for_difficulty: [medium, high]
+
+  - handle: "@amritraj404"
+    name: "Amrit Rai"
+    level: 1
+    skills: [frontend]
+    can_primary_for_difficulty: [low]
+
+  - handle: "@htetaunglin-coder"
+    name: "Kelvin"
+    level: 2
+    skills: [fullstack]
+    can_primary_for_difficulty: [low, medium]
+
+review_policy:
+  request_individuals_only: true
+  always_request_codeowner: true
+  additional_reviewers: 1
+  allow_intern_primary_if_difficulty_at_most: low
+
+difficulty_heuristics:
+  low:
+    max_files_changed: 8
+    max_lines_changed: 300
+  medium:
+    max_files_changed: 25
+    max_lines_changed: 1500
+  high:
+    high_risk_paths:
+      - "packages/**"
+      - ".github/**"
+      - "**/migrations/**"
+      - "**/infra/**"
+
+greptile:
+  bot_login: "greptile-apps[bot]"
+  signal_phrases:
+    - "Issue Found"
+    - "Confidence Score"
+    - "Important Files Changed"

--- a/.github/workflows/greptile-informer.yml
+++ b/.github/workflows/greptile-informer.yml
@@ -1,0 +1,184 @@
+name: Greptile informer (review routing suggestion)
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  inform:
+    # Only run when Greptile is the reviewer
+    if: github.actor == 'greptile-apps[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Post reviewer suggestion comment (no auto-assign)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ruby <<'RUBY'
+            require 'json'
+            require 'yaml'
+            require 'net/http'
+            require 'uri'
+
+            def api_get(repo, path, token)
+              uri = URI("https://api.github.com/repos/#{repo}#{path}")
+              req = Net::HTTP::Get.new(uri)
+              req['Authorization'] = "Bearer #{token}"
+              req['Accept'] = "application/vnd.github+json"
+              res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+              raise "GET #{path} failed: #{res.code} #{res.body}" unless res.code.to_i.between?(200,299)
+              JSON.parse(res.body)
+            end
+
+            def api_post(repo, path, token, body_hash)
+              uri = URI("https://api.github.com/repos/#{repo}#{path}")
+              req = Net::HTTP::Post.new(uri)
+              req['Authorization'] = "Bearer #{token}"
+              req['Accept'] = "application/vnd.github+json"
+              req['Content-Type'] = "application/json"
+              req.body = JSON.dump(body_hash)
+              res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+              raise "POST #{path} failed: #{res.code} #{res.body}" unless res.code.to_i.between?(200,299)
+              JSON.parse(res.body)
+            end
+
+            def fnmatch_any?(patterns, path)
+              patterns.any? { |pat| File.fnmatch?(pat, path, File::FNM_PATHNAME) }
+            end
+
+            token = ENV.fetch('GITHUB_TOKEN')
+            repo  = ENV.fetch('GITHUB_REPOSITORY') # "owner/repo"
+            event = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
+
+            pr_number  = event.dig('pull_request', 'number')
+            review_id  = event.dig('review', 'id')
+            review_url = event.dig('review', 'html_url')
+            review_body = (event.dig('review', 'body') || "").to_s
+
+            # Load reviewers.yml
+            cfg_path = ".github/reviewers.yml"
+            unless File.exist?(cfg_path)
+              puts "Missing #{cfg_path}; exiting."
+              exit 0
+            end
+            cfg = YAML.load_file(cfg_path)
+
+            # Fetch PR metadata
+            pr = api_get(repo, "/pulls/#{pr_number}", token)
+            pr_author = pr.dig('user', 'login').to_s
+            changed_files = pr['changed_files'].to_i
+            additions = pr['additions'].to_i
+            deletions = pr['deletions'].to_i
+            total_lines = additions + deletions
+
+            # Fetch PR file list (for high-risk matching + frontend heaviness)
+            files = []
+            page = 1
+            loop do
+              batch = api_get(repo, "/pulls/#{pr_number}/files?per_page=100&page=#{page}", token)
+              break if batch.empty?
+              files.concat(batch)
+              page += 1
+              break if page > 20 # safety cap
+            end
+            paths = files.map { |f| f['filename'] }.compact
+
+            # Determine difficulty
+            heur = cfg.fetch('difficulty_heuristics', {})
+            low_h  = heur.fetch('low', {})
+            med_h  = heur.fetch('medium', {})
+            high_h = heur.fetch('high', {})
+            high_risk = (high_h['high_risk_paths'] || [])
+
+            touches_high_risk = paths.any? { |p| fnmatch_any?(high_risk, p) }
+
+            difficulty =
+              if touches_high_risk
+                'high'
+              elsif changed_files <= low_h.fetch('max_files_changed', 8).to_i && total_lines <= low_h.fetch('max_lines_changed', 300).to_i
+                'low'
+              elsif changed_files <= med_h.fetch('max_files_changed', 25).to_i && total_lines <= med_h.fetch('max_lines_changed', 1500).to_i
+                'medium'
+              else
+                'high'
+              end
+
+            # Frontend-heavy heuristic (only used to prefer frontend on low difficulty)
+            fe_exts = %w[.tsx .jsx .css .scss .sass .less .mdx]
+            fe_count = paths.count { |p| fe_exts.any? { |ext| p.end_with?(ext) } }
+            frontend_heavy = paths.any? && (fe_count.to_f / paths.size) >= 0.6
+
+            # Exclude already-requested reviewers + author
+            already_requested = (pr['requested_reviewers'] || []).map { |u| "@#{u['login']}" }
+            excluded_handles = already_requested + ["@#{pr_author}"]
+
+            # Choose suggestion from reviewers.yml (NO auto-assign)
+            people = cfg.fetch('people', [])
+            candidates = people.select do |p|
+              diffs = (p['can_primary_for_difficulty'] || []).map(&:to_s)
+              diffs.include?(difficulty) && !excluded_handles.include?(p['handle'])
+            end
+
+            # If low difficulty and intern allowed up to low, keep level 1 eligible; otherwise level filtering is naturally handled by can_primary_for_difficulty
+            # Score: prefer higher level; for low+frontend-heavy, prefer frontend skill
+            best = candidates.max_by do |p|
+              score = p['level'].to_i * 10
+              if difficulty == 'low' && frontend_heavy && (p['skills'] || []).map(&:to_s).include?('frontend')
+                score += 20
+              end
+              score
+            end
+
+            # Extract Greptile signals (lightweight)
+            greptile_cfg = cfg.fetch('greptile', {})
+            phrases = (greptile_cfg['signal_phrases'] || [])
+            found_lines = phrases.map do |ph|
+              review_body.lines.find { |ln| ln.include?(ph) }
+            end.compact.map(&:strip).uniq
+
+            marker = "<!-- greptile-informer:review-id=#{review_id} -->"
+
+            # Idempotency: avoid posting twice for same review
+            comments = api_get(repo, "/issues/#{pr_number}/comments?per_page=100", token)
+            if comments.any? { |c| c['body'].to_s.include?(marker) }
+              puts "Already commented for review #{review_id}; exiting."
+              exit 0
+            end
+
+            suggestion_text =
+              if best
+                "#{best['handle']} (level #{best['level']}, #{(best['skills'] || []).join(', ')})"
+              else
+                "_No suggestion found_ (everyone eligible is already requested, or config doesn’t match this PR)."
+              end
+
+            risk_note = touches_high_risk ? "High-risk paths detected (#{high_risk.join(', ')})." : "No high-risk paths detected."
+
+            lines = []
+            lines << marker
+            lines << "🦜 **Greptile has reviewed this PR.**"
+            lines << ""
+            lines << "- Review: #{review_url}" if review_url
+            lines << "- Detected difficulty: **#{difficulty}** (files=#{changed_files}, lines=#{total_lines}). #{risk_note}"
+            if difficulty == 'low' && frontend_heavy
+              lines << "- Heuristic: frontend-heavy changes (#{fe_count}/#{paths.size} UI-ish files)."
+            end
+            if found_lines.any?
+              lines << "- Signals: " + found_lines.map { |l| "`#{l}`" }.join(" · ")
+            end
+            lines << ""
+            lines << "✅ **Suggested additional reviewer (info only):** #{suggestion_text}"
+            lines << ""
+            lines << "_Note: This workflow does **not** auto-request reviewers; it only posts a suggestion._"
+
+            api_post(repo, "/issues/#{pr_number}/comments", token, { body: lines.join("\n") })
+            puts "Posted suggestion comment."
+          RUBY


### PR DESCRIPTION
## Summary
Add reviewer configuration (`.github/reviewers.yml`) and a Greptile informer workflow (`.github/workflows/greptile-informer.yml`), and extend the ship-working-tree command doc with format-baseline and reviewer-selection behavior.

## Why
- **reviewers.yml**: Single source for difficulty heuristics and reviewer pool so PRs can request CODEOWNERS + one additional reviewer by difficulty (low/medium/high).
- **greptile-informer.yml**: When Greptile reviews a PR, post a comment with difficulty + suggested additional reviewer (info only; no auto-request).
- **5-ship-working-tree.md**: Document formatting drift handling and CODEOWNERS + reviewers.yml flow.

## How to test
- **Local gates (already run):**
  - `bun run format:check && bun run lint && bun run typecheck && bun run build && bun run test:unit`
- **reviewers.yml:** Valid YAML; no runtime test.
- **greptile-informer:** Triggers on `pull_request_review` when actor is `greptile-apps[bot]`; verify in a PR after Greptile reviews.

## Risk notes
- New workflow runs only when Greptile submits a review; no impact on other CI.
- Ship command doc and reviewers config are additive; no behavior change to existing flows until the ship command (or other tooling) uses them.
