### PR TITLE
chore: verify Greptile→Codex — wait mode (do not merge)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,5 @@ By making a contribution to this project, I certify that:
 (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
 (d) I understand and agree that this project and the contribution are public and that a record of the contribution, including all personal information I submit with it, is maintained indefinitely and may be redistributed consistent with this project or the open source license involved.
+
+<!-- workflow-verify-20260329-wait: ephemeral test PR — user will signal cleanup -->


### PR DESCRIPTION
Ephemeral test. Agent stops after `@codex review` is posted; maintainer signals cleanup.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is an ephemeral workflow-verification PR that appends a single HTML comment to `CONTRIBUTING.md` in order to test the Greptile→Codex review pipeline in "wait mode"; the PR description explicitly states it should not be merged.

- **Change scope**: Documentation only — one HTML comment added to the end of `CONTRIBUTING.md` (line 67). No source code, configuration, schema, or test files are touched.
- **No material issues found**: There are no correctness, security, data-integrity, build, or runtime concerns introduced by this change.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge from a code-quality standpoint; the PR itself is marked do not merge by the author as it is an ephemeral test.

The only change is an inert HTML comment appended to a documentation file. There are no P0/P1 findings and no production risk whatsoever.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Appends a single HTML comment at the end of the file — documentation-only, no logic or behavior changed. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: ephemeral CONTRIBUTING stub for G..."](https://github.com/asymmetric-al/core/commit/a2e67526ee3195852483616aedf03ce59cb9d509) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26680574)</sub>

<!-- /greptile_comment -->