### PR TITLE
Add workflow for Codex review request to code owner

### DIFF
--- a/.github/workflows/codex-review-notify-code-owner.yml
+++ b/.github/workflows/codex-review-notify-code-owner.yml
@@ -1,0 +1,31 @@
+name: Codex Review Request Code Owner
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  request_code_owner_review:
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == 'chatgpt-codex-connector[bot]' &&
+      contains(github.event.comment.body, 'Codex Review')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Request review from code owner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CODE_OWNER_USERNAME: II-ricky-bobby-II
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+            -f reviewers[]="$CODE_OWNER_USERNAME" || true


### PR DESCRIPTION
## Deploy Checklist (for PRs to `epic` or `develop`)

- [ ] CI passes
- [ ] Migrations reviewed (or N/A)
- [ ] Migrations tested on staging (or N/A)
- [ ] New env vars added to all 3 Vercel projects (or N/A)
- [ ] Rollback plan reviewed
- [ ] Post-deploy smoke tests planned

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow (`.github/workflows/codex-review-notify-code-owner.yml`) that completes the Codex automated-review loop already established by `greptile-trigger-codex-review.yml`. When the `chatgpt-codex-connector[bot]` posts a PR comment containing "Codex Review", this workflow automatically requests a review from the hardcoded code owner (`II-ricky-bobby-II`) via the GitHub API.

**Key observations:**
- The trigger is tightly scoped: it only fires when both the actor (`chatgpt-codex-connector[bot]`) and the comment body (`contains 'Codex Review'`) match, reducing unintended invocations.
- Permissions are appropriately minimal: `contents: read` + `pull-requests: write`.
- `GITHUB_TOKEN` (not a personal access token) is used to request the reviewer, which is sufficient for the `pull-requests: write` scope.
- The `|| true` at the end of the API call silently suppresses any API errors, making it difficult to notice when the reviewer request fails (e.g. if the user is removed from the org or rate-limited). This is the only non-trivial concern.
- No secrets are exposed and no user-controlled input is interpolated into the shell `run:` block, so there is no injection risk.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single new workflow with no security risks and no impact on application code.

The only finding is P2 (silent error suppression via `|| true`). No P0/P1 issues exist. The workflow logic is correct, permissions are minimal and appropriate, and no injection vectors are present.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codex-review-notify-code-owner.yml | New workflow that listens for comments by `chatgpt-codex-connector[bot]` containing "Codex Review" and auto-requests a review from the hardcoded code owner; logic is correct and scoped safely, with one minor silent-failure concern from `|| true`. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Greptile as Greptile Apps (check_run)
    participant GH as GitHub Actions
    participant CodexTrigger as greptile-trigger-codex-review.yml
    participant Codex as chatgpt-codex-connector[bot]
    participant NotifyWF as codex-review-notify-code-owner.yml
    participant API as GitHub API

    Greptile->>GH: check_run completed (Greptile Review, success)
    GH->>CodexTrigger: Trigger workflow
    CodexTrigger->>API: POST issue comment "@codex review" (code owner token)
    API->>Codex: Notifies bot to perform review
    Codex->>API: POST PR comment containing "Codex Review"
    API->>GH: issue_comment created event
    GH->>NotifyWF: Trigger workflow (bot == chatgpt-codex-connector[bot] && body contains "Codex Review")
    NotifyWF->>API: POST /pulls/{PR}/requested_reviewers (reviewers[]=II-ricky-bobby-II)
    API-->>NotifyWF: 201 Created (or error, silently suppressed)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fcodex-review-notify-code-owner.yml%3A31%0A**Silent%20failure%20suppression%20hides%20missed%20review%20requests**%0A%0AThe%20%60%7C%7C%20true%60%20means%20the%20step%20always%20exits%200%2C%20so%20if%20the%20%60gh%20api%60%20call%20fails%20%28e.g.%20%60II-ricky-bobby-II%60%20is%20no%20longer%20a%20collaborator%2C%20rate-limiting%2C%20or%20a%20permission%20error%29%2C%20the%20workflow%20appears%20green%20but%20the%20reviewer%20was%20never%20actually%20added.%20For%20a%20notification%20workflow%20this%20is%20low-risk%2C%20but%20it%20makes%20debugging%20silent%20failures%20very%20hard.%0A%0AConsider%20removing%20%60%7C%7C%20true%60%20and%20letting%20the%20step%20fail%20visibly%20so%20the%20author%20knows%20to%20investigate%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20gh%20api%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20--method%20POST%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20-H%20%22Accept%3A%20application%2Fvnd.github%2Bjson%22%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22%2Frepos%2F%24REPO%2Fpulls%2F%24PR_NUMBER%2Frequested_reviewers%22%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20-f%20reviewers%5B%5D%3D%22%24CODE_OWNER_USERNAME%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Cursor-black?logo=cursor&logoColor=white"><img alt="Fix All in Cursor" src="https://img.shields.io/badge/Fix_All_in_Cursor-white?logo=cursor&logoColor=black"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add workflow for Codex review request to..."](https://github.com/asymmetric-al/core/commit/63a28b742bbb67d83b697b3805a9c55292aeab91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26682653)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->