### PR TITLE
replay(pr-89): apply safe UX and correctness improvements

### DIFF
--- a/apps/admin/app/(auth)/login/loading.tsx
+++ b/apps/admin/app/(auth)/login/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@asym/ui/components/shadcn/skeleton";
+
+export default function LoginLoading() {
+  return (
+    <div
+      className="flex min-h-[50vh] flex-col items-center justify-center gap-6 p-6"
+      aria-busy="true"
+      aria-label="Loading sign-in"
+    >
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-4 w-72 max-w-full" />
+      <Skeleton className="h-64 w-full max-w-md rounded-xl" />
+    </div>
+  );
+}

--- a/apps/admin/app/(auth)/login/page.tsx
+++ b/apps/admin/app/(auth)/login/page.tsx
@@ -3,8 +3,16 @@ import {
   safeNextParam,
 } from "@asym/auth/demo-login";
 import { createClient } from "@asym/database/supabase/server";
+import { serverEnv } from "@asym/env";
 import { LoginScreen } from "@asym/ui/components/auth/LoginScreen";
 import { redirect } from "next/navigation";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign in",
+  description: "Sign in to the admin portal.",
+};
 
 type LoginPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -29,7 +37,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     <LoginScreen
       appId="admin"
       nextPath={nextPath}
-      demoOnly={process.env.DEMO_ONLY_LOGIN === "true"}
+      demoOnly={serverEnv.DEMO_ONLY_LOGIN === true}
       title="Sign In"
       subtitle="Access the admin portal"
       registerHref="/register"

--- a/apps/donor/app/(auth)/login/loading.tsx
+++ b/apps/donor/app/(auth)/login/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@asym/ui/components/shadcn/skeleton";
+
+export default function LoginLoading() {
+  return (
+    <div
+      className="flex min-h-[50vh] flex-col items-center justify-center gap-6 p-6"
+      aria-busy="true"
+      aria-label="Loading sign-in"
+    >
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-4 w-72 max-w-full" />
+      <Skeleton className="h-64 w-full max-w-md rounded-xl" />
+    </div>
+  );
+}

--- a/apps/donor/app/(auth)/login/page.tsx
+++ b/apps/donor/app/(auth)/login/page.tsx
@@ -3,8 +3,16 @@ import {
   safeNextParam,
 } from "@asym/auth/demo-login";
 import { createClient } from "@asym/database/supabase/server";
+import { serverEnv } from "@asym/env";
 import { LoginScreen } from "@asym/ui/components/auth/LoginScreen";
 import { redirect } from "next/navigation";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign in",
+  description: "Sign in to the donor portal.",
+};
 
 type LoginPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -29,7 +37,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     <LoginScreen
       appId="donor"
       nextPath={nextPath}
-      demoOnly={process.env.DEMO_ONLY_LOGIN === "true"}
+      demoOnly={serverEnv.DEMO_ONLY_LOGIN === true}
       title="Sign In"
       subtitle="Access the donor portal"
       registerHref="/register"

--- a/apps/missionary/app/(auth)/login/loading.tsx
+++ b/apps/missionary/app/(auth)/login/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@asym/ui/components/shadcn/skeleton";
+
+export default function LoginLoading() {
+  return (
+    <div
+      className="flex min-h-[50vh] flex-col items-center justify-center gap-6 p-6"
+      aria-busy="true"
+      aria-label="Loading sign-in"
+    >
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-4 w-72 max-w-full" />
+      <Skeleton className="h-64 w-full max-w-md rounded-xl" />
+    </div>
+  );
+}

--- a/apps/missionary/app/(auth)/login/page.tsx
+++ b/apps/missionary/app/(auth)/login/page.tsx
@@ -3,8 +3,16 @@ import {
   safeNextParam,
 } from "@asym/auth/demo-login";
 import { createClient } from "@asym/database/supabase/server";
+import { serverEnv } from "@asym/env";
 import { LoginScreen } from "@asym/ui/components/auth/LoginScreen";
 import { redirect } from "next/navigation";
+
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign in",
+  description: "Sign in to the missionary portal.",
+};
 
 type LoginPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -29,7 +37,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     <LoginScreen
       appId="missionary"
       nextPath={nextPath}
-      demoOnly={process.env.DEMO_ONLY_LOGIN === "true"}
+      demoOnly={serverEnv.DEMO_ONLY_LOGIN === true}
       title="Sign In"
       subtitle="Access the missionary portal"
       registerHref="/register"

--- a/packages/api/src/posts/post.ts
+++ b/packages/api/src/posts/post.ts
@@ -10,6 +10,7 @@ import { ZodError } from "zod";
 
 import { postIdParamSchema } from "../schemas/posts";
 import { CACHE_TAGS } from "../shared/cache-tags";
+import { findProfileByUserId } from "../shared/queries";
 
 function revalidatePostTags(postId: string, tenantId: string) {
   revalidateTag(CACHE_TAGS.tenantPosts(tenantId), "max");
@@ -34,8 +35,6 @@ function toAuthAwareErrorResponse(error: unknown) {
   }
   return NextResponse.json({ error: message }, { status: 500 });
 }
-
-import { findProfileByUserId } from "../shared/queries";
 
 export async function PATCH(
   request: NextRequest,


### PR DESCRIPTION
## Deploy Checklist (for PRs to `epic` or `develop`)

- [ ] CI passes
- [ ] Migrations reviewed (or N/A)
- [ ] Migrations tested on staging (or N/A)
- [ ] New env vars added to all 3 Vercel projects (or N/A)
- [ ] Rollback plan reviewed
- [ ] Post-deploy smoke tests planned

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**Scope:** Frontend — authentication pages across all three portals (`apps/admin`, `apps/donor`, `apps/missionary`). Secondary: API layer (`packages/api/src/posts/post.ts`).

This PR replays the safe UX and correctness improvements from PR #89, applying three categories of change across the monorepo:

- **Loading skeletons (new files):** `loading.tsx` files are added to the `(auth)/login` route segment for all three apps. Next.js App Router automatically renders this file while the login page is loading, giving users a visual placeholder instead of a blank screen. The skeletons include proper ARIA attributes (`aria-busy`, `aria-label`) for accessibility.
- **Page metadata (SEO):** Each login page now exports a `metadata` object with a `title` and `description`. This improves browser tab labels and search engine indexing for the sign-in pages.
- **Type-safe env access:** The `DEMO_ONLY_LOGIN` environment variable check is migrated from the raw `process.env.DEMO_ONLY_LOGIN === "true"` string comparison to `serverEnv.DEMO_ONLY_LOGIN === true`, which reads from the validated, Zod-typed env object in `@asym/env`. This is a correctness improvement — the env package schema transforms the raw string into a proper `boolean` at startup, making the downstream check type-safe and consistent.
- **Import order fix (`post.ts`):** A `findProfileByUserId` import that was incorrectly placed after function declarations (a lint/style violation) is moved to the top of the file where all imports belong.

**Findings:**

- The `=== true` comparison against `serverEnv.DEMO_ONLY_LOGIN` is redundant: because the Zod schema for `DEMO_ONLY_LOGIN` uses `.transform((v) => v === "true")`, the field is always a `boolean`, never `undefined`. You can pass it directly as `demoOnly={serverEnv.DEMO_ONLY_LOGIN}`. This appears in all three login pages.
- The three `loading.tsx` files are byte-for-byte identical. Extracting the skeleton markup into a single shared component in `@asym/ui` would eliminate the duplication and make future design updates a single-file change.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all changes are additive or correctness improvements with no risk to existing functionality.
- All changes are well-scoped: new loading UI files have no side effects, metadata exports are additive, the env access change is strictly safer than the previous raw string comparison, and the import reorder in post.ts is purely cosmetic. The only findings are minor style suggestions (redundant boolean comparison, triplicated loading file), neither of which affects runtime behaviour.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/admin/app/(auth)/login/loading.tsx | New loading skeleton for the admin login page with correct a11y attributes; identical file duplicated across all three apps. |
| apps/donor/app/(auth)/login/loading.tsx | New loading skeleton for the donor login page — verbatim copy of admin loading.tsx. |
| apps/missionary/app/(auth)/login/loading.tsx | New loading skeleton for the missionary login page — verbatim copy of admin loading.tsx. |
| apps/admin/app/(auth)/login/page.tsx | Adds page metadata and migrates DEMO_ONLY_LOGIN from raw process.env string comparison to typed serverEnv boolean; redundant === true comparison flagged. |
| apps/donor/app/(auth)/login/page.tsx | Same changes as admin login page: metadata added, DEMO_ONLY_LOGIN reads from typed serverEnv. |
| apps/missionary/app/(auth)/login/page.tsx | Same changes as admin login page: metadata added, DEMO_ONLY_LOGIN reads from typed serverEnv. |
| packages/api/src/posts/post.ts | Moves a misplaced import statement to the top of the file; no functional change. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant NextJS as Next.js App Router
    participant LoadingTSX as loading.tsx (new)
    participant LoginPage as login/page.tsx
    participant EnvPkg as @asym/env (serverEnv)
    participant SupabaseDB as Supabase

    Browser->>NextJS: GET /login
    NextJS-->>Browser: Stream loading.tsx skeleton (immediately)
    Note over Browser: Skeleton shown with aria-busy=true
    NextJS->>LoginPage: Render async Server Component
    LoginPage->>EnvPkg: Read serverEnv.DEMO_ONLY_LOGIN (boolean)
    LoginPage->>SupabaseDB: createClient() — check session
    SupabaseDB-->>LoginPage: Session result
    alt User already signed in
        LoginPage-->>NextJS: redirect(nextPath)
    else No session
        LoginPage-->>NextJS: Render LoginScreen (demoOnly=bool, metadata)
    end
    NextJS-->>Browser: Replace skeleton with full login UI
```

<sub>Last reviewed commit: ["replay(pr-89): apply..."](https://github.com/asymmetric-al/core/commit/ced1e92c28a1d5111f416df01f26dab5ad38b05b)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->