### PR TITLE
Rh best modern practices

### DIFF
--- a/.agents/skills/building-components/SKILL.md
+++ b/.agents/skills/building-components/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: building-components
+description: Build modern, accessible, composable UI components with strong typing, explicit state patterns, and distribution-ready APIs.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/vercel/components.build/building-components"
+    repo: "vercel/components.build"
+    path: "skills/building-components/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Building Components
+
+Use this skill for component architecture and implementation decisions in React/Next.js UI work.
+
+## When to Apply
+
+Use this skill when:
+
+- Creating new reusable UI components (primitives, composed components, blocks)
+- Designing component APIs (slots, composition, polymorphism, as-child patterns)
+- Implementing component accessibility defaults
+- Establishing design-token/styling contracts
+- Preparing components for npm/registry distribution
+
+Do not use this skill when:
+
+- The task is only page-level styling with existing components
+- The task is primarily data fetching/caching behavior (use cache-focused skills)
+
+## Core Rules
+
+1. Prefer composition over monolithic boolean-prop component APIs.
+2. Use semantic HTML first; add ARIA only where needed.
+3. Keep components accessible by default (keyboard, focus, naming).
+4. Expose clear, typed interfaces and extend native element props where appropriate.
+5. Keep component state contracts explicit (controlled/uncontrolled patterns).
+6. Preserve customization hooks (tokens, className, data attributes, variants).
+
+## Workflow
+
+1. Define artifact level (primitive, component, block, template).
+2. Split responsibilities into focused subcomponents where needed.
+3. Define typed prop/state contracts.
+4. Implement semantic + keyboard + ARIA behavior.
+5. Add styling/token strategy and data-attribute hooks.
+6. Document usage and extension paths before shipping.
+
+## Checklist
+
+- [ ] API favors composition and explicit variants
+- [ ] Component uses semantic HTML and keyboard-safe interactions
+- [ ] Required ARIA roles/attributes are present and correct
+- [ ] Props/types are exported and extensible
+- [ ] Controlled/uncontrolled behavior is intentional
+- [ ] Styling/theming hooks are documented (tokens/classes/variants)
+
+## References
+
+- `references/upstream.md` for source mapping and attribution

--- a/.agents/skills/building-components/references/upstream.md
+++ b/.agents/skills/building-components/references/upstream.md
@@ -1,0 +1,21 @@
+---
+source_name: vercel/components.build (building-components)
+source_url: https://github.com/vercel/components.build
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/building-components/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/components.build/building-components
+- GitHub repository: https://github.com/vercel/components.build
+- Upstream skill path: `skills/building-components/SKILL.md`
+
+## Related upstream references
+
+- `skills/building-components/references/principles.mdx`
+- `skills/building-components/references/composition.mdx`
+- `skills/building-components/references/accessibility.mdx`
+- `skills/building-components/references/types.mdx`

--- a/.agents/skills/next-cache-components/references/upstream.md
+++ b/.agents/skills/next-cache-components/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: vercel-labs/next-skills (next-cache-components)
+source_url: https://github.com/vercel-labs/next-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/next-cache-components/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/nextjs-skills/next-cache-components
+- GitHub repository: https://github.com/vercel-labs/next-skills
+- Upstream skill path: `skills/next-cache-components/SKILL.md`
+
+## Notes
+
+- This skill complements the repo-local `cache-components` skill by preserving
+  upstream-oriented Cache Components details and migration patterns.

--- a/.agents/skills/turborepo/references/upstream.md
+++ b/.agents/skills/turborepo/references/upstream.md
@@ -1,0 +1,22 @@
+---
+source_name: vercel/turborepo (turborepo skill)
+source_url: https://github.com/vercel/turborepo
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/turborepo/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/turborepo/turborepo
+- GitHub repository: https://github.com/vercel/turborepo
+- Upstream skill path: `skills/turborepo/SKILL.md`
+
+## Related upstream references
+
+- `skills/turborepo/references/configuration/*`
+- `skills/turborepo/references/caching/*`
+- `skills/turborepo/references/environment/*`
+- `skills/turborepo/references/filtering/*`
+- `skills/turborepo/references/ci/*`

--- a/.agents/skills/ultracite/SKILL.md
+++ b/.agents/skills/ultracite/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ultracite
+description: Apply Ultracite lint/format workflows and code standards for JS/TS projects with strict quality, accessibility, and maintainability defaults.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/haydenbleasel/ultracite/ultracite"
+    repo: "haydenbleasel/ultracite"
+    path: "skills/ultracite/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Ultracite
+
+Use this skill when a task involves ultracite-managed linting, formatting, or code-style policy.
+
+## When to Apply
+
+Use this skill when:
+
+- Initializing or using Ultracite (`init`, `check`, `fix`, `doctor`)
+- Debugging lint/format behavior in Ultracite-enabled repos
+- Applying consistent JS/TS/React coding standards
+- Auditing code quality against explicit standards
+
+Do not use this skill when:
+
+- The project does not use Ultracite and there is no instruction to add it
+
+## Core Rules
+
+1. Detect the active lint stack and use Ultracite commands as the first-line workflow.
+2. Prefer standards that increase correctness and maintainability (`unknown` over `any`, no unused values, explicit async handling).
+3. Enforce accessibility and semantic HTML as baseline quality requirements.
+4. Keep runtime/debug-only statements out of production code paths.
+5. Align formatting and style decisions with shared standards for consistency.
+
+## Workflow
+
+1. Detect setup (`ultracite` dependency + config files).
+2. Run `check` to identify issues; run `fix` where safe.
+3. Use `doctor` for setup/config conflicts.
+4. Apply code standards from `references/code-standards.md`.
+5. Re-run checks after changes and document any intentional exceptions.
+
+## Checklist
+
+- [ ] Ultracite context is confirmed before applying rules
+- [ ] `check` and/or `fix` workflow is used
+- [ ] Accessibility/security/style standards are respected
+- [ ] No debug artifacts remain in production code
+- [ ] Any exceptions are explicit and justified
+
+## References
+
+- `references/code-standards.md` for practical standards
+- `references/upstream.md` for source mapping and attribution

--- a/.agents/skills/ultracite/references/code-standards.md
+++ b/.agents/skills/ultracite/references/code-standards.md
@@ -1,0 +1,79 @@
+# Ultracite Code Standards (Reference)
+
+Adapted from upstream:
+https://github.com/haydenbleasel/ultracite/blob/HEAD/skills/ultracite/references/code-standards.md
+
+## Core Principles
+
+Write code that is accessible, performant, type-safe, and maintainable.
+Prefer clarity and explicit intent over cleverness.
+
+## Type Safety & Explicitness
+
+- Prefer explicit types where they improve readability.
+- Prefer `unknown` over `any` when type is not yet known.
+- Use `as const` for immutable literals and stable unions.
+- Prefer narrowing and guards over unsafe assertions.
+- Extract magic numbers into well-named constants.
+
+## Modern JavaScript / TypeScript
+
+- Prefer `const`; use `let` only for reassignment; never use `var`.
+- Prefer arrow functions for callbacks and small helpers.
+- Prefer `for...of` over `.forEach()` in iteration-heavy logic.
+- Prefer template literals over string concatenation.
+- Prefer optional chaining (`?.`) and nullish coalescing (`??`).
+- Avoid enums; prefer objects + `as const`.
+- Avoid nested ternaries.
+
+## Async & Promises
+
+- Always await promises in async functions.
+- Prefer async/await over promise chains when practical.
+- Handle async errors intentionally (`try/catch` or propagated errors).
+- Do not use async functions as Promise constructors/executors.
+
+## React & JSX
+
+- Use function components.
+- Call hooks only at the top level.
+- Keep hook dependency arrays complete and correct.
+- Use stable `key` values for lists (avoid array index keys).
+- Avoid defining components inside other components unless required.
+- Use semantic HTML and ARIA-friendly structures.
+
+## Error Handling & Debugging
+
+- Remove `console.log`, `debugger`, and `alert` from production paths.
+- Throw `Error` objects with meaningful messages.
+- Prefer early returns to deeply nested conditionals.
+
+## Security
+
+- Add `rel="noopener"` with `target="_blank"`.
+- Avoid `dangerouslySetInnerHTML` unless absolutely required.
+- Do not use `eval()` or direct `document.cookie` mutation patterns.
+- Validate and sanitize user input.
+
+## Performance
+
+- Avoid spread accumulation in loops.
+- Hoist regex literals/constants outside loops.
+- Prefer specific imports over broad namespace imports.
+- Avoid barrel-file overuse in hot code paths.
+
+## Formatting / Style Baseline
+
+- 2-space indentation
+- LF line endings
+- 80-character line width (target)
+- Semicolons enabled
+- Double quotes (single quotes in JSX where required by toolchain)
+- ES5 trailing commas
+- Kebab-case filenames where applicable
+
+## Testing Hygiene
+
+- Keep assertions inside test cases (`it` / `test` blocks).
+- Avoid committed `.only` / `.skip`.
+- Prefer async/await in async tests over callback-style completion.

--- a/.agents/skills/ultracite/references/upstream.md
+++ b/.agents/skills/ultracite/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: haydenbleasel/ultracite (ultracite skill)
+source_url: https://github.com/haydenbleasel/ultracite
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/ultracite/` is adapted from:
+
+- Skills page: https://skills.sh/haydenbleasel/ultracite/ultracite
+- GitHub repository: https://github.com/haydenbleasel/ultracite
+- Upstream skill path: `skills/ultracite/SKILL.md`
+
+The standards reference in this skill is sourced from:
+
+- `skills/ultracite/references/code-standards.md`
+  - https://github.com/haydenbleasel/ultracite/blob/HEAD/skills/ultracite/references/code-standards.md

--- a/.cursor/skills/building-components/SKILL.md
+++ b/.cursor/skills/building-components/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: building-components
+description: Build modern, accessible, composable UI components with strong typing, explicit state patterns, and distribution-ready APIs.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/vercel/components.build/building-components"
+    repo: "vercel/components.build"
+    path: "skills/building-components/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Building Components
+
+Use this skill for component architecture and implementation decisions in React/Next.js UI work.
+
+## When to Apply
+
+Use this skill when:
+
+- Creating new reusable UI components (primitives, composed components, blocks)
+- Designing component APIs (slots, composition, polymorphism, as-child patterns)
+- Implementing component accessibility defaults
+- Establishing design-token/styling contracts
+- Preparing components for npm/registry distribution
+
+Do not use this skill when:
+
+- The task is only page-level styling with existing components
+- The task is primarily data fetching/caching behavior (use cache-focused skills)
+
+## Core Rules
+
+1. Prefer composition over monolithic boolean-prop component APIs.
+2. Use semantic HTML first; add ARIA only where needed.
+3. Keep components accessible by default (keyboard, focus, naming).
+4. Expose clear, typed interfaces and extend native element props where appropriate.
+5. Keep component state contracts explicit (controlled/uncontrolled patterns).
+6. Preserve customization hooks (tokens, className, data attributes, variants).
+
+## Workflow
+
+1. Define artifact level (primitive, component, block, template).
+2. Split responsibilities into focused subcomponents where needed.
+3. Define typed prop/state contracts.
+4. Implement semantic + keyboard + ARIA behavior.
+5. Add styling/token strategy and data-attribute hooks.
+6. Document usage and extension paths before shipping.
+
+## Checklist
+
+- [ ] API favors composition and explicit variants
+- [ ] Component uses semantic HTML and keyboard-safe interactions
+- [ ] Required ARIA roles/attributes are present and correct
+- [ ] Props/types are exported and extensible
+- [ ] Controlled/uncontrolled behavior is intentional
+- [ ] Styling/theming hooks are documented (tokens/classes/variants)
+
+## References
+
+- `references/upstream.md` for source mapping and attribution

--- a/.cursor/skills/building-components/references/upstream.md
+++ b/.cursor/skills/building-components/references/upstream.md
@@ -1,0 +1,21 @@
+---
+source_name: vercel/components.build (building-components)
+source_url: https://github.com/vercel/components.build
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/building-components/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/components.build/building-components
+- GitHub repository: https://github.com/vercel/components.build
+- Upstream skill path: `skills/building-components/SKILL.md`
+
+## Related upstream references
+
+- `skills/building-components/references/principles.mdx`
+- `skills/building-components/references/composition.mdx`
+- `skills/building-components/references/accessibility.mdx`
+- `skills/building-components/references/types.mdx`

--- a/.cursor/skills/next-cache-components/references/upstream.md
+++ b/.cursor/skills/next-cache-components/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: vercel-labs/next-skills (next-cache-components)
+source_url: https://github.com/vercel-labs/next-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/next-cache-components/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/nextjs-skills/next-cache-components
+- GitHub repository: https://github.com/vercel-labs/next-skills
+- Upstream skill path: `skills/next-cache-components/SKILL.md`
+
+## Notes
+
+- This skill complements the repo-local `cache-components` skill by preserving
+  upstream-oriented Cache Components details and migration patterns.

--- a/.cursor/skills/turborepo/references/upstream.md
+++ b/.cursor/skills/turborepo/references/upstream.md
@@ -1,0 +1,22 @@
+---
+source_name: vercel/turborepo (turborepo skill)
+source_url: https://github.com/vercel/turborepo
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/turborepo/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/turborepo/turborepo
+- GitHub repository: https://github.com/vercel/turborepo
+- Upstream skill path: `skills/turborepo/SKILL.md`
+
+## Related upstream references
+
+- `skills/turborepo/references/configuration/*`
+- `skills/turborepo/references/caching/*`
+- `skills/turborepo/references/environment/*`
+- `skills/turborepo/references/filtering/*`
+- `skills/turborepo/references/ci/*`

--- a/.cursor/skills/ultracite/SKILL.md
+++ b/.cursor/skills/ultracite/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ultracite
+description: Apply Ultracite lint/format workflows and code standards for JS/TS projects with strict quality, accessibility, and maintainability defaults.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/haydenbleasel/ultracite/ultracite"
+    repo: "haydenbleasel/ultracite"
+    path: "skills/ultracite/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Ultracite
+
+Use this skill when a task involves ultracite-managed linting, formatting, or code-style policy.
+
+## When to Apply
+
+Use this skill when:
+
+- Initializing or using Ultracite (`init`, `check`, `fix`, `doctor`)
+- Debugging lint/format behavior in Ultracite-enabled repos
+- Applying consistent JS/TS/React coding standards
+- Auditing code quality against explicit standards
+
+Do not use this skill when:
+
+- The project does not use Ultracite and there is no instruction to add it
+
+## Core Rules
+
+1. Detect the active lint stack and use Ultracite commands as the first-line workflow.
+2. Prefer standards that increase correctness and maintainability (`unknown` over `any`, no unused values, explicit async handling).
+3. Enforce accessibility and semantic HTML as baseline quality requirements.
+4. Keep runtime/debug-only statements out of production code paths.
+5. Align formatting and style decisions with shared standards for consistency.
+
+## Workflow
+
+1. Detect setup (`ultracite` dependency + config files).
+2. Run `check` to identify issues; run `fix` where safe.
+3. Use `doctor` for setup/config conflicts.
+4. Apply code standards from `references/code-standards.md`.
+5. Re-run checks after changes and document any intentional exceptions.
+
+## Checklist
+
+- [ ] Ultracite context is confirmed before applying rules
+- [ ] `check` and/or `fix` workflow is used
+- [ ] Accessibility/security/style standards are respected
+- [ ] No debug artifacts remain in production code
+- [ ] Any exceptions are explicit and justified
+
+## References
+
+- `references/code-standards.md` for practical standards
+- `references/upstream.md` for source mapping and attribution

--- a/.cursor/skills/ultracite/references/code-standards.md
+++ b/.cursor/skills/ultracite/references/code-standards.md
@@ -1,0 +1,79 @@
+# Ultracite Code Standards (Reference)
+
+Adapted from upstream:
+https://github.com/haydenbleasel/ultracite/blob/HEAD/skills/ultracite/references/code-standards.md
+
+## Core Principles
+
+Write code that is accessible, performant, type-safe, and maintainable.
+Prefer clarity and explicit intent over cleverness.
+
+## Type Safety & Explicitness
+
+- Prefer explicit types where they improve readability.
+- Prefer `unknown` over `any` when type is not yet known.
+- Use `as const` for immutable literals and stable unions.
+- Prefer narrowing and guards over unsafe assertions.
+- Extract magic numbers into well-named constants.
+
+## Modern JavaScript / TypeScript
+
+- Prefer `const`; use `let` only for reassignment; never use `var`.
+- Prefer arrow functions for callbacks and small helpers.
+- Prefer `for...of` over `.forEach()` in iteration-heavy logic.
+- Prefer template literals over string concatenation.
+- Prefer optional chaining (`?.`) and nullish coalescing (`??`).
+- Avoid enums; prefer objects + `as const`.
+- Avoid nested ternaries.
+
+## Async & Promises
+
+- Always await promises in async functions.
+- Prefer async/await over promise chains when practical.
+- Handle async errors intentionally (`try/catch` or propagated errors).
+- Do not use async functions as Promise constructors/executors.
+
+## React & JSX
+
+- Use function components.
+- Call hooks only at the top level.
+- Keep hook dependency arrays complete and correct.
+- Use stable `key` values for lists (avoid array index keys).
+- Avoid defining components inside other components unless required.
+- Use semantic HTML and ARIA-friendly structures.
+
+## Error Handling & Debugging
+
+- Remove `console.log`, `debugger`, and `alert` from production paths.
+- Throw `Error` objects with meaningful messages.
+- Prefer early returns to deeply nested conditionals.
+
+## Security
+
+- Add `rel="noopener"` with `target="_blank"`.
+- Avoid `dangerouslySetInnerHTML` unless absolutely required.
+- Do not use `eval()` or direct `document.cookie` mutation patterns.
+- Validate and sanitize user input.
+
+## Performance
+
+- Avoid spread accumulation in loops.
+- Hoist regex literals/constants outside loops.
+- Prefer specific imports over broad namespace imports.
+- Avoid barrel-file overuse in hot code paths.
+
+## Formatting / Style Baseline
+
+- 2-space indentation
+- LF line endings
+- 80-character line width (target)
+- Semicolons enabled
+- Double quotes (single quotes in JSX where required by toolchain)
+- ES5 trailing commas
+- Kebab-case filenames where applicable
+
+## Testing Hygiene
+
+- Keep assertions inside test cases (`it` / `test` blocks).
+- Avoid committed `.only` / `.skip`.
+- Prefer async/await in async tests over callback-style completion.

--- a/.cursor/skills/ultracite/references/upstream.md
+++ b/.cursor/skills/ultracite/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: haydenbleasel/ultracite (ultracite skill)
+source_url: https://github.com/haydenbleasel/ultracite
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/ultracite/` is adapted from:
+
+- Skills page: https://skills.sh/haydenbleasel/ultracite/ultracite
+- GitHub repository: https://github.com/haydenbleasel/ultracite
+- Upstream skill path: `skills/ultracite/SKILL.md`
+
+The standards reference in this skill is sourced from:
+
+- `skills/ultracite/references/code-standards.md`
+  - https://github.com/haydenbleasel/ultracite/blob/HEAD/skills/ultracite/references/code-standards.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,65 @@ Answer with citations/paths from the repo and avoid external sources unless just
 
 ---
 
+## Nia context policy for this repo
+
+### Goal
+Reduce wrong assumptions by grounding implementation decisions in up to date sources. Use Nia as the default way to fetch context for any external library, service, API, or spec.
+
+### When you must use Nia
+Use Nia before you write or change code when work depends on any of these:
+- React, Next.js, shadcn ui, Base UI, Tailwind, Turborepo, Bun, TypeScript, Node APIs
+- Any third party SDK, API, auth provider, payments, databases, cloud services
+- Any standards or specs
+
+### Source priority
+1. This repo content already indexed in Nia
+2. Official docs for the tool or framework
+3. The upstream GitHub repo source for the tool or framework
+4. Package source search if the repo or docs are not indexed yet
+
+### Default workflow
+1. Check what is already indexed
+   - Use manage_resource(action="list", query="react") and similar queries
+2. If missing, index the sources you need
+   - index(url="https://docs.example.com")
+   - index(url="https://github.com/owner/repo")
+3. Confirm indexing is ready
+   - manage_resource(action="status", resource_type="documentation", identifier="...")
+4. Pull exact details
+   - Use search for a natural language question
+   - Use nia_grep for exact strings or symbols
+   - Use nia_read to quote the exact lines you will rely on
+   - Use nia_explore when you need structure before reading
+5. If you need dependency wide context
+   - Use auto_subscribe_dependencies on the repo package.json contents
+6. Save findings that will matter later
+   - context(action="save", title="...", summary="...", content="...", agent_source="cursor", memory_type="procedural")
+
+### Required behavior for agents
+- Cite what you found. Include the source and the file path or doc path.
+- Prefer reading exact code or docs over memory.
+- If sources disagree, show both, then pick one and explain why.
+- If you cannot find evidence with Nia, say so and ask for a link or permission to index it.
+
+### Practical examples
+- Before using a Next.js feature, index docs plus the nextjs repo and confirm the current behavior in code.
+- Before using shadcn ui components, check the shadcn docs and the component source patterns.
+- Before adopting a Base UI primitive, read its repo source for the prop contracts and accessibility patterns.
+
+### Nia tool cheat sheet
+- index. Index repos, docs, papers, or local folders
+- manage_resource. List and check status
+- search. Semantic search across indexed sources
+- nia_grep. Regex search in repos or docs
+- nia_read. Read exact lines from repos or docs
+- nia_explore. Tree or ls for structure
+- auto_subscribe_dependencies. Index docs for dependencies from package.json
+- nia_package_search_hybrid. Search package source code without indexing
+- context. Save and reuse research across sessions
+
+---
+
 ## Routing Rules (Deterministic)
 
 Load rulebooks before editing files in their domain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,24 +132,6 @@ Answer with citations/paths from the repo and avoid external sources unless just
 
 ---
 
-### Context7 (default for third-party APIs)
-
-**Use when:**
-
-- any third-party library/framework/API surface is involved
-
-**Actions:**
-
-- resolve library ID
-- query docs for the exact API
-
-**If Context7 is unavailable:**
-
-- consult upstream docs
-- state assumptions explicitly
-
----
-
 ## Nia context policy for this repo
 
 ### Goal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,11 +199,15 @@ Load the skill(s) below when the trigger matches.
 
 - **Next.js App Router structure, rendering, data fetching:** `docs/ai/skills/nextjs-app-router/SKILL.md`
 - **Cache Components / PPR / cacheTag & invalidation:** `docs/ai/skills/cache-components/SKILL.md`
+- **Next.js Cache Components deep reference / migration details:** `docs/ai/skills/next-cache-components/SKILL.md`
+- **Reusable component architecture/composition/accessibility:** `docs/ai/skills/building-components/SKILL.md`
 - **React component design/refactor:** `docs/ai/skills/react-component-dev/SKILL.md`
 - **shadcn/ui system usage:** `docs/ai/skills/moai-library-shadcn/SKILL.md`
 - **Motion animations (`motion/react`):** `docs/ai/skills/motion/SKILL.md`
 - **Recharts:** `docs/ai/skills/rechart/SKILL.md`
 - **TanStack Table v8:** `docs/ai/skills/tanstack-table/SKILL.md`
+- **Turborepo task graph/caching/filtering/CI patterns:** `docs/ai/skills/turborepo/SKILL.md`
+- **Ultracite lint/format + code quality standards:** `docs/ai/skills/ultracite/SKILL.md`
 - **GitHub issue/PR workflows (AL-###):**
   - Write issue: `docs/ai/skills/write-issue/SKILL.md`
   - Build issue: `docs/ai/skills/build-issue/SKILL.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,53 @@ Use Nia before you write or change code when work depends on any of these:
 
 ---
 
+## Nia MCP usage rules for Cursor agents
+
+### Use Nia for external truth
+When implementing or modifying anything that depends on external behavior, do not trust general knowledge. Use Nia MCP tools to fetch the current docs and upstream code.
+
+### Always do this before coding
+1. List relevant indexed sources
+   - manage_resource(action="list", query="<library or service name>")
+2. If not present, index official docs and the upstream repo
+   - index(url="<official docs url>")
+   - index(url="https://github.com/<owner>/<repo>")
+3. Wait until indexing is complete
+   - manage_resource(action="status", resource_type="documentation", identifier="...")
+   - manage_resource(action="status", resource_type="repository", identifier="owner/repo")
+4. Answer using evidence
+   - search(query="How do I do X in <tool>?", repositories=["owner/repo"])
+   - nia_read(...) for exact lines you will rely on
+   - nia_grep(...) for exact symbols, config keys, or APIs
+
+### Dependency wide setup
+For new projects, migrations, or big feature work, run dependency indexing early:
+- Read package.json from this repo and call auto_subscribe_dependencies(manifest_content="...")
+
+### React and Next.js specific expectation
+For framework behavior, prefer the upstream repo when possible. Use docs for recommended patterns, and use repo source to confirm defaults, edge cases, and current APIs.
+
+### shadcn ui and component libraries
+Treat component libraries as source driven.
+- Use docs for usage patterns
+- Use repo source for prop contracts, variants, accessibility behavior, and composition patterns
+
+### Package source fallback
+If you do not want to index a whole repo, or you need quick confirmation, use:
+- nia_package_search_hybrid(registry="npm", package_name="<name>", query="...")
+
+### Save high value context
+If you discover a pattern we will reuse, save it:
+- context(action="save", title="...", summary="...", content="...", agent_source="cursor", memory_type="procedural")
+
+### Output standard
+When you propose code that depends on external facts, include:
+- The doc page or repo file you used
+- The relevant snippet or line range you relied on
+- A short note describing what you verified
+
+---
+
 ## Routing Rules (Deterministic)
 
 Load rulebooks before editing files in their domain.
@@ -248,7 +295,7 @@ Load the skill(s) below when the trigger matches.
 
 - [ ] Identified domain(s) and opened the matching rulebook(s)
 - [ ] Applied required skills based on triggers
-- [ ] Used Nia or Context7 when required (or explicitly noted fallback)
+- [ ] Used Nia when required (or explicitly noted why Nia evidence was unavailable)
 - [ ] Nia tool calls are repo-scoped to `Asymmetric-al/core`
 - [ ] Nia search calls include the "Nia query preamble" built from `docs/ai/working-set.md` + `docs/ai/stack-registry.md`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,106 +135,49 @@ Answer with citations/paths from the repo and avoid external sources unless just
 ## Nia context policy for this repo
 
 ### Goal
-Reduce wrong assumptions by grounding implementation decisions in up to date sources. Use Nia as the default way to fetch context for any external library, service, API, or spec.
+Use Nia as the default external source-of-truth workflow to reduce assumptions and align implementation with current upstream behavior.
 
 ### When you must use Nia
-Use Nia before you write or change code when work depends on any of these:
+Use Nia before writing or modifying code when work depends on:
 - React, Next.js, shadcn ui, Base UI, Tailwind, Turborepo, Bun, TypeScript, Node APIs
-- Any third party SDK, API, auth provider, payments, databases, cloud services
-- Any standards or specs
+- Any third-party SDK/API/auth provider/payments/database/cloud service
+- Any standards/spec behavior
 
 ### Source priority
 1. This repo content already indexed in Nia
-2. Official docs for the tool or framework
-3. The upstream GitHub repo source for the tool or framework
-4. Package source search if the repo or docs are not indexed yet
+2. Official docs for the tool/framework
+3. Upstream GitHub repo source
+4. Package source search if docs/repo are not indexed yet
 
 ### Default workflow
-1. Check what is already indexed
-   - Use manage_resource(action="list", query="react") and similar queries
-2. If missing, index the sources you need
-   - index(url="https://docs.example.com")
-   - index(url="https://github.com/owner/repo")
-3. Confirm indexing is ready
-   - manage_resource(action="status", resource_type="documentation", identifier="...")
-4. Pull exact details
-   - Use search for a natural language question
-   - Use nia_grep for exact strings or symbols
-   - Use nia_read to quote the exact lines you will rely on
-   - Use nia_explore when you need structure before reading
-5. If you need dependency wide context
-   - Use auto_subscribe_dependencies on the repo package.json contents
-6. Save findings that will matter later
-   - context(action="save", title="...", summary="...", content="...", agent_source="cursor", memory_type="procedural")
+1. List indexed sources
+   - `manage_resource(action="list", query="<library or service name>")`
+2. Index missing official docs/upstream repos
+   - `index(url="<official docs url>")`
+   - `index(url="https://github.com/<owner>/<repo>")`
+3. Wait for indexing readiness
+   - `manage_resource(action="status", resource_type="documentation", identifier="...")`
+   - `manage_resource(action="status", resource_type="repository", identifier="owner/repo")`
+4. Gather exact evidence
+   - `search(...)` for semantic answers
+   - `nia_read(...)` for exact lines relied on
+   - `nia_grep(...)` for exact symbols/config keys/APIs
+   - `nia_explore(...)` when structure discovery is needed first
+5. For big/new work, index dependencies early
+   - `auto_subscribe_dependencies(manifest_content="...")` from this repo's `package.json`
+6. Save reusable findings
+   - `context(action="save", title="...", summary="...", content="...", agent_source="cursor", memory_type="procedural")`
 
-### Required behavior for agents
-- Cite what you found. Include the source and the file path or doc path.
-- Prefer reading exact code or docs over memory.
-- If sources disagree, show both, then pick one and explain why.
-- If you cannot find evidence with Nia, say so and ask for a link or permission to index it.
-
-### Practical examples
-- Before using a Next.js feature, index docs plus the nextjs repo and confirm the current behavior in code.
-- Before using shadcn ui components, check the shadcn docs and the component source patterns.
-- Before adopting a Base UI primitive, read its repo source for the prop contracts and accessibility patterns.
-
-### Nia tool cheat sheet
-- index. Index repos, docs, papers, or local folders
-- manage_resource. List and check status
-- search. Semantic search across indexed sources
-- nia_grep. Regex search in repos or docs
-- nia_read. Read exact lines from repos or docs
-- nia_explore. Tree or ls for structure
-- auto_subscribe_dependencies. Index docs for dependencies from package.json
-- nia_package_search_hybrid. Search package source code without indexing
-- context. Save and reuse research across sessions
-
----
-
-## Nia MCP usage rules for Cursor agents
-
-### Use Nia for external truth
-When implementing or modifying anything that depends on external behavior, do not trust general knowledge. Use Nia MCP tools to fetch the current docs and upstream code.
-
-### Always do this before coding
-1. List relevant indexed sources
-   - manage_resource(action="list", query="<library or service name>")
-2. If not present, index official docs and the upstream repo
-   - index(url="<official docs url>")
-   - index(url="https://github.com/<owner>/<repo>")
-3. Wait until indexing is complete
-   - manage_resource(action="status", resource_type="documentation", identifier="...")
-   - manage_resource(action="status", resource_type="repository", identifier="owner/repo")
-4. Answer using evidence
-   - search(query="How do I do X in <tool>?", repositories=["owner/repo"])
-   - nia_read(...) for exact lines you will rely on
-   - nia_grep(...) for exact symbols, config keys, or APIs
-
-### Dependency wide setup
-For new projects, migrations, or big feature work, run dependency indexing early:
-- Read package.json from this repo and call auto_subscribe_dependencies(manifest_content="...")
-
-### React and Next.js specific expectation
-For framework behavior, prefer the upstream repo when possible. Use docs for recommended patterns, and use repo source to confirm defaults, edge cases, and current APIs.
-
-### shadcn ui and component libraries
-Treat component libraries as source driven.
-- Use docs for usage patterns
-- Use repo source for prop contracts, variants, accessibility behavior, and composition patterns
-
-### Package source fallback
-If you do not want to index a whole repo, or you need quick confirmation, use:
-- nia_package_search_hybrid(registry="npm", package_name="<name>", query="...")
-
-### Save high value context
-If you discover a pattern we will reuse, save it:
-- context(action="save", title="...", summary="...", content="...", agent_source="cursor", memory_type="procedural")
-
-### Output standard
-When you propose code that depends on external facts, include:
-- The doc page or repo file you used
-- The relevant snippet or line range you relied on
-- A short note describing what you verified
+### Required behavior
+- Cite source + file/doc path.
+- Prefer exact docs/source reads over memory.
+- If sources disagree, show both and explain the chosen source.
+- If Nia evidence is unavailable, say so explicitly and request a link or permission to index.
+- For framework behavior (React/Next.js) and component libraries (shadcn/Base UI), use docs for usage patterns and upstream source to confirm defaults, edge cases, prop contracts, variants, accessibility, and composition patterns.
+- When proposing code based on external facts, include:
+  - doc page or repo file used
+  - relevant snippet/line range relied on
+  - short note of what was verified
 
 ---
 

--- a/docs/ai/skills/building-components/SKILL.md
+++ b/docs/ai/skills/building-components/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: building-components
+description: Build modern, accessible, composable UI components with strong typing, explicit state patterns, and distribution-ready APIs.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/vercel/components.build/building-components"
+    repo: "vercel/components.build"
+    path: "skills/building-components/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Building Components
+
+Use this skill for component architecture and implementation decisions in React/Next.js UI work.
+
+## When to Apply
+
+Use this skill when:
+
+- Creating new reusable UI components (primitives, composed components, blocks)
+- Designing component APIs (slots, composition, polymorphism, as-child patterns)
+- Implementing component accessibility defaults
+- Establishing design-token/styling contracts
+- Preparing components for npm/registry distribution
+
+Do not use this skill when:
+
+- The task is only page-level styling with existing components
+- The task is primarily data fetching/caching behavior (use cache-focused skills)
+
+## Core Rules
+
+1. Prefer composition over monolithic boolean-prop component APIs.
+2. Use semantic HTML first; add ARIA only where needed.
+3. Keep components accessible by default (keyboard, focus, naming).
+4. Expose clear, typed interfaces and extend native element props where appropriate.
+5. Keep component state contracts explicit (controlled/uncontrolled patterns).
+6. Preserve customization hooks (tokens, className, data attributes, variants).
+
+## Workflow
+
+1. Define artifact level (primitive, component, block, template).
+2. Split responsibilities into focused subcomponents where needed.
+3. Define typed prop/state contracts.
+4. Implement semantic + keyboard + ARIA behavior.
+5. Add styling/token strategy and data-attribute hooks.
+6. Document usage and extension paths before shipping.
+
+## Checklist
+
+- [ ] API favors composition and explicit variants
+- [ ] Component uses semantic HTML and keyboard-safe interactions
+- [ ] Required ARIA roles/attributes are present and correct
+- [ ] Props/types are exported and extensible
+- [ ] Controlled/uncontrolled behavior is intentional
+- [ ] Styling/theming hooks are documented (tokens/classes/variants)
+
+## References
+
+- `references/upstream.md` for source mapping and attribution

--- a/docs/ai/skills/building-components/references/upstream.md
+++ b/docs/ai/skills/building-components/references/upstream.md
@@ -1,0 +1,21 @@
+---
+source_name: vercel/components.build (building-components)
+source_url: https://github.com/vercel/components.build
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/building-components/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/components.build/building-components
+- GitHub repository: https://github.com/vercel/components.build
+- Upstream skill path: `skills/building-components/SKILL.md`
+
+## Related upstream references
+
+- `skills/building-components/references/principles.mdx`
+- `skills/building-components/references/composition.mdx`
+- `skills/building-components/references/accessibility.mdx`
+- `skills/building-components/references/types.mdx`

--- a/docs/ai/skills/next-cache-components/SKILL.md
+++ b/docs/ai/skills/next-cache-components/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: next-cache-components
+description: Deep operational guidance for Next.js Cache Components (`use cache`, `cacheLife`, `cacheTag`, `updateTag`, `revalidateTag`) and PPR boundaries.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/vercel/nextjs-skills/next-cache-components"
+    repo: "vercel-labs/next-skills"
+    path: "skills/next-cache-components/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Next Cache Components
+
+Use this skill for detailed Next.js 16 cache component implementation and migration patterns.
+
+## When to Apply
+
+Use this skill when:
+
+- Enabling or operating `cacheComponents: true`
+- Designing static/cached/dynamic route boundaries under App Router
+- Migrating `experimental.ppr` or `unstable_cache` usage
+- Implementing tag-based cache invalidation after mutations
+
+Do not use this skill when:
+
+- The task is only generic App Router structure with no cache-boundary changes
+
+## Core Rules
+
+1. Use `'use cache'` for shared async data; keep request-specific reads dynamic.
+2. Do not read `cookies()`, `headers()`, or `searchParams` directly inside cached scopes (except documented private-cache cases).
+3. Always pair cached data with explicit `cacheLife` and/or `cacheTag` strategy.
+4. Use `updateTag` for immediate consistency and `revalidateTag` for stale-while-revalidate flows.
+5. Wrap dynamic user/request sections in Suspense boundaries when combining with cached shells.
+
+## Workflow
+
+1. Classify each dependency: static, cached, or request-dynamic.
+2. Apply `'use cache'` + lifetime/tag policy to cacheable units.
+3. Isolate runtime APIs outside cached scopes and pass serializable inputs.
+4. Choose invalidation mode (`updateTag` vs `revalidateTag`) per UX requirement.
+5. Validate PPR behavior and cache refresh semantics with representative flows.
+
+## Checklist
+
+- [ ] Cache Components are enabled intentionally for the target app
+- [ ] Cached scopes avoid runtime request APIs
+- [ ] Lifetime and tag strategy is explicit
+- [ ] Mutation paths invalidate the right tags
+- [ ] Dynamic content is isolated with Suspense where applicable
+- [ ] Migration away from legacy caching APIs is complete where touched
+
+## References
+
+- `references/upstream.md` for source mapping and attribution

--- a/docs/ai/skills/next-cache-components/references/upstream.md
+++ b/docs/ai/skills/next-cache-components/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: vercel-labs/next-skills (next-cache-components)
+source_url: https://github.com/vercel-labs/next-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/next-cache-components/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/nextjs-skills/next-cache-components
+- GitHub repository: https://github.com/vercel-labs/next-skills
+- Upstream skill path: `skills/next-cache-components/SKILL.md`
+
+## Notes
+
+- This skill complements the repo-local `cache-components` skill by preserving
+  upstream-oriented Cache Components details and migration patterns.

--- a/docs/ai/skills/turborepo/SKILL.md
+++ b/docs/ai/skills/turborepo/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: turborepo
+description: Configure and operate Turborepo tasks, caching, filtering, boundaries, and CI workflows for Bun-based monorepos.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/vercel/turborepo/turborepo"
+    repo: "vercel/turborepo"
+    path: "skills/turborepo/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Turborepo
+
+Use this skill when changing task graphs, cache behavior, filters, or monorepo orchestration.
+
+## When to Apply
+
+Use this skill when:
+
+- Editing `turbo.json` tasks/dependsOn/inputs/outputs/env
+- Changing package scripts orchestrated by `turbo run ...`
+- Debugging cache misses, affected runs, or CI Turbo behavior
+- Creating/organizing packages in a Turborepo monorepo
+
+Do not use this skill when:
+
+- The task is strictly UI logic with no monorepo/task impact
+
+## Core Rules
+
+1. Define task scripts in package `package.json` files; root scripts should delegate with `turbo run`.
+2. Declare correct task dependencies (`dependsOn`) and outputs for cacheability.
+3. Prefer `--affected` or explicit filters for scoped runs.
+4. Treat env/input declarations as cache correctness requirements, not optional metadata.
+5. Keep workspace/package boundaries explicit and avoid cross-package internal path imports.
+
+## Workflow
+
+1. Identify affected tasks/packages and dependency direction.
+2. Update package scripts first, then task orchestration in `turbo.json`.
+3. Verify cache inputs/outputs and environment declarations.
+4. Validate with scoped Turbo commands (`--filter`, `--affected`) before broad runs.
+5. Confirm CI/deployment task behavior remains deterministic.
+
+## Checklist
+
+- [ ] Package-level scripts are the source of task behavior
+- [ ] Root scripts delegate via `turbo run`
+- [ ] Task `dependsOn` graph is correct for build order
+- [ ] Cache `outputs` and relevant `inputs/env` are declared
+- [ ] Filters/affected run patterns are documented for the change
+- [ ] No boundary-breaking imports introduced
+
+## References
+
+- `references/upstream.md` for source mapping and attribution

--- a/docs/ai/skills/turborepo/references/upstream.md
+++ b/docs/ai/skills/turborepo/references/upstream.md
@@ -1,0 +1,22 @@
+---
+source_name: vercel/turborepo (turborepo skill)
+source_url: https://github.com/vercel/turborepo
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/turborepo/` is adapted from:
+
+- Skills page: https://skills.sh/vercel/turborepo/turborepo
+- GitHub repository: https://github.com/vercel/turborepo
+- Upstream skill path: `skills/turborepo/SKILL.md`
+
+## Related upstream references
+
+- `skills/turborepo/references/configuration/*`
+- `skills/turborepo/references/caching/*`
+- `skills/turborepo/references/environment/*`
+- `skills/turborepo/references/filtering/*`
+- `skills/turborepo/references/ci/*`

--- a/docs/ai/skills/ultracite/SKILL.md
+++ b/docs/ai/skills/ultracite/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ultracite
+description: Apply Ultracite lint/format workflows and code standards for JS/TS projects with strict quality, accessibility, and maintainability defaults.
+metadata:
+  owner: "skills-steward"
+  last_updated: 2026-03-06
+  status: "active"
+  upstream:
+    url: "https://skills.sh/haydenbleasel/ultracite/ultracite"
+    repo: "haydenbleasel/ultracite"
+    path: "skills/ultracite/SKILL.md"
+    license: "MIT"
+license: MIT
+---
+
+# Ultracite
+
+Use this skill when a task involves ultracite-managed linting, formatting, or code-style policy.
+
+## When to Apply
+
+Use this skill when:
+
+- Initializing or using Ultracite (`init`, `check`, `fix`, `doctor`)
+- Debugging lint/format behavior in Ultracite-enabled repos
+- Applying consistent JS/TS/React coding standards
+- Auditing code quality against explicit standards
+
+Do not use this skill when:
+
+- The project does not use Ultracite and there is no instruction to add it
+
+## Core Rules
+
+1. Detect the active lint stack and use Ultracite commands as the first-line workflow.
+2. Prefer standards that increase correctness and maintainability (`unknown` over `any`, no unused values, explicit async handling).
+3. Enforce accessibility and semantic HTML as baseline quality requirements.
+4. Keep runtime/debug-only statements out of production code paths.
+5. Align formatting and style decisions with shared standards for consistency.
+
+## Workflow
+
+1. Detect setup (`ultracite` dependency + config files).
+2. Run `check` to identify issues; run `fix` where safe.
+3. Use `doctor` for setup/config conflicts.
+4. Apply code standards from `references/code-standards.md`.
+5. Re-run checks after changes and document any intentional exceptions.
+
+## Checklist
+
+- [ ] Ultracite context is confirmed before applying rules
+- [ ] `check` and/or `fix` workflow is used
+- [ ] Accessibility/security/style standards are respected
+- [ ] No debug artifacts remain in production code
+- [ ] Any exceptions are explicit and justified
+
+## References
+
+- `references/code-standards.md` for practical standards
+- `references/upstream.md` for source mapping and attribution

--- a/docs/ai/skills/ultracite/references/code-standards.md
+++ b/docs/ai/skills/ultracite/references/code-standards.md
@@ -1,0 +1,79 @@
+# Ultracite Code Standards (Reference)
+
+Adapted from upstream:
+https://github.com/haydenbleasel/ultracite/blob/HEAD/skills/ultracite/references/code-standards.md
+
+## Core Principles
+
+Write code that is accessible, performant, type-safe, and maintainable.
+Prefer clarity and explicit intent over cleverness.
+
+## Type Safety & Explicitness
+
+- Prefer explicit types where they improve readability.
+- Prefer `unknown` over `any` when type is not yet known.
+- Use `as const` for immutable literals and stable unions.
+- Prefer narrowing and guards over unsafe assertions.
+- Extract magic numbers into well-named constants.
+
+## Modern JavaScript / TypeScript
+
+- Prefer `const`; use `let` only for reassignment; never use `var`.
+- Prefer arrow functions for callbacks and small helpers.
+- Prefer `for...of` over `.forEach()` in iteration-heavy logic.
+- Prefer template literals over string concatenation.
+- Prefer optional chaining (`?.`) and nullish coalescing (`??`).
+- Avoid enums; prefer objects + `as const`.
+- Avoid nested ternaries.
+
+## Async & Promises
+
+- Always await promises in async functions.
+- Prefer async/await over promise chains when practical.
+- Handle async errors intentionally (`try/catch` or propagated errors).
+- Do not use async functions as Promise constructors/executors.
+
+## React & JSX
+
+- Use function components.
+- Call hooks only at the top level.
+- Keep hook dependency arrays complete and correct.
+- Use stable `key` values for lists (avoid array index keys).
+- Avoid defining components inside other components unless required.
+- Use semantic HTML and ARIA-friendly structures.
+
+## Error Handling & Debugging
+
+- Remove `console.log`, `debugger`, and `alert` from production paths.
+- Throw `Error` objects with meaningful messages.
+- Prefer early returns to deeply nested conditionals.
+
+## Security
+
+- Add `rel="noopener"` with `target="_blank"`.
+- Avoid `dangerouslySetInnerHTML` unless absolutely required.
+- Do not use `eval()` or direct `document.cookie` mutation patterns.
+- Validate and sanitize user input.
+
+## Performance
+
+- Avoid spread accumulation in loops.
+- Hoist regex literals/constants outside loops.
+- Prefer specific imports over broad namespace imports.
+- Avoid barrel-file overuse in hot code paths.
+
+## Formatting / Style Baseline
+
+- 2-space indentation
+- LF line endings
+- 80-character line width (target)
+- Semicolons enabled
+- Double quotes (single quotes in JSX where required by toolchain)
+- ES5 trailing commas
+- Kebab-case filenames where applicable
+
+## Testing Hygiene
+
+- Keep assertions inside test cases (`it` / `test` blocks).
+- Avoid committed `.only` / `.skip`.
+- Prefer async/await in async tests over callback-style completion.

--- a/docs/ai/skills/ultracite/references/upstream.md
+++ b/docs/ai/skills/ultracite/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: haydenbleasel/ultracite (ultracite skill)
+source_url: https://github.com/haydenbleasel/ultracite
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/ultracite/` is adapted from:
+
+- Skills page: https://skills.sh/haydenbleasel/ultracite/ultracite
+- GitHub repository: https://github.com/haydenbleasel/ultracite
+- Upstream skill path: `skills/ultracite/SKILL.md`
+
+The standards reference in this skill is sourced from:
+
+- `skills/ultracite/references/code-standards.md`
+  - https://github.com/haydenbleasel/ultracite/blob/HEAD/skills/ultracite/references/code-standards.md

--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -17,6 +17,10 @@ const targetRoots = [
 const skillsToSync = [
   "supabase-postgres-best-practices",
   "nextjs-supabase-auth",
+  "building-components",
+  "turborepo",
+  "next-cache-components",
+  "ultracite",
 ];
 
 async function overlayDirectory(sourceDir, targetDir) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Deploy Checklist (for PRs to `epic` or `develop`)

- [ ] CI passes
- [ ] Migrations reviewed (or N/A)
- [ ] Migrations tested on staging (or N/A)
- [ ] New env vars added to all 3 Vercel projects (or N/A)
- [ ] Rollback plan reviewed
- [ ] Post-deploy smoke tests planned

## Description

This PR introduces a new "Nia context policy for this repo" section to `AGENTS.md`.

**Why this change?**
The goal is to establish clear, up-to-date guidance for agents on when and how to use Nia for context gathering. This policy makes Nia the default method for fetching context on external libraries, services, APIs, or specs, aiming to reduce assumptions and ground implementation decisions in reliable sources.

**Key aspects of the policy:**
- Defines when Nia must be used.
- Prioritizes sources for context.
- Outlines a default workflow for using Nia.
- Specifies required behavior for agents.
- Provides practical examples and a tool cheat sheet.

**Note:** Existing non-Nia related guidance (e.g., Context7 policy) was intentionally left untouched to adhere to specific instructions. A follow-up PR could be created to harmonize any overlapping policies if needed.

---
<p><a href="https://cursor.com/agents/bc-35b1ba7f-d3db-41f8-a15f-f6e69d495749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35b1ba7f-d3db-41f8-a15f-f6e69d495749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**Primary scope: Agent documentation / developer tooling infrastructure.** Secondary areas touched: frontend component design (building-components skill), monorepo build tooling (turborepo skill), code quality (ultracite skill), and Next.js 16 caching patterns (next-cache-components skill).

This PR does three distinct things: it adds a new `## Nia context policy for this repo` section to `AGENTS.md` to make Nia the default context-gathering mechanism for external libraries and APIs; it introduces four new canonical skill documents under `docs/ai/skills/` (building-components, turborepo, next-cache-components, ultracite) each with structured frontmatter, upstream attribution, and workflow checklists; and it ships a new `scripts/sync-agent-skills.mjs` that propagates those canonical skills into `.agents/skills/` and `.cursor/skills/` via a non-destructive overlay strategy.

The SKILL.md files and their reference documents are clean, well-structured, and consistent with the repo's existing patterns. The sync script logic is sound and the `mirrorAgentSkillToCursor` error handling is appropriately lenient for agent-only skills. The main concerns are:

- **`scripts/sync-agent-skills.mjs`**: Canonical skills are written to `.cursor/skills/` twice — once by `syncCanonicalSkill` (which targets both `targetRoots`) and again by `mirrorAgentSkillToCursor`. Reducing `targetRoots` to just `.agents/skills/` would make the canonical → agent → cursor data-flow unambiguous.
- **`scripts/sync-agent-skills.mjs`**: `syncCanonicalSkill` will hard-fail (exit code 1) if any name in `skillsToSync` is missing from `docs/ai/skills/`. The two entries not added in this PR (`supabase-postgres-best-practices`, `nextjs-supabase-auth`) should be confirmed to already exist in the base branch.
- **`AGENTS.md`** (flagged in prior review threads, still unresolved): bare tool names in the Default workflow, conflicting fallback behavior between the two Nia sections, hardcoded `agent_source="cursor"`, and heading-level promotion from H3 to H2.

<h3>Confidence Score: 3/5</h3>

- Safe to merge the skill files and sync script, but AGENTS.md has unresolved policy conflicts from prior review threads that should be addressed before merge to avoid agent misbehavior.
- The four SKILL.md documents and their reference files are clean and present no risk. The sync script is correct and well-structured with only minor redundancy. The score is held at 3 because the AGENTS.md changes carry forward unresolved conflicts (conflicting fallback instructions, bare tool names, hardcoded agent_source) that were flagged in earlier review rounds and not yet addressed — those conflicts directly affect how every agent in this repo behaves when hitting the Nia policy section.
- AGENTS.md requires attention before merge — four open issues from prior review threads remain unresolved and will cause agent ambiguity at runtime.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | New "Nia context policy" H2 section added with four open issues (already flagged in prior review threads): bare tool names in Default workflow, conflicting fallback behavior vs existing section, hardcoded agent_source="cursor", and heading-level promotion from H3 to H2. Unresolved conflicts keep this file below merge-ready. |
| scripts/sync-agent-skills.mjs | New sync script that overlays canonical skills from docs/ai/skills/ into .agents/skills/ and .cursor/skills/. Logic is clear and error-handling is reasonable, but canonical skills end up double-written to .cursor/skills/ — once by syncCanonicalSkill (which targets both roots) and again by mirrorAgentSkillToCursor. |
| docs/ai/skills/building-components/SKILL.md | New canonical skill doc for building-components; well-structured with proper frontmatter, When to Apply, Core Rules, Workflow, Checklist, and References sections. No issues found. |
| docs/ai/skills/turborepo/SKILL.md | New canonical skill doc for Turborepo monorepo orchestration. Fully structured, accurate, and aligned with the repo's Bun+Turbo setup. No issues found. |
| docs/ai/skills/ultracite/SKILL.md | New canonical skill doc for the Ultracite lint/format workflow. Proper upstream attribution and practical workflow steps. No issues found. |
| docs/ai/skills/next-cache-components/SKILL.md | New canonical skill doc for Next.js 16 Cache Components / PPR patterns. Well-targeted scope and correct technical content for the repo's Next.js 16 baseline. No issues found. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sync-agent-skills.mjs main] --> B[Loop: skillsToSync]
    B --> C[syncCanonicalSkill skillName]
    C --> D[docs/ai/skills/skillName/]
    D -->|cp recursive force| E[.agents/skills/skillName/]
    D -->|cp recursive force| F[.cursor/skills/skillName/]
    
    B --> G[listAgentSkillsForMirror]
    G --> H[readdir .agents/skills/]
    H -->|filter: has SKILL.md| I[agentToCursorMirrorSkills]
    
    I --> J[Loop: mirrorAgentSkillToCursor]
    J --> K{realpath source == target?}
    K -->|Yes: symlink/junction| L[skip — already mapped]
    K -->|No| M[overlayDirectory .agents → .cursor]
    M -->|EINVAL| L
    M -->|ENOENT| N[warn: source missing]
    M -->|other error| O[warn: source unreadable]
    M -->|success| P[.cursor/skills/skillName/]

    style F fill:#ffd700,stroke:#999,color:#000
    style P fill:#ffd700,stroke:#999,color:#000
    note1[" ⚠️ Canonical skills hit .cursor/skills twice\n(F and P are the same directory) "]
    F -.->|redundant second write| note1
    P -.-> note1
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/sync-agent-skills.mjs`, line 11-15 ([link](https://github.com/asymmetric-al/core/blob/55a2c18336c1ec8779ca5b28aa30bf83ffb84dc6/scripts/sync-agent-skills.mjs#L11-L15)) 

   **Canonical skills double-written to `.cursor/skills/`**

   `syncCanonicalSkill` (called on lines 125–127) pushes each canonical skill to *both* entries in `targetRoots` — meaning it already writes to `.cursor/skills/<skill>`. Then, after that loop completes, `listAgentSkillsForMirror` picks up those same skills from `.agents/skills/` and `mirrorAgentSkillToCursor` (lines 131–133) copies them to `.cursor/skills/<skill>` a second time.

   The mirror pass is useful for catching *agent-only* skills that live in `.agents/skills/` but aren't in `docs/ai/skills/` (and thus aren't in `skillsToSync`). But for canonical skills, the second write is pure redundant work. Consider narrowing `targetRoots` so `syncCanonicalSkill` only writes to `.agents/skills/`, and lets `mirrorAgentSkillToCursor` handle the propagation to `.cursor/skills/` as the single path for that direction:

   ```js
   const targetRoots = [
     path.join(repoRoot, ".agents", "skills"),
     // Remove .cursor/skills here — mirrorAgentSkillToCursor handles this
   ];
   ```

   This makes the data-flow unambiguous: canonical → `.agents/`, then `.agents/` → `.cursor/`.


2. `scripts/sync-agent-skills.mjs`, line 39-50 ([link](https://github.com/asymmetric-al/core/blob/55a2c18336c1ec8779ca5b28aa30bf83ffb84dc6/scripts/sync-agent-skills.mjs#L39-L50)) 

   **`syncCanonicalSkill` has no graceful handling for a missing source directory**

   `mirrorAgentSkillToCursor` explicitly handles `ENOENT` (lines 91–94) and logs a warning + returns. `syncCanonicalSkill` does not — if any name in `skillsToSync` doesn't have a corresponding directory under `docs/ai/skills/`, `overlayDirectory` will throw an unhandled `ENOENT` that propagates all the way to `main()`'s catch and exits the entire script with code 1, aborting every remaining sync.

   This is an intentional "fail-fast" posture for canonical skills, which is reasonable — but since `skillsToSync` currently includes `"supabase-postgres-best-practices"` and `"nextjs-supabase-auth"` (which aren't being added in this PR), it would be worth either:
   - confirming those directories already exist in `docs/ai/skills/` in the base branch, or
   - adding a clear comment to the function documenting the fail-fast contract so future contributors know that adding a name to `skillsToSync` without the corresponding canonical directory is a hard failure.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 55a2c18</sub>

<!-- /greptile_comment -->