### PR TITLE
Unlayer skills integration

### DIFF
--- a/.agents/skills/unlayer-config/SKILL.md
+++ b/.agents/skills/unlayer-config/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: unlayer-config
+description: Configure Unlayer behavior in this repo. Use when changing feature flags, appearance, merge tags, design tags, uploads, security, allowed domains, white-label settings, or environment-driven editor configuration.
+---
+
+# Unlayer Config
+
+Use this skill for editor configuration, security, and setup concerns across the repo’s Unlayer-based studio features.
+
+## Apply This Skill When
+
+- Adjusting feature flags or editor options
+- Changing appearance, theme, fonts, or panel behavior
+- Adding or updating merge tags or design tags
+- Working on uploads, file manager, or storage integration
+- Handling allowed domains, white-label mode, or project configuration
+- Reviewing HMAC / user identification guidance
+
+## Repo Surfaces to Check First
+
+- Email Studio config: `packages/config/email-studio.ts`
+- PDF Studio config: `packages/config/pdf-studio.ts`
+- Environment schema: `packages/env/src/schema.ts`
+- Example env file: `.env.example`
+- Product docs:
+  - `docs/guides/features/email-studio.md`
+  - `docs/guides/features/pdf-studio.md`
+
+## Repo-Relevant Environment Keys
+
+- `NEXT_PUBLIC_UNLAYER_PROJECT_ID`
+- `NEXT_PUBLIC_UNLAYER_WHITE_LABEL`
+- `NEXT_PUBLIC_UNLAYER_ALLOWED_DOMAINS`
+
+## Core Rules
+
+- Keep browser-safe Unlayer configuration in `NEXT_PUBLIC_UNLAYER_*` vars only.
+- Never place project secrets or cloud API keys in client-side code or committed docs.
+- Prefer shared config modules over page-local configuration drift.
+- Keep merge tags, appearance, and feature flags consistent with the shared studio setup.
+- Use server-side generation for HMAC signatures or other secret-backed security flows.
+
+## Workflow
+
+1. Identify whether the task belongs in shared config, env schema, or product docs.
+2. Update `packages/config/email-studio.ts` and/or `packages/config/pdf-studio.ts` before adding page-local overrides.
+3. If new browser-safe config is required, update:
+   - `packages/env/src/schema.ts`
+   - `.env.example`
+4. Keep security-sensitive values server-side and documented without secrets.
+5. Verify the setup guidance, status components, and docs still reflect the actual configuration model.
+
+## Checklist
+
+- [ ] Shared config updated before app-local overrides
+- [ ] `NEXT_PUBLIC_UNLAYER_*` usage remains browser-safe
+- [ ] No secrets or project-specific identifiers added to committed files
+- [ ] Merge tags / appearance / feature flags remain consistent across studio surfaces
+- [ ] Setup docs and env examples match the new configuration behavior
+
+## References
+
+- Feature flags reference: `references/feature-flags.md`
+- File storage reference: `references/file-storage.md`
+- Security reference: `references/security.md`
+- Upstream attribution: `references/upstream.md`

--- a/.agents/skills/unlayer-config/references/feature-flags.md
+++ b/.agents/skills/unlayer-config/references/feature-flags.md
@@ -1,0 +1,55 @@
+# Unlayer Feature Flags Reference
+
+All available flags for `features` in `unlayer.init()`:
+
+```javascript
+features: {
+  // --- CORE ---
+  audit: true,
+  preview: true, // or object
+  blocks: true,
+  undoRedo: true, // or { enabled: true, autoSelect: true, autoFocus: true }
+  stockImages: true, // or { enabled: true, safeSearch: true, defaultSearchTerm: 'business' }
+  userUploads: true, // or { enabled: true, search: true }
+  preheaderText: true,
+  headersAndFooters: false,
+  sendTestEmail: false,
+
+  // --- TEXT EDITOR ---
+  textEditor: {
+    spellChecker: true,
+    tables: false,
+    cleanPaste: "confirm", // true | false | "basic" | "confirm"
+    emojis: true,
+    textDirection: true,
+    inlineFontControls: true,
+    customButtons: [],
+  },
+
+  // --- AI ---
+  ai: true, // or object
+
+  // --- IMAGE EDITOR ---
+  imageEditor: true, // or { enabled: true, tools: { resize: true } }
+
+  // --- COLOR PICKER ---
+  colorPicker: {
+    colors: ["#FF0000"], // string[] or ColorGroup[]
+    limit: 50,
+    recentColors: true,
+  },
+
+  // --- COLLABORATION ---
+  collaboration: false,
+
+  // --- LEGACY ---
+  legacy: {
+    disableHoverButtonColors: false,
+  },
+}
+```
+
+Notes:
+
+- Prefer shared config modules in this repo over page-local flag drift.
+- Keep paid or entitlement-backed features documented without committing secrets or tenant-specific settings.

--- a/.agents/skills/unlayer-config/references/file-storage.md
+++ b/.agents/skills/unlayer-config/references/file-storage.md
@@ -1,0 +1,70 @@
+# Unlayer File Storage Reference
+
+## Custom Image Upload with Progress (XHR)
+
+```javascript
+unlayer.registerCallback("image", function (file, done) {
+  var xhr = new XMLHttpRequest();
+
+  xhr.upload.onprogress = function (e) {
+    done({ progress: Math.round((e.loaded / e.total) * 100) });
+  };
+
+  xhr.onload = function () {
+    var result = JSON.parse(xhr.responseText);
+    done({ progress: 100, url: result.url });
+  };
+
+  xhr.onerror = function () {
+    console.error("Upload failed");
+  };
+
+  var data = new FormData();
+  data.append("file", file.attachments[0]);
+  xhr.open("POST", "/api/uploads");
+  xhr.send(data);
+});
+```
+
+## File Manager Provider
+
+```javascript
+unlayer.registerProvider("userUploads", function (params, done) {
+  var page = params.page || 1;
+  var perPage = params.perPage || 20;
+  var searchText = params.searchText;
+
+  fetch(`/api/images?page=${page}&perPage=${perPage}&search=${searchText || ""}`)
+    .then((r) => r.json())
+    .then((data) => {
+      var images = data.items.map((img) => ({
+        id: img.id,
+        location: img.url,
+        width: img.width,
+        height: img.height,
+        contentType: img.contentType,
+        source: "user",
+      }));
+      done(images, {
+        hasMore: data.total > page * perPage,
+        page: page,
+        perPage: perPage,
+        total: data.total,
+      });
+    });
+});
+```
+
+## Handle Image Deletion
+
+```javascript
+unlayer.registerCallback("image:removed", function (image, done) {
+  fetch(`/api/images/${image.id}`, { method: "DELETE" }).then(() => done());
+});
+```
+
+## Amazon S3 Setup Notes
+
+- Configure storage in the Unlayer dashboard under **Settings -> Storage**.
+- Keep credentials out of client code and committed docs.
+- If this repo adds upload flows, route secret-backed behavior through server-side boundaries.

--- a/.agents/skills/unlayer-config/references/security.md
+++ b/.agents/skills/unlayer-config/references/security.md
@@ -1,0 +1,58 @@
+# Unlayer Security Reference
+
+Identity verification prevents impersonation of logged-in users. Generate HMAC signatures **server-side** with the project secret.
+
+## Node.js
+
+```javascript
+const crypto = require("crypto");
+
+const signature = crypto
+  .createHmac("sha256", "YOUR_PROJECT_SECRET")
+  .update(String(userId))
+  .digest("hex");
+```
+
+## Python / Django
+
+```python
+import hmac
+import hashlib
+
+signature = hmac.new(
+    b"YOUR_PROJECT_SECRET",
+    bytes(str(request.user.id), encoding="utf-8"),
+    digestmod=hashlib.sha256
+).hexdigest()
+```
+
+## Client-Side Usage
+
+```javascript
+unlayer.init({
+  user: {
+    id: 1,
+    signature: signatureFromServer,
+    name: "John Doe",
+    email: "john.doe@example.com",
+  },
+});
+```
+
+## End-User Identification
+
+```javascript
+unlayer.init({
+  user: {
+    id: 1,
+    name: "John Doe",
+    email: "john@example.com",
+  },
+});
+```
+
+Rules for this repo:
+
+- Never commit project secrets or cloud API keys.
+- Keep signature generation server-side only.
+- Treat any future HMAC integration like other secret-backed auth/config work in this repo.

--- a/.agents/skills/unlayer-config/references/upstream.md
+++ b/.agents/skills/unlayer-config/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-config)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-config/` is adapted from Unlayer's official configuration skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-config
+- Upstream skill path: `unlayer-config/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve upstream guidance around feature flags, merge tags, uploads, and security.
+- Keep repo-local guidance focused on shared config modules, env schema, and browser-safe configuration boundaries.

--- a/.agents/skills/unlayer-custom-tools/SKILL.md
+++ b/.agents/skills/unlayer-custom-tools/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: unlayer-custom-tools
+description: Build or extend custom Unlayer tools in this repo. Use when registering custom drag-and-drop blocks, property editors, custom widgets, or shared tool configuration for Email Studio or PDF Studio.
+---
+
+# Unlayer Custom Tools
+
+Use this skill when the task involves custom Unlayer blocks or editors that should live in shared studio infrastructure rather than being duplicated in a single app page.
+
+## Apply This Skill When
+
+- Registering a custom Unlayer tool
+- Adding or changing a custom property editor
+- Extending shared tool configuration passed into the editor
+- Building reusable drag-and-drop blocks for Email Studio or PDF Studio
+- Debugging custom tool rendering or exporter behavior
+
+## Do Not Use When
+
+- The task is only editor setup, lifecycle, or wrapper integration -> use `docs/ai/skills/unlayer-integration/SKILL.md`
+- The task is only export/save/load behavior -> use `docs/ai/skills/unlayer-export/SKILL.md`
+- The task is only appearance, merge tags, uploads, or security -> use `docs/ai/skills/unlayer-config/SKILL.md`
+
+## Repo Surfaces to Check First
+
+- Shared wrapper and editor options: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email Studio consumer: `apps/admin/app/email/page.tsx`
+- PDF Studio consumer: `apps/admin/app/pdf/page.tsx`
+
+## Core Rules
+
+- Prefer shared, reusable tool registration over page-local one-off blocks.
+- If the tool is meant to work in multiple studio surfaces, wire it through shared infrastructure.
+- Keep tool behavior aligned with the target display mode (`email` vs `document` vs `web`).
+- For email-safe output, respect Unlayer’s table-based exporter guidance for email HTML.
+- Keep any editor customization declarative and discoverable through shared configuration when possible.
+
+## Workflow
+
+1. Decide whether the tool belongs in shared studio infrastructure or only a single consumer.
+2. Inspect `UnlayerEditor.tsx` for the right integration point:
+   - shared `tools` config
+   - custom CSS / JS
+   - display-mode-specific handling
+3. Keep tool registration and configuration centralized when the feature is reusable.
+4. Verify renderers/exporters stay compatible with the intended output mode.
+5. If the task introduces related upload, merge-tag, or feature-flag work, also apply `docs/ai/skills/unlayer-config/SKILL.md`.
+
+## Checklist
+
+- [ ] Custom tool belongs in shared infrastructure when reusable
+- [ ] Tool registration is not duplicated across app pages
+- [ ] Output mode compatibility considered (`email`, `document`, `web`, `popup`)
+- [ ] Email-safe HTML constraints respected when applicable
+- [ ] Related config/export concerns routed to the right Unlayer sub-skill
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/.agents/skills/unlayer-custom-tools/references/upstream.md
+++ b/.agents/skills/unlayer-custom-tools/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-custom-tools)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-custom-tools/` is adapted from Unlayer's official custom tools skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-custom-tools
+- Upstream skill path: `unlayer-custom-tools/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve the upstream concepts for tool registration, property editors, and exporter behavior.
+- Keep repo-local guidance focused on shared studio infrastructure instead of app-local duplication.

--- a/.agents/skills/unlayer-export/SKILL.md
+++ b/.agents/skills/unlayer-export/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: unlayer-export
+description: Export and persist Unlayer content in this repo. Use when working on HTML or PDF export, save/load design flows, design JSON persistence, auto-save patterns, or editor export methods in Email Studio or PDF Studio.
+---
+
+# Unlayer Export
+
+Use this skill for save/load/export work across the repo’s Unlayer-based studio features.
+
+## Apply This Skill When
+
+- Changing `exportHtml`, `exportPdf`, or save/load behavior
+- Persisting or restoring Unlayer design JSON
+- Adjusting auto-save or debounced save flows
+- Working on HTML output, PDF export, or export-related UX
+- Debugging design restoration or export return payloads
+
+## Repo Surfaces to Check First
+
+- Shared wrapper export methods: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email Studio docs and examples: `docs/guides/features/email-studio.md`
+- PDF Studio docs and examples: `docs/guides/features/pdf-studio.md`
+- Consumers:
+  - `apps/admin/app/email/page.tsx`
+  - `apps/admin/app/pdf/page.tsx`
+
+## Core Rules
+
+- Always preserve design JSON alongside exported output so designs remain editable.
+- Prefer shared wrapper methods for export logic over duplicating raw Unlayer calls in app pages.
+- Keep save/load behavior consistent across Email Studio and PDF Studio where possible.
+- For cloud export behavior (image/PDF/ZIP), keep secrets and API keys out of client code and docs.
+
+## Workflow
+
+1. Identify whether the task affects:
+   - shared wrapper export methods
+   - page-level export UX
+   - persistence / restore flow
+   - design JSON structure assumptions
+2. Start with `UnlayerEditor.tsx` and existing docs to understand the current shared pattern.
+3. Keep save/load/export responsibilities centralized when the same behavior is used by multiple studio surfaces.
+4. Verify both the exported artifact and the returned design payload shape.
+5. If the change also affects merge tags, uploads, or feature flags, apply `docs/ai/skills/unlayer-config/SKILL.md` too.
+
+## Checklist
+
+- [ ] Design JSON is preserved for editable templates
+- [ ] Shared export methods used or updated before app-local duplication
+- [ ] Email Studio and PDF Studio behavior remains consistent when intended
+- [ ] No client-side secrets introduced for cloud export flows
+- [ ] Export-related docs and references remain accurate
+
+## References
+
+- Design JSON reference: `references/design-json.md`
+- Upstream attribution: `references/upstream.md`

--- a/.agents/skills/unlayer-export/references/design-json.md
+++ b/.agents/skills/unlayer-export/references/design-json.md
@@ -1,0 +1,128 @@
+# Unlayer Design JSON Reference
+
+## Top-Level Structure
+
+```typescript
+interface JSONTemplate {
+  counters: Record<string, number>;
+  schemaVersion: number;
+  body: {
+    id: string;
+    rows: Row[];
+    headers: Row[];
+    footers: Row[];
+    values: BodyValues;
+  };
+}
+```
+
+## Body Values
+
+```typescript
+interface BodyValues {
+  backgroundColor: string;
+  contentWidth: string;
+  fontFamily: { label: string; value: string };
+  textColor: string;
+  linkStyle: {
+    inherit: boolean;
+    linkColor: string;
+    linkHoverColor: string;
+    linkUnderline: boolean;
+    linkHoverUnderline: boolean;
+  };
+  popupPosition?: string;
+  popupWidth?: string;
+  popupHeight?: string;
+  borderRadius?: string;
+  contentAlign?: string;
+  contentVerticalAlign?: string;
+}
+```
+
+## Row and Column Shape
+
+```typescript
+interface Row {
+  id: string;
+  cells: number[];
+  columns: Column[];
+  values: {
+    displayCondition: object | null;
+    columns: boolean;
+    backgroundColor: string;
+    columnsBackgroundColor: string;
+    backgroundImage: {
+      url: string;
+      fullWidth: boolean;
+      repeat: boolean;
+      center: boolean;
+      cover: boolean;
+    };
+    padding: string;
+    _meta: { htmlID: string; htmlClassNames: string };
+  };
+}
+
+interface Column {
+  id: string;
+  contents: ContentItem[];
+  values: {
+    _meta: { htmlID: string; htmlClassNames: string };
+    border: object;
+    padding: string;
+    backgroundColor: string;
+  };
+}
+```
+
+## Content Items
+
+```typescript
+interface ContentItem {
+  id: string;
+  type: string;
+  values: {
+    containerPadding: string;
+    anchor: string;
+    textAlign: string;
+    lineHeight: string;
+    linkStyle: {
+      inherit: boolean;
+      linkColor: string;
+      linkHoverColor: string;
+      linkUnderline: boolean;
+      linkHoverUnderline: boolean;
+    };
+    hideDesktop: boolean;
+    displayCondition: object | null;
+    _meta: { htmlID: string; htmlClassNames: string };
+    selectable: boolean;
+    draggable: boolean;
+    duplicatable: boolean;
+    deletable: boolean;
+    hideable: boolean;
+  };
+}
+```
+
+Common content types:
+
+- `text`
+- `heading`
+- `button`
+- `image`
+- `divider`
+- `social`
+- `html`
+- `video`
+- `menu`
+- `timer`
+- `table`
+- `carousel`
+- `paragraph`
+
+Repo reminder:
+
+- Save the design JSON alongside exported HTML/PDF flows so templates remain editable.
+- Treat `schemaVersion` and shape compatibility carefully when restoring stored designs.

--- a/.agents/skills/unlayer-export/references/upstream.md
+++ b/.agents/skills/unlayer-export/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-export)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-export/` is adapted from Unlayer's official export skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-export
+- Upstream skill path: `unlayer-export/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve upstream guidance around design JSON, save/load patterns, and export methods.
+- Keep repo-local guidance centered on the shared `UnlayerEditor` wrapper and existing Email/PDF Studio workflows.

--- a/.agents/skills/unlayer-integration/SKILL.md
+++ b/.agents/skills/unlayer-integration/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: unlayer-integration
+description: Integrate or extend Unlayer inside this repo using the shared editor wrapper and existing Email/PDF Studio surfaces. Use when working on react-email-editor setup, editor options, display modes, project configuration, or shared editor plumbing.
+---
+
+# Unlayer Integration
+
+This repo already embeds Unlayer through a shared wrapper:
+
+- `packages/ui/components/studio/UnlayerEditor.tsx`
+
+Primary consumers today:
+
+- `apps/admin/app/email/page.tsx`
+- `apps/admin/app/pdf/page.tsx`
+
+Prefer evolving the shared wrapper and shared config before adding raw `react-email-editor` usage in app pages.
+
+## Apply This Skill When
+
+- Adding Unlayer to a new repo surface
+- Extending `UnlayerEditor` props or editor setup behavior
+- Changing display modes (`email`, `web`, `popup`, `document`)
+- Wiring project ID, locale, merge tags, appearance, or user context into the editor
+- Debugging editor readiness, design loading, or save/export access patterns
+
+## Do Not Use When
+
+- The task is primarily merge tags, uploads, feature flags, or security only -> use `docs/ai/skills/unlayer-config/SKILL.md`
+- The task is primarily export/save/load behavior -> use `docs/ai/skills/unlayer-export/SKILL.md`
+- The task is primarily custom tool registration -> use `docs/ai/skills/unlayer-custom-tools/SKILL.md`
+
+## Repo Surfaces to Check First
+
+- Shared editor wrapper: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email config: `packages/config/email-studio.ts`
+- PDF config: `packages/config/pdf-studio.ts`
+- Env schema: `packages/env/src/schema.ts`
+- Example env values: `.env.example`
+- Product docs:
+  - `docs/guides/features/email-studio.md`
+  - `docs/guides/features/pdf-studio.md`
+
+## Workflow
+
+1. Start with the shared wrapper and identify whether the change belongs in:
+   - wrapper props / editor options
+   - shared config
+   - consuming page logic
+2. Reuse existing wrapper abstractions before introducing raw `react-email-editor` calls in app code.
+3. Keep environment-driven settings (`NEXT_PUBLIC_UNLAYER_*`) in config/env files, not in page-local constants.
+4. If the change affects both Email Studio and PDF Studio, implement it in shared infrastructure first.
+5. Verify that editor load, ready, design load, and imperative handle methods still follow the existing shared pattern.
+
+## Checklist
+
+- [ ] Shared `UnlayerEditor` considered before app-local integration
+- [ ] Email/PDF Studio consumers remain consistent
+- [ ] Environment-driven config lives in `packages/config/*` and `packages/env/*`
+- [ ] No duplicate wrapper logic introduced in `apps/*`
+- [ ] Follow-up export/config/custom-tool work routed to the right skill if needed
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/.agents/skills/unlayer-integration/references/upstream.md
+++ b/.agents/skills/unlayer-integration/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-integration)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-integration/` is adapted from Unlayer's official integration skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-integration
+- Upstream skill path: `unlayer-integration/SKILL.md`
+
+## Notes for Maintainers
+
+- The upstream skill is framework-generic; this repo-local version intentionally steers agents toward the shared `UnlayerEditor` wrapper and existing admin surfaces.
+- Preserve attribution while preferring repo-native file paths, env handling, and shared wrapper patterns.

--- a/.agents/skills/unlayer/SKILL.md
+++ b/.agents/skills/unlayer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: unlayer
+description: Route Unlayer work in this repo to the right sub-skill. Use when the task involves the Unlayer visual editor, Email Studio, PDF Studio, editor configuration, exports, merge tags, custom tools, or embedded editor integration.
+---
+
+# Unlayer
+
+Use this skill as the router for Unlayer work in Asymmetric.al. The repo already has a shared Unlayer wrapper and two main product surfaces:
+
+- `packages/ui/components/studio/UnlayerEditor.tsx`
+- `apps/admin/app/email/page.tsx`
+- `apps/admin/app/pdf/page.tsx`
+
+Do not default to raw one-off framework examples when the task belongs in the shared studio infrastructure.
+
+## Route to the Right Skill
+
+| If the task is about... | Use this skill |
+| --- | --- |
+| Embedding or extending the shared editor wrapper | `docs/ai/skills/unlayer-integration/SKILL.md` |
+| HTML/PDF export, save/load flows, design JSON persistence | `docs/ai/skills/unlayer-export/SKILL.md` |
+| Appearance, merge tags, security, allowed domains, uploads, feature flags | `docs/ai/skills/unlayer-config/SKILL.md` |
+| Custom drag-and-drop blocks, property editors, or tool registration | `docs/ai/skills/unlayer-custom-tools/SKILL.md` |
+
+## Workflow
+
+1. Identify whether the request is primarily **integration**, **export**, **configuration**, or **custom tools**.
+2. Read the matching sub-skill before editing.
+3. Prefer repo-native surfaces (`UnlayerEditor`, Email Studio, PDF Studio, shared config) over page-local duplication.
+4. If multiple concerns are involved, apply the skills in this order:
+   1. `unlayer-integration`
+   2. `unlayer-config`
+   3. `unlayer-export`
+   4. `unlayer-custom-tools`
+5. Verify changes via `bun run skills:sync` when skill files change, then run targeted repo checks.
+
+## Checklist
+
+- [ ] Correct Unlayer sub-skill selected
+- [ ] Shared wrapper and existing admin studio surfaces considered first
+- [ ] No duplicate one-off editor integration introduced
+- [ ] Any new skill guidance remains consistent with repo-specific Unlayer architecture
+
+## Example Routing
+
+- “Add Unlayer to a new admin feature” -> `docs/ai/skills/unlayer-integration/SKILL.md`
+- “Add merge tags for donation receipts” -> `docs/ai/skills/unlayer-config/SKILL.md`
+- “Adjust PDF export/save flow” -> `docs/ai/skills/unlayer-export/SKILL.md`
+- “Create a reusable custom content block” -> `docs/ai/skills/unlayer-custom-tools/SKILL.md`
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/.agents/skills/unlayer/references/upstream.md
+++ b/.agents/skills/unlayer/references/upstream.md
@@ -1,0 +1,21 @@
+---
+source_name: unlayer/unlayer-skills (unlayer)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer/` is adapted from Unlayer's official skills repository:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer
+- Upstream skill path: `unlayer/SKILL.md`
+- Upstream changelog: initial `1.0.0` release on 2026-02-18
+
+## Notes for Maintainers
+
+- Keep routing guidance aligned with the repo’s shared Unlayer wrapper and admin studio surfaces.
+- Preserve upstream attribution while favoring repo-specific file paths and workflows.
+- Do not copy secrets, project IDs, or environment-specific identifiers into skill content.

--- a/.cursor/skills/unlayer-config/SKILL.md
+++ b/.cursor/skills/unlayer-config/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: unlayer-config
+description: Configure Unlayer behavior in this repo. Use when changing feature flags, appearance, merge tags, design tags, uploads, security, allowed domains, white-label settings, or environment-driven editor configuration.
+---
+
+# Unlayer Config
+
+Use this skill for editor configuration, security, and setup concerns across the repo’s Unlayer-based studio features.
+
+## Apply This Skill When
+
+- Adjusting feature flags or editor options
+- Changing appearance, theme, fonts, or panel behavior
+- Adding or updating merge tags or design tags
+- Working on uploads, file manager, or storage integration
+- Handling allowed domains, white-label mode, or project configuration
+- Reviewing HMAC / user identification guidance
+
+## Repo Surfaces to Check First
+
+- Email Studio config: `packages/config/email-studio.ts`
+- PDF Studio config: `packages/config/pdf-studio.ts`
+- Environment schema: `packages/env/src/schema.ts`
+- Example env file: `.env.example`
+- Product docs:
+  - `docs/guides/features/email-studio.md`
+  - `docs/guides/features/pdf-studio.md`
+
+## Repo-Relevant Environment Keys
+
+- `NEXT_PUBLIC_UNLAYER_PROJECT_ID`
+- `NEXT_PUBLIC_UNLAYER_WHITE_LABEL`
+- `NEXT_PUBLIC_UNLAYER_ALLOWED_DOMAINS`
+
+## Core Rules
+
+- Keep browser-safe Unlayer configuration in `NEXT_PUBLIC_UNLAYER_*` vars only.
+- Never place project secrets or cloud API keys in client-side code or committed docs.
+- Prefer shared config modules over page-local configuration drift.
+- Keep merge tags, appearance, and feature flags consistent with the shared studio setup.
+- Use server-side generation for HMAC signatures or other secret-backed security flows.
+
+## Workflow
+
+1. Identify whether the task belongs in shared config, env schema, or product docs.
+2. Update `packages/config/email-studio.ts` and/or `packages/config/pdf-studio.ts` before adding page-local overrides.
+3. If new browser-safe config is required, update:
+   - `packages/env/src/schema.ts`
+   - `.env.example`
+4. Keep security-sensitive values server-side and documented without secrets.
+5. Verify the setup guidance, status components, and docs still reflect the actual configuration model.
+
+## Checklist
+
+- [ ] Shared config updated before app-local overrides
+- [ ] `NEXT_PUBLIC_UNLAYER_*` usage remains browser-safe
+- [ ] No secrets or project-specific identifiers added to committed files
+- [ ] Merge tags / appearance / feature flags remain consistent across studio surfaces
+- [ ] Setup docs and env examples match the new configuration behavior
+
+## References
+
+- Feature flags reference: `references/feature-flags.md`
+- File storage reference: `references/file-storage.md`
+- Security reference: `references/security.md`
+- Upstream attribution: `references/upstream.md`

--- a/.cursor/skills/unlayer-config/references/feature-flags.md
+++ b/.cursor/skills/unlayer-config/references/feature-flags.md
@@ -1,0 +1,55 @@
+# Unlayer Feature Flags Reference
+
+All available flags for `features` in `unlayer.init()`:
+
+```javascript
+features: {
+  // --- CORE ---
+  audit: true,
+  preview: true, // or object
+  blocks: true,
+  undoRedo: true, // or { enabled: true, autoSelect: true, autoFocus: true }
+  stockImages: true, // or { enabled: true, safeSearch: true, defaultSearchTerm: 'business' }
+  userUploads: true, // or { enabled: true, search: true }
+  preheaderText: true,
+  headersAndFooters: false,
+  sendTestEmail: false,
+
+  // --- TEXT EDITOR ---
+  textEditor: {
+    spellChecker: true,
+    tables: false,
+    cleanPaste: "confirm", // true | false | "basic" | "confirm"
+    emojis: true,
+    textDirection: true,
+    inlineFontControls: true,
+    customButtons: [],
+  },
+
+  // --- AI ---
+  ai: true, // or object
+
+  // --- IMAGE EDITOR ---
+  imageEditor: true, // or { enabled: true, tools: { resize: true } }
+
+  // --- COLOR PICKER ---
+  colorPicker: {
+    colors: ["#FF0000"], // string[] or ColorGroup[]
+    limit: 50,
+    recentColors: true,
+  },
+
+  // --- COLLABORATION ---
+  collaboration: false,
+
+  // --- LEGACY ---
+  legacy: {
+    disableHoverButtonColors: false,
+  },
+}
+```
+
+Notes:
+
+- Prefer shared config modules in this repo over page-local flag drift.
+- Keep paid or entitlement-backed features documented without committing secrets or tenant-specific settings.

--- a/.cursor/skills/unlayer-config/references/file-storage.md
+++ b/.cursor/skills/unlayer-config/references/file-storage.md
@@ -1,0 +1,70 @@
+# Unlayer File Storage Reference
+
+## Custom Image Upload with Progress (XHR)
+
+```javascript
+unlayer.registerCallback("image", function (file, done) {
+  var xhr = new XMLHttpRequest();
+
+  xhr.upload.onprogress = function (e) {
+    done({ progress: Math.round((e.loaded / e.total) * 100) });
+  };
+
+  xhr.onload = function () {
+    var result = JSON.parse(xhr.responseText);
+    done({ progress: 100, url: result.url });
+  };
+
+  xhr.onerror = function () {
+    console.error("Upload failed");
+  };
+
+  var data = new FormData();
+  data.append("file", file.attachments[0]);
+  xhr.open("POST", "/api/uploads");
+  xhr.send(data);
+});
+```
+
+## File Manager Provider
+
+```javascript
+unlayer.registerProvider("userUploads", function (params, done) {
+  var page = params.page || 1;
+  var perPage = params.perPage || 20;
+  var searchText = params.searchText;
+
+  fetch(`/api/images?page=${page}&perPage=${perPage}&search=${searchText || ""}`)
+    .then((r) => r.json())
+    .then((data) => {
+      var images = data.items.map((img) => ({
+        id: img.id,
+        location: img.url,
+        width: img.width,
+        height: img.height,
+        contentType: img.contentType,
+        source: "user",
+      }));
+      done(images, {
+        hasMore: data.total > page * perPage,
+        page: page,
+        perPage: perPage,
+        total: data.total,
+      });
+    });
+});
+```
+
+## Handle Image Deletion
+
+```javascript
+unlayer.registerCallback("image:removed", function (image, done) {
+  fetch(`/api/images/${image.id}`, { method: "DELETE" }).then(() => done());
+});
+```
+
+## Amazon S3 Setup Notes
+
+- Configure storage in the Unlayer dashboard under **Settings -> Storage**.
+- Keep credentials out of client code and committed docs.
+- If this repo adds upload flows, route secret-backed behavior through server-side boundaries.

--- a/.cursor/skills/unlayer-config/references/security.md
+++ b/.cursor/skills/unlayer-config/references/security.md
@@ -1,0 +1,58 @@
+# Unlayer Security Reference
+
+Identity verification prevents impersonation of logged-in users. Generate HMAC signatures **server-side** with the project secret.
+
+## Node.js
+
+```javascript
+const crypto = require("crypto");
+
+const signature = crypto
+  .createHmac("sha256", "YOUR_PROJECT_SECRET")
+  .update(String(userId))
+  .digest("hex");
+```
+
+## Python / Django
+
+```python
+import hmac
+import hashlib
+
+signature = hmac.new(
+    b"YOUR_PROJECT_SECRET",
+    bytes(str(request.user.id), encoding="utf-8"),
+    digestmod=hashlib.sha256
+).hexdigest()
+```
+
+## Client-Side Usage
+
+```javascript
+unlayer.init({
+  user: {
+    id: 1,
+    signature: signatureFromServer,
+    name: "John Doe",
+    email: "john.doe@example.com",
+  },
+});
+```
+
+## End-User Identification
+
+```javascript
+unlayer.init({
+  user: {
+    id: 1,
+    name: "John Doe",
+    email: "john@example.com",
+  },
+});
+```
+
+Rules for this repo:
+
+- Never commit project secrets or cloud API keys.
+- Keep signature generation server-side only.
+- Treat any future HMAC integration like other secret-backed auth/config work in this repo.

--- a/.cursor/skills/unlayer-config/references/upstream.md
+++ b/.cursor/skills/unlayer-config/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-config)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-config/` is adapted from Unlayer's official configuration skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-config
+- Upstream skill path: `unlayer-config/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve upstream guidance around feature flags, merge tags, uploads, and security.
+- Keep repo-local guidance focused on shared config modules, env schema, and browser-safe configuration boundaries.

--- a/.cursor/skills/unlayer-custom-tools/SKILL.md
+++ b/.cursor/skills/unlayer-custom-tools/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: unlayer-custom-tools
+description: Build or extend custom Unlayer tools in this repo. Use when registering custom drag-and-drop blocks, property editors, custom widgets, or shared tool configuration for Email Studio or PDF Studio.
+---
+
+# Unlayer Custom Tools
+
+Use this skill when the task involves custom Unlayer blocks or editors that should live in shared studio infrastructure rather than being duplicated in a single app page.
+
+## Apply This Skill When
+
+- Registering a custom Unlayer tool
+- Adding or changing a custom property editor
+- Extending shared tool configuration passed into the editor
+- Building reusable drag-and-drop blocks for Email Studio or PDF Studio
+- Debugging custom tool rendering or exporter behavior
+
+## Do Not Use When
+
+- The task is only editor setup, lifecycle, or wrapper integration -> use `docs/ai/skills/unlayer-integration/SKILL.md`
+- The task is only export/save/load behavior -> use `docs/ai/skills/unlayer-export/SKILL.md`
+- The task is only appearance, merge tags, uploads, or security -> use `docs/ai/skills/unlayer-config/SKILL.md`
+
+## Repo Surfaces to Check First
+
+- Shared wrapper and editor options: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email Studio consumer: `apps/admin/app/email/page.tsx`
+- PDF Studio consumer: `apps/admin/app/pdf/page.tsx`
+
+## Core Rules
+
+- Prefer shared, reusable tool registration over page-local one-off blocks.
+- If the tool is meant to work in multiple studio surfaces, wire it through shared infrastructure.
+- Keep tool behavior aligned with the target display mode (`email` vs `document` vs `web`).
+- For email-safe output, respect Unlayer’s table-based exporter guidance for email HTML.
+- Keep any editor customization declarative and discoverable through shared configuration when possible.
+
+## Workflow
+
+1. Decide whether the tool belongs in shared studio infrastructure or only a single consumer.
+2. Inspect `UnlayerEditor.tsx` for the right integration point:
+   - shared `tools` config
+   - custom CSS / JS
+   - display-mode-specific handling
+3. Keep tool registration and configuration centralized when the feature is reusable.
+4. Verify renderers/exporters stay compatible with the intended output mode.
+5. If the task introduces related upload, merge-tag, or feature-flag work, also apply `docs/ai/skills/unlayer-config/SKILL.md`.
+
+## Checklist
+
+- [ ] Custom tool belongs in shared infrastructure when reusable
+- [ ] Tool registration is not duplicated across app pages
+- [ ] Output mode compatibility considered (`email`, `document`, `web`, `popup`)
+- [ ] Email-safe HTML constraints respected when applicable
+- [ ] Related config/export concerns routed to the right Unlayer sub-skill
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/.cursor/skills/unlayer-custom-tools/references/upstream.md
+++ b/.cursor/skills/unlayer-custom-tools/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-custom-tools)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-custom-tools/` is adapted from Unlayer's official custom tools skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-custom-tools
+- Upstream skill path: `unlayer-custom-tools/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve the upstream concepts for tool registration, property editors, and exporter behavior.
+- Keep repo-local guidance focused on shared studio infrastructure instead of app-local duplication.

--- a/.cursor/skills/unlayer-export/SKILL.md
+++ b/.cursor/skills/unlayer-export/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: unlayer-export
+description: Export and persist Unlayer content in this repo. Use when working on HTML or PDF export, save/load design flows, design JSON persistence, auto-save patterns, or editor export methods in Email Studio or PDF Studio.
+---
+
+# Unlayer Export
+
+Use this skill for save/load/export work across the repo’s Unlayer-based studio features.
+
+## Apply This Skill When
+
+- Changing `exportHtml`, `exportPdf`, or save/load behavior
+- Persisting or restoring Unlayer design JSON
+- Adjusting auto-save or debounced save flows
+- Working on HTML output, PDF export, or export-related UX
+- Debugging design restoration or export return payloads
+
+## Repo Surfaces to Check First
+
+- Shared wrapper export methods: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email Studio docs and examples: `docs/guides/features/email-studio.md`
+- PDF Studio docs and examples: `docs/guides/features/pdf-studio.md`
+- Consumers:
+  - `apps/admin/app/email/page.tsx`
+  - `apps/admin/app/pdf/page.tsx`
+
+## Core Rules
+
+- Always preserve design JSON alongside exported output so designs remain editable.
+- Prefer shared wrapper methods for export logic over duplicating raw Unlayer calls in app pages.
+- Keep save/load behavior consistent across Email Studio and PDF Studio where possible.
+- For cloud export behavior (image/PDF/ZIP), keep secrets and API keys out of client code and docs.
+
+## Workflow
+
+1. Identify whether the task affects:
+   - shared wrapper export methods
+   - page-level export UX
+   - persistence / restore flow
+   - design JSON structure assumptions
+2. Start with `UnlayerEditor.tsx` and existing docs to understand the current shared pattern.
+3. Keep save/load/export responsibilities centralized when the same behavior is used by multiple studio surfaces.
+4. Verify both the exported artifact and the returned design payload shape.
+5. If the change also affects merge tags, uploads, or feature flags, apply `docs/ai/skills/unlayer-config/SKILL.md` too.
+
+## Checklist
+
+- [ ] Design JSON is preserved for editable templates
+- [ ] Shared export methods used or updated before app-local duplication
+- [ ] Email Studio and PDF Studio behavior remains consistent when intended
+- [ ] No client-side secrets introduced for cloud export flows
+- [ ] Export-related docs and references remain accurate
+
+## References
+
+- Design JSON reference: `references/design-json.md`
+- Upstream attribution: `references/upstream.md`

--- a/.cursor/skills/unlayer-export/references/design-json.md
+++ b/.cursor/skills/unlayer-export/references/design-json.md
@@ -1,0 +1,128 @@
+# Unlayer Design JSON Reference
+
+## Top-Level Structure
+
+```typescript
+interface JSONTemplate {
+  counters: Record<string, number>;
+  schemaVersion: number;
+  body: {
+    id: string;
+    rows: Row[];
+    headers: Row[];
+    footers: Row[];
+    values: BodyValues;
+  };
+}
+```
+
+## Body Values
+
+```typescript
+interface BodyValues {
+  backgroundColor: string;
+  contentWidth: string;
+  fontFamily: { label: string; value: string };
+  textColor: string;
+  linkStyle: {
+    inherit: boolean;
+    linkColor: string;
+    linkHoverColor: string;
+    linkUnderline: boolean;
+    linkHoverUnderline: boolean;
+  };
+  popupPosition?: string;
+  popupWidth?: string;
+  popupHeight?: string;
+  borderRadius?: string;
+  contentAlign?: string;
+  contentVerticalAlign?: string;
+}
+```
+
+## Row and Column Shape
+
+```typescript
+interface Row {
+  id: string;
+  cells: number[];
+  columns: Column[];
+  values: {
+    displayCondition: object | null;
+    columns: boolean;
+    backgroundColor: string;
+    columnsBackgroundColor: string;
+    backgroundImage: {
+      url: string;
+      fullWidth: boolean;
+      repeat: boolean;
+      center: boolean;
+      cover: boolean;
+    };
+    padding: string;
+    _meta: { htmlID: string; htmlClassNames: string };
+  };
+}
+
+interface Column {
+  id: string;
+  contents: ContentItem[];
+  values: {
+    _meta: { htmlID: string; htmlClassNames: string };
+    border: object;
+    padding: string;
+    backgroundColor: string;
+  };
+}
+```
+
+## Content Items
+
+```typescript
+interface ContentItem {
+  id: string;
+  type: string;
+  values: {
+    containerPadding: string;
+    anchor: string;
+    textAlign: string;
+    lineHeight: string;
+    linkStyle: {
+      inherit: boolean;
+      linkColor: string;
+      linkHoverColor: string;
+      linkUnderline: boolean;
+      linkHoverUnderline: boolean;
+    };
+    hideDesktop: boolean;
+    displayCondition: object | null;
+    _meta: { htmlID: string; htmlClassNames: string };
+    selectable: boolean;
+    draggable: boolean;
+    duplicatable: boolean;
+    deletable: boolean;
+    hideable: boolean;
+  };
+}
+```
+
+Common content types:
+
+- `text`
+- `heading`
+- `button`
+- `image`
+- `divider`
+- `social`
+- `html`
+- `video`
+- `menu`
+- `timer`
+- `table`
+- `carousel`
+- `paragraph`
+
+Repo reminder:
+
+- Save the design JSON alongside exported HTML/PDF flows so templates remain editable.
+- Treat `schemaVersion` and shape compatibility carefully when restoring stored designs.

--- a/.cursor/skills/unlayer-export/references/upstream.md
+++ b/.cursor/skills/unlayer-export/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-export)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-export/` is adapted from Unlayer's official export skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-export
+- Upstream skill path: `unlayer-export/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve upstream guidance around design JSON, save/load patterns, and export methods.
+- Keep repo-local guidance centered on the shared `UnlayerEditor` wrapper and existing Email/PDF Studio workflows.

--- a/.cursor/skills/unlayer-integration/SKILL.md
+++ b/.cursor/skills/unlayer-integration/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: unlayer-integration
+description: Integrate or extend Unlayer inside this repo using the shared editor wrapper and existing Email/PDF Studio surfaces. Use when working on react-email-editor setup, editor options, display modes, project configuration, or shared editor plumbing.
+---
+
+# Unlayer Integration
+
+This repo already embeds Unlayer through a shared wrapper:
+
+- `packages/ui/components/studio/UnlayerEditor.tsx`
+
+Primary consumers today:
+
+- `apps/admin/app/email/page.tsx`
+- `apps/admin/app/pdf/page.tsx`
+
+Prefer evolving the shared wrapper and shared config before adding raw `react-email-editor` usage in app pages.
+
+## Apply This Skill When
+
+- Adding Unlayer to a new repo surface
+- Extending `UnlayerEditor` props or editor setup behavior
+- Changing display modes (`email`, `web`, `popup`, `document`)
+- Wiring project ID, locale, merge tags, appearance, or user context into the editor
+- Debugging editor readiness, design loading, or save/export access patterns
+
+## Do Not Use When
+
+- The task is primarily merge tags, uploads, feature flags, or security only -> use `docs/ai/skills/unlayer-config/SKILL.md`
+- The task is primarily export/save/load behavior -> use `docs/ai/skills/unlayer-export/SKILL.md`
+- The task is primarily custom tool registration -> use `docs/ai/skills/unlayer-custom-tools/SKILL.md`
+
+## Repo Surfaces to Check First
+
+- Shared editor wrapper: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email config: `packages/config/email-studio.ts`
+- PDF config: `packages/config/pdf-studio.ts`
+- Env schema: `packages/env/src/schema.ts`
+- Example env values: `.env.example`
+- Product docs:
+  - `docs/guides/features/email-studio.md`
+  - `docs/guides/features/pdf-studio.md`
+
+## Workflow
+
+1. Start with the shared wrapper and identify whether the change belongs in:
+   - wrapper props / editor options
+   - shared config
+   - consuming page logic
+2. Reuse existing wrapper abstractions before introducing raw `react-email-editor` calls in app code.
+3. Keep environment-driven settings (`NEXT_PUBLIC_UNLAYER_*`) in config/env files, not in page-local constants.
+4. If the change affects both Email Studio and PDF Studio, implement it in shared infrastructure first.
+5. Verify that editor load, ready, design load, and imperative handle methods still follow the existing shared pattern.
+
+## Checklist
+
+- [ ] Shared `UnlayerEditor` considered before app-local integration
+- [ ] Email/PDF Studio consumers remain consistent
+- [ ] Environment-driven config lives in `packages/config/*` and `packages/env/*`
+- [ ] No duplicate wrapper logic introduced in `apps/*`
+- [ ] Follow-up export/config/custom-tool work routed to the right skill if needed
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/.cursor/skills/unlayer-integration/references/upstream.md
+++ b/.cursor/skills/unlayer-integration/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-integration)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-integration/` is adapted from Unlayer's official integration skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-integration
+- Upstream skill path: `unlayer-integration/SKILL.md`
+
+## Notes for Maintainers
+
+- The upstream skill is framework-generic; this repo-local version intentionally steers agents toward the shared `UnlayerEditor` wrapper and existing admin surfaces.
+- Preserve attribution while preferring repo-native file paths, env handling, and shared wrapper patterns.

--- a/.cursor/skills/unlayer/SKILL.md
+++ b/.cursor/skills/unlayer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: unlayer
+description: Route Unlayer work in this repo to the right sub-skill. Use when the task involves the Unlayer visual editor, Email Studio, PDF Studio, editor configuration, exports, merge tags, custom tools, or embedded editor integration.
+---
+
+# Unlayer
+
+Use this skill as the router for Unlayer work in Asymmetric.al. The repo already has a shared Unlayer wrapper and two main product surfaces:
+
+- `packages/ui/components/studio/UnlayerEditor.tsx`
+- `apps/admin/app/email/page.tsx`
+- `apps/admin/app/pdf/page.tsx`
+
+Do not default to raw one-off framework examples when the task belongs in the shared studio infrastructure.
+
+## Route to the Right Skill
+
+| If the task is about... | Use this skill |
+| --- | --- |
+| Embedding or extending the shared editor wrapper | `docs/ai/skills/unlayer-integration/SKILL.md` |
+| HTML/PDF export, save/load flows, design JSON persistence | `docs/ai/skills/unlayer-export/SKILL.md` |
+| Appearance, merge tags, security, allowed domains, uploads, feature flags | `docs/ai/skills/unlayer-config/SKILL.md` |
+| Custom drag-and-drop blocks, property editors, or tool registration | `docs/ai/skills/unlayer-custom-tools/SKILL.md` |
+
+## Workflow
+
+1. Identify whether the request is primarily **integration**, **export**, **configuration**, or **custom tools**.
+2. Read the matching sub-skill before editing.
+3. Prefer repo-native surfaces (`UnlayerEditor`, Email Studio, PDF Studio, shared config) over page-local duplication.
+4. If multiple concerns are involved, apply the skills in this order:
+   1. `unlayer-integration`
+   2. `unlayer-config`
+   3. `unlayer-export`
+   4. `unlayer-custom-tools`
+5. Verify changes via `bun run skills:sync` when skill files change, then run targeted repo checks.
+
+## Checklist
+
+- [ ] Correct Unlayer sub-skill selected
+- [ ] Shared wrapper and existing admin studio surfaces considered first
+- [ ] No duplicate one-off editor integration introduced
+- [ ] Any new skill guidance remains consistent with repo-specific Unlayer architecture
+
+## Example Routing
+
+- “Add Unlayer to a new admin feature” -> `docs/ai/skills/unlayer-integration/SKILL.md`
+- “Add merge tags for donation receipts” -> `docs/ai/skills/unlayer-config/SKILL.md`
+- “Adjust PDF export/save flow” -> `docs/ai/skills/unlayer-export/SKILL.md`
+- “Create a reusable custom content block” -> `docs/ai/skills/unlayer-custom-tools/SKILL.md`
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/.cursor/skills/unlayer/references/upstream.md
+++ b/.cursor/skills/unlayer/references/upstream.md
@@ -1,0 +1,21 @@
+---
+source_name: unlayer/unlayer-skills (unlayer)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer/` is adapted from Unlayer's official skills repository:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer
+- Upstream skill path: `unlayer/SKILL.md`
+- Upstream changelog: initial `1.0.0` release on 2026-02-18
+
+## Notes for Maintainers
+
+- Keep routing guidance aligned with the repo’s shared Unlayer wrapper and admin studio surfaces.
+- Preserve upstream attribution while favoring repo-specific file paths and workflows.
+- Do not copy secrets, project IDs, or environment-specific identifiers into skill content.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,11 @@ Load the skill(s) below when the trigger matches.
 - **Motion animations (`motion/react`):** `docs/ai/skills/motion/SKILL.md`
 - **Recharts:** `docs/ai/skills/rechart/SKILL.md`
 - **TanStack Table v8:** `docs/ai/skills/tanstack-table/SKILL.md`
+- **Unlayer skill router (Email Studio / PDF Studio / editor tasks):** `docs/ai/skills/unlayer/SKILL.md`
+- **Unlayer shared integration / wrapper work:** `docs/ai/skills/unlayer-integration/SKILL.md`
+- **Unlayer export, save/load, and design JSON flows:** `docs/ai/skills/unlayer-export/SKILL.md`
+- **Unlayer configuration, merge tags, uploads, and security:** `docs/ai/skills/unlayer-config/SKILL.md`
+- **Unlayer custom drag-and-drop tools:** `docs/ai/skills/unlayer-custom-tools/SKILL.md`
 - **GitHub issue/PR workflows (AL-###):**
   - Write issue: `docs/ai/skills/write-issue/SKILL.md`
   - Build issue: `docs/ai/skills/build-issue/SKILL.md`
@@ -224,6 +229,9 @@ Load the skill(s) below when the trigger matches.
 
 - **"Where is auth handled?"** -> Update `docs/ai/working-set.md`; use Nia (scoped + preambled) to find auth entry points; then open `docs/ai/rules/backend.md`.
 - **"Add a new UI card component."** -> Open `docs/ai/rules/frontend.md` and `docs/ai/skills/react-component-dev/SKILL.md`. Use Nia to find existing patterns/components in this repo before writing new ones.
+- **"Add merge tags or appearance settings to Email Studio."** -> Open `docs/ai/skills/unlayer/SKILL.md`, then apply `docs/ai/skills/unlayer-config/SKILL.md` and inspect `packages/config/email-studio.ts`.
+- **"Change PDF export or save/load behavior in the editor."** -> Open `docs/ai/skills/unlayer/SKILL.md`, then apply `docs/ai/skills/unlayer-export/SKILL.md` and inspect `packages/ui/components/studio/UnlayerEditor.tsx`.
+- **"Create a custom Unlayer content block."** -> Open `docs/ai/skills/unlayer/SKILL.md`, then apply `docs/ai/skills/unlayer-custom-tools/SKILL.md`.
 - **"Use /cui for a page."** -> Open `docs/ai/rules/shadcn-studio-mcp.md` and follow its workflow exactly.
 
 ---

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ bun run skills:sync
 - Canonical source: `docs/ai/skills/*`
 - Runtime mirrors: `.agents/skills/*` and `.cursor/skills/*`
 
+Bundled repo-local skill families include:
+
+- Supabase Postgres best practices (upstream-adapted, deduped in-place)
+- Unlayer router, integration, export, config, and custom-tools guidance
+
 ### Package Manager
 
 This project uses **bun** (v1.3+). Do not use npm/yarn/pnpm.

--- a/docs/ai/skills/unlayer-config/SKILL.md
+++ b/docs/ai/skills/unlayer-config/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: unlayer-config
+description: Configure Unlayer behavior in this repo. Use when changing feature flags, appearance, merge tags, design tags, uploads, security, allowed domains, white-label settings, or environment-driven editor configuration.
+---
+
+# Unlayer Config
+
+Use this skill for editor configuration, security, and setup concerns across the repo’s Unlayer-based studio features.
+
+## Apply This Skill When
+
+- Adjusting feature flags or editor options
+- Changing appearance, theme, fonts, or panel behavior
+- Adding or updating merge tags or design tags
+- Working on uploads, file manager, or storage integration
+- Handling allowed domains, white-label mode, or project configuration
+- Reviewing HMAC / user identification guidance
+
+## Repo Surfaces to Check First
+
+- Email Studio config: `packages/config/email-studio.ts`
+- PDF Studio config: `packages/config/pdf-studio.ts`
+- Environment schema: `packages/env/src/schema.ts`
+- Example env file: `.env.example`
+- Product docs:
+  - `docs/guides/features/email-studio.md`
+  - `docs/guides/features/pdf-studio.md`
+
+## Repo-Relevant Environment Keys
+
+- `NEXT_PUBLIC_UNLAYER_PROJECT_ID`
+- `NEXT_PUBLIC_UNLAYER_WHITE_LABEL`
+- `NEXT_PUBLIC_UNLAYER_ALLOWED_DOMAINS`
+
+## Core Rules
+
+- Keep browser-safe Unlayer configuration in `NEXT_PUBLIC_UNLAYER_*` vars only.
+- Never place project secrets or cloud API keys in client-side code or committed docs.
+- Prefer shared config modules over page-local configuration drift.
+- Keep merge tags, appearance, and feature flags consistent with the shared studio setup.
+- Use server-side generation for HMAC signatures or other secret-backed security flows.
+
+## Workflow
+
+1. Identify whether the task belongs in shared config, env schema, or product docs.
+2. Update `packages/config/email-studio.ts` and/or `packages/config/pdf-studio.ts` before adding page-local overrides.
+3. If new browser-safe config is required, update:
+   - `packages/env/src/schema.ts`
+   - `.env.example`
+4. Keep security-sensitive values server-side and documented without secrets.
+5. Verify the setup guidance, status components, and docs still reflect the actual configuration model.
+
+## Checklist
+
+- [ ] Shared config updated before app-local overrides
+- [ ] `NEXT_PUBLIC_UNLAYER_*` usage remains browser-safe
+- [ ] No secrets or project-specific identifiers added to committed files
+- [ ] Merge tags / appearance / feature flags remain consistent across studio surfaces
+- [ ] Setup docs and env examples match the new configuration behavior
+
+## References
+
+- Feature flags reference: `references/feature-flags.md`
+- File storage reference: `references/file-storage.md`
+- Security reference: `references/security.md`
+- Upstream attribution: `references/upstream.md`

--- a/docs/ai/skills/unlayer-config/references/feature-flags.md
+++ b/docs/ai/skills/unlayer-config/references/feature-flags.md
@@ -1,0 +1,55 @@
+# Unlayer Feature Flags Reference
+
+All available flags for `features` in `unlayer.init()`:
+
+```javascript
+features: {
+  // --- CORE ---
+  audit: true,
+  preview: true, // or object
+  blocks: true,
+  undoRedo: true, // or { enabled: true, autoSelect: true, autoFocus: true }
+  stockImages: true, // or { enabled: true, safeSearch: true, defaultSearchTerm: 'business' }
+  userUploads: true, // or { enabled: true, search: true }
+  preheaderText: true,
+  headersAndFooters: false,
+  sendTestEmail: false,
+
+  // --- TEXT EDITOR ---
+  textEditor: {
+    spellChecker: true,
+    tables: false,
+    cleanPaste: "confirm", // true | false | "basic" | "confirm"
+    emojis: true,
+    textDirection: true,
+    inlineFontControls: true,
+    customButtons: [],
+  },
+
+  // --- AI ---
+  ai: true, // or object
+
+  // --- IMAGE EDITOR ---
+  imageEditor: true, // or { enabled: true, tools: { resize: true } }
+
+  // --- COLOR PICKER ---
+  colorPicker: {
+    colors: ["#FF0000"], // string[] or ColorGroup[]
+    limit: 50,
+    recentColors: true,
+  },
+
+  // --- COLLABORATION ---
+  collaboration: false,
+
+  // --- LEGACY ---
+  legacy: {
+    disableHoverButtonColors: false,
+  },
+}
+```
+
+Notes:
+
+- Prefer shared config modules in this repo over page-local flag drift.
+- Keep paid or entitlement-backed features documented without committing secrets or tenant-specific settings.

--- a/docs/ai/skills/unlayer-config/references/file-storage.md
+++ b/docs/ai/skills/unlayer-config/references/file-storage.md
@@ -1,0 +1,72 @@
+# Unlayer File Storage Reference
+
+## Custom Image Upload with Progress (XHR)
+
+```javascript
+unlayer.registerCallback("image", function (file, done) {
+  var xhr = new XMLHttpRequest();
+
+  xhr.upload.onprogress = function (e) {
+    done({ progress: Math.round((e.loaded / e.total) * 100) });
+  };
+
+  xhr.onload = function () {
+    var result = JSON.parse(xhr.responseText);
+    done({ progress: 100, url: result.url });
+  };
+
+  xhr.onerror = function () {
+    console.error("Upload failed");
+  };
+
+  var data = new FormData();
+  data.append("file", file.attachments[0]);
+  xhr.open("POST", "/api/uploads");
+  xhr.send(data);
+});
+```
+
+## File Manager Provider
+
+```javascript
+unlayer.registerProvider("userUploads", function (params, done) {
+  var page = params.page || 1;
+  var perPage = params.perPage || 20;
+  var searchText = params.searchText;
+
+  fetch(
+    `/api/images?page=${page}&perPage=${perPage}&search=${searchText || ""}`,
+  )
+    .then((r) => r.json())
+    .then((data) => {
+      var images = data.items.map((img) => ({
+        id: img.id,
+        location: img.url,
+        width: img.width,
+        height: img.height,
+        contentType: img.contentType,
+        source: "user",
+      }));
+      done(images, {
+        hasMore: data.total > page * perPage,
+        page: page,
+        perPage: perPage,
+        total: data.total,
+      });
+    });
+});
+```
+
+## Handle Image Deletion
+
+```javascript
+unlayer.registerCallback("image:removed", function (image, done) {
+  fetch(`/api/images/${image.id}`, { method: "DELETE" }).then(() => done());
+});
+```
+
+## Amazon S3 Setup Notes
+
+- Configure storage in the Unlayer dashboard under **Settings -> Storage**.
+- Keep credentials out of client code and committed docs.
+- If this repo adds upload flows, route secret-backed behavior through server-side boundaries.

--- a/docs/ai/skills/unlayer-config/references/security.md
+++ b/docs/ai/skills/unlayer-config/references/security.md
@@ -1,0 +1,58 @@
+# Unlayer Security Reference
+
+Identity verification prevents impersonation of logged-in users. Generate HMAC signatures **server-side** with the project secret.
+
+## Node.js
+
+```javascript
+const crypto = require("crypto");
+
+const signature = crypto
+  .createHmac("sha256", "YOUR_PROJECT_SECRET")
+  .update(String(userId))
+  .digest("hex");
+```
+
+## Python / Django
+
+```python
+import hmac
+import hashlib
+
+signature = hmac.new(
+    b"YOUR_PROJECT_SECRET",
+    bytes(str(request.user.id), encoding="utf-8"),
+    digestmod=hashlib.sha256
+).hexdigest()
+```
+
+## Client-Side Usage
+
+```javascript
+unlayer.init({
+  user: {
+    id: 1,
+    signature: signatureFromServer,
+    name: "John Doe",
+    email: "john.doe@example.com",
+  },
+});
+```
+
+## End-User Identification
+
+```javascript
+unlayer.init({
+  user: {
+    id: 1,
+    name: "John Doe",
+    email: "john@example.com",
+  },
+});
+```
+
+Rules for this repo:
+
+- Never commit project secrets or cloud API keys.
+- Keep signature generation server-side only.
+- Treat any future HMAC integration like other secret-backed auth/config work in this repo.

--- a/docs/ai/skills/unlayer-config/references/upstream.md
+++ b/docs/ai/skills/unlayer-config/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-config)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-config/` is adapted from Unlayer's official configuration skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-config
+- Upstream skill path: `unlayer-config/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve upstream guidance around feature flags, merge tags, uploads, and security.
+- Keep repo-local guidance focused on shared config modules, env schema, and browser-safe configuration boundaries.

--- a/docs/ai/skills/unlayer-custom-tools/SKILL.md
+++ b/docs/ai/skills/unlayer-custom-tools/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: unlayer-custom-tools
+description: Build or extend custom Unlayer tools in this repo. Use when registering custom drag-and-drop blocks, property editors, custom widgets, or shared tool configuration for Email Studio or PDF Studio.
+---
+
+# Unlayer Custom Tools
+
+Use this skill when the task involves custom Unlayer blocks or editors that should live in shared studio infrastructure rather than being duplicated in a single app page.
+
+## Apply This Skill When
+
+- Registering a custom Unlayer tool
+- Adding or changing a custom property editor
+- Extending shared tool configuration passed into the editor
+- Building reusable drag-and-drop blocks for Email Studio or PDF Studio
+- Debugging custom tool rendering or exporter behavior
+
+## Do Not Use When
+
+- The task is only editor setup, lifecycle, or wrapper integration -> use `docs/ai/skills/unlayer-integration/SKILL.md`
+- The task is only export/save/load behavior -> use `docs/ai/skills/unlayer-export/SKILL.md`
+- The task is only appearance, merge tags, uploads, or security -> use `docs/ai/skills/unlayer-config/SKILL.md`
+
+## Repo Surfaces to Check First
+
+- Shared wrapper and editor options: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email Studio consumer: `apps/admin/app/email/page.tsx`
+- PDF Studio consumer: `apps/admin/app/pdf/page.tsx`
+
+## Core Rules
+
+- Prefer shared, reusable tool registration over page-local one-off blocks.
+- If the tool is meant to work in multiple studio surfaces, wire it through shared infrastructure.
+- Keep tool behavior aligned with the target display mode (`email` vs `document` vs `web`).
+- For email-safe output, respect Unlayer’s table-based exporter guidance for email HTML.
+- Keep any editor customization declarative and discoverable through shared configuration when possible.
+
+## Workflow
+
+1. Decide whether the tool belongs in shared studio infrastructure or only a single consumer.
+2. Inspect `UnlayerEditor.tsx` for the right integration point:
+   - shared `tools` config
+   - custom CSS / JS
+   - display-mode-specific handling
+3. Keep tool registration and configuration centralized when the feature is reusable.
+4. Verify renderers/exporters stay compatible with the intended output mode.
+5. If the task introduces related upload, merge-tag, or feature-flag work, also apply `docs/ai/skills/unlayer-config/SKILL.md`.
+
+## Checklist
+
+- [ ] Custom tool belongs in shared infrastructure when reusable
+- [ ] Tool registration is not duplicated across app pages
+- [ ] Output mode compatibility considered (`email`, `document`, `web`, `popup`)
+- [ ] Email-safe HTML constraints respected when applicable
+- [ ] Related config/export concerns routed to the right Unlayer sub-skill
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/docs/ai/skills/unlayer-custom-tools/references/upstream.md
+++ b/docs/ai/skills/unlayer-custom-tools/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-custom-tools)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-custom-tools/` is adapted from Unlayer's official custom tools skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-custom-tools
+- Upstream skill path: `unlayer-custom-tools/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve the upstream concepts for tool registration, property editors, and exporter behavior.
+- Keep repo-local guidance focused on shared studio infrastructure instead of app-local duplication.

--- a/docs/ai/skills/unlayer-export/SKILL.md
+++ b/docs/ai/skills/unlayer-export/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: unlayer-export
+description: Export and persist Unlayer content in this repo. Use when working on HTML or PDF export, save/load design flows, design JSON persistence, auto-save patterns, or editor export methods in Email Studio or PDF Studio.
+---
+
+# Unlayer Export
+
+Use this skill for save/load/export work across the repo’s Unlayer-based studio features.
+
+## Apply This Skill When
+
+- Changing `exportHtml`, `exportPdf`, or save/load behavior
+- Persisting or restoring Unlayer design JSON
+- Adjusting auto-save or debounced save flows
+- Working on HTML output, PDF export, or export-related UX
+- Debugging design restoration or export return payloads
+
+## Repo Surfaces to Check First
+
+- Shared wrapper export methods: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email Studio docs and examples: `docs/guides/features/email-studio.md`
+- PDF Studio docs and examples: `docs/guides/features/pdf-studio.md`
+- Consumers:
+  - `apps/admin/app/email/page.tsx`
+  - `apps/admin/app/pdf/page.tsx`
+
+## Core Rules
+
+- Always preserve design JSON alongside exported output so designs remain editable.
+- Prefer shared wrapper methods for export logic over duplicating raw Unlayer calls in app pages.
+- Keep save/load behavior consistent across Email Studio and PDF Studio where possible.
+- For cloud export behavior (image/PDF/ZIP), keep secrets and API keys out of client code and docs.
+
+## Workflow
+
+1. Identify whether the task affects:
+   - shared wrapper export methods
+   - page-level export UX
+   - persistence / restore flow
+   - design JSON structure assumptions
+2. Start with `UnlayerEditor.tsx` and existing docs to understand the current shared pattern.
+3. Keep save/load/export responsibilities centralized when the same behavior is used by multiple studio surfaces.
+4. Verify both the exported artifact and the returned design payload shape.
+5. If the change also affects merge tags, uploads, or feature flags, apply `docs/ai/skills/unlayer-config/SKILL.md` too.
+
+## Checklist
+
+- [ ] Design JSON is preserved for editable templates
+- [ ] Shared export methods used or updated before app-local duplication
+- [ ] Email Studio and PDF Studio behavior remains consistent when intended
+- [ ] No client-side secrets introduced for cloud export flows
+- [ ] Export-related docs and references remain accurate
+
+## References
+
+- Design JSON reference: `references/design-json.md`
+- Upstream attribution: `references/upstream.md`

--- a/docs/ai/skills/unlayer-export/references/design-json.md
+++ b/docs/ai/skills/unlayer-export/references/design-json.md
@@ -1,0 +1,128 @@
+# Unlayer Design JSON Reference
+
+## Top-Level Structure
+
+```typescript
+interface JSONTemplate {
+  counters: Record<string, number>;
+  schemaVersion: number;
+  body: {
+    id: string;
+    rows: Row[];
+    headers: Row[];
+    footers: Row[];
+    values: BodyValues;
+  };
+}
+```
+
+## Body Values
+
+```typescript
+interface BodyValues {
+  backgroundColor: string;
+  contentWidth: string;
+  fontFamily: { label: string; value: string };
+  textColor: string;
+  linkStyle: {
+    inherit: boolean;
+    linkColor: string;
+    linkHoverColor: string;
+    linkUnderline: boolean;
+    linkHoverUnderline: boolean;
+  };
+  popupPosition?: string;
+  popupWidth?: string;
+  popupHeight?: string;
+  borderRadius?: string;
+  contentAlign?: string;
+  contentVerticalAlign?: string;
+}
+```
+
+## Row and Column Shape
+
+```typescript
+interface Row {
+  id: string;
+  cells: number[];
+  columns: Column[];
+  values: {
+    displayCondition: object | null;
+    columns: boolean;
+    backgroundColor: string;
+    columnsBackgroundColor: string;
+    backgroundImage: {
+      url: string;
+      fullWidth: boolean;
+      repeat: boolean;
+      center: boolean;
+      cover: boolean;
+    };
+    padding: string;
+    _meta: { htmlID: string; htmlClassNames: string };
+  };
+}
+
+interface Column {
+  id: string;
+  contents: ContentItem[];
+  values: {
+    _meta: { htmlID: string; htmlClassNames: string };
+    border: object;
+    padding: string;
+    backgroundColor: string;
+  };
+}
+```
+
+## Content Items
+
+```typescript
+interface ContentItem {
+  id: string;
+  type: string;
+  values: {
+    containerPadding: string;
+    anchor: string;
+    textAlign: string;
+    lineHeight: string;
+    linkStyle: {
+      inherit: boolean;
+      linkColor: string;
+      linkHoverColor: string;
+      linkUnderline: boolean;
+      linkHoverUnderline: boolean;
+    };
+    hideDesktop: boolean;
+    displayCondition: object | null;
+    _meta: { htmlID: string; htmlClassNames: string };
+    selectable: boolean;
+    draggable: boolean;
+    duplicatable: boolean;
+    deletable: boolean;
+    hideable: boolean;
+  };
+}
+```
+
+Common content types:
+
+- `text`
+- `heading`
+- `button`
+- `image`
+- `divider`
+- `social`
+- `html`
+- `video`
+- `menu`
+- `timer`
+- `table`
+- `carousel`
+- `paragraph`
+
+Repo reminder:
+
+- Save the design JSON alongside exported HTML/PDF flows so templates remain editable.
+- Treat `schemaVersion` and shape compatibility carefully when restoring stored designs.

--- a/docs/ai/skills/unlayer-export/references/upstream.md
+++ b/docs/ai/skills/unlayer-export/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-export)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-export/` is adapted from Unlayer's official export skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-export
+- Upstream skill path: `unlayer-export/SKILL.md`
+
+## Notes for Maintainers
+
+- Preserve upstream guidance around design JSON, save/load patterns, and export methods.
+- Keep repo-local guidance centered on the shared `UnlayerEditor` wrapper and existing Email/PDF Studio workflows.

--- a/docs/ai/skills/unlayer-integration/SKILL.md
+++ b/docs/ai/skills/unlayer-integration/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: unlayer-integration
+description: Integrate or extend Unlayer inside this repo using the shared editor wrapper and existing Email/PDF Studio surfaces. Use when working on react-email-editor setup, editor options, display modes, project configuration, or shared editor plumbing.
+---
+
+# Unlayer Integration
+
+This repo already embeds Unlayer through a shared wrapper:
+
+- `packages/ui/components/studio/UnlayerEditor.tsx`
+
+Primary consumers today:
+
+- `apps/admin/app/email/page.tsx`
+- `apps/admin/app/pdf/page.tsx`
+
+Prefer evolving the shared wrapper and shared config before adding raw `react-email-editor` usage in app pages.
+
+## Apply This Skill When
+
+- Adding Unlayer to a new repo surface
+- Extending `UnlayerEditor` props or editor setup behavior
+- Changing display modes (`email`, `web`, `popup`, `document`)
+- Wiring project ID, locale, merge tags, appearance, or user context into the editor
+- Debugging editor readiness, design loading, or save/export access patterns
+
+## Do Not Use When
+
+- The task is primarily merge tags, uploads, feature flags, or security only -> use `docs/ai/skills/unlayer-config/SKILL.md`
+- The task is primarily export/save/load behavior -> use `docs/ai/skills/unlayer-export/SKILL.md`
+- The task is primarily custom tool registration -> use `docs/ai/skills/unlayer-custom-tools/SKILL.md`
+
+## Repo Surfaces to Check First
+
+- Shared editor wrapper: `packages/ui/components/studio/UnlayerEditor.tsx`
+- Email config: `packages/config/email-studio.ts`
+- PDF config: `packages/config/pdf-studio.ts`
+- Env schema: `packages/env/src/schema.ts`
+- Example env values: `.env.example`
+- Product docs:
+  - `docs/guides/features/email-studio.md`
+  - `docs/guides/features/pdf-studio.md`
+
+## Workflow
+
+1. Start with the shared wrapper and identify whether the change belongs in:
+   - wrapper props / editor options
+   - shared config
+   - consuming page logic
+2. Reuse existing wrapper abstractions before introducing raw `react-email-editor` calls in app code.
+3. Keep environment-driven settings (`NEXT_PUBLIC_UNLAYER_*`) in config/env files, not in page-local constants.
+4. If the change affects both Email Studio and PDF Studio, implement it in shared infrastructure first.
+5. Verify that editor load, ready, design load, and imperative handle methods still follow the existing shared pattern.
+
+## Checklist
+
+- [ ] Shared `UnlayerEditor` considered before app-local integration
+- [ ] Email/PDF Studio consumers remain consistent
+- [ ] Environment-driven config lives in `packages/config/*` and `packages/env/*`
+- [ ] No duplicate wrapper logic introduced in `apps/*`
+- [ ] Follow-up export/config/custom-tool work routed to the right skill if needed
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/docs/ai/skills/unlayer-integration/references/upstream.md
+++ b/docs/ai/skills/unlayer-integration/references/upstream.md
@@ -1,0 +1,19 @@
+---
+source_name: unlayer/unlayer-skills (unlayer-integration)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer-integration/` is adapted from Unlayer's official integration skill:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer-integration
+- Upstream skill path: `unlayer-integration/SKILL.md`
+
+## Notes for Maintainers
+
+- The upstream skill is framework-generic; this repo-local version intentionally steers agents toward the shared `UnlayerEditor` wrapper and existing admin surfaces.
+- Preserve attribution while preferring repo-native file paths, env handling, and shared wrapper patterns.

--- a/docs/ai/skills/unlayer/SKILL.md
+++ b/docs/ai/skills/unlayer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: unlayer
+description: Route Unlayer work in this repo to the right sub-skill. Use when the task involves the Unlayer visual editor, Email Studio, PDF Studio, editor configuration, exports, merge tags, custom tools, or embedded editor integration.
+---
+
+# Unlayer
+
+Use this skill as the router for Unlayer work in Asymmetric.al. The repo already has a shared Unlayer wrapper and two main product surfaces:
+
+- `packages/ui/components/studio/UnlayerEditor.tsx`
+- `apps/admin/app/email/page.tsx`
+- `apps/admin/app/pdf/page.tsx`
+
+Do not default to raw one-off framework examples when the task belongs in the shared studio infrastructure.
+
+## Route to the Right Skill
+
+| If the task is about...                                                   | Use this skill                                 |
+| ------------------------------------------------------------------------- | ---------------------------------------------- |
+| Embedding or extending the shared editor wrapper                          | `docs/ai/skills/unlayer-integration/SKILL.md`  |
+| HTML/PDF export, save/load flows, design JSON persistence                 | `docs/ai/skills/unlayer-export/SKILL.md`       |
+| Appearance, merge tags, security, allowed domains, uploads, feature flags | `docs/ai/skills/unlayer-config/SKILL.md`       |
+| Custom drag-and-drop blocks, property editors, or tool registration       | `docs/ai/skills/unlayer-custom-tools/SKILL.md` |
+
+## Workflow
+
+1. Identify whether the request is primarily **integration**, **export**, **configuration**, or **custom tools**.
+2. Read the matching sub-skill before editing.
+3. Prefer repo-native surfaces (`UnlayerEditor`, Email Studio, PDF Studio, shared config) over page-local duplication.
+4. If multiple concerns are involved, apply the skills in this order:
+   1. `unlayer-integration`
+   2. `unlayer-config`
+   3. `unlayer-export`
+   4. `unlayer-custom-tools`
+5. Verify changes via `bun run skills:sync` when skill files change, then run targeted repo checks.
+
+## Checklist
+
+- [ ] Correct Unlayer sub-skill selected
+- [ ] Shared wrapper and existing admin studio surfaces considered first
+- [ ] No duplicate one-off editor integration introduced
+- [ ] Any new skill guidance remains consistent with repo-specific Unlayer architecture
+
+## Example Routing
+
+- “Add Unlayer to a new admin feature” -> `docs/ai/skills/unlayer-integration/SKILL.md`
+- “Add merge tags for donation receipts” -> `docs/ai/skills/unlayer-config/SKILL.md`
+- “Adjust PDF export/save flow” -> `docs/ai/skills/unlayer-export/SKILL.md`
+- “Create a reusable custom content block” -> `docs/ai/skills/unlayer-custom-tools/SKILL.md`
+
+## References
+
+- Upstream attribution: `references/upstream.md`

--- a/docs/ai/skills/unlayer/references/upstream.md
+++ b/docs/ai/skills/unlayer/references/upstream.md
@@ -1,0 +1,21 @@
+---
+source_name: unlayer/unlayer-skills (unlayer)
+source_url: https://github.com/unlayer/unlayer-skills
+license: MIT
+last_reviewed: 2026-03-06
+---
+
+# Upstream Attribution
+
+This repo-local skill `docs/ai/skills/unlayer/` is adapted from Unlayer's official skills repository:
+
+- Skills repo: https://github.com/unlayer/unlayer-skills
+- Skills page: https://skills.sh/unlayer/unlayer-skills/unlayer
+- Upstream skill path: `unlayer/SKILL.md`
+- Upstream changelog: initial `1.0.0` release on 2026-02-18
+
+## Notes for Maintainers
+
+- Keep routing guidance aligned with the repo’s shared Unlayer wrapper and admin studio surfaces.
+- Preserve upstream attribution while favoring repo-specific file paths and workflows.
+- Do not copy secrets, project IDs, or environment-specific identifiers into skill content.

--- a/docs/ai/working-set.md
+++ b/docs/ai/working-set.md
@@ -1,22 +1,26 @@
 # Working Set
 
-- Date: 2026-02-22
+- Date: 2026-03-06
 - Repo: Asymmetric-al/core
-- Goal: Implement a hybrid Supabase CLI workflow (global-first + pinned fallback) and align setup/scripts/docs with secure contributor defaults.
-- Primary area: `scripts/supabase-cli.mjs`, `package.json`, `scripts/seed-demo.sh`, `scripts/setup/*`, `README.md`, `docs/ops/environments.md`, `docs/ai/rules/backend.md`
+- Goal: Add the upstream Unlayer skill family as repo-local canonical + runtime-ready skills, while preserving the existing Supabase upstream skill without duplication.
+- Primary area: `docs/ai/skills/unlayer*`, `AGENTS.md`, `scripts/sync-agent-skills.mjs`, `README.md`, `.agents/skills/*`, `.cursor/skills/*`
 - Constraints:
-  - No hardcoded secrets.
-  - Keep Supabase auth client boundaries unchanged (`@supabase/ssr` server/client separation).
-  - Preserve migration safety for hosted flows (`SUPABASE_DB_URL`, URL targeting checks).
-  - Keep contributor setup non-blocking while improving reproducibility.
+  - No hardcoded secrets, project IDs, API keys, or environment-specific identifiers.
+  - Keep `docs/ai/skills/*` as the canonical source of truth.
+  - Keep runtime mirrors in `.agents/skills/*` and `.cursor/skills/*`.
+  - Adapt Unlayer guidance to the repo’s shared editor wrapper and existing Email/PDF Studio surfaces.
+  - Do not duplicate `supabase-postgres-best-practices`; verify and preserve the existing integration.
 - Evidence sources used:
-  - `package.json`
-  - `scripts/seed-demo.sh`
-  - `scripts/setup/index.sh`
-  - `scripts/setup.ps1`
-  - `scripts/setup/index.ps1`
+  - `AGENTS.md`
   - `README.md`
-  - `docs/ops/environments.md`
-  - `docs/ai/rules/backend.md`
+  - `scripts/sync-agent-skills.mjs`
+  - `packages/ui/components/studio/UnlayerEditor.tsx`
+  - `apps/admin/app/email/page.tsx`
+  - `apps/admin/app/pdf/page.tsx`
+  - `packages/config/email-studio.ts`
+  - `packages/config/pdf-studio.ts`
+  - `packages/env/src/schema.ts`
+  - `.env.example`
+  - upstream repos: `unlayer/unlayer-skills`, `supabase/agent-skills`
 - Tooling note:
-  - Repo uses Bun-first workflows; Supabase runner should work with/without globally installed `supabase` binary.
+  - Use `bun run skills:sync` after canonical skill changes to refresh runtime mirrors.

--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -19,6 +19,11 @@ const skillsToSync = [
   "nextjs-supabase-auth",
   "moai-library-shadcn",
   "base-ui",
+  "unlayer",
+  "unlayer-integration",
+  "unlayer-custom-tools",
+  "unlayer-export",
+  "unlayer-config",
 ];
 
 async function overlayDirectory(sourceDir, targetDir) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Deploy Checklist (for PRs to `epic` or `develop`)

- [ ] CI passes
- [ ] Migrations reviewed (or N/A)
- [ ] Migrations tested on staging (or N/A)
- [ ] New env vars added to all 3 Vercel projects (or N/A)
- [ ] Rollback plan reviewed
- [ ] Post-deploy smoke tests planned

## feat: Integrate Unlayer AI Agent Skills

This PR integrates the requested Unlayer AI agent skills into the repository, making them always ready for use by AI assistants.

**Why this change:**
- To provide AI agents with specific, context-aware guidance for working with Unlayer within this repository's existing architecture (e.g., `UnlayerEditor.tsx`, Email/PDF Studio).
- To ensure these skills are consistently available in all environments (local, cloud, sandbox) by using a canonical documentation + vendored runtime mirror approach, avoiding network dependencies or submodules.

**What was done:**
- Added 5 new Unlayer skill families (`unlayer`, `unlayer-integration`, `unlayer-custom-tools`, `unlayer-export`, `unlayer-config`) as canonical documentation under `docs/ai/skills/`.
- Established runtime mirrors for these skills in `.agents/skills/` and `.cursor/skills/`.
- Updated `AGENTS.md` to route Unlayer-related prompts to these new skills.
- Modified `scripts/sync-agent-skills.mjs` to automatically sync these new skills.
- Included upstream attribution and relevant reference documentation.
- Verified that existing Supabase skills (`supabase-postgres-best-practices`) were already present and avoided duplication.

**How to test:**
1. Run `bun run skills:sync` to ensure runtime mirrors are up-to-date.
2. Run `bun run format:check` to verify code style.
3. Confirm the new Unlayer skill directories exist in `.agents/skills/` and `.cursor/skills/`.

**Caveats:**
- This PR focuses solely on skill integration and documentation; no application UI or logic changes were made.
- The `supabase/agent-skills` reference was found to already be covered by the existing `supabase-postgres-best-practices` skill, so no new Supabase skills were added to avoid duplication.

---
<p><a href="https://cursor.com/agents/bc-6da99f25-b6d8-4b68-b8af-5e2115e054f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6da99f25-b6d8-4b68-b8af-5e2115e054f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**Primary scope: AI/agent tooling infrastructure (documentation, tooling scripts, no application logic changes).** Secondary areas touched: `AGENTS.md` routing table, `README.md` package overview, and `docs/ai/working-set.md` session state.

This PR introduces 5 Unlayer skill families — `unlayer` (router), `unlayer-integration`, `unlayer-export`, `unlayer-config`, and `unlayer-custom-tools` — as repo-local, context-aware AI agent guidance. The canonical files live in `docs/ai/skills/`, with runtime mirrors in `.agents/skills/` and `.cursor/skills/`. The AGENTS.md dispatch table and 3 concrete example prompts are added so agents can find the right skill for any Unlayer-related task. The sync script gains the 5 new skill names. No application UI or business logic is changed.

Key findings:

- **Runtime mirrors diverge from canonical source** — the `.agents/skills/` and `.cursor/skills/` trees were written by hand rather than generated via `bun run skills:sync`. Two concrete blob-level differences are visible: `unlayer/SKILL.md` has a different Markdown table format, and `unlayer-config/references/file-storage.md` is 70 lines in the mirrors vs 72 in the canonical. This breaks the single-source-of-truth contract the PR describes. The fix is to run `bun run skills:sync` after finalizing canonical files and commit the sync output.
- **`docs/ai/working-set.md` is a per-session scratchpad that clobbers past context on every PR** — worth deciding whether to append, archive, or gitignore this file rather than overwriting it.
- The error-handling gaps in `file-storage.md` (missing `done()` in `xhr.onerror`, missing `.catch()` on the fetch provider) were flagged in a previous review thread and are not repeated here.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for functionality — no application logic is changed — but the committed runtime mirrors are out of sync with the canonical source, violating the PR's own stated architecture.
- Score reflects that the changes are documentation-only and carry zero runtime risk for the application, but the core invariant this PR establishes (canonical `docs/ai/skills/` → sync → mirrors) is broken at merge time. Two skill files in both `.agents/` and `.cursor/` have divergent content from their canonical counterparts, meaning agents reading from mirror paths will receive different guidance than what's in `docs/ai/`. Running `bun run skills:sync` post-merge would auto-correct this, but the inconsistency is baked into the commit history.
- `.agents/skills/unlayer/SKILL.md`, `.cursor/skills/unlayer/SKILL.md`, `.agents/skills/unlayer-config/references/file-storage.md`, and `.cursor/skills/unlayer-config/references/file-storage.md` — all four diverge from their canonical counterparts and should be regenerated via `bun run skills:sync`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/sync-agent-skills.mjs | Adds 5 new Unlayer skill names to the `skillsToSync` array; no logic changes to the sync mechanism itself. |
| AGENTS.md | Adds 5 Unlayer skill routing entries and 3 example prompts to the agent dispatch table; changes are additive and well-organized. |
| docs/ai/skills/unlayer/SKILL.md | Canonical router skill with a properly Prettier-formatted, column-aligned Markdown table; this is the source-of-truth version. |
| .agents/skills/unlayer/SKILL.md | Runtime mirror diverges from the canonical `docs/ai/skills/unlayer/SKILL.md` — the routing table uses compact, unaligned column formatting (git blob `509858c`) vs the canonical's aligned table (blob `b0743c6`), indicating this mirror was not generated via `bun run skills:sync`. |
| docs/ai/skills/unlayer-config/references/file-storage.md | Canonical version (72 lines, blob `b812af4`) has a Prettier-wrapped multi-line `fetch()` call in the File Manager Provider example; differs from the 70-line mirror versions. |
| .agents/skills/unlayer-config/references/file-storage.md | Mirror version (70 lines, blob `db0f2bc`) diverges from the canonical `docs/ai/` source — `fetch()` is on a single line vs the canonical's 3-line Prettier-formatted form, confirming the mirror was not generated via sync. |
| docs/ai/skills/unlayer-config/references/security.md | HMAC guidance is correct — server-side only, placeholder secrets, both Node.js and Python examples look syntactically valid. |
| docs/ai/working-set.md | Session-state artifact updated to track the Unlayer skill integration goal; previous Supabase CLI goal replaced, which loses historical working-set context in the file's git history. |
| docs/ai/skills/unlayer-export/references/design-json.md | Comprehensive TypeScript interface definitions for Unlayer's JSON template shape; identical across all three canonical and mirror locations. |
| docs/ai/skills/unlayer-integration/SKILL.md | Well-structured integration skill with repo-specific surface references; identical across canonical and mirror locations. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AI Agent receives Unlayer task] --> B[unlayer/SKILL.md\nRouter skill]
    B --> C{What is the\nprimary concern?}
    C -->|Embed / extend editor wrapper| D[unlayer-integration\nSKILL.md]
    C -->|HTML/PDF export, save/load,\ndesign JSON| E[unlayer-export\nSKILL.md]
    C -->|Feature flags, merge tags,\nuploads, security| F[unlayer-config\nSKILL.md]
    C -->|Custom drag-and-drop\nblocks / tools| G[unlayer-custom-tools\nSKILL.md]

    D --> H[UnlayerEditor.tsx\nShared wrapper]
    E --> H
    F --> I[packages/config/\nemail-studio.ts\npdf-studio.ts]
    F --> J[packages/env/\nsrc/schema.ts]
    G --> H

    subgraph Canonical
        K[docs/ai/skills/unlayer*/]
    end
    subgraph Mirrors synced via bun run skills:sync
        L[.agents/skills/unlayer*/]
        M[.cursor/skills/unlayer*/]
    end
    K -->|sync| L
    K -->|sync| M
```

<sub>Last reviewed commit: 0533ac7</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->