### PR TITLE
Update Codex review trigger to use code owner token

### DIFF
--- a/.github/workflows/greptile-trigger-codex-review.yml
+++ b/.github/workflows/greptile-trigger-codex-review.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Trigger Codex review
+      - name: Trigger Codex review as code owner
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CODE_OWNER_GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.check_run.pull_requests[0].number }}
         run: |


### PR DESCRIPTION
## Deploy Checklist (for PRs to `epic` or `develop`)

- [ ] CI passes
- [ ] Migrations reviewed (or N/A)
- [ ] Migrations tested on staging (or N/A)
- [ ] New env vars added to all 3 Vercel projects (or N/A)
- [ ] Rollback plan reviewed
- [ ] Post-deploy smoke tests planned

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a single, targeted change to the Greptile Codex review trigger workflow: replacing the built-in `GITHUB_TOKEN` with a `CODE_OWNER_GITHUB_TOKEN` PAT when posting the `@codex review` comment on PRs.

**Why this matters:** Many bots (including Codex) only respond to `@mentions` originating from real user accounts, not the GitHub Actions bot identity. By posting the trigger comment as a code owner (via a PAT), the `@codex` bot can properly detect and act on the mention.

**Key changes:**
- `GH_TOKEN` now references `secrets.CODE_OWNER_GITHUB_TOKEN` instead of `secrets.GITHUB_TOKEN`
- Step name updated to `Trigger Codex review as code owner` to reflect the intent

**No material issues found.** The secret is referenced correctly via GitHub's secret mechanism, the workflow trigger and filter conditions are unchanged, and the `permissions` block at the workflow level (which scoped `GITHUB_TOKEN`) is still valid but simply no longer the active token for this step.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, intentional one-line token swap with no correctness or security issues.

The change is a single token substitution with a clear, valid motivation (enabling bot mention detection). The secret is referenced correctly, no new permissions are introduced in code, and the rest of the workflow is unchanged.

No files require special attention. Operationally, ensure the CODE_OWNER_GITHUB_TOKEN secret is configured in the repository/org secrets before merging.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/greptile-trigger-codex-review.yml | Swaps the built-in GITHUB_TOKEN for a CODE_OWNER_GITHUB_TOKEN PAT when posting the @codex review trigger comment; step name updated to reflect this intent. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub
    participant GRA as GitHub Actions
    participant CO as Code Owner PAT
    participant CB as Codex Bot

    GH->>GRA: check_run completed (Greptile Review = success)
    GRA->>GRA: Evaluate job condition
    GRA->>CO: Authenticate with CODE_OWNER_GITHUB_TOKEN
    CO->>GH: POST comment "@codex review" on PR
    GH->>CB: Notify: mention from real user
    CB->>GH: Trigger Codex review on PR
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Update Codex review trigger to use code ..."](https://github.com/asymmetric-al/core/commit/a4a4e94a7d5d33c13742a3370a4009274712bbd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26681359)</sub>

<!-- /greptile_comment -->