### PR TITLE
docs(support-hub): phase 1 discovery, file map, and parity map

### DIFF
--- a/docs/features/support-hub/chatwoot-gray-parity-map.md
+++ b/docs/features/support-hub/chatwoot-gray-parity-map.md
@@ -1,0 +1,159 @@
+# Support Hub — Feature Parity Map
+
+> Companion to [`phase-01-discovery.md`](./phase-01-discovery.md) and
+> [`file-map.md`](./file-map.md). This document maps every feature surface
+> from our two donor systems to the surface we will build inside Mission
+> Control. We never paste donor source code; we recreate behavior using our
+> own stack.
+>
+> **Donors:**
+>
+> - **Structure donor:** [`Jason-uxui/gray-ui-csm`](https://github.com/Jason-uxui/gray-ui-csm)
+>   — Next.js + shadcn/ui inbox with board / table layout, sidebar filter
+>   rail, search toolbar, view slices.
+> - **Behavior donor:** [`chatwoot/chatwoot`](https://github.com/chatwoot/chatwoot)
+>   CE — Rails + Vue customer-support platform; we mirror the email
+>   conversation lifecycle, reply / note / assignment / label / macro /
+>   signature semantics, and the seven-report shape.
+>
+> **Stack we use to recreate them:** Next.js 16 App Router (`apps/admin`),
+> React 19, TypeScript, Tailwind v4 (Maia / Zinc tokens), shadcn/ui via
+> `@asym/ui`, TanStack Query 5 + Table 8 + Virtual 3, `nuqs` 2,
+> Tiptap 3 via `@asym/ui/components/shadcn/rich-text-editor`, Supabase
+> (RLS + realtime), Resend through `@asym/email`.
+
+## Legend
+
+- **MVP** — ships in the first inbox build (Phase 2 of the roadmap).
+- **Phase 3** — built after MVP lands.
+- **Phase 4** — reports / settings UI / CRM linkage.
+- **Out** — explicitly out of scope for this build.
+- "Repo target" cells point to the file or symbol the feature will live
+  in. Paths come from [`file-map.md`](./file-map.md).
+
+## 1. Inbox shell and navigation (structure: gray-ui-csm)
+
+| Donor surface (gray-ui-csm)                                                                                       | Donor cue / file                                            | Repo target                                                                                       | Phase | Notes                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Top-level nav with Inbox / Tickets / Customers / Internal Notes / Knowledge Base / Macros / Automation / Settings | `components/app-sidebar.tsx`                                | Existing `MCShell` `toolNav` already lists Support Hub under Tools. We do not add a parallel nav. | MVP   | Settings / Reports remain nested routes (`/support/settings`, `/support/reports`).                                                                                                      |
+| Tickets page composed of stat cards + toolbar + board / table                                                     | `components/tickets/tickets-page.tsx`                       | `apps/admin/features/support-hub/components/SupportInbox.tsx`                                     | MVP   | Wrapped by `<PageShell title="Support Hub">`.                                                                                                                                           |
+| Sidebar filter rail (Views, Categories, Priority) with badge counts                                               | `components/tickets/ticket-sidebar-filters.tsx`             | `apps/admin/features/support-hub/components/sidebar/SupportSidebarFilters.tsx`                    | MVP   | Built on `@asym/ui/components/shadcn/sidebar` primitives without a nested `<SidebarProvider>`. We rename "Categories" to "Labels" to align with Chatwoot vocabulary and our data model. |
+| Stat cards above the inbox (Total / Open / Pending / Resolved with WoW deltas)                                    | `components/tickets/ticket-stats.tsx`                       | `apps/admin/features/support-hub/components/SupportInbox.tsx` (top section)                       | MVP   | Reuses the Maia/Zinc stat-card pattern from `apps/admin/app/contributions/main-body.tsx`.                                                                                               |
+| Search toolbar with status dropdown + board/table toggle                                                          | `components/tickets/ticket-search-toolbar.tsx`              | `apps/admin/features/support-hub/components/toolbar/SupportSearchToolbar.tsx`                     | MVP   | Status dropdown wires to `?status=` search param; layout toggle wires to `?layout=`.                                                                                                    |
+| View slices (`all`, `mine`, `unassigned`, `past-due`, `escalated`)                                                | `lib/tickets/types.ts` (`TicketViewKey`)                    | `apps/admin/features/support-hub/types.ts` (`SupportViewKey`) and `?view=` param                  | MVP   | Computed in the API read layer, not stored.                                                                                                                                             |
+| Board ↔ table layout toggle                                                                                       | `lib/tickets/types.ts` (`TicketLayoutMode`)                 | `?layout=` param + `SupportInbox` switching between `SupportBoardView` and `SupportTableView`     | MVP   | Default `board` (matches donor).                                                                                                                                                        |
+| Drag-and-drop kanban with HTML5 native DnD                                                                        | `components/tickets/ticket-board.tsx`                       | `apps/admin/features/support-hub/components/board/SupportBoardView.tsx`                           | MVP   | Persisted via `useSetSupportConversationStatus` mutation; `board_order` updates batched.                                                                                                |
+| Bulk action bar above the table (status / priority / assignee)                                                    | `components/tickets/tickets-page.tsx` (`tableToolbarProps`) | `apps/admin/features/support-hub/components/toolbar/SupportBulkActions.tsx`                       | MVP   | Hooks into `DataTableResponsive` selection state.                                                                                                                                       |
+
+## 2. Inbox list, board, table (structure + behavior overlap)
+
+| Capability                                                                                | gray-ui-csm cue                       | Chatwoot cue                                    | Repo target                                                                                                   | Phase |
+| ----------------------------------------------------------------------------------------- | ------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----- |
+| Conversation row with subject, status badge, priority indicator, assignee, channel, label | `components/tickets/ticket-table.tsx` | `Conversation` model + `ConversationCard` (Vue) | `apps/admin/features/support-hub/components/list/ConversationListItem.tsx` and `components/table/columns.tsx` | MVP   |
+| Mobile card view of the same row                                                          | gray-ui-csm responsive table          | Chatwoot mobile dashboard                       | `mobileCardConfig` on `<DataTableResponsive />`                                                               | MVP   |
+| Server-side sort / paginate / filter / search                                             | gray-ui-csm sort presets              | Chatwoot conversation filters                   | `useSupportConversations` + `urlState` on `DataTableResponsive` (manual modes)                                | MVP   |
+| Saved views per agent / workspace                                                         | (not in donor)                        | Chatwoot custom folders                         | `support_saved_views` table + `useSupportSavedViews` + `SupportSavedViews.tsx`                                | MVP   |
+| Faceted filters (status, label, assignee, channel)                                        | gray-ui-csm sidebar facets            | Chatwoot inbox filters                          | `DataTableFacetedFilter` + `?status=` / `?label=` / `?assignee=` URL state                                    | MVP   |
+| Realtime new-message badge                                                                | (not in donor)                        | Chatwoot ActionCable                            | `useSupabaseRealtime({ tableName: 'support_messages' })` invalidating `supportHubQueryKeys.conversations`     | MVP   |
+| Virtualized table for large tenants                                                       | gray-ui-csm large list                | Chatwoot infinite scroll                        | `useDataTableVirtualization` baked into `DataTableResponsive`                                                 | MVP   |
+| Bulk reassign / status change / label                                                     | gray-ui-csm bulk action bar           | Chatwoot bulk actions                           | `SupportBulkActions` calling mutation hooks                                                                   | MVP   |
+
+## 3. Conversation detail (behavior: Chatwoot)
+
+| Chatwoot surface                                                                 | Chatwoot cue                                | Repo target                                                                                                                      | Phase   | Notes                                                                                                    |
+| -------------------------------------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| Three-pane dashboard with conversation list, conversation panel, contact sidecar | `chatwoot-101 → Lesson 2: Dashboard Basics` | `SupportInbox.tsx` (3-pane) + `ConversationDetail.tsx` + `ContactSidecar.tsx`                                                    | MVP     | On mobile the detail opens as full-screen `Sheet`.                                                       |
+| Email thread rendering with sender, recipients, date, body, attachments          | Chatwoot email channel                      | `EmailThread.tsx` + `EmailMessageBubble.tsx` reading from `support_messages` joined with `support_message_attachments`           | MVP     | HTML rendered through a sanitizer; falls back to `parsed_text`.                                          |
+| Reply composer with rich text, attachments, signature                            | Chatwoot reply box                          | `ReplyComposer.tsx` wrapping `EditorRoot` + `EditorContent` + `EditorToolbar` from `@asym/ui/components/shadcn/rich-text-editor` | MVP     | Send via `useSendSupportReply` → `sendEmail()` → writes back to `support_messages.outbound_send_log_id`. |
+| Private notes with `@mention`                                                    | Chatwoot private note tab                   | `NoteComposer.tsx` (same Tiptap stack) writing rows with `is_private = true`                                                     | MVP     | `@` mention surface deferred to Phase 3 (uses Tiptap mention extension).                                 |
+| Status menu: open / pending / snoozed / resolved                                 | Chatwoot conversation actions               | `StatusMenu.tsx` → `useSetSupportConversationStatus`                                                                             | MVP     | `closed` is intentionally absent; resolved + 30 days can archive later.                                  |
+| Snooze until time                                                                | Chatwoot snooze                             | `SnoozeMenu.tsx` writing `snoozed_until`                                                                                         | MVP     | Re-open on inbound reply (logic in `inbound-router.ts`).                                                 |
+| Assign agent / team                                                              | Chatwoot assignment dropdowns               | `AssignMenu.tsx` → `useAssignSupportConversation`                                                                                | MVP     | Team assignment column ships in MVP; team management UI ships in Phase 3.                                |
+| Add / remove labels                                                              | Chatwoot labels                             | `LabelMenu.tsx` → `useAddSupportLabel` / `useRemoveSupportLabel`                                                                 | MVP     | Color comes from `support_labels.color`; no hex hardcoding in components.                                |
+| Activity log of state changes                                                    | Chatwoot activity log                       | `ActivityLog.tsx` reading `support_audit_log`                                                                                    | MVP     | Audit rows written by every mutation in `packages/api/src/admin/support-hub/audit.ts`.                   |
+| Send transcript to email                                                         | Chatwoot send transcript                    | (deferred)                                                                                                                       | Phase 3 | Reuses `sendEmail()`.                                                                                    |
+| Mute conversation                                                                | Chatwoot mute                               | (deferred)                                                                                                                       | Phase 3 | Stored as `support_conversation_mutes(user_id, conversation_id)`.                                        |
+| Macros (sequence of actions)                                                     | Chatwoot macros                             | `useSupportMacros` + macros menu in `ConversationActions.tsx`                                                                    | Phase 3 | Tables shipped in MVP migration; runner shipped in Phase 3.                                              |
+| Canned responses with shortcodes                                                 | Chatwoot canned responses                   | `CannedResponseMenu` slash command in `ReplyComposer`                                                                            | Phase 3 | Tables shipped in MVP migration.                                                                         |
+| Personal signature appended to outbound replies                                  | Chatwoot signatures                         | `support_signatures` table + composer toggle                                                                                     | Phase 3 | Default loaded for the current user.                                                                     |
+| Mentions notify teammate                                                         | Chatwoot mentions view                      | (deferred)                                                                                                                       | Phase 4 | Notifications surface lives outside Support Hub.                                                         |
+| Attachments preview / download                                                   | Chatwoot attachments                        | `EmailMessageBubble` lists `support_message_attachments` with download button via `getReceivedEmail()` URLs                      | MVP     | Attachment retrieval happens server-side and is short-lived signed URL.                                  |
+
+## 4. Filters, folders, saved views
+
+| Capability                                           | Chatwoot equivalent                | gray-ui-csm equivalent     | Repo target                                                                                  | Phase |
+| ---------------------------------------------------- | ---------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------- | ----- |
+| Conversation filters with operators                  | Chatwoot filter builder            | gray-ui-csm sidebar facets | Reuse `@asym/ui/components/shadcn/data-table/filters` (`FilterBuilder`, `useAdvancedFilter`) | MVP   |
+| Save filter as folder / segment                      | Chatwoot folders, contact segments | gray-ui-csm view tabs      | `support_saved_views` + `SavedFilters` UI from existing data-table package                   | MVP   |
+| Workspace-wide vs personal saved views               | Chatwoot folder scopes             | (not in donor)             | `support_saved_views.scope` (`workspace` / `personal`)                                       | MVP   |
+| Quick view tabs in toolbar (Mine / Unassigned / All) | Chatwoot tabs                      | gray-ui-csm view tabs      | `?view=` param + sidebar items in `SupportSidebarFilters`                                    | MVP   |
+
+## 5. Settings (Phase 3 / 4)
+
+| Setting                                              | Chatwoot location            | Repo target                                                                                                 | Phase   |
+| ---------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------- | ------- |
+| Inbox connection (sender, signature, business hours) | Settings → Inboxes           | Reuses existing `apps/admin/app/settings/integrations/resend/page.tsx` + new `/support/settings/inbox/[id]` | Phase 3 |
+| Agents and roles                                     | Settings → Agents            | Existing tenant member management; Support Hub reads agent list from `profiles` filtered by membership      | Phase 3 |
+| Teams                                                | Settings → Teams             | New `support_teams` table + UI under `/support/settings/teams`                                              | Phase 3 |
+| Labels                                               | Settings → Labels            | `/support/settings/labels` CRUD over `support_labels`                                                       | Phase 3 |
+| Macros                                               | Settings → Macros            | `/support/settings/macros` CRUD over `support_macros`                                                       | Phase 3 |
+| Canned responses                                     | Settings → Canned responses  | `/support/settings/canned-responses`                                                                        | Phase 3 |
+| Custom attributes                                    | Settings → Custom attributes | (deferred)                                                                                                  | Phase 4 |
+| Automation rules                                     | Settings → Automation        | (deferred — out of scope for this build)                                                                    | Out     |
+| Business hours                                       | Settings → Business hours    | `/support/settings/business-hours`                                                                          | Phase 3 |
+| SLA policies                                         | Settings → SLAs              | `/support/settings/sla`                                                                                     | Phase 3 |
+| Round-robin assignment                               | Inbox setting                | Toggle on inbox; logic in `assign.ts`                                                                       | Phase 3 |
+
+## 6. Reports (Phase 4)
+
+| Chatwoot report | Repo target                      | Phase   | Notes                                                           |
+| --------------- | -------------------------------- | ------- | --------------------------------------------------------------- |
+| Overview        | `/support/reports/overview`      | Phase 4 | Reads from `support_audit_log` + `support_messages` aggregates. |
+| Conversations   | `/support/reports/conversations` | Phase 4 | Includes first response time / resolution time.                 |
+| Agents          | `/support/reports/agents`        | Phase 4 | Reuses Maia stat cards + `Recharts` (already a repo skill).     |
+| Teams           | `/support/reports/teams`         | Phase 4 | Same chart kit.                                                 |
+| Labels          | `/support/reports/labels`        | Phase 4 | Volume per label.                                               |
+| CSAT            | `/support/reports/csat`          | Phase 4 | Backed by new `support_csat_responses` table.                   |
+| Inbox           | `/support/reports/inbox`         | Phase 4 | Per-inbox volume, channel mix.                                  |
+
+Conversation-centric metrics needed for six of the seven report shapes live
+in the MVP `support_*` sketch; **CSAT** additionally needs
+`support_csat_responses` (Phase 4 — see `phase-01-discovery.md` §3.4 deferred
+tables). All report **UIs** ship Phase 4.
+
+## 7. Channels and integrations
+
+| Channel                                         | Chatwoot support   | Repo decision                                                                                                  | Phase   |
+| ----------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------- | ------- |
+| Email (IMAP / SMTP)                             | Native             | Resend inbound + outbound (already wired). `support_conversations.channel = 'email'` is the only value in MVP. | MVP     |
+| Web live chat                                   | Native             | (out)                                                                                                          | Out     |
+| WhatsApp / Facebook / Instagram / Twitter / SMS | Native             | (out)                                                                                                          | Out     |
+| API-only inbox                                  | Native             | (deferred — Resend covers our case)                                                                            | Out     |
+| Chatwoot mobile SDK                             | Native             | (out)                                                                                                          | Out     |
+| Slack notify on new conversation                | Native integration | (deferred)                                                                                                     | Phase 4 |
+
+## 8. CRM-ready hooks
+
+We do not build CRM linkage in MVP, but the schema is ready for it:
+
+- `support_conversations.contact_id` is a nullable FK to the existing
+  CRM contacts surface (`apps/admin/app/crm`).
+- `support_conversations.external_contact_email` is always populated and
+  is the join key Phase 4 uses to backfill `contact_id` once the CRM
+  matcher exists.
+- `ContactSidecar.tsx` reads from `support_conversations.contact_id` when
+  present; otherwise it shows the raw `from` address with a "Link to CRM"
+  affordance that is wired in Phase 4.
+
+## 9. What we deliberately leave on the floor
+
+- No vendored Chatwoot Rails or Vue source.
+- No new design system. Maia / Zinc tokens via `packages/ui/styles/globals.css`.
+- No replacement for the existing Resend integration.
+- No additional global state library (no Zustand, per
+  `docs/ai/rules/frontend.md`).
+- No new editor — Tiptap via `@asym/ui/components/shadcn/rich-text-editor`
+  is the only rich text surface.
+- No fork of the donor's `data-grid/` (it is a spreadsheet primitive).
+- No mobile-app surface, no chat widget surface, no public help-center
+  surface (existing CMS owns the public help docs).

--- a/docs/features/support-hub/file-map.md
+++ b/docs/features/support-hub/file-map.md
@@ -1,0 +1,258 @@
+# Support Hub — File Map
+
+> Companion to [`phase-01-discovery.md`](./phase-01-discovery.md). This doc
+> lists every file the Support Hub will create or touch, with one-sentence
+> intent for each. Paths are **planned targets** grounded in existing repo
+> precedents (Care Hub, Contributions, Resend integration); exact route
+> granularity and filenames may shift slightly during implementation while
+> keeping package boundaries stable.
+
+## 0. Conventions used here
+
+- New file → `+`
+- Modified existing file → `~`
+- Path uses repo-relative form.
+
+## 1. App layer (`apps/admin`)
+
+### 1.1 Pages and route handlers
+
+```
+~ apps/admin/app/support/page.tsx
+~ apps/admin/app/support/loading.tsx
++ apps/admin/app/api/admin/support/conversations/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/messages/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/replies/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/notes/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/assign/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/status/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/snooze/route.ts
++ apps/admin/app/api/admin/support/conversations/[id]/labels/route.ts
++ apps/admin/app/api/admin/support/labels/route.ts
++ apps/admin/app/api/admin/support/saved-views/route.ts
++ apps/admin/app/api/admin/support/counts/route.ts
+```
+
+Each handler is a thin re-export per
+`docs/guides/architecture/data-access-boundary.md`. Pattern source:
+`apps/admin/app/api/admin/member-care/dashboard/route.ts`.
+
+### 1.2 Feature module (`apps/admin/features/support-hub/`)
+
+Mirrors `apps/admin/features/mission-control/care/` structure.
+
+```
++ apps/admin/features/support-hub/index.ts
++ apps/admin/features/support-hub/types.ts
++ apps/admin/features/support-hub/constants.ts
++ apps/admin/features/support-hub/utils.ts
+
++ apps/admin/features/support-hub/hooks/use-support-inbox-state.ts
++ apps/admin/features/support-hub/hooks/use-support-conversation.ts
++ apps/admin/features/support-hub/hooks/use-support-mutations.ts
+
++ apps/admin/features/support-hub/components/SupportInbox.tsx
++ apps/admin/features/support-hub/components/SupportInboxSkeleton.tsx
++ apps/admin/features/support-hub/components/SupportEmptyState.tsx
+
++ apps/admin/features/support-hub/components/sidebar/SupportSidebarFilters.tsx
++ apps/admin/features/support-hub/components/sidebar/SupportSavedViews.tsx
++ apps/admin/features/support-hub/components/sidebar/SupportLabelList.tsx
+
++ apps/admin/features/support-hub/components/toolbar/SupportSearchToolbar.tsx
++ apps/admin/features/support-hub/components/toolbar/SupportLayoutToggle.tsx
++ apps/admin/features/support-hub/components/toolbar/SupportBulkActions.tsx
+
++ apps/admin/features/support-hub/components/list/SupportListView.tsx
++ apps/admin/features/support-hub/components/list/ConversationListItem.tsx
+
++ apps/admin/features/support-hub/components/board/SupportBoardView.tsx
++ apps/admin/features/support-hub/components/board/BoardColumn.tsx
++ apps/admin/features/support-hub/components/board/BoardCard.tsx
+
++ apps/admin/features/support-hub/components/table/SupportTableView.tsx
++ apps/admin/features/support-hub/components/table/columns.tsx
++ apps/admin/features/support-hub/components/table/cells.tsx
+
++ apps/admin/features/support-hub/components/detail/ConversationDetail.tsx
++ apps/admin/features/support-hub/components/detail/ConversationHeader.tsx
++ apps/admin/features/support-hub/components/detail/EmailThread.tsx
++ apps/admin/features/support-hub/components/detail/EmailMessageBubble.tsx
++ apps/admin/features/support-hub/components/detail/PrivateNoteBubble.tsx
++ apps/admin/features/support-hub/components/detail/ReplyComposer.tsx
++ apps/admin/features/support-hub/components/detail/NoteComposer.tsx
++ apps/admin/features/support-hub/components/detail/ConversationActions.tsx
++ apps/admin/features/support-hub/components/detail/AssignMenu.tsx
++ apps/admin/features/support-hub/components/detail/LabelMenu.tsx
++ apps/admin/features/support-hub/components/detail/StatusMenu.tsx
++ apps/admin/features/support-hub/components/detail/SnoozeMenu.tsx
++ apps/admin/features/support-hub/components/detail/ContactSidecar.tsx
++ apps/admin/features/support-hub/components/detail/ActivityLog.tsx
+```
+
+Notes:
+
+- `ReplyComposer.tsx` and `NoteComposer.tsx` both wrap
+  `EditorRoot` / `EditorContent` / `EditorToolbar` from
+  `@asym/ui/components/shadcn/rich-text-editor`. No alternative editor.
+- `SupportTableView.tsx` is `<DataTableResponsive />` with
+  `urlState`, mobile card config, virtualization, and realtime — same
+  pattern as `apps/admin/app/contributions/main-body.tsx`.
+- `SupportInbox.tsx` wraps the three panes inside a single
+  `SidebarProvider`-aware container so the donor's left sub-rail does not
+  fight `MCShell`'s outer sidebar (we use it as a plain panel rather than
+  a nested `<Sidebar>` to avoid double providers).
+
+## 2. Shared API package (`packages/api`)
+
+```
++ packages/api/src/admin/support-hub/index.ts
++ packages/api/src/admin/support-hub/route-helpers.ts
++ packages/api/src/admin/support-hub/schemas.ts
++ packages/api/src/admin/support-hub/types.ts
+
++ packages/api/src/admin/support-hub/reads/conversations.ts
++ packages/api/src/admin/support-hub/reads/messages.ts
++ packages/api/src/admin/support-hub/reads/labels.ts
++ packages/api/src/admin/support-hub/reads/saved-views.ts
++ packages/api/src/admin/support-hub/reads/counts.ts
+
++ packages/api/src/admin/support-hub/mutations/assign.ts
++ packages/api/src/admin/support-hub/mutations/status.ts
++ packages/api/src/admin/support-hub/mutations/snooze.ts
++ packages/api/src/admin/support-hub/mutations/labels.ts
++ packages/api/src/admin/support-hub/mutations/reply.ts
++ packages/api/src/admin/support-hub/mutations/note.ts
++ packages/api/src/admin/support-hub/mutations/saved-views.ts
+
++ packages/api/src/admin/support-hub/inbound-router.ts
++ packages/api/src/admin/support-hub/audit.ts
+~ packages/api/src/email/webhooks/resend.ts
+```
+
+Patterns:
+
+- `route-helpers.ts` mirrors
+  `packages/api/src/admin/member-care/route-helpers.ts`
+  (`requireSupportHubAccess()`, `parseJson()`, `toApiErrorResponse()`).
+- `mutations/reply.ts` calls `sendEmail()` from `@asym/email` with a
+  deterministic `idempotency_key = support_message:{id}` and writes the
+  resulting `email_send_logs` id back to `support_messages.outbound_send_log_id`.
+- `inbound-router.ts` is invoked from the Resend webhook route inside the
+  `email.received` branch in `packages/api/src/email/webhooks/resend.ts`.
+
+## 3. Database hooks and types (`packages/database`)
+
+```
++ packages/database/hooks/support-hub.ts
+~ packages/database/hooks/index.ts
+~ packages/database/query-keys.ts
+~ packages/database/types/database.ts
+```
+
+- New TanStack Query hooks: `useSupportConversations`,
+  `useSupportConversation`, `useSupportMessages`, `useSupportLabels`,
+  `useSupportSavedViews`, `useSupportConversationCounts`, plus mutation
+  hooks: `useAssignSupportConversation`, `useSetSupportConversationStatus`,
+  `useSnoozeSupportConversation`, `useAddSupportLabel`,
+  `useRemoveSupportLabel`, `useSendSupportReply`, `useAddSupportNote`,
+  `useSaveSupportView`.
+- `query-keys.ts` gets a `supportHubQueryKeys` entry with sub-keys:
+  `conversations`, `conversation(id)`, `messages(id)`, `labels`,
+  `savedViews`, `counts`.
+- `types/database.ts` gets typed shapes for the new `support_*` tables
+  (mirrors how member-care types were added).
+
+## 4. Email package (`packages/email`)
+
+No source-of-truth changes in MVP. We re-export typed helpers:
+
+```
+~ packages/email/types.ts            # (only if a new outbound option is needed; otherwise untouched)
+```
+
+The Support Hub talks to Resend exclusively through existing exports:
+`sendEmail`, `getReceivedEmail`, `listReceivedEmailAttachments`,
+`verifyResendWebhookSignature`.
+
+## 5. Database migrations (`supabase`)
+
+```
++ supabase/migrations/<ts>_support_hub_foundation.sql
++ supabase/migrations/rollback_<ts>_support_hub_foundation.sql
+~ supabase/seed.sql                  # optional: seed default labels per demo tenant
+~ supabase/schema.sql                # regenerated after migration
+```
+
+Migration scope:
+
+- All `support_*` tables in `phase-01-discovery.md` §3.4 (MVP sketch) plus
+  the **Deferred tables** subsection (Phase 3/4), each in the migration that
+  ships its feature.
+- Indexes on `(tenant_id, status, last_message_at desc)`,
+  `(tenant_id, assignee_user_id, status)`,
+  `(tenant_id, lower(external_contact_email))`,
+  `(tenant_id, resend_thread_key)` and a GIN index on
+  `support_messages.references_headers`.
+- RLS policies that gate by
+  `tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')::uuid`,
+  with insert/update/delete restricted to the tenant's authenticated
+  users. Pattern source:
+  `supabase/migrations/20260414180338_member_care_foundation.sql`.
+- Bridging columns on `email_inbound_messages`
+  (`conversation_id`, `message_id_header`, `in_reply_to_header`,
+  `references_headers`).
+- Helper SQL functions:
+  `fn_support_normalize_subject(text) returns text` and
+  `fn_support_thread_key(text) returns text` for stable threading.
+
+## 6. Tests
+
+```
++ tests/unit/packages/api/admin/support-hub/inbound-router.test.ts
++ tests/unit/packages/api/admin/support-hub/reads.test.ts
++ tests/unit/packages/api/admin/support-hub/mutations.test.ts
+~ tests/unit/packages/api/email/webhooks-resend.test.ts
++ tests/e2e/admin-support-hub.smoke.spec.ts
+```
+
+Smoke spec covers: inbox loads, switch view (`mine` ↔ `all`), switch
+layout (`board` ↔ `table`), select conversation, send reply, add note,
+assign, label, change status, snooze, resolve.
+
+## 7. Docs and config
+
+```
++ docs/guides/features/support-hub.md
+~ packages/lib/mission-control/tiles.ts          # if tile copy/quick-actions change
+~ packages/lib/mission-control/nav.ts            # if nav copy changes
+~ packages/config/tiles.ts                       # mirror of above
+~ packages/config/navigation.ts                  # mirror of above
+~ docs/ai/working-set.md                         # add a Support Hub entry per implementation pass
+```
+
+## 8. Files we explicitly do NOT touch in this build
+
+- `apps/admin/app/mc-shell.tsx` (shell stays put).
+- `apps/admin/app/layout.tsx` (provider order stays put).
+- `packages/ui/components/shadcn/page-shell.tsx` (no chrome changes).
+- `packages/ui/components/shadcn/data-table/*` (we consume it; we do not
+  modify it).
+- `packages/ui/components/shadcn/rich-text-editor/*` (we consume it; we
+  do not modify it).
+- `packages/ui/components/shadcn/data-grid/*` (not used by Support Hub).
+- `packages/email/resend.ts` (extension happens in the API layer, not in
+  the client SDK).
+- Any file under `apps/donor` or `apps/missionary`.
+
+## 9. Naming and location rules locked in
+
+- Feature folder: **`apps/admin/features/support-hub/`** (kebab-case to
+  match `mission-control/care`).
+- Symbol prefix: **`Support*`** for components, **`useSupport*`** for
+  hooks, **`support_*`** for tables, **`supportHubQueryKeys`** for the
+  query-key registry.
+- Search-param keys: `view`, `layout`, `status`, `q`, `label`, `assignee`,
+  `id`. Do not invent more without updating
+  `phase-01-discovery.md` §3.1.

--- a/docs/features/support-hub/phase-01-discovery.md
+++ b/docs/features/support-hub/phase-01-discovery.md
@@ -1,0 +1,489 @@
+# Support Hub — Phase 1 Discovery & Build Spec
+
+> Status: spec only. No feature code is shipped in this phase. Later phases
+> consume this document as the source of truth for the architecture.
+>
+> Sister documents:
+>
+> - [`file-map.md`](./file-map.md) — concrete file/folder layout
+> - [`chatwoot-gray-parity-map.md`](./chatwoot-gray-parity-map.md) — feature
+>   parity matrix for the two donor systems
+
+## 1. Goal
+
+Build a donor-care **Support Hub** inside the Mission Control admin app to
+manage every donor question that arrives by email. The result must feel
+fully native to Mission Control:
+
+- **Structure donor:** [`Jason-uxui/gray-ui-csm`](https://github.com/Jason-uxui/gray-ui-csm)
+  — drives the inbox layout, board ↔ table layout switch, sidebar filter rail
+  (Views / Categories / Priority), search toolbar, view slices
+  (`all | mine | unassigned | past-due | escalated`).
+- **Behavior donor:** [`chatwoot/chatwoot`](https://github.com/chatwoot/chatwoot)
+  CE — drives the conversation lifecycle (open / pending / snoozed /
+  resolved), email thread rendering, reply composer, private notes,
+  assignment to agent and team, labels, macros, canned responses,
+  signatures, mute, send-transcript, business hours, SLA.
+- **Visual finish:** the existing repo Maia / Zinc theme via
+  `MCShell` + `PageShell` + `@asym/ui`.
+
+Neither donor's source code ships in our repo. We study them, then we
+implement the same surfaces using our own stack.
+
+## 2. Repo realities discovered
+
+These are the load-bearing facts that the rest of this spec assumes are
+true. Each is grounded in a current file in the repo.
+
+### 2.1 Mission Control shell
+
+- Root layout: `apps/admin/app/layout.tsx` mounts
+  `ThemeProvider (forcedTheme="light") → BoneyardRegistry → QueryProvider →
+MotionProvider → Suspense → NuqsAdapter → MCShell`.
+- Shell: `apps/admin/app/mc-shell.tsx` (`MCShell`,
+  `ApplicationShell`, `AppSidebar`, `AppHeader`,
+  `RouteMainViewTransitionBoundary`).
+- Page chrome: `packages/ui/components/shadcn/page-shell.tsx` (`PageShell`).
+- Nav already lists Support Hub: `mc-shell.tsx` (`toolNav`),
+  `packages/lib/mission-control/nav.ts`, `packages/config/tiles.ts`,
+  `packages/config/navigation.ts`. Roles for `/support` (nav id
+  `support`): `member_care`, `admin` — see `packages/lib/mission-control/nav.ts`.
+  **`requireSupportHubAccess()` (planned)** must authorize the same cohort
+  (plus `super_admin` for platform operators); it must **not** blindly reuse
+  `requireMemberCareAccess()`'s `staff` \| `admin` \| `super_admin` predicate
+  alone, or `member_care` users would see the nav item and get `403` on API
+  routes (see `packages/api/src/admin/member-care/route-helpers.ts`).
+- Forced light theme is intentional and must be preserved.
+
+### 2.2 Existing `/support` page
+
+- `apps/admin/app/support/page.tsx` is a static placeholder built from
+  `PageShell`, `Card`, and motion tiles. It will be **replaced** in a later
+  phase with the real inbox; this phase only documents the replacement.
+
+### 2.3 Shared UI primitives we will reuse
+
+- `@asym/ui/components/shadcn/data-table` exposes
+  `DataTableResponsive`, URL state hooks (`useDataTableUrlState`,
+  `useDataTableStateWithUrl`), virtualization
+  (`useDataTableVirtualization`), faceted filters, advanced filter builder,
+  saved filters, mobile card view, mutation
+  (`useDataTableMutation`, `useDataTableBulkMutation`,
+  `useCollectionMutation`), realtime (`useSupabaseRealtime`,
+  `useDataTableWithRealtime`), CSV export, and cell variants
+  (`BadgeCell`, `AvatarCell`, etc.). This is the canonical table system in
+  the repo and is the right tool for the Support Hub list and table views.
+- `@asym/ui/components/shadcn/data-grid` exists too, but it is a spreadsheet
+  primitive (`DataGridCell`, copy/paste/undo) and not a fit for the inbox.
+- `@asym/ui/components/shadcn/sidebar` (`Sidebar`, `SidebarMenu`,
+  `SidebarMenuBadge`, `SidebarGroup`, etc.) is what the donor's
+  ticket sidebar filters were built on; we reuse it for the inbox sub-rail.
+- `@asym/ui/components/shadcn/rich-text-editor` exposes
+  `EditorRoot` / `EditorContent` / `EditorToolbar` / `RichTextViewer` /
+  `LegacyRichTextEditor`, all backed by Tiptap with
+  `immediatelyRender: false`. This is the **only** rich-text editor we use,
+  for both the reply composer and private notes.
+- Stat cards, badges, sheets, dropdowns, command, kbd, separator, tooltip,
+  empty, sonner toasts, motion, view-transitions are all available under
+  `@asym/ui/components/shadcn/*`. No new primitives are required for MVP.
+
+### 2.4 Email plumbing already in place
+
+The Resend integration is fully wired and the Support Hub will plug into it
+rather than reinvent it. Source of truth lives in:
+
+- Migration: `supabase/migrations/20260223120000_resend_email_foundation.sql`
+- Schema snapshot: `supabase/migrations/20260402100000_resend_validation_snapshot.sql`
+- API: `packages/api/src/email/{connect,test-send,settings-store,crypto}.ts`
+- Webhook router: `packages/api/src/email/webhooks/resend.ts`
+- Client surface: `packages/email/{resend,types,constants,deliverability-warnings}.ts`
+- Routes: `apps/admin/app/api/email/{connect,test-send,webhooks/resend}/*`
+
+Tables we depend on:
+
+- `tenant_email_settings` — connection state, default sender, encrypted
+  API key, webhook URL.
+- `email_send_logs` — outbound sends with idempotency_key, correlation_id,
+  status, `resend_message_id`, error fields.
+- `email_events` — outbound delivery/open/click/bounce/complaint events.
+- `email_suppressions` + `email_suppression_groups`.
+- `email_inbound_messages` — every `email.received` webhook lands here with
+  `from`, `to/cc/bcc`, `subject`, `payload jsonb`, `parsed_text`,
+  `parsed_html`, `attachment_count`, `received_at`, deterministic
+  `resend_email_id`.
+
+Inbound retrieval helpers exist:
+`getReceivedEmail()` and `listReceivedEmailAttachments()` in
+`packages/email/resend.ts`.
+
+### 2.5 Data-access boundary
+
+- `docs/guides/architecture/data-access-boundary.md`: route handlers in
+  `apps/*/app/api/**` are thin re-exports; business logic lives in
+  `packages/api/src/*`. We follow this exactly.
+- `docs/ai/rules/backend.md`: server uses `@asym/database/supabase/server`
+  (or admin); client uses the singleton browser client. RLS assumed active.
+  Mutations validated with Zod.
+- Auth helpers: `getAuthContext()` and `hasAnyContextRole()` from
+  `@asym/auth/context`. The pattern we mirror is
+  `packages/api/src/admin/member-care/route-helpers.ts`
+  (`requireMemberCareAccess()` returning a discriminated union).
+
+### 2.6 Frontend rules
+
+- `docs/ai/rules/frontend.md`: Maia/Zinc tokens only, `cn()` for class
+  merging, no arbitrary Tailwind values, shadcn additions go through
+  `--cwd packages/ui`, complex client forms use TanStack Form + Zod, simple
+  filter/search forms can be native or `next/form`, no Zustand.
+- `apps/admin/next.config.ts` enables `cacheComponents: true` and
+  `reactCompiler.compilationMode = "annotation"`. Keep
+  `apps/admin/app/support/page.tsx` as a Server Component wrapper and mount an
+  interactive `SupportInbox` client surface beneath it. Server reads in
+  `packages/api` must remain request-scoped.
+
+### 2.7 TanStack stack already in repo
+
+- `@tanstack/react-table` 8.21+, `@tanstack/react-query` 5.96+,
+  `@tanstack/react-virtual` 3.13+. `nuqs` 2.8+ is mounted at the root via
+  `NuqsAdapter`. No TanStack DB collections in MVP — the
+  `useDataTableMutation` + `useSupabaseRealtime` combo already covers our
+  needs and is what the Contributions surface uses.
+
+## 3. Locked decisions
+
+### 3.1 Route shape
+
+- **Default route stays `/support`.**
+- Inbox state lives in URL search params via `nuqs` so deep links and
+  saved views work out of the box:
+  - `view` — one of `all | mine | unassigned | past-due | escalated`
+    (gray-ui-csm structural slice). Default `all`.
+  - `layout` — one of `board | table` (gray-ui-csm layout toggle).
+    Default `board`.
+  - `status` — one of `open | pending | snoozed | resolved | all`
+    (Chatwoot behavior status filter). Default `all`.
+  - `q` — free-text search (subject, sender, message body).
+  - `label` — comma-separated label slugs.
+  - `assignee` — agent id, `me`, or `unassigned`.
+  - `id` — selected conversation id; opens the right detail pane (or full
+    `Sheet` on mobile).
+- **Settings and reports** are deferred to nested routes that do not exist
+  yet:
+  - `/support/settings/{labels,macros,canned-responses,signatures,business-hours,sla,assignment}`
+  - `/support/reports/{overview,agents,teams,labels,csat}`
+- Justification: MVP is a single-screen email inbox. Putting settings or
+  reports under tabs inside `/support` would force a bigger shell and
+  collide with the donor's full-bleed inbox layout. Putting them in
+  `/admin/*` would leak Support concerns into the wrong surface. Nested
+  routes match how Care, CRM and Contributions already organize sub-pages.
+
+### 3.2 Status model
+
+Two orthogonal axes, exactly as Chatwoot and gray-ui-csm split them:
+
+| Axis                   | Values                                               | Source                | Stored as                                  |
+| ---------------------- | ---------------------------------------------------- | --------------------- | ------------------------------------------ |
+| **Status** (lifecycle) | `open`, `pending`, `snoozed`, `resolved`             | Chatwoot behavior     | column `status` on `support_conversations` |
+| **View** (slice)       | `all`, `mine`, `unassigned`, `past-due`, `escalated` | gray-ui-csm structure | derived in the query layer; not stored     |
+
+Notes:
+
+- We drop Chatwoot's separate `closed` because it adds no donor-care value
+  past `resolved`; resolved + 30 days can be archived later without a new
+  state.
+- `snoozed` carries `snoozed_until timestamptz`; an Inngest-style cron is
+  out of scope for MVP. **MVP rule:** list/board queries treat a row as
+  "wake-ready" when `now() > snoozed_until` (computed filter / view), without
+  automatically flipping `status` until an agent acts or an inbound message
+  arrives; Phase 3 may add a job to auto-open if product wants clock-only
+  wake.
+- `escalated` and `past_due` are computed from
+  `escalated_at is not null` and SLA timestamps; no separate table.
+
+### 3.3 Final file map
+
+See [`file-map.md`](./file-map.md). Summary:
+
+- `apps/admin/features/support-hub/*` for client feature code (mirrors
+  `apps/admin/features/mission-control/care/*`).
+- `apps/admin/app/support/page.tsx` becomes the inbox shell wrapper.
+- `apps/admin/app/api/admin/support/**` for thin route handlers.
+- `packages/api/src/admin/support-hub/*` for all business logic.
+- `packages/database/hooks/support-hub.ts` for typed query/mutation hooks.
+- `supabase/migrations/<timestamp>_support_hub_foundation.sql` for the
+  schema bring-up.
+
+### 3.4 Final data model (MVP)
+
+Tenant-scoped, RLS-on, `gen_random_uuid()` PKs, `tenant_id` FK to
+`public.tenants(id) on delete cascade`. Audit columns
+(`created_at`, `updated_at`, `created_by`, `updated_by`) on every table.
+
+```sql
+-- High-level shape; full migration ships in Phase 2 build.
+support_conversations (
+  id, tenant_id, subject, status, priority,
+  channel,                            -- 'email' for MVP, enum for future
+  view_flags,                         -- generated columns: is_unassigned, is_past_due, is_escalated
+  assignee_user_id  null,             -- FK profiles
+  team_id           null,             -- FK support_teams (deferred to Phase 2)
+  contact_id        null,             -- FK crm contact (CRM-ready hook)
+  external_contact_email,             -- always populated; dedup key
+  inbox_id,                           -- FK tenant_email_settings or future support_inboxes
+  first_message_at, last_message_at, last_customer_message_at,
+  first_response_at, resolved_at, snoozed_until,
+  escalated_at, past_due_at, sla_policy_id null,
+  message_count int default 0,
+  unread_count  int default 0,
+  board_order int null,               -- kanban ordering within status column; batched updates from board view
+  resend_thread_key text,             -- normalized Message-Id family
+  metadata jsonb default '{}'::jsonb
+)
+support_messages (
+  id, tenant_id, conversation_id,
+  direction,                          -- 'inbound' | 'outbound'
+  message_type,                       -- 'email' | 'note'
+  author_user_id null,                -- null for inbound emails
+  author_email, author_name,
+  to_recipients text[], cc_recipients text[], bcc_recipients text[],
+  subject,
+  body_html, body_text,
+  message_id_header, in_reply_to_header, references_headers text[],
+  inbound_email_id null,              -- FK email_inbound_messages.id
+  outbound_send_log_id null,          -- FK email_send_logs.id
+  resend_message_id null,
+  attachment_count int default 0,
+  is_private boolean default false,   -- true for notes
+  posted_at timestamptz not null
+)
+support_message_attachments (
+  id, tenant_id, message_id,
+  filename, content_type, size_bytes,
+  storage_url null,                   -- if mirrored to Supabase storage
+  resend_attachment_id null
+)
+support_labels (
+  id, tenant_id, name, slug, color, description
+)
+support_conversation_labels (
+  conversation_id, label_id, created_by, primary key (conversation_id, label_id)
+)
+support_assignments (
+  id, tenant_id, conversation_id, assignee_user_id null, team_id null,
+  assigned_by, assigned_at, unassigned_at null,
+  reason text                         -- 'manual', 'round_robin', 'macro', 'inbound'
+)
+support_saved_views (
+  id, tenant_id, owner_user_id null,  -- null = workspace-wide
+  name, slug, scope,                  -- 'personal' | 'workspace'
+  filter jsonb                        -- view+status+label+assignee+q
+)
+support_macros (
+  id, tenant_id, owner_user_id null,
+  name, description,
+  actions jsonb                       -- ordered list: assign, label, status, send-canned, snooze
+)
+support_canned_responses (
+  id, tenant_id, owner_user_id null,
+  short_code, title, body_html, body_text
+)
+support_signatures (
+  id, tenant_id, owner_user_id, name, body_html, is_default
+)
+support_business_hours (              -- Phase 2 (table created in MVP, UI later)
+  id, tenant_id, name, timezone, weekly_schedule jsonb, holidays jsonb
+)
+support_sla_policies (                -- Phase 2 (table created in MVP, UI later)
+  id, tenant_id, name,
+  first_response_minutes int, next_response_minutes int, resolution_minutes int,
+  business_hours_id null
+)
+support_audit_log (
+  id, tenant_id, conversation_id, actor_user_id null,
+  action, payload jsonb, created_at
+)
+```
+
+**Deferred tables (named in parity map; migrations ship with the phase that
+implements the feature):**
+
+- **`support_csat_responses`** — backs CSAT report in Phase 4; expect
+  `tenant_id`, `conversation_id`, `score`, `submitted_at`, audit columns, and
+  RLS mirroring other `support_*` tables. Final columns in the Phase 4
+  migration PR.
+- **`support_conversation_mutes`** — Phase 3 mute; expect `tenant_id`,
+  `user_id`, `conversation_id`, unique `(user_id, conversation_id)`, RLS.
+
+Bridge to existing email tables:
+
+- New columns on `email_inbound_messages`:
+  `conversation_id uuid null` (FK `support_conversations`),
+  `message_id_header text null`, `in_reply_to_header text null`,
+  `references_headers text[] null`. The existing `payload jsonb` already
+  carries the raw headers; we lift them into typed columns for indexable
+  threading.
+- The inbound webhook router (`packages/api/src/email/webhooks/resend.ts`)
+  is extended to call a new `routeInboundToSupportHub()` step that
+  upserts a `support_messages` row and resolves or creates a
+  `support_conversations` row by:
+  1. `In-Reply-To` → existing `support_messages.message_id_header`
+  2. any `References` → existing `support_messages.message_id_header`
+  3. `(tenant_id, external_contact_email, normalized_subject_hash)` open
+     conversation within 14 days
+  4. otherwise create a new conversation.
+- Outbound replies call `@asym/email` `sendEmail()` with deterministic
+  `idempotency_key = support_message:{id}` and a `correlation_id` of
+  `support_conversation:{id}`. The resulting `email_send_logs` row id is
+  written back to `support_messages.outbound_send_log_id` so analytics work
+  end to end.
+
+### 3.5 Reports (metrics-ready in MVP; UI and CSAT in Phase 4)
+
+The MVP schema keeps the fields needed for the seven Chatwoot-style report
+shapes. **Reports UI** and **CSAT collection** ship in **Phase 4** (see §3.6
+and `chatwoot-gray-parity-map.md` §6). Optional materialized aggregates for
+heavy queries may land in a Phase 3 infra PR if needed, but user-facing
+reports are not a Phase 3 deliverable — that avoids contradicting the phase
+table below.
+
+- Overview (volume, status mix, channel mix)
+- Conversations (CSAT, first response, resolution time)
+- Agents
+- Teams
+- Labels
+- CSAT (table reserved: `support_csat_responses`)
+- Inbox
+
+### 3.6 Final phase split
+
+| Phase                         | In                                                                                                                                                                                                                                                                        | Out                                                                                                                                                                           |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MVP (Phase 2 build)**       | Migration, RLS, inbound router, list/board/table views, conversation detail, reply composer (Tiptap), private notes (Tiptap), assignment, labels, status (open/pending/snoozed/resolved), snooze, resolve, saved views, basic search, mobile card view, audit log writes. | Macros, canned responses, signatures, round-robin, SLA timers UI, escalation UI, reports, settings UI, social channels, automations builder, CSAT collection, knowledge base. |
+| **Phase 3**                   | Macros, canned responses, signatures, round-robin assignment, business hours, SLA timer surfacing, escalation actions, mute, send-transcript.                                                                                                                             | Reports UI.                                                                                                                                                                   |
+| **Phase 4**                   | Reports (overview/agents/teams/labels/CSAT/inbox), CSAT collection, inbox settings UI, CRM linkage (auto-link `support_conversations.contact_id` from `crm.contacts`), knowledge-base deflection.                                                                         | Multi-channel chat surfaces.                                                                                                                                                  |
+| **Out of scope (this build)** | Multi-channel chat (web widget, WhatsApp, FB), heavy automations builder, global shell rewrite.                                                                                                                                                                           |
+
+### 3.7 Final grid plan
+
+- Reuse `@asym/ui/components/shadcn/data-table` → `DataTableResponsive`
+  for the **table view** with:
+  - URL state via `urlState` prop (already wired through `nuqs`)
+  - `manualPagination`/`manualSorting`/`manualFiltering` for server reads
+  - `useSupabaseRealtime` to invalidate `["admin","support","conversations"]`
+    on inserts/updates/deletes
+  - `useDataTableVirtualization` for >200 rows
+  - `mobileCardConfig` to render a Chatwoot-style stacked card per row on
+    mobile
+- Build the **board view** as a local component inside
+  `apps/admin/features/support-hub/components/board/` using simple
+  HTML5 drag-and-drop (matches the donor) and TanStack Query mutations to
+  persist `(status, board_order)` updates. We do not pull a kanban library.
+- The `data-grid/` package is **not** used by Support Hub — it is a
+  spreadsheet primitive.
+- ReUI's data-grid is referenced by the prompt only as a Maia/Zinc visual
+  reference. Our `DataTableResponsive` already follows the Maia visual
+  language; no third-party grid is added.
+
+## 4. Conflict list (resolved)
+
+| Conflict           | Resolution                                                                                                                                                                                                                                                                                |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shell ownership    | Keep `MCShell`. Inbox renders inside `<PageShell>`. No alternative shell.                                                                                                                                                                                                                 |
+| Shared tokens      | No new tokens. Map donor's sky/amber/emerald/rose status colors to our existing dot-and-badge pattern (see `apps/admin/app/contributions/main-body.tsx` for the precedent).                                                                                                               |
+| Forced light theme | `MCShell` forces light. Drop all `dark:*` classes from any code we adapt from the donor.                                                                                                                                                                                                  |
+| TipTap reuse       | Use `@asym/ui/components/shadcn/rich-text-editor` for replies and notes. Do **not** repeat the legacy `Textarea` placeholder pattern in `apps/admin/features/mission-control/care/components/RichTextEditor.tsx`.                                                                         |
+| TanStack stack     | TanStack Query 5 + Table 8 + Virtual 3 + `nuqs` 2 + the repo's mutation/realtime hooks. No TanStack DB collections in MVP.                                                                                                                                                                |
+| Data grid fit      | `DataTableResponsive` for the table view; bespoke board for the kanban view; no fork of the donor's `data-grid/`.                                                                                                                                                                         |
+| Route shape        | `/support` plus search params; nested `/support/settings`, `/support/reports` deferred.                                                                                                                                                                                                   |
+| Mobile behavior    | List uses `DataTableResponsive` mobile card mode. Conversation detail opens in a full-screen `Sheet` on mobile and as a third pane on desktop.                                                                                                                                            |
+| Auth               | `requireSupportHubAccess()` follows the same **shape** as `requireMemberCareAccess()` (discriminated union, 401/403), but the **role predicate** must match Support Hub nav: allow `member_care`, `admin`, and `super_admin` (verify against `hasAnyContextRole` at implementation time). |
+| Cache Components   | Keep `/support` as a thin Server Component `page.tsx` wrapper that mounts an interactive client `SupportInbox` surface. `cacheComponents: true` does not change client-only inbox state; server reads in `packages/api/src/admin/support-hub` stay request-scoped.                        |
+| Email backbone     | Use the existing `tenant_email_settings`, `email_send_logs`, `email_events`, `email_inbound_messages`. Add bridging columns; do not duplicate tables.                                                                                                                                     |
+| RLS                | All `support_*` tables RLS-on with `tenant_id = auth.jwt()->'app_metadata'->>'tenant_id'`. Match the pattern in member-care foundation.                                                                                                                                                   |
+
+## 5. Implementation order (later phases follow this exactly)
+
+1. **Migration**
+   - `supabase/migrations/<ts>_support_hub_foundation.sql` creates all
+     `support_*` tables, indexes, RLS, helper functions
+     (`fn_support_normalize_subject`, `fn_support_thread_key`).
+   - Adds bridging columns to `email_inbound_messages`.
+   - Down/rollback file mirrored under
+     `supabase/migrations/rollback_<ts>_support_hub_foundation.sql`.
+2. **Inbound router**
+   - Extend `packages/api/src/email/webhooks/resend.ts` to call
+     `routeInboundToSupportHub()` from
+     `packages/api/src/admin/support-hub/inbound-router.ts`.
+   - Update `tests/unit/packages/api/email/webhooks-resend.test.ts` and add
+     `tests/unit/packages/api/admin/support-hub/inbound-router.test.ts`.
+3. **API layer (`packages/api/src/admin/support-hub/`)**
+   - `route-helpers.ts` — `requireSupportHubAccess()`,
+     `parseJson()`, `toApiErrorResponse()`.
+   - `reads.ts` — `listConversations()`, `getConversation()`,
+     `listMessages()`, `listLabels()`, `listSavedViews()`, view counts.
+   - `mutations.ts` — `assignConversation()`, `setStatus()`,
+     `snoozeConversation()`, `addLabel()`, `removeLabel()`, `sendReply()`,
+     `addPrivateNote()`.
+   - `inbound-router.ts` — message threading + conversation upsert.
+   - `schemas.ts` — Zod schemas for every mutation payload.
+   - `types.ts` — derived TS types.
+4. **Route handlers** — `apps/admin/app/api/admin/support/**` (thin
+   `route.ts` files per resource)
+   - One folder per resource, each `route.ts` calls `requireSupportHubAccess()`
+     then delegates to `@asym/api/admin/support-hub/*`. Thin re-exports only
+     (Data Access Boundary rule).
+5. **Hooks (`packages/database/hooks/support-hub.ts`)**
+   - `useSupportConversations()`, `useSupportConversation()`,
+     `useSupportMessages()`, `useSupportLabels()`, `useSupportSavedViews()`,
+     plus mutation hooks. Re-export from `packages/database/hooks/index.ts`.
+   - Add `supportHubQueryKeys` to `packages/database/query-keys.ts`.
+6. **Feature module (`apps/admin/features/support-hub/`)**
+   - `index.ts`, `types.ts`, `constants.ts`, `utils.ts`.
+   - `components/SupportInbox.tsx` (3-pane shell using `Sidebar` + main +
+     detail).
+   - `components/sidebar/SupportSidebarFilters.tsx` (Views / Status /
+     Labels / Saved views — donor-style sub-rail using `SidebarMenu`).
+   - `components/toolbar/SupportSearchToolbar.tsx` (search + status
+     dropdown + board/table toggle).
+   - `components/list/SupportListView.tsx`,
+     `components/board/SupportBoardView.tsx`,
+     `components/table/SupportTableView.tsx`.
+   - `components/detail/ConversationDetail.tsx` with subcomponents
+     `EmailThread.tsx`, `ReplyComposer.tsx` (Tiptap),
+     `NoteComposer.tsx` (Tiptap), `ConversationActions.tsx`,
+     `AssignMenu.tsx`, `LabelMenu.tsx`, `StatusMenu.tsx`,
+     `SnoozeMenu.tsx`, `ContactSidecar.tsx`.
+   - `hooks/use-support-inbox-state.ts` (nuqs-backed search-param state).
+7. **Page wiring**
+   - `apps/admin/app/support/page.tsx` becomes a thin shell:
+     `<PageShell><SupportInbox /></PageShell>`.
+   - `apps/admin/app/support/loading.tsx` shows the inbox skeleton.
+8. **Tests**
+   - Vitest: inbound router (threading), reads/mutations (auth gates,
+     happy path, RLS smoke).
+   - Playwright admin smoke: inbox loads, view switch, layout switch
+     (`board`↔`table`), select conversation, send reply, add note, change
+     status, snooze, resolve, label add/remove.
+9. **Docs**
+   - `docs/guides/features/support-hub.md` (operational guide, mirrors
+     `care-hub.md` structure).
+   - Update `packages/lib/mission-control/tiles.ts`,
+     `packages/config/tiles.ts`,
+     `packages/config/navigation.ts` if labels/quick actions change.
+
+## 6. Out of scope for this build (explicit)
+
+- Multi-channel chat surfaces beyond email (web widget, WhatsApp, FB).
+- Heavy automations builder if it would block inbox MVP.
+- Settings overhauls outside `/support`.
+- Global shell rewrites (`MCShell`, `PageShell`, `ThemeProvider` order).
+- Replacing the Resend integration. We extend it; we do not rebuild it.
+
+## 7. Definition of done for Phase 1
+
+- This file exists.
+- `file-map.md` exists with concrete paths.
+- `chatwoot-gray-parity-map.md` exists with the parity matrix.
+- No production code is changed in this phase.
+- Future phases can be implemented straight from these three documents
+  without rethinking architecture.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 discovery for the donor-care **Support Hub** inside Mission Control.
This PR is **docs only** — it locks the route shape, status model, file
map, data model, conflict list, and implementation order so later phases
can build the email-first ticketing surface without rethinking the
architecture.

Three new files under `docs/features/support-hub/`:

- `phase-01-discovery.md` — repo realities surveyed, locked decisions,
  data model (`support_*` tables + `email_inbound_messages` bridging
  columns), conflict resolution table, phased implementation order.
- `file-map.md` — every file the build will create or touch, grouped by
  app, shared API, database hooks, email package, migrations, tests, and
  docs. Each placement is grounded in an existing precedent
  (Care Hub, Contributions, Resend integration).
- `chatwoot-gray-parity-map.md` — feature parity matrix from
  `Jason-uxui/gray-ui-csm` (structure donor) and `chatwoot/chatwoot` CE
  (behavior donor) mapped to concrete repo targets and a phase tag for
  each row.

## Locked decisions (full detail in the discovery doc)

- **Route stays `/support`**, with `nuqs` search params `view`, `layout`,
  `status`, `q`, `label`, `assignee`, `id`. Settings/reports go in nested
  routes deferred to later phases.
- **Status axes (orthogonal):** Chatwoot lifecycle
  `open | pending | snoozed | resolved` and gray-ui-csm view slices
  `all | mine | unassigned | past-due | escalated`.
- **Reuse `MCShell` and `PageShell`.** No alternative shell, no global
  rewrite, no override of `forcedTheme="light"`.
- **Reuse `@asym/ui/components/shadcn/data-table`** (`DataTableResponsive`
  with URL state, virtualization, faceted filters, mobile cards,
  realtime, mutation hooks). `data-grid/` is not used by Support Hub.
- **Reuse `@asym/ui/components/shadcn/rich-text-editor` (Tiptap)** for
  both the reply composer and private notes. No second editor.
- **Data Access Boundary respected:** business logic in
  `packages/api/src/admin/support-hub/*`; route handlers in
  `apps/admin/app/api/admin/support/**` are thin re-exports.
- **Email backbone reused:** new `support_*` tables bridge to
  `email_inbound_messages` and `email_send_logs`. Inbound webhook router
  is extended; the Resend integration is not rebuilt.
- **Auth:** new `requireSupportHubAccess()` mirrors
  `requireMemberCareAccess()` and gates on `staff | admin | super_admin`,
  matching the existing `/support` nav role config.

## Phase split

- **MVP:** inbox (list + board + table + detail), reply composer, private
  notes, assign, label, status, snooze, resolve, saved views, ingestion.
- **Phase 3:** macros, canned responses, signatures, round-robin,
  business hours, SLA timers, escalation, mute, send-transcript.
- **Phase 4:** reports (overview / agents / teams / labels / CSAT /
  inbox), inbox settings UI, CRM linkage hooks.
- **Out of scope this build:** social channels, automations builder,
  global shell rewrites.

## Verification

- All file paths and existing modules referenced in the docs were
  verified to exist in the working tree (`apps/admin/app/mc-shell.tsx`,
  `packages/ui/components/shadcn/data-table`,
  `packages/ui/components/shadcn/rich-text-editor`,
  `packages/api/src/email/webhooks/resend.ts`,
  `supabase/migrations/20260223120000_resend_email_foundation.sql`,
  `packages/api/src/admin/member-care/route-helpers.ts`, etc.).
- Prettier formatted.

## Deploy Checklist (for PRs to `epic` or `develop`)

- [x] CI passes _(docs-only change; no compiled output)_
- [x] Migrations reviewed (or N/A) — N/A (docs only)
- [x] Migrations tested on staging (or N/A) — N/A (docs only)
- [x] New env vars added to all 3 Vercel projects (or N/A) — N/A
- [x] Rollback plan reviewed — revert this commit; no runtime impact
- [x] Post-deploy smoke tests planned — N/A (no runtime change)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e91f213-beab-4856-a75f-6863f3631899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e91f213-beab-4856-a75f-6863f3631899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Docs-only Phase 1 discovery for the Support Hub feature inside Mission Control: three new files lock the route shape, data model, file map, and feature-parity matrix so Phase 2–4 implementations can proceed without rethinking architecture.

- `phase-01-discovery.md` captures repo realities, the locked data model (`support_*` tables bridging to `email_inbound_messages`/`email_send_logs`), conflict resolutions (auth, shell, editor, grid, RLS), and the phased implementation order; the auth mismatch and `board_order` gap flagged in earlier review rounds are now resolved in the current version.
- `file-map.md` lists every file the build will create or touch, grounded in existing Care Hub / Contributions / Resend precedents, with clear package-boundary rules.
- `chatwoot-gray-parity-map.md` maps all donor features (gray-ui-csm structure + Chatwoot behavior) to repo targets with phase tags for each row.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a docs-only change with one spec ambiguity that must be resolved before Phase 2 migration work begins

The `inbox_id` column annotation leaves the FK target undecided between `tenant_email_settings` and a future `support_inboxes` table. If Phase 2 commits to one target and Phase 3 needs to change it, the resulting ALTER TABLE on a production table is operationally risky. Everything else — auth roles, board_order, deferred CSAT table, RLS pattern, shell/editor/grid decisions — is now clearly specified and internally consistent.

docs/features/support-hub/phase-01-discovery.md — the `inbox_id` FK ambiguity and the incomplete report route list in §3.1
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/features/support-hub/phase-01-discovery.md | Main spec for the Support Hub; auth role set and board_order are now correctly documented; two remaining issues: report route list in §3.1 is missing `conversations` and `inbox` vs. parity map §6, and `inbox_id` FK target is unresolved |
| docs/features/support-hub/file-map.md | Comprehensive file map covering all planned app, API, DB hook, email, migration, test, and docs paths; package boundaries and thin-handler pattern correctly specified; no issues found |
| docs/features/support-hub/chatwoot-gray-parity-map.md | Feature parity matrix maps all donor surfaces to repo targets with phase tags; §6 defines seven report routes while phase-01-discovery.md §3.1 only enumerates five — cross-doc inconsistency captured in discovery doc comment |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/features/support-hub/phase-01-discovery.md`, line 665-667 ([link](https://github.com/asymmetric-al/core/blob/25511c9d011ea14f661aaf270f50eacbe648f433/docs/features/support-hub/phase-01-discovery.md#L665-L667)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`inbox_id` FK target is ambiguous — needs resolution before Phase 2 migration**

   The annotation `-- FK tenant_email_settings or future support_inboxes` leaves the foreign-key target undecided. If Phase 2 writes `inbox_id uuid references tenant_email_settings(id)` and Phase 3 introduces `support_inboxes`, the Phase 3 migration would need to drop and recreate the constraint on a production table — a non-trivial operation that risks downtime. The spec should commit to one of these two designs before Phase 2 ships:

   1. **Point directly at `tenant_email_settings(id)` for MVP** and document that Phase 3 will add `support_inboxes` as a layer on top.
   2. **Create a thin `support_inboxes` table in the MVP migration** as a stable FK target so the conversations FK never needs to change.

   Either is fine; the ambiguity is the problem.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["docs(support-hub): keep phase 1 discover..."](https://github.com/asymmetric-al/core/commit/25511c9d011ea14f661aaf270f50eacbe648f433) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28858233)</sub>

<!-- /greptile_comment -->