### PR TITLE
Add GitHub Actions workflow for Codex review trigger

### DIFF
--- a/.github/workflows/greptile-trigger-codex-review.yml
+++ b/.github/workflows/greptile-trigger-codex-review.yml
@@ -1,0 +1,30 @@
+name: Greptile Trigger Codex Review
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  trigger_codex_review:
+    if: >
+      github.event.check_run.app.name == 'Greptile Apps' &&
+      github.event.check_run.name == 'Greptile Review' &&
+      github.event.check_run.conclusion == 'success' &&
+      github.event.check_run.pull_requests[0].number != null
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Codex review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.check_run.pull_requests[0].number }}
+        run: |
+          gh issue comment "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "@codex review"


### PR DESCRIPTION
## Deploy Checklist (for PRs to `epic` or `develop`)

- [ ] CI passes
- [ ] Migrations reviewed (or N/A)
- [ ] Migrations tested on staging (or N/A)
- [ ] New env vars added to all 3 Vercel projects (or N/A)
- [ ] Rollback plan reviewed
- [ ] Post-deploy smoke tests planned

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single GitHub Actions workflow (`.github/workflows/greptile-trigger-codex-review.yml`) that listens for `check_run` completion events, and — when the Greptile Review check passes — automatically posts an `@codex review` comment on the associated PR to trigger a follow-up Codex review.

The overall design is straightforward, but there are two issues worth addressing before merging:

- **Broken null guard (P1):** `github.event.check_run.pull_requests[0].number != null` is intended to prevent the job from running when there is no PR associated with the check run (e.g. a direct push to `epic`). In GitHub Actions expression syntax, accessing an out-of-bounds array index returns `''` (empty string), not `null`, so `'' != null` evaluates to `true` and the guard is silently bypassed. This causes a failed `gh issue comment \"\"` run whenever Greptile checks a branch-push with no open PR.
- **Over-permissioned token (P2):** `pull-requests: write` is granted but never used — `issues: write` alone is sufficient for `gh issue comment`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the null-guard expression — the current form can produce unnecessary failed runs on push-to-branch events.

One P1 correctness issue: the `pull_requests[0].number != null` guard does not behave as intended due to GitHub Actions empty-string vs null semantics, which can cause spurious failing workflow runs. One P2 least-privilege issue with the token scopes. Neither causes data loss or a security exploit, but the P1 guard issue represents a real behavioral defect on the changed path.

.github/workflows/greptile-trigger-codex-review.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/greptile-trigger-codex-review.yml | New workflow that posts `@codex review` on a PR when a Greptile check run completes successfully; the `pull_requests[0].number != null` guard is broken (empty-string vs null semantics) and `pull-requests: write` is over-permissioned. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Events
    participant WF as greptile-trigger-codex-review
    participant GHCLI as gh CLI
    participant PR as Pull Request

    GH->>WF: check_run completed
    WF->>WF: if: app == 'Greptile Apps' &&<br/>name == 'Greptile Review' &&<br/>conclusion == 'success' &&<br/>pull_requests[0].number != null (⚠️ broken guard)
    alt Conditions met
        WF->>GHCLI: gh issue comment $PR_NUMBER --body "@codex review"
        GHCLI->>PR: Post "@codex review" comment
    else Conditions not met (or guard silently bypassed)
        WF-->>WF: Job skipped (or fails with empty PR_NUMBER)
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fgreptile-trigger-codex-review.yml%3A18%0A**Null%20guard%20doesn't%20protect%20against%20missing%20PR%20association**%0A%0AIn%20GitHub%20Actions%20expression%20syntax%2C%20accessing%20an%20out-of-bounds%20array%20index%20%28e.g.%20%60pull_requests%5B0%5D%60%20when%20%60pull_requests%60%20is%20an%20empty%20array%29%20returns%20%60''%60%20%28empty%20string%29%2C%20not%20%60null%60.%20Because%20%60''%20!%3D%20null%60%20evaluates%20to%20%60true%60%2C%20this%20condition%20**does%20not**%20prevent%20the%20job%20from%20running%20when%20Greptile%20fires%20a%20check%20run%20on%20a%20direct%20push%20to%20a%20branch%20with%20no%20associated%20PR.%0A%0AWhen%20that%20happens%2C%20%60PR_NUMBER%60%20is%20set%20to%20%60''%60%2C%20and%20the%20%60gh%20issue%20comment%20%22%22%60%20command%20fails%20with%20a%20CLI%20error.%20The%20practical%20impact%20is%20a%20noisy%20failed%20workflow%20run%20on%20every%20push-to-branch%20Greptile%20check%20%E2%80%94%20but%20it%20also%20means%20the%20safety%20guard%20you%20intended%20isn't%20actually%20working.%0A%0AA%20reliable%20guard%20is%20to%20check%20for%20a%20non-empty%20string%20instead%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20github.event.check_run.pull_requests%5B0%5D.number%20!%3D%20''%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fgreptile-trigger-codex-review.yml%3A10%0A**%60pull-requests%3A%20write%60%20permission%20is%20unused**%0A%0AThe%20only%20write%20operation%20in%20this%20workflow%20is%20%60gh%20issue%20comment%60%2C%20which%20posts%20to%20the%20issue%2FPR%20comments%20API%20endpoint%20and%20only%20requires%20%60issues%3A%20write%60.%20The%20%60pull-requests%3A%20write%60%20permission%20is%20never%20exercised.%0A%0AGranting%20unnecessary%20token%20scopes%20violates%20least-privilege%20and%2C%20if%20a%20step%20were%20ever%20compromised%2C%20gives%20the%20token%20more%20surface%20area%20than%20needed%20%28e.g.%20approving%20reviews%2C%20dismissing%20review%20requests%29.%0A%0ARemove%20%60pull-requests%3A%20write%60%20%E2%80%94%20%60issues%3A%20write%60%20is%20sufficient%20for%20the%20%60gh%20issue%20comment%60%20call.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add GitHub Actions workflow for Codex re..."](https://github.com/asymmetric-al/core/commit/e0a2ccc6a302437611a86a733e3d2732f768fc9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26679750)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->