### PR TITLE
ci(greptile): parse difficulty from review and auto-request reviewer

### DIFF
--- a/.cursor/commands/5-ship-working-tree.md
+++ b/.cursor/commands/5-ship-working-tree.md
@@ -1,7 +1,7 @@
 # 5-ship-working-tree
 
 **Name:** `5-ship-working-tree`  
-**Purpose:** Turn **local, uncommitted changes** into a clean feature branch + (draft) PR, request the correct CODEOWNERS reviewers, push to GitHub, and **watch CI checks** until pass/fail—then notify the user and offer troubleshooting on failures.
+**Purpose:** Turn **local, uncommitted changes** into a clean feature branch + (draft) PR, request the correct **CODEOWNERS reviewer(s)** (only) immediately, push to GitHub, and **watch CI checks** until pass/fail—then notify the user and offer troubleshooting on failures. **Additional reviewer routing happens later via Greptile-triggered GitHub Action** using `.github/reviewers.yml`.
 
 **Applies when:** You have meaningful local changes (staged/unstaged/untracked) that you want shipped via PR.  
 **Do not use when:** You are mid-rebase/merge, you suspect secrets are present, or you need a multi-commit / multi-PR breakdown.
@@ -481,46 +481,53 @@ Optional but recommended:
 
 ---
 
-### 11) Resolve CODEOWNERS → request review in GitHub
+### 11) Resolve CODEOWNERS → request review in GitHub (CODEOWNERS only)
 
 **Important:** CODEOWNERS does not always auto-request reviews unless repo settings/branch protection require it. Always explicitly request reviewers.
 
-Steps:
+**Goal:** Request **only** the relevant **CODEOWNER(s)** (prefer individuals).  
+This command **must not** request an additional reviewer—reviewer routing happens later via GitHub Actions after Greptile posts.
+
+#### 11.1) Resolve CODEOWNERS (source-of-truth)
 
 1. Locate CODEOWNERS file (first found wins):
    - `.github/CODEOWNERS`
    - `CODEOWNERS`
    - `docs/CODEOWNERS`
 2. Determine changed files:
+   - `git fetch origin --prune`
    - `git diff --name-only origin/<base>...HEAD`
 3. Resolve owners:
-   - Apply CODEOWNERS pattern matching in order (last matching pattern wins, per GitHub behavior).
+   - Apply CODEOWNERS pattern matching in order (**last matching pattern wins**, per GitHub behavior).
    - Owners can be `@user` or `@org/team`.
-4. Build a reviewer set:
-   - Prefer owners for the most files changed.
-   - De-duplicate.
-   - If result is empty → fall back to:
-     - repo default owner, or
-     - prompt user for a reviewer.
 
-Then request reviews (run with `GITHUB_TOKEN` unset):
+Build a **codeowner reviewer set**:
 
-```bash
-env -u GITHUB_TOKEN gh pr edit --add-reviewer "<owner1>" --add-reviewer "<owner2>"
-```
+- De-duplicate.
+- If empty → prompt the user for a reviewer.
 
-**If GitHub rejects a review request because the only resolved owner is the PR author** (`HTTP 422: Review cannot be requested from pull request author.`):
+> If CODEOWNERS returns only teams but you prefer individuals, you may try to expand team members via GitHub API (`read:org`). If expansion fails, request the team as-is.
 
-- The command must **not** treat this as success.
-- Prompt the user for a fallback reviewer/team handle (e.g., `@org/team` or `@username`) and request that instead.
+#### 11.2) Request CODEOWNERS via GitHub (explicit)
 
-Also set PR assignee to the author:
+Request CODEOWNERS:
 
 ```bash
-gh pr edit --add-assignee "@me"
+env -u GITHUB_TOKEN gh pr edit --add-reviewer "<codeowner1>" --add-reviewer "<codeowner2>"
 ```
 
----
+**Edge case: CODEOWNER == PR author**
+GitHub does **not** allow requesting review from the PR author (`HTTP 422: Review cannot be requested from pull request author.`).  
+If the only resolved CODEOWNER(s) are the PR author:
+
+- Do **not** request reviewers.
+- Leave a short PR comment noting: “CODEOWNER is PR author; cannot request self-review.”
+
+(Optional) Set PR assignee to the author:
+
+```bash
+env -u GITHUB_TOKEN gh pr edit --add-assignee "@me"
+```
 
 ### 12) Watch CI checks until pass/fail
 
@@ -528,6 +535,21 @@ Watch checks:
 
 ```bash
 gh pr checks --watch
+```
+
+Greptile (async reviewer routing):
+
+- **Do not block/wait** for Greptile inside Cursor.
+- When Greptile submits its PR review, GitHub Actions (`.github/workflows/greptile-informer.yml`) will:
+  - read Greptile’s **Confidence Score (1–5)** (if present),
+  - combine it with PR file/line heuristics,
+  - and request **1 additional reviewer** from `.github/reviewers.yml`.
+- It will also post a short comment documenting the decision.
+
+Optional one-time check:
+
+```bash
+gh pr view --comments | rg -n "greptile|Reviewer routing|Assigned additional reviewer|difficulty" || true
 ```
 
 On **success**:

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -37,6 +37,10 @@ greptile:
   bot_login: "greptile-apps[bot]"
   # The action will try these patterns against the Greptile review body.
   # It accepts either "Difficulty: 4/5" or "Difficulty Score: 4/5" (case-insensitive).
+  confidence_regexes:
+    - '(?i)\bconfidence\s*score\b\s*:\s*([1-5])\s*/\s*5'
+    - '(?i)\bconfidence\b\s*:\s*([1-5])\s*/\s*5'
+  # Back-compat: if Greptile ever emits Difficulty/Complexity instead, we still parse it.
   difficulty_regexes:
     - '(?i)\bdifficulty\b(?:\s*score)?\s*:\s*([1-5])\s*/\s*5'
     - '(?i)\bcomplexity\b(?:\s*score)?\s*:\s*([1-5])\s*/\s*5'

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -22,7 +22,7 @@ people:
   - handle: "@htetaunglin-coder"
     name: "Kelvin"
     level: 2
-    skills: [fullstack]
+    skills: [frontend]
     can_primary_for_difficulty: [low, medium]
 
 review_policy:

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -31,6 +31,23 @@ review_policy:
   additional_reviewers: 1
   allow_intern_primary_if_difficulty_at_most: low
 
+# Used by the GitHub Action (greptile-informer.yml) to map Greptile's 1–5 difficulty
+# into the low/medium/high buckets used above.
+greptile:
+  bot_login: "greptile-apps[bot]"
+  # The action will try these patterns against the Greptile review body.
+  # It accepts either "Difficulty: 4/5" or "Difficulty Score: 4/5" (case-insensitive).
+  difficulty_regexes:
+    - '(?i)\bdifficulty\b(?:\s*score)?\s*:\s*([1-5])\s*/\s*5'
+    - '(?i)\bcomplexity\b(?:\s*score)?\s*:\s*([1-5])\s*/\s*5'
+  # Map 1–5 to a routing bucket.
+  map_to_bucket:
+    "1": low
+    "2": low
+    "3": medium
+    "4": high
+    "5": high
+
 difficulty_heuristics:
   low:
     max_files_changed: 8
@@ -44,10 +61,3 @@ difficulty_heuristics:
       - ".github/**"
       - "**/migrations/**"
       - "**/infra/**"
-
-greptile:
-  bot_login: "greptile-apps[bot]"
-  signal_phrases:
-    - "Issue Found"
-    - "Confidence Score"
-    - "Important Files Changed"

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,53 @@
+version: 1
+
+people:
+  - handle: "@loclv94"
+    name: "Loc"
+    level: 4
+    skills: [fullstack]
+    can_primary_for_difficulty: [medium, high]
+
+  - handle: "@musab03"
+    name: "Musab"
+    level: 3
+    skills: [fullstack]
+    can_primary_for_difficulty: [medium, high]
+
+  - handle: "@amritraj404"
+    name: "Amrit Rai"
+    level: 1
+    skills: [frontend]
+    can_primary_for_difficulty: [low]
+
+  - handle: "@htetaunglin-coder"
+    name: "Kelvin"
+    level: 2
+    skills: [fullstack]
+    can_primary_for_difficulty: [low, medium]
+
+review_policy:
+  request_individuals_only: true
+  always_request_codeowner: true
+  additional_reviewers: 1
+  allow_intern_primary_if_difficulty_at_most: low
+
+difficulty_heuristics:
+  low:
+    max_files_changed: 8
+    max_lines_changed: 300
+  medium:
+    max_files_changed: 25
+    max_lines_changed: 1500
+  high:
+    high_risk_paths:
+      - "packages/**"
+      - ".github/**"
+      - "**/migrations/**"
+      - "**/infra/**"
+
+greptile:
+  bot_login: "greptile-apps[bot]"
+  signal_phrases:
+    - "Issue Found"
+    - "Confidence Score"
+    - "Important Files Changed"

--- a/.github/workflows/greptile-informer.yml
+++ b/.github/workflows/greptile-informer.yml
@@ -11,8 +11,14 @@ permissions:
 
 jobs:
   route:
-    # Only run when Greptile submits the review, and avoid running on forked PRs for safety.
+    # Prevent duplicate processing for the same PR when webhooks/retries happen close together.
+    concurrency:
+      group: greptile-reviewer-routing-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    # Only run when Greptile submits the review, and only for PRs whose head repo is this repo (not a fork).
     if: github.actor == 'greptile-apps[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-latest
 
     steps:
@@ -23,34 +29,42 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install pyyaml
 
-      - name: Route 1 additional reviewer from reviewers.yml (no labels)
+      - name: Route 1 additional reviewer from reviewers.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 - <<'PY'
-          import json, os, re, fnmatch, urllib.request, urllib.error
+          import json
+          import os
+          import re
+          import fnmatch
+          import urllib.request
+          import urllib.error
+          import time
           from pathlib import Path
 
-          def gh_api(method, url, token, body=None):
+
+          def gh_api(method: str, url: str, token: str, body=None):
             req = urllib.request.Request(url, method=method)
             req.add_header("Authorization", f"Bearer {token}")
             req.add_header("Accept", "application/vnd.github+json")
+            data = None
             if body is not None:
               data = json.dumps(body).encode("utf-8")
               req.add_header("Content-Type", "application/json")
-            else:
-              data = None
             try:
               with urllib.request.urlopen(req, data=data) as r:
                 return json.loads(r.read().decode("utf-8"))
             except urllib.error.HTTPError as e:
               raise RuntimeError(f"{method} {url} failed: {e.code} {e.read().decode('utf-8', 'ignore')}") from e
 
-          def list_all_pages(token, base_url):
+
+          def list_all_pages(token: str, base_url: str):
             out = []
             page = 1
             while True:
-              data = gh_api("GET", f"{base_url}{'&' if '?' in base_url else '?'}per_page=100&page={page}", token)
+              sep = "&" if "?" in base_url else "?"
+              data = gh_api("GET", f"{base_url}{sep}per_page=100&page={page}", token)
               if not data:
                 break
               out.extend(data)
@@ -59,17 +73,20 @@ jobs:
                 break
             return out
 
-          def parse_greptile_difficulty(body: str, regexes):
+
+          def parse_score_1_to_5(text: str, regexes):
             for pat in regexes:
-              m = re.search(pat, body or "")
-              if m:
-                try:
-                  v = int(m.group(1))
-                  if 1 <= v <= 5:
-                    return v
-                except Exception:
-                  pass
+              m = re.search(pat, text or "")
+              if not m:
+                continue
+              try:
+                v = int(m.group(1))
+                if 1 <= v <= 5:
+                  return v
+              except Exception:
+                pass
             return None
+
 
           def to_bucket_default(score_1_5: int):
             if score_1_5 <= 2:
@@ -78,11 +95,12 @@ jobs:
               return "medium"
             return "high"
 
+
           def heuristic_score(files_changed, lines_changed, paths, cfg):
-            heur = cfg.get("difficulty_heuristics", {})
-            low = heur.get("low", {})
-            med = heur.get("medium", {})
-            high = heur.get("high", {})
+            heur = cfg.get("difficulty_heuristics", {}) or {}
+            low = heur.get("low", {}) or {}
+            med = heur.get("medium", {}) or {}
+            high = heur.get("high", {}) or {}
             high_risk = high.get("high_risk_paths", []) or []
 
             touches_high_risk = any(any(fnmatch.fnmatch(p, pat) for pat in high_risk) for p in paths)
@@ -92,7 +110,7 @@ jobs:
             med_files = int(med.get("max_files_changed", 25))
             med_lines = int(med.get("max_lines_changed", 1500))
 
-            # Map heuristics into a 1–5-ish score (used only when Greptile rating missing).
+            # Map heuristics into an approximate 1–5 score. Only used when Greptile score can't be parsed.
             if files_changed <= low_files and lines_changed <= low_lines:
               score = 2
             elif files_changed <= med_files and lines_changed <= med_lines:
@@ -103,19 +121,18 @@ jobs:
             if files_changed >= 80 or lines_changed >= 6000:
               score = 5
 
+            # If high-risk paths touched, ensure at least 4 (unless config remaps it differently).
             if touches_high_risk and score < 4:
               score = 4
 
             return score, touches_high_risk
 
-          def pick_reviewer(bucket, greptile_score, people, exclude_handles, paths):
-            # Filter to eligible by bucket, excluding author + already-requested.
+
+          def pick_reviewer(bucket, score, people, exclude_handles, paths):
             candidates = []
             for p in people:
               handle = str(p.get("handle", "")).strip()
-              if not handle:
-                continue
-              if handle in exclude_handles:
+              if not handle or handle in exclude_handles:
                 continue
               diffs = [str(x) for x in (p.get("can_primary_for_difficulty") or [])]
               if bucket not in diffs:
@@ -125,31 +142,24 @@ jobs:
             if not candidates:
               return None
 
-            # Optional frontend-heavy hint
-            fe_exts = (".tsx", ".jsx", ".css", ".scss", ".sass", ".less", ".mdx")
-            fe_count = sum(1 for p in paths if p.endswith(fe_exts))
-            frontend_heavy = bool(paths) and (fe_count / max(1, len(paths)) >= 0.6)
-
             def lvl(p): return int(p.get("level", 0))
 
             if bucket == "low":
-              # For Greptile=1, strongly prefer level 1 if available.
-              if greptile_score == 1:
+              # If score is the easiest, strongly prefer interns (level 1) when available.
+              if score == 1:
                 lvl1 = [p for p in candidates if lvl(p) == 1]
                 if lvl1:
                   candidates = lvl1
-              # Lowest level first
-              candidates.sort(key=lambda p: (lvl(p), 0 if ("frontend" in (p.get("skills") or []) and frontend_heavy) else 1))
+              candidates.sort(key=lambda p: (lvl(p),))
               return candidates[0]
 
             if bucket == "high":
-              # For Greptile=5, strongly prefer level 4 if available.
-              if greptile_score == 5:
+              # If score is max, strongly prefer top-tier (level 4) when available.
+              if score == 5:
                 lvl4 = [p for p in candidates if lvl(p) == 4]
                 if lvl4:
                   candidates = lvl4
-              # Highest level first
-              candidates.sort(key=lambda p: (-lvl(p), 0 if ("fullstack" in (p.get("skills") or []) ) else 1))
+              candidates.sort(key=lambda p: (-lvl(p),))
               return candidates[0]
 
             # medium: prefer 3, then 2, then 4, then 1
@@ -157,110 +167,173 @@ jobs:
             candidates.sort(key=lambda p: (order.get(lvl(p), 9), -lvl(p)))
             return candidates[0]
 
+
           token = os.environ["GITHUB_TOKEN"]
           repo = os.environ["GITHUB_REPOSITORY"]  # owner/repo
 
           event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
           pr_number = int(event["pull_request"]["number"])
           review_id = event["review"]["id"]
-          greptile_body = (event["review"].get("body") or "")
+          event_review_body = (event["review"].get("body") or "").strip()
 
           cfg_path = Path(".github/reviewers.yml")
           if not cfg_path.exists():
             print("Missing .github/reviewers.yml; exiting.")
             raise SystemExit(0)
 
-          # Minimal YAML parser (avoid external deps): very small, strict YAML only.
-          # Use a tiny fallback if PyYAML isn't available.
+          # YAML load with correct error reporting (import vs parse)
           try:
             import yaml  # type: ignore
+          except ImportError as exc:
+            raise RuntimeError("PyYAML import failed on runner; check the 'Install Python deps' step.") from exc
+
+          try:
             cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
-          except Exception:
-            raise RuntimeError("PyYAML import failed on runner; check the 'Install Python deps' step.")
+          except getattr(yaml, "YAMLError", Exception) as exc:
+            raise RuntimeError(f"Failed to parse .github/reviewers.yml (YAML syntax error?): {exc}") from exc
+          except Exception as exc:
+            raise RuntimeError(f"Failed to read/parse .github/reviewers.yml: {exc}") from exc
 
           greptile_cfg = cfg.get("greptile", {}) or {}
-          map_to_bucket = (greptile_cfg.get("map_to_bucket") or {})
-          # normalize keys to strings
-          map_to_bucket = {str(k): str(v) for k, v in map_to_bucket.items()}
+          map_to_bucket = {str(k): str(v) for k, v in (greptile_cfg.get("map_to_bucket") or {}).items()}
+
           confidence_regexes = greptile_cfg.get("confidence_regexes", []) or []
           difficulty_regexes = greptile_cfg.get("difficulty_regexes", []) or []
-          # Greptile currently emits "Confidence Score: X/5" in review bodies.
           regexes = list(confidence_regexes) + list(difficulty_regexes)
-          score = parse_greptile_difficulty(greptile_body, regexes)
 
-          # Fetch PR (authoritative)
+          def collect_greptile_text():
+            texts = []
+            if event_review_body:
+              texts.append(event_review_body)
+
+            # Greptile sometimes posts the real summary as an issue comment, or the review body can be empty.
+            try:
+              reviews = list_all_pages(token, f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews")
+              for r in reversed(reviews):
+                u = (r.get("user") or {}).get("login")
+                if u in ("greptile-apps[bot]", "greptile-apps"):
+                  b = (r.get("body") or "").strip()
+                  if b:
+                    texts.append(b)
+                    break
+            except Exception:
+              pass
+
+            try:
+              comments = list_all_pages(token, f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments")
+              count = 0
+              for c in reversed(comments):
+                u = (c.get("user") or {}).get("login")
+                if u in ("greptile-apps[bot]", "greptile-apps"):
+                  b = (c.get("body") or "").strip()
+                  if b:
+                    texts.append(b)
+                    count += 1
+                    if count >= 3:
+                      break
+            except Exception:
+              pass
+
+            return "\n\n".join(texts).strip()
+
+          greptile_text = collect_greptile_text()
+          score = parse_score_1_to_5(greptile_text, regexes)
+          if score is None:
+            # Greptile sometimes posts the summary comment a few seconds after the review event.
+            # Poll briefly to avoid falling back to heuristics prematurely.
+            for _ in range(3):
+              time.sleep(10)
+              greptile_text = collect_greptile_text()
+              score = parse_score_1_to_5(greptile_text, regexes)
+              if score is not None:
+                break
+
+          # Fetch PR details (authoritative)
           pr = gh_api("GET", f"https://api.github.com/repos/{repo}/pulls/{pr_number}", token)
           author = pr["user"]["login"]
-          requested = [f"@{u['login']}" for u in (pr.get("requested_reviewers") or [])]
 
+          # requested_reviewers only includes pending requests; exclude users who already reviewed too.
+          requested = [f"@{u['login']}" for u in (pr.get("requested_reviewers") or [])]
+          past_reviewers = set()
+          try:
+            all_reviews = list_all_pages(token, f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews")
+            for r in all_reviews:
+              u = (r.get("user") or {}).get("login")
+              if u and u not in ("greptile-apps[bot]", "greptile-apps"):
+                past_reviewers.add(f"@{u}")
+          except Exception:
+            pass
+
+          # File list for heuristics + risk paths
           files = list_all_pages(token, f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files")
-          paths = [f.get("filename","") for f in files if f.get("filename")]
+          paths = [f.get("filename", "") for f in files if f.get("filename")]
 
           files_changed = int(pr.get("changed_files") or len(paths))
           lines_changed = int(pr.get("additions", 0)) + int(pr.get("deletions", 0))
 
-          # If Greptile confidence score missing, compute heuristic score.
           heuristic, touches_high_risk = heuristic_score(files_changed, lines_changed, paths, cfg)
           final_score = score if score is not None else heuristic
           bucket = map_to_bucket.get(str(final_score), to_bucket_default(final_score))
 
           people = cfg.get("people", []) or []
-
           exclude = set(requested)
+          exclude |= past_reviewers
           exclude.add(f"@{author}")
 
           choice = pick_reviewer(bucket, final_score, people, exclude, paths)
 
           marker = f"<!-- greptile-reviewer-routing:review-id={review_id} -->"
 
-          # Idempotency: if we've already commented for this review, exit
-          comments = list_all_pages(token, f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments")
-          if any(marker in (c.get("body") or "") for c in comments):
-            print("Already processed this Greptile review; exiting.")
+          # Idempotency: if we've already commented for this review_id, exit.
+          existing_comments = list_all_pages(token, f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments")
+          if any(marker in (c.get("body") or "") for c in existing_comments):
+            print("Already processed this Greptile event; exiting.")
             raise SystemExit(0)
 
-          # If no candidate, comment and exit
           if not choice:
             body = "\n".join([
               marker,
               "🦜 **Reviewer routing (Greptile)**",
               "",
-              f"- Greptile confidence score: **{score}/5**" if score is not None else "- Greptile confidence score: _(not found in review body)_",
+              f"- Greptile confidence score: **{score}/5**" if score is not None else "- Greptile confidence score: _(not found in Greptile text)_",
               f"- Heuristic routing fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
               f"- Final routing score used: **{final_score}/5** → **{bucket}**",
               "",
-              "⚠️ No eligible reviewer found in `.github/reviewers.yml` after exclusions (author/already requested).",
+              "⚠️ No eligible reviewer found in `.github/reviewers.yml` after exclusions (author/already requested/past reviewers).",
             ])
             gh_api("POST", f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments", token, {"body": body})
             raise SystemExit(0)
 
           reviewer_login = str(choice["handle"]).lstrip("@")
 
-          # Request reviewer (if not already requested)
           assigned = False
+          err = None
           try:
-            gh_api("POST", f"https://api.github.com/repos/{repo}/pulls/{pr_number}/requested_reviewers", token, {"reviewers": [reviewer_login]})
+            gh_api(
+              "POST",
+              f"https://api.github.com/repos/{repo}/pulls/{pr_number}/requested_reviewers",
+              token,
+              {"reviewers": [reviewer_login]},
+            )
             assigned = True
           except Exception as e:
             err = str(e)
-          else:
-            err = None
 
-          summary_lines = [
+          summary = [
             marker,
             "🦜 **Reviewer routing (Greptile)**",
             "",
-            f"- Greptile confidence score: **{score}/5**" if score is not None else "- Greptile confidence score: _(not found in review body)_",
+            f"- Greptile confidence score: **{score}/5**" if score is not None else "- Greptile confidence score: _(not found in Greptile text)_",
             f"- Heuristic routing fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
             f"- Final routing score used: **{final_score}/5** → **{bucket}**",
             f"- Selected reviewer: **@{reviewer_login}** (level {choice.get('level')}, skills: {', '.join(choice.get('skills') or [])})",
           ]
 
           if assigned:
-            summary_lines += ["", "✅ Requested this reviewer in GitHub (review request)."]
+            summary += ["", "✅ Requested this reviewer in GitHub (review request)."]
           else:
-            summary_lines += ["", f"⚠️ Could not request reviewer automatically. Error: `{err}`", "Please request manually in the PR UI."]
+            summary += ["", f"⚠️ Could not request reviewer automatically. Error: `{err}`", "Please request manually in the PR UI."]
 
-          gh_api("POST", f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments", token, {"body": "\n".join(summary_lines)})
+          gh_api("POST", f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments", token, {"body": "\n".join(summary)})
           print("Done.")
           PY

--- a/.github/workflows/greptile-informer.yml
+++ b/.github/workflows/greptile-informer.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   route:
     # Only run when Greptile submits the review, and avoid running on forked PRs for safety.
-    if: github.actor == 'greptile-apps[bot]' && github.event.pull_request.head.repo.fork == false
+    if: github.actor == 'greptile-apps[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -71,7 +71,7 @@ jobs:
                   pass
             return None
 
-          def to_bucket(score_1_5: int):
+          def to_bucket_default(score_1_5: int):
             if score_1_5 <= 2:
               return "low"
             if score_1_5 == 3:
@@ -176,10 +176,16 @@ jobs:
             import yaml  # type: ignore
             cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
           except Exception:
-            raise RuntimeError("PyYAML not available on runner; add `pip install pyyaml` step or convert reviewers.yml to JSON.")
+            raise RuntimeError("PyYAML import failed on runner; check the 'Install Python deps' step.")
 
           greptile_cfg = cfg.get("greptile", {}) or {}
-          regexes = greptile_cfg.get("difficulty_regexes", []) or []
+          map_to_bucket = (greptile_cfg.get("map_to_bucket") or {})
+          # normalize keys to strings
+          map_to_bucket = {str(k): str(v) for k, v in map_to_bucket.items()}
+          confidence_regexes = greptile_cfg.get("confidence_regexes", []) or []
+          difficulty_regexes = greptile_cfg.get("difficulty_regexes", []) or []
+          # Greptile currently emits "Confidence Score: X/5" in review bodies.
+          regexes = list(confidence_regexes) + list(difficulty_regexes)
           score = parse_greptile_difficulty(greptile_body, regexes)
 
           # Fetch PR (authoritative)
@@ -193,10 +199,10 @@ jobs:
           files_changed = int(pr.get("changed_files") or len(paths))
           lines_changed = int(pr.get("additions", 0)) + int(pr.get("deletions", 0))
 
-          # If Greptile difficulty missing, compute heuristic score.
+          # If Greptile confidence score missing, compute heuristic score.
           heuristic, touches_high_risk = heuristic_score(files_changed, lines_changed, paths, cfg)
           final_score = score if score is not None else heuristic
-          bucket = to_bucket(final_score)
+          bucket = map_to_bucket.get(str(final_score), to_bucket_default(final_score))
 
           people = cfg.get("people", []) or []
 
@@ -219,9 +225,9 @@ jobs:
               marker,
               "🦜 **Reviewer routing (Greptile)**",
               "",
-              f"- Greptile difficulty: **{score}/5**" if score is not None else "- Greptile difficulty: _(not found in review body)_",
-              f"- Heuristic difficulty fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
-              f"- Final difficulty used: **{final_score}/5** → **{bucket}**",
+              f"- Greptile confidence score: **{score}/5**" if score is not None else "- Greptile confidence score: _(not found in review body)_",
+              f"- Heuristic routing fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
+              f"- Final routing score used: **{final_score}/5** → **{bucket}**",
               "",
               "⚠️ No eligible reviewer found in `.github/reviewers.yml` after exclusions (author/already requested).",
             ])
@@ -244,9 +250,9 @@ jobs:
             marker,
             "🦜 **Reviewer routing (Greptile)**",
             "",
-            f"- Greptile difficulty: **{score}/5**" if score is not None else "- Greptile difficulty: _(not found in review body)_",
-            f"- Heuristic difficulty fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
-            f"- Final difficulty used: **{final_score}/5** → **{bucket}**",
+            f"- Greptile confidence score: **{score}/5**" if score is not None else "- Greptile confidence score: _(not found in review body)_",
+            f"- Heuristic routing fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
+            f"- Final routing score used: **{final_score}/5** → **{bucket}**",
             f"- Selected reviewer: **@{reviewer_login}** (level {choice.get('level')}, skills: {', '.join(choice.get('skills') or [])})",
           ]
 

--- a/.github/workflows/greptile-informer.yml
+++ b/.github/workflows/greptile-informer.yml
@@ -142,7 +142,26 @@ jobs:
             if not candidates:
               return None
 
-            def lvl(p): return int(p.get("level", 0))
+            # Determine whether this PR is frontend-heavy (used for tie-breaks / deprioritizing frontend-only on non-frontend PRs).
+            fe_exts = (".tsx", ".jsx", ".css", ".scss", ".sass", ".less", ".mdx")
+            fe_count = sum(1 for pth in paths if str(pth).endswith(fe_exts))
+            frontend_heavy = bool(paths) and (fe_count / max(1, len(paths)) >= 0.6)
+
+            def lvl(p):
+              return int(p.get("level", 0))
+
+            def skills(p):
+              return set(str(s) for s in (p.get("skills") or []))
+
+            def is_fullstack(p):
+              return "fullstack" in skills(p)
+
+            def is_frontend(p):
+              return "frontend" in skills(p)
+
+            # Helper: for non-frontend PRs, strongly prefer fullstack reviewers.
+            def non_frontend_penalty(p):
+              return 0 if is_fullstack(p) else 1
 
             if bucket == "low":
               # If score is the easiest, strongly prefer interns (level 1) when available.
@@ -150,7 +169,13 @@ jobs:
                 lvl1 = [p for p in candidates if lvl(p) == 1]
                 if lvl1:
                   candidates = lvl1
-              candidates.sort(key=lambda p: (lvl(p),))
+
+              # Low: still prioritize lowest level, but:
+              # - if NOT frontend-heavy, prefer fullstack among same level (avoid routing backend-ish low PRs to frontend-only when possible)
+              if frontend_heavy:
+                candidates.sort(key=lambda p: (lvl(p), 0 if is_frontend(p) else 1))
+              else:
+                candidates.sort(key=lambda p: (lvl(p), non_frontend_penalty(p)))
               return candidates[0]
 
             if bucket == "high":
@@ -159,14 +184,21 @@ jobs:
                 lvl4 = [p for p in candidates if lvl(p) == 4]
                 if lvl4:
                   candidates = lvl4
+
+              # High: highest level first; non-frontend penalty is irrelevant here because only fullstack people should be eligible for high.
               candidates.sort(key=lambda p: (-lvl(p),))
               return candidates[0]
 
-            # medium: prefer 3, then 2, then 4, then 1
+            # medium bucket:
+            # - primary ordering: prefer 3, then 2, then 4, then 1
+            # - if NOT frontend-heavy, strongly prefer fullstack (avoid routing backend-ish PRs to frontend-only)
+            # - if frontend-heavy, keep level ordering and only tie-break toward frontend (do NOT override level 3 preference)
             order = {3: 0, 2: 1, 4: 2, 1: 3}
-            candidates.sort(key=lambda p: (order.get(lvl(p), 9), -lvl(p)))
+            if frontend_heavy:
+              candidates.sort(key=lambda p: (order.get(lvl(p), 9), -lvl(p), 0 if is_frontend(p) else 1))
+            else:
+              candidates.sort(key=lambda p: (non_frontend_penalty(p), order.get(lvl(p), 9), -lvl(p)))
             return candidates[0]
-
 
           token = os.environ["GITHUB_TOKEN"]
           repo = os.environ["GITHUB_REPOSITORY"]  # owner/repo

--- a/.github/workflows/greptile-informer.yml
+++ b/.github/workflows/greptile-informer.yml
@@ -1,0 +1,184 @@
+name: Greptile informer (review routing suggestion)
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  inform:
+    # Only run when Greptile is the reviewer
+    if: github.actor == 'greptile-apps[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Post reviewer suggestion comment (no auto-assign)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ruby <<'RUBY'
+            require 'json'
+            require 'yaml'
+            require 'net/http'
+            require 'uri'
+
+            def api_get(repo, path, token)
+              uri = URI("https://api.github.com/repos/#{repo}#{path}")
+              req = Net::HTTP::Get.new(uri)
+              req['Authorization'] = "Bearer #{token}"
+              req['Accept'] = "application/vnd.github+json"
+              res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+              raise "GET #{path} failed: #{res.code} #{res.body}" unless res.code.to_i.between?(200,299)
+              JSON.parse(res.body)
+            end
+
+            def api_post(repo, path, token, body_hash)
+              uri = URI("https://api.github.com/repos/#{repo}#{path}")
+              req = Net::HTTP::Post.new(uri)
+              req['Authorization'] = "Bearer #{token}"
+              req['Accept'] = "application/vnd.github+json"
+              req['Content-Type'] = "application/json"
+              req.body = JSON.dump(body_hash)
+              res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+              raise "POST #{path} failed: #{res.code} #{res.body}" unless res.code.to_i.between?(200,299)
+              JSON.parse(res.body)
+            end
+
+            def fnmatch_any?(patterns, path)
+              patterns.any? { |pat| File.fnmatch?(pat, path, File::FNM_PATHNAME) }
+            end
+
+            token = ENV.fetch('GITHUB_TOKEN')
+            repo  = ENV.fetch('GITHUB_REPOSITORY') # "owner/repo"
+            event = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
+
+            pr_number  = event.dig('pull_request', 'number')
+            review_id  = event.dig('review', 'id')
+            review_url = event.dig('review', 'html_url')
+            review_body = (event.dig('review', 'body') || "").to_s
+
+            # Load reviewers.yml
+            cfg_path = ".github/reviewers.yml"
+            unless File.exist?(cfg_path)
+              puts "Missing #{cfg_path}; exiting."
+              exit 0
+            end
+            cfg = YAML.load_file(cfg_path)
+
+            # Fetch PR metadata
+            pr = api_get(repo, "/pulls/#{pr_number}", token)
+            pr_author = pr.dig('user', 'login').to_s
+            changed_files = pr['changed_files'].to_i
+            additions = pr['additions'].to_i
+            deletions = pr['deletions'].to_i
+            total_lines = additions + deletions
+
+            # Fetch PR file list (for high-risk matching + frontend heaviness)
+            files = []
+            page = 1
+            loop do
+              batch = api_get(repo, "/pulls/#{pr_number}/files?per_page=100&page=#{page}", token)
+              break if batch.empty?
+              files.concat(batch)
+              page += 1
+              break if page > 20 # safety cap
+            end
+            paths = files.map { |f| f['filename'] }.compact
+
+            # Determine difficulty
+            heur = cfg.fetch('difficulty_heuristics', {})
+            low_h  = heur.fetch('low', {})
+            med_h  = heur.fetch('medium', {})
+            high_h = heur.fetch('high', {})
+            high_risk = (high_h['high_risk_paths'] || [])
+
+            touches_high_risk = paths.any? { |p| fnmatch_any?(high_risk, p) }
+
+            difficulty =
+              if touches_high_risk
+                'high'
+              elsif changed_files <= low_h.fetch('max_files_changed', 8).to_i && total_lines <= low_h.fetch('max_lines_changed', 300).to_i
+                'low'
+              elsif changed_files <= med_h.fetch('max_files_changed', 25).to_i && total_lines <= med_h.fetch('max_lines_changed', 1500).to_i
+                'medium'
+              else
+                'high'
+              end
+
+            # Frontend-heavy heuristic (only used to prefer frontend on low difficulty)
+            fe_exts = %w[.tsx .jsx .css .scss .sass .less .mdx]
+            fe_count = paths.count { |p| fe_exts.any? { |ext| p.end_with?(ext) } }
+            frontend_heavy = paths.any? && (fe_count.to_f / paths.size) >= 0.6
+
+            # Exclude already-requested reviewers + author
+            already_requested = (pr['requested_reviewers'] || []).map { |u| "@#{u['login']}" }
+            excluded_handles = already_requested + ["@#{pr_author}"]
+
+            # Choose suggestion from reviewers.yml (NO auto-assign)
+            people = cfg.fetch('people', [])
+            candidates = people.select do |p|
+              diffs = (p['can_primary_for_difficulty'] || []).map(&:to_s)
+              diffs.include?(difficulty) && !excluded_handles.include?(p['handle'])
+            end
+
+            # If low difficulty and intern allowed up to low, keep level 1 eligible; otherwise level filtering is naturally handled by can_primary_for_difficulty
+            # Score: prefer higher level; for low+frontend-heavy, prefer frontend skill
+            best = candidates.max_by do |p|
+              score = p['level'].to_i * 10
+              if difficulty == 'low' && frontend_heavy && (p['skills'] || []).map(&:to_s).include?('frontend')
+                score += 20
+              end
+              score
+            end
+
+            # Extract Greptile signals (lightweight)
+            greptile_cfg = cfg.fetch('greptile', {})
+            phrases = (greptile_cfg['signal_phrases'] || [])
+            found_lines = phrases.map do |ph|
+              review_body.lines.find { |ln| ln.include?(ph) }
+            end.compact.map(&:strip).uniq
+
+            marker = "<!-- greptile-informer:review-id=#{review_id} -->"
+
+            # Idempotency: avoid posting twice for same review
+            comments = api_get(repo, "/issues/#{pr_number}/comments?per_page=100", token)
+            if comments.any? { |c| c['body'].to_s.include?(marker) }
+              puts "Already commented for review #{review_id}; exiting."
+              exit 0
+            end
+
+            suggestion_text =
+              if best
+                "#{best['handle']} (level #{best['level']}, #{(best['skills'] || []).join(', ')})"
+              else
+                "_No suggestion found_ (everyone eligible is already requested, or config doesn’t match this PR)."
+              end
+
+            risk_note = touches_high_risk ? "High-risk paths detected (#{high_risk.join(', ')})." : "No high-risk paths detected."
+
+            lines = []
+            lines << marker
+            lines << "🦜 **Greptile has reviewed this PR.**"
+            lines << ""
+            lines << "- Review: #{review_url}" if review_url
+            lines << "- Detected difficulty: **#{difficulty}** (files=#{changed_files}, lines=#{total_lines}). #{risk_note}"
+            if difficulty == 'low' && frontend_heavy
+              lines << "- Heuristic: frontend-heavy changes (#{fe_count}/#{paths.size} UI-ish files)."
+            end
+            if found_lines.any?
+              lines << "- Signals: " + found_lines.map { |l| "`#{l}`" }.join(" · ")
+            end
+            lines << ""
+            lines << "✅ **Suggested additional reviewer (info only):** #{suggestion_text}"
+            lines << ""
+            lines << "_Note: This workflow does **not** auto-request reviewers; it only posts a suggestion._"
+
+            api_post(repo, "/issues/#{pr_number}/comments", token, { body: lines.join("\n") })
+            puts "Posted suggestion comment."
+          RUBY

--- a/.github/workflows/greptile-informer.yml
+++ b/.github/workflows/greptile-informer.yml
@@ -1,4 +1,4 @@
-name: Greptile informer (review routing suggestion)
+name: Greptile reviewer routing
 
 on:
   pull_request_review:
@@ -6,179 +6,255 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:
-  inform:
-    # Only run when Greptile is the reviewer
-    if: github.actor == 'greptile-apps[bot]'
+  route:
+    # Only run when Greptile submits the review, and avoid running on forked PRs for safety.
+    if: github.actor == 'greptile-apps[bot]' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Post reviewer suggestion comment (no auto-assign)
+      - name: Install Python deps
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pyyaml
+
+      - name: Route 1 additional reviewer from reviewers.yml (no labels)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ruby <<'RUBY'
-            require 'json'
-            require 'yaml'
-            require 'net/http'
-            require 'uri'
+          python3 - <<'PY'
+          import json, os, re, fnmatch, urllib.request, urllib.error
+          from pathlib import Path
 
-            def api_get(repo, path, token)
-              uri = URI("https://api.github.com/repos/#{repo}#{path}")
-              req = Net::HTTP::Get.new(uri)
-              req['Authorization'] = "Bearer #{token}"
-              req['Accept'] = "application/vnd.github+json"
-              res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
-              raise "GET #{path} failed: #{res.code} #{res.body}" unless res.code.to_i.between?(200,299)
-              JSON.parse(res.body)
-            end
+          def gh_api(method, url, token, body=None):
+            req = urllib.request.Request(url, method=method)
+            req.add_header("Authorization", f"Bearer {token}")
+            req.add_header("Accept", "application/vnd.github+json")
+            if body is not None:
+              data = json.dumps(body).encode("utf-8")
+              req.add_header("Content-Type", "application/json")
+            else:
+              data = None
+            try:
+              with urllib.request.urlopen(req, data=data) as r:
+                return json.loads(r.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+              raise RuntimeError(f"{method} {url} failed: {e.code} {e.read().decode('utf-8', 'ignore')}") from e
 
-            def api_post(repo, path, token, body_hash)
-              uri = URI("https://api.github.com/repos/#{repo}#{path}")
-              req = Net::HTTP::Post.new(uri)
-              req['Authorization'] = "Bearer #{token}"
-              req['Accept'] = "application/vnd.github+json"
-              req['Content-Type'] = "application/json"
-              req.body = JSON.dump(body_hash)
-              res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
-              raise "POST #{path} failed: #{res.code} #{res.body}" unless res.code.to_i.between?(200,299)
-              JSON.parse(res.body)
-            end
-
-            def fnmatch_any?(patterns, path)
-              patterns.any? { |pat| File.fnmatch?(pat, path, File::FNM_PATHNAME) }
-            end
-
-            token = ENV.fetch('GITHUB_TOKEN')
-            repo  = ENV.fetch('GITHUB_REPOSITORY') # "owner/repo"
-            event = JSON.parse(File.read(ENV.fetch('GITHUB_EVENT_PATH')))
-
-            pr_number  = event.dig('pull_request', 'number')
-            review_id  = event.dig('review', 'id')
-            review_url = event.dig('review', 'html_url')
-            review_body = (event.dig('review', 'body') || "").to_s
-
-            # Load reviewers.yml
-            cfg_path = ".github/reviewers.yml"
-            unless File.exist?(cfg_path)
-              puts "Missing #{cfg_path}; exiting."
-              exit 0
-            end
-            cfg = YAML.load_file(cfg_path)
-
-            # Fetch PR metadata
-            pr = api_get(repo, "/pulls/#{pr_number}", token)
-            pr_author = pr.dig('user', 'login').to_s
-            changed_files = pr['changed_files'].to_i
-            additions = pr['additions'].to_i
-            deletions = pr['deletions'].to_i
-            total_lines = additions + deletions
-
-            # Fetch PR file list (for high-risk matching + frontend heaviness)
-            files = []
+          def list_all_pages(token, base_url):
+            out = []
             page = 1
-            loop do
-              batch = api_get(repo, "/pulls/#{pr_number}/files?per_page=100&page=#{page}", token)
-              break if batch.empty?
-              files.concat(batch)
+            while True:
+              data = gh_api("GET", f"{base_url}{'&' if '?' in base_url else '?'}per_page=100&page={page}", token)
+              if not data:
+                break
+              out.extend(data)
               page += 1
-              break if page > 20 # safety cap
-            end
-            paths = files.map { |f| f['filename'] }.compact
+              if page > 20:
+                break
+            return out
 
-            # Determine difficulty
-            heur = cfg.fetch('difficulty_heuristics', {})
-            low_h  = heur.fetch('low', {})
-            med_h  = heur.fetch('medium', {})
-            high_h = heur.fetch('high', {})
-            high_risk = (high_h['high_risk_paths'] || [])
+          def parse_greptile_difficulty(body: str, regexes):
+            for pat in regexes:
+              m = re.search(pat, body or "")
+              if m:
+                try:
+                  v = int(m.group(1))
+                  if 1 <= v <= 5:
+                    return v
+                except Exception:
+                  pass
+            return None
 
-            touches_high_risk = paths.any? { |p| fnmatch_any?(high_risk, p) }
+          def to_bucket(score_1_5: int):
+            if score_1_5 <= 2:
+              return "low"
+            if score_1_5 == 3:
+              return "medium"
+            return "high"
 
-            difficulty =
-              if touches_high_risk
-                'high'
-              elsif changed_files <= low_h.fetch('max_files_changed', 8).to_i && total_lines <= low_h.fetch('max_lines_changed', 300).to_i
-                'low'
-              elsif changed_files <= med_h.fetch('max_files_changed', 25).to_i && total_lines <= med_h.fetch('max_lines_changed', 1500).to_i
-                'medium'
-              else
-                'high'
-              end
+          def heuristic_score(files_changed, lines_changed, paths, cfg):
+            heur = cfg.get("difficulty_heuristics", {})
+            low = heur.get("low", {})
+            med = heur.get("medium", {})
+            high = heur.get("high", {})
+            high_risk = high.get("high_risk_paths", []) or []
 
-            # Frontend-heavy heuristic (only used to prefer frontend on low difficulty)
-            fe_exts = %w[.tsx .jsx .css .scss .sass .less .mdx]
-            fe_count = paths.count { |p| fe_exts.any? { |ext| p.end_with?(ext) } }
-            frontend_heavy = paths.any? && (fe_count.to_f / paths.size) >= 0.6
+            touches_high_risk = any(any(fnmatch.fnmatch(p, pat) for pat in high_risk) for p in paths)
 
-            # Exclude already-requested reviewers + author
-            already_requested = (pr['requested_reviewers'] || []).map { |u| "@#{u['login']}" }
-            excluded_handles = already_requested + ["@#{pr_author}"]
+            low_files = int(low.get("max_files_changed", 8))
+            low_lines = int(low.get("max_lines_changed", 300))
+            med_files = int(med.get("max_files_changed", 25))
+            med_lines = int(med.get("max_lines_changed", 1500))
 
-            # Choose suggestion from reviewers.yml (NO auto-assign)
-            people = cfg.fetch('people', [])
-            candidates = people.select do |p|
-              diffs = (p['can_primary_for_difficulty'] || []).map(&:to_s)
-              diffs.include?(difficulty) && !excluded_handles.include?(p['handle'])
-            end
+            # Map heuristics into a 1–5-ish score (used only when Greptile rating missing).
+            if files_changed <= low_files and lines_changed <= low_lines:
+              score = 2
+            elif files_changed <= med_files and lines_changed <= med_lines:
+              score = 3
+            else:
+              score = 4
 
-            # If low difficulty and intern allowed up to low, keep level 1 eligible; otherwise level filtering is naturally handled by can_primary_for_difficulty
-            # Score: prefer higher level; for low+frontend-heavy, prefer frontend skill
-            best = candidates.max_by do |p|
-              score = p['level'].to_i * 10
-              if difficulty == 'low' && frontend_heavy && (p['skills'] || []).map(&:to_s).include?('frontend')
-                score += 20
-              end
-              score
-            end
+            if files_changed >= 80 or lines_changed >= 6000:
+              score = 5
 
-            # Extract Greptile signals (lightweight)
-            greptile_cfg = cfg.fetch('greptile', {})
-            phrases = (greptile_cfg['signal_phrases'] || [])
-            found_lines = phrases.map do |ph|
-              review_body.lines.find { |ln| ln.include?(ph) }
-            end.compact.map(&:strip).uniq
+            if touches_high_risk and score < 4:
+              score = 4
 
-            marker = "<!-- greptile-informer:review-id=#{review_id} -->"
+            return score, touches_high_risk
 
-            # Idempotency: avoid posting twice for same review
-            comments = api_get(repo, "/issues/#{pr_number}/comments?per_page=100", token)
-            if comments.any? { |c| c['body'].to_s.include?(marker) }
-              puts "Already commented for review #{review_id}; exiting."
-              exit 0
-            end
+          def pick_reviewer(bucket, greptile_score, people, exclude_handles, paths):
+            # Filter to eligible by bucket, excluding author + already-requested.
+            candidates = []
+            for p in people:
+              handle = str(p.get("handle", "")).strip()
+              if not handle:
+                continue
+              if handle in exclude_handles:
+                continue
+              diffs = [str(x) for x in (p.get("can_primary_for_difficulty") or [])]
+              if bucket not in diffs:
+                continue
+              candidates.append(p)
 
-            suggestion_text =
-              if best
-                "#{best['handle']} (level #{best['level']}, #{(best['skills'] || []).join(', ')})"
-              else
-                "_No suggestion found_ (everyone eligible is already requested, or config doesn’t match this PR)."
-              end
+            if not candidates:
+              return None
 
-            risk_note = touches_high_risk ? "High-risk paths detected (#{high_risk.join(', ')})." : "No high-risk paths detected."
+            # Optional frontend-heavy hint
+            fe_exts = (".tsx", ".jsx", ".css", ".scss", ".sass", ".less", ".mdx")
+            fe_count = sum(1 for p in paths if p.endswith(fe_exts))
+            frontend_heavy = bool(paths) and (fe_count / max(1, len(paths)) >= 0.6)
 
-            lines = []
-            lines << marker
-            lines << "🦜 **Greptile has reviewed this PR.**"
-            lines << ""
-            lines << "- Review: #{review_url}" if review_url
-            lines << "- Detected difficulty: **#{difficulty}** (files=#{changed_files}, lines=#{total_lines}). #{risk_note}"
-            if difficulty == 'low' && frontend_heavy
-              lines << "- Heuristic: frontend-heavy changes (#{fe_count}/#{paths.size} UI-ish files)."
-            end
-            if found_lines.any?
-              lines << "- Signals: " + found_lines.map { |l| "`#{l}`" }.join(" · ")
-            end
-            lines << ""
-            lines << "✅ **Suggested additional reviewer (info only):** #{suggestion_text}"
-            lines << ""
-            lines << "_Note: This workflow does **not** auto-request reviewers; it only posts a suggestion._"
+            def lvl(p): return int(p.get("level", 0))
 
-            api_post(repo, "/issues/#{pr_number}/comments", token, { body: lines.join("\n") })
-            puts "Posted suggestion comment."
-          RUBY
+            if bucket == "low":
+              # For Greptile=1, strongly prefer level 1 if available.
+              if greptile_score == 1:
+                lvl1 = [p for p in candidates if lvl(p) == 1]
+                if lvl1:
+                  candidates = lvl1
+              # Lowest level first
+              candidates.sort(key=lambda p: (lvl(p), 0 if ("frontend" in (p.get("skills") or []) and frontend_heavy) else 1))
+              return candidates[0]
+
+            if bucket == "high":
+              # For Greptile=5, strongly prefer level 4 if available.
+              if greptile_score == 5:
+                lvl4 = [p for p in candidates if lvl(p) == 4]
+                if lvl4:
+                  candidates = lvl4
+              # Highest level first
+              candidates.sort(key=lambda p: (-lvl(p), 0 if ("fullstack" in (p.get("skills") or []) ) else 1))
+              return candidates[0]
+
+            # medium: prefer 3, then 2, then 4, then 1
+            order = {3: 0, 2: 1, 4: 2, 1: 3}
+            candidates.sort(key=lambda p: (order.get(lvl(p), 9), -lvl(p)))
+            return candidates[0]
+
+          token = os.environ["GITHUB_TOKEN"]
+          repo = os.environ["GITHUB_REPOSITORY"]  # owner/repo
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          pr_number = int(event["pull_request"]["number"])
+          review_id = event["review"]["id"]
+          greptile_body = (event["review"].get("body") or "")
+
+          cfg_path = Path(".github/reviewers.yml")
+          if not cfg_path.exists():
+            print("Missing .github/reviewers.yml; exiting.")
+            raise SystemExit(0)
+
+          # Minimal YAML parser (avoid external deps): very small, strict YAML only.
+          # Use a tiny fallback if PyYAML isn't available.
+          try:
+            import yaml  # type: ignore
+            cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+          except Exception:
+            raise RuntimeError("PyYAML not available on runner; add `pip install pyyaml` step or convert reviewers.yml to JSON.")
+
+          greptile_cfg = cfg.get("greptile", {}) or {}
+          regexes = greptile_cfg.get("difficulty_regexes", []) or []
+          score = parse_greptile_difficulty(greptile_body, regexes)
+
+          # Fetch PR (authoritative)
+          pr = gh_api("GET", f"https://api.github.com/repos/{repo}/pulls/{pr_number}", token)
+          author = pr["user"]["login"]
+          requested = [f"@{u['login']}" for u in (pr.get("requested_reviewers") or [])]
+
+          files = list_all_pages(token, f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files")
+          paths = [f.get("filename","") for f in files if f.get("filename")]
+
+          files_changed = int(pr.get("changed_files") or len(paths))
+          lines_changed = int(pr.get("additions", 0)) + int(pr.get("deletions", 0))
+
+          # If Greptile difficulty missing, compute heuristic score.
+          heuristic, touches_high_risk = heuristic_score(files_changed, lines_changed, paths, cfg)
+          final_score = score if score is not None else heuristic
+          bucket = to_bucket(final_score)
+
+          people = cfg.get("people", []) or []
+
+          exclude = set(requested)
+          exclude.add(f"@{author}")
+
+          choice = pick_reviewer(bucket, final_score, people, exclude, paths)
+
+          marker = f"<!-- greptile-reviewer-routing:review-id={review_id} -->"
+
+          # Idempotency: if we've already commented for this review, exit
+          comments = list_all_pages(token, f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments")
+          if any(marker in (c.get("body") or "") for c in comments):
+            print("Already processed this Greptile review; exiting.")
+            raise SystemExit(0)
+
+          # If no candidate, comment and exit
+          if not choice:
+            body = "\n".join([
+              marker,
+              "🦜 **Reviewer routing (Greptile)**",
+              "",
+              f"- Greptile difficulty: **{score}/5**" if score is not None else "- Greptile difficulty: _(not found in review body)_",
+              f"- Heuristic difficulty fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
+              f"- Final difficulty used: **{final_score}/5** → **{bucket}**",
+              "",
+              "⚠️ No eligible reviewer found in `.github/reviewers.yml` after exclusions (author/already requested).",
+            ])
+            gh_api("POST", f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments", token, {"body": body})
+            raise SystemExit(0)
+
+          reviewer_login = str(choice["handle"]).lstrip("@")
+
+          # Request reviewer (if not already requested)
+          assigned = False
+          try:
+            gh_api("POST", f"https://api.github.com/repos/{repo}/pulls/{pr_number}/requested_reviewers", token, {"reviewers": [reviewer_login]})
+            assigned = True
+          except Exception as e:
+            err = str(e)
+          else:
+            err = None
+
+          summary_lines = [
+            marker,
+            "🦜 **Reviewer routing (Greptile)**",
+            "",
+            f"- Greptile difficulty: **{score}/5**" if score is not None else "- Greptile difficulty: _(not found in review body)_",
+            f"- Heuristic difficulty fallback: **{heuristic}/5**" + (" (high-risk paths touched)" if touches_high_risk else ""),
+            f"- Final difficulty used: **{final_score}/5** → **{bucket}**",
+            f"- Selected reviewer: **@{reviewer_login}** (level {choice.get('level')}, skills: {', '.join(choice.get('skills') or [])})",
+          ]
+
+          if assigned:
+            summary_lines += ["", "✅ Requested this reviewer in GitHub (review request)."]
+          else:
+            summary_lines += ["", f"⚠️ Could not request reviewer automatically. Error: `{err}`", "Please request manually in the PR UI."]
+
+          gh_api("POST", f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments", token, {"body": "\n".join(summary_lines)})
+          print("Done.")
+          PY


### PR DESCRIPTION
Use reviewers.yml greptile difficulty/confidence regexes and map_to_bucket to map 1-5 to low/medium/high. Rewrite workflow in Python; request one additional reviewer via GitHub API when Greptile submits a review. Skip forked PRs. Includes reviewers config, greptile-informer workflow, and ship-working-tree command doc updates.

Made with [Cursor](https://cursor.com)