### PR TITLE
ci: add Nia reindex GitHub Actions workflow

### DIFF
--- a/.github/workflows/nia-reindex.yml
+++ b/.github/workflows/nia-reindex.yml
@@ -1,0 +1,49 @@
+name: Nia reindex
+
+on:
+  push:
+    branches:
+      - epic
+  workflow_dispatch:
+
+jobs:
+  reindex:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find Nia source id
+        env:
+          NIA_API_KEY: ${{ secrets.NIA_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          response="$(curl --fail --silent --show-error --get \
+            'https://apigcp.trynia.ai/v2/sources' \
+            -H "Authorization: Bearer ${NIA_API_KEY}" \
+            --data-urlencode 'type=repository' \
+            --data-urlencode 'query=asymmetric-al/core' \
+            --data-urlencode 'limit=100')"
+
+          source_id="$(printf '%s' "$response" | python3 -c "import sys, json; data=json.load(sys.stdin); items=data.get('items', []); match=next((i for i in items if (i.get('identifier') or '').rstrip('/').lower() in ('https://github.com/asymmetric-al/core','asymmetric-al/core')), None); print((match or items[0])['id'])")"
+
+          if [ -z "$source_id" ]; then
+            echo "Could not find a Nia source for asymmetric-al/core"
+            exit 1
+          fi
+
+          echo "SOURCE_ID=$source_id" >> "$GITHUB_ENV"
+          echo "Using Nia source: $source_id"
+
+      - name: Trigger Nia sync
+        env:
+          NIA_API_KEY: ${{ secrets.NIA_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          curl --fail --silent --show-error \
+            -X POST "https://apigcp.trynia.ai/v2/sources/${SOURCE_ID}/sync" \
+            -H "Authorization: Bearer ${NIA_API_KEY}" \
+            -H 'Content-Type: application/json' \
+            --data '{}'
+
+          echo "Triggered Nia sync for source ${SOURCE_ID}"


### PR DESCRIPTION
Adds `.github/workflows/nia-reindex.yml` to trigger Nia source sync on pushes to `epic` and via workflow_dispatch. Requires `NIA_API_KEY` repo secret.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**Scope:** Infrastructure / CI — this PR adds a single GitHub Actions workflow file. No frontend, backend, database, or auth code is touched.

This PR introduces `.github/workflows/nia-reindex.yml`, a CI workflow that automatically triggers a Nia source sync whenever code is pushed to the `epic` branch (or manually via `workflow_dispatch`). The workflow makes two sequential API calls to Nia: first to look up the registered source ID for `asymmetric-al/core`, then to POST a sync request against that ID. This keeps Nia's code index current with the `epic` branch, which is referenced throughout `AGENTS.md` as the required context tool for repo-scoped searches.

**Key findings:**

- **P1 — Logic bug: silent wrong-source sync.** The Python one-liner at line 27 falls back to `items[0]` when no source whose identifier matches `asymmetric-al/core` is found. Because `items[0]` is non-empty whenever _any_ Nia source exists in the workspace, the downstream `if [ -z "$source_id" ]` guard never fires, and the workflow silently syncs the wrong repository. The fallback should be replaced with a hard `sys.exit(...)` so the job fails loudly.
- **P2 — Missing `concurrency` group.** Rapid consecutive pushes to `epic` can queue multiple overlapping sync jobs. A `concurrency` key with `cancel-in-progress: true` would ensure only the latest push triggers a sync.
- **P2 — No explicit `permissions` block.** The job inherits default repository token permissions even though it never checks out the repo. Adding `permissions: {}` (or `contents: read`) follows least-privilege best practice.

<h3>Confidence Score: 3/5</h3>

- The workflow has one concrete logic bug — the silent `items[0]` fallback — that could cause it to sync the wrong Nia source in production without any visible error; fix that before merging.
- The workflow is small and its intent is clear. The P2 style issues (concurrency, permissions) are non-blocking. However, the P1 fallback bug at line 27 is a real correctness issue: in any environment where the Nia workspace contains more than one source, a mis-matched identifier would silently sync `items[0]` rather than failing loudly. That's a production reliability issue on the primary user path of this workflow (correct sync targeting), which warrants a 3 rather than a 4.
- `.github/workflows/nia-reindex.yml` — specifically line 27 (the Python one-liner with the silent `items[0]` fallback).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/nia-reindex.yml | New GitHub Actions workflow that discovers the Nia source ID for this repo via the Nia API, then triggers a sync — contains a logic bug where a silent `items[0]` fallback can cause the wrong source to be synced without surfacing an error. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub (push to epic)
    participant WF as nia-reindex workflow
    participant NIA as apigcp.trynia.ai

    GH->>WF: Trigger on push / workflow_dispatch
    WF->>NIA: GET /v2/sources?type=repository&query=asymmetric-al/core&limit=100
    NIA-->>WF: { items: [...] }
    WF->>WF: Python: find identifier match → source_id<br/>(falls back to items[0] if no match found ⚠️)
    WF->>WF: Export SOURCE_ID to GITHUB_ENV
    WF->>NIA: POST /v2/sources/{SOURCE_ID}/sync
    NIA-->>WF: 200 OK
    WF->>WF: echo "Triggered Nia sync"
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fnia-reindex.yml%3A27-32%0A**Silent%20fallback%20silences%20the%20%22wrong%20source%22%20guard**%0A%0AThe%20Python%20expression%20%60%28match%20or%20items%5B0%5D%29%5B'id'%5D%60%20will%20silently%20use%20the%20first%20Nia%20source%20in%20the%20list%20whenever%20the%20identifier%20lookup%20fails%20to%20find%20%60asymmetric-al%2Fcore%60.%20The%20%60if%20%5B%20-z%20%22%24source_id%22%20%5D%60%20guard%20immediately%20below%20is%20meant%20to%20catch%20a%20missing%20source%2C%20but%20it%20only%20triggers%20when%20%60source_id%60%20is%20an%20empty%20string%20%E2%80%94%20which%20will%20never%20happen%20as%20long%20as%20_any_%20source%20exists%20in%20the%20Nia%20workspace.%20If%20the%20first%20source%20in%20the%20list%20happens%20to%20be%20a%20different%20repository%2C%20the%20workflow%20will%20silently%20sync%20the%20wrong%20codebase%20with%20no%20error%20or%20warning.%0A%0A**Plain-language%20explanation%3A**%20Imagine%20you%20ask%20for%20%22book%20A%22%20in%20a%20library.%20This%20code%20says%20%22if%20you%20can't%20find%20book%20A%2C%20just%20grab%20whatever%20is%20on%20the%20first%20shelf.%22%20The%20alarm%20that's%20supposed%20to%20trigger%20when%20the%20book%20isn't%20found%20never%20goes%20off%2C%20because%20the%20first%20shelf%20always%20has%20_something_%20on%20it.%0A%0A**Fix%3A**%20Remove%20the%20fallback%20and%20raise%20a%20Python%20error%20explicitly%20if%20no%20match%20is%20found%2C%20so%20the%20%60set%20-e%60%20shell%20option%20propagates%20the%20failure%20cleanly.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20source_id%3D%22%24%28printf%20'%25s'%20%22%24response%22%20%7C%20python3%20-c%20%22import%20sys%2C%20json%3B%20data%3Djson.load%28sys.stdin%29%3B%20items%3Ddata.get%28'items'%2C%20%5B%5D%29%3B%20match%3Dnext%28%28i%20for%20i%20in%20items%20if%20%28i.get%28'identifier'%29%20or%20''%29.rstrip%28'%2F'%29.lower%28%29%20in%20%28'https%3A%2F%2Fgithub.com%2Fasymmetric-al%2Fcore'%2C'asymmetric-al%2Fcore'%29%29%2C%20None%29%3B%20sys.exit%28'Could%20not%20find%20a%20Nia%20source%20for%20asymmetric-al%2Fcore'%29%20if%20not%20match%20else%20print%28match%5B'id'%5D%29%22%29%22%0A%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20-z%20%22%24source_id%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Could%20not%20find%20a%20Nia%20source%20for%20asymmetric-al%2Fcore%22%0A%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20fi%0A%60%60%60%0A%0A**AI%20agent%20fix%20handoff%20prompt%3A**%0A%0A%3E%20File%3A%20%60.github%2Fworkflows%2Fnia-reindex.yml%60%2C%20line%2027.%0A%3E%20Problem%3A%20the%20Python%20one-liner%20uses%20%60%28match%20or%20items%5B0%5D%29%5B'id'%5D%60%20as%20a%20fallback%20when%20no%20matching%20Nia%20source%20is%20found.%20This%20bypasses%20the%20%60if%20%5B%20-z%20%22%24source_id%22%20%5D%60%20guard%20because%20%60items%5B0%5D%60%20is%20non-empty.%20The%20fallback%20must%20be%20removed%3B%20instead%2C%20call%20%60sys.exit%28...%29%60%20when%20%60match%60%20is%20%60None%60%20so%20the%20shell%20%60set%20-e%60%20propagates%20the%20failure.%20The%20%60if%20%5B%20-z%20%22%24source_id%22%20%5D%60%20check%20below%20can%20remain%20as%20a%20belt-and-suspenders%20guard.%0A%3E%20Validation%3A%20run%20the%20workflow%20with%20a%20%60NIA_API_KEY%60%20that%20returns%20an%20empty%20%60items%60%20list%20or%20an%20items%20list%20with%20no%20matching%20identifier%2C%20and%20confirm%20the%20job%20fails%20instead%20of%20proceeding%20with%20a%20wrong%20source%20ID.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fnia-reindex.yml%3A9-11%0A**Add%20%60concurrency%60%20and%20%60permissions%60%20blocks**%0A%0ATwo%20common%20hardening%20additions%20for%20external-API%20workflows%3A%0A%0A1.%20**Concurrency%3A**%20Without%20a%20%60concurrency%60%20group%2C%20rapid%20successive%20pushes%20to%20%60epic%60%20can%20queue%20multiple%20sync%20jobs%20simultaneously%2C%20potentially%20causing%20the%20Nia%20API%20to%20receive%20overlapping%20or%20redundant%20sync%20requests.%20A%20concurrency%20group%20with%20%60cancel-in-progress%3A%20true%60%20ensures%20only%20the%20latest%20push%20triggers%20a%20sync.%0A%0A2.%20**Permissions%3A**%20No%20explicit%20%60permissions%60%20key%20means%20the%20job%20inherits%20the%20repository's%20default%20token%20permissions%20%28which%20may%20include%20%60contents%3A%20write%60%2C%20%60pull-requests%3A%20write%60%2C%20etc.%20depending%20on%20org%20settings%29.%20Since%20this%20job%20only%20calls%20an%20external%20API%20and%20never%20touches%20the%20repo%20checkout%2C%20restricting%20permissions%20to%20the%20minimum%20is%20best%20practice.%0A%0A**Plain-language%20explanation%3A**%20Without%20the%20concurrency%20setting%2C%20five%20quick%20commits%20to%20%60epic%60%20could%20kick%20off%20five%20separate%20%22sync%22%20jobs%20at%20once%2C%20all%20racing%20each%20other.%20Without%20the%20permissions%20setting%2C%20the%20workflow%20runs%20with%20more%20access%20to%20the%20repository%20than%20it%20actually%20needs%2C%20which%20is%20a%20security%20hygiene%20concern.%0A%0A%60%60%60suggestion%0A%20%20%20%20runs-on%3A%20ubuntu-latest%0A%20%20%20%20permissions%3A%20%7B%7D%0A%0A%60%60%60%0A%0AAnd%20add%20at%20the%20top%20of%20the%20%60jobs%60%20section%20%28before%20%60reindex%3A%60%29%3A%0A%0A%60%60%60yaml%0Aconcurrency%3A%0A%20%20group%3A%20nia-reindex-%24%7B%7B%20github.ref%20%7D%7D%0A%20%20cancel-in-progress%3A%20true%0A%60%60%60%0A%0A**AI%20agent%20fix%20handoff%20prompt%3A**%0A%0A%3E%20File%3A%20%60.github%2Fworkflows%2Fnia-reindex.yml%60.%0A%3E%201.%20Add%20a%20top-level%20%60concurrency%60%20key%20%28sibling%20of%20%60jobs%60%29%20with%20%60group%3A%20nia-reindex-%24%7B%7B%20github.ref%20%7D%7D%60%20and%20%60cancel-in-progress%3A%20true%60%20to%20prevent%20overlapping%20sync%20jobs%20on%20rapid%20pushes.%0A%3E%202.%20Add%20%60permissions%3A%20%7B%7D%60%20under%20the%20%60reindex%60%20job%20definition%20%28or%20%60permissions%3A%20contents%3A%20read%60%20at%20minimum%29%20to%20lock%20down%20the%20GITHUB_TOKEN%20scope%20since%20no%20repo%20checkout%20is%20performed.%0A%3E%20Validation%3A%20push%20two%20commits%20to%20%60epic%60%20in%20rapid%20succession%20and%20confirm%20that%20only%20the%20second%20job%20runs%20%28the%20first%20is%20cancelled%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add Nia reindex workflow"](https://github.com/asymmetric-al/core/commit/82dc3112ccb0403431b260d82d9f7832150064fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26265197)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->