### PR TITLE
Add bendc frontend guidelines as canonical agent skill

### DIFF
--- a/.agents/skills/.repo-canonical-skills.json
+++ b/.agents/skills/.repo-canonical-skills.json
@@ -3,6 +3,7 @@
   "canonicalSkills": [
     "anim",
     "base-ui",
+    "bendc-frontend-guidelines",
     "cache-components",
     "commit",
     "components-build",

--- a/.agents/skills/bendc-frontend-guidelines/SKILL.md
+++ b/.agents/skills/bendc-frontend-guidelines/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bendc-frontend-guidelines
+description: "HTML, CSS, and JavaScript craft guidelines from bendc/frontend-guidelines — semantics, a11y basics, selector discipline, motion-friendly CSS, and readable JS. Use for markup review, static HTML/CSS, email HTML, or general front-end hygiene; pair with repo frontend rules and TypeScript lint policy."
+metadata:
+  owner: core
+  last_updated: 2026-05-15
+  status: active
+  version: "1.0.0"
+---
+
+# bendc Frontend Guidelines (repo skill)
+
+## Triggers
+
+Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from Benjamin De Cock’s widely referenced checklist ([`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)), including:
+
+- Semantic HTML, document structure, `lang`, charset, and meaningful elements (`main`, `article`, `time`, etc.)
+- Accessibility basics called out upstream: `alt` text, real links and buttons, not relying on color alone, labelling controls
+- CSS structure: selector weight, avoiding unnecessary `!important`, inheritance, shorthand, flow and layout (flex/grid over absolute positioning when appropriate)
+- CSS performance habits: prefer `opacity` / `transform` for animation; avoid animating layout-heavy properties (aligns with repo motion rules)
+- Vanilla or legacy JS style: readability, native APIs, avoiding foot-guns called out in the upstream doc
+
+**Also load** `docs/ai/rules/frontend.md` for any **`apps/*` or `packages/ui`** work in this monorepo.
+
+## Do not use when
+
+- The task is strictly backend, migrations, or database-only work.
+- You only need **React / Next.js / App Router** patterns — prefer `docs/ai/skills/nextjs-app-router/SKILL.md` and framework docs.
+- You only need **Tailwind, design tokens, or shared `@asym/ui` primitives** — the upstream doc is not Tailwind-specific; follow `docs/ai/rules/frontend.md` first.
+
+## Precedence (this repo wins)
+
+The full text of the upstream guide lives in **`references/readme-original.md`**. When anything below disagrees with that file, **follow this section**.
+
+| Topic | Authoritative in this repo |
+| ----- | -------------------------- |
+| Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components | `docs/ai/rules/frontend.md` |
+| Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md` |
+| TypeScript types, `strict`, equality (`===`), linted patterns | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
+| React component structure, Server Components, hooks | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md` |
+
+Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS — not as a reason to weaken types, tokens, or repo motion policy.
+
+## Workflow
+
+1. Confirm the surface is in scope (markup, styles, or JS where the upstream checklist applies).
+2. Load **`references/readme-original.md`** (or skim the sections you need: HTML, CSS, JavaScript).
+3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, or TS types.
+4. For shared UI or app routes, reconcile recommendations with **`docs/ai/rules/frontend.md`** and nearby components.
+5. Prefer small, evidence-based edits; do not rewrite large areas solely to match upstream brevity examples if repo style differs.
+
+## Checklist
+
+- [ ] Confirmed triggers match (HTML/CSS/JS craft vs pure React/Next/backend).
+- [ ] Read the relevant sections of `references/readme-original.md` or the live upstream README.
+- [ ] Applied **Precedence**: repo frontend rules, motion skills, and TypeScript lint are satisfied.
+- [ ] Did not strip accessibility or semantics for brevity.
+- [ ] If you edited files under `docs/ai/skills/bendc-frontend-guidelines/`, ran `bun run skills:sync` and `bun run skills:verify` before committing.
+
+## See also
+
+- **Repo UI policy:** `docs/ai/rules/frontend.md`
+- **Motion craft:** `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md`
+- **React component patterns:** `docs/ai/skills/react-component-dev/SKILL.md`
+- **Maintainer refresh notes:** `references/upstream.md`

--- a/.agents/skills/bendc-frontend-guidelines/SKILL.md
+++ b/.agents/skills/bendc-frontend-guidelines/SKILL.md
@@ -8,11 +8,11 @@ metadata:
   version: "1.0.0"
 ---
 
-# bendc Frontend Guidelines (repo skill)
+# bendc Frontend Guidelines
 
 ## Triggers
 
-Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from Benjamin De Cock’s widely referenced checklist ([`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)), including:
+Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from the vendored [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) checklist, including:
 
 - Semantic HTML, document structure, `lang`, charset, and meaningful elements (`main`, `article`, `time`, etc.)
 - Accessibility basics called out upstream: `alt` text, real links and buttons, not relying on color alone, labelling controls
@@ -30,22 +30,23 @@ Use this skill when the task benefits from **foundational HTML, CSS, and vanilla
 
 ## Precedence (this repo wins)
 
-The full text of the upstream guide lives in **`references/readme-original.md`**. When anything below disagrees with that file, **follow this section**.
+The full text of the upstream guide lives in **`references/readme-original.md`**. When that reference conflicts with the **Precedence** table below, **follow the table**.
 
-| Topic | Authoritative in this repo |
-| ----- | -------------------------- |
-| Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components | `docs/ai/rules/frontend.md` |
-| Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md` |
-| TypeScript types, `strict`, equality (`===`), linted patterns | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
-| React component structure, Server Components, hooks | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md` |
+| Topic                                                                               | Authoritative in this repo                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components                  | `docs/ai/rules/frontend.md`                                                                                                                 |
+| Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md`                              |
+| General JavaScript / TypeScript code shape, control flow, helper extraction         | Root `AGENTS.md` code style — prefer explicit, straightforward code over upstream terseness, loop avoidance, recursion, or shorthand        |
+| TypeScript types, `strict`, equality (`===`), linted patterns                       | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
+| React component structure, Server Components, hooks                                 | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md`                                                                              |
 
-Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS — not as a reason to weaken types, tokens, or repo motion policy.
+Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS. Do not copy upstream JavaScript advice about terseness, avoiding loops, recursion, composition, or shorthand unless it improves clarity under this repo's `AGENTS.md` conventions.
 
 ## Workflow
 
 1. Confirm the surface is in scope (markup, styles, or JS where the upstream checklist applies).
 2. Load **`references/readme-original.md`** (or skim the sections you need: HTML, CSS, JavaScript).
-3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, or TS types.
+3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, JS/TS code shape, or TS types.
 4. For shared UI or app routes, reconcile recommendations with **`docs/ai/rules/frontend.md`** and nearby components.
 5. Prefer small, evidence-based edits; do not rewrite large areas solely to match upstream brevity examples if repo style differs.
 
@@ -53,7 +54,7 @@ Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS disci
 
 - [ ] Confirmed triggers match (HTML/CSS/JS craft vs pure React/Next/backend).
 - [ ] Read the relevant sections of `references/readme-original.md` or the live upstream README.
-- [ ] Applied **Precedence**: repo frontend rules, motion skills, and TypeScript lint are satisfied.
+- [ ] Applied **Precedence**: repo frontend rules, motion skills, `AGENTS.md` code style, and TypeScript lint are satisfied.
 - [ ] Did not strip accessibility or semantics for brevity.
 - [ ] If you edited files under `docs/ai/skills/bendc-frontend-guidelines/`, ran `bun run skills:sync` and `bun run skills:verify` before committing.
 

--- a/.agents/skills/bendc-frontend-guidelines/references/readme-original.md
+++ b/.agents/skills/bendc-frontend-guidelines/references/readme-original.md
@@ -1,0 +1,896 @@
+> **Vendored reference:** [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) — `README.md` on branch `master`, snapshot 2026-05-15.
+>
+> GitHub did not report an SPDX license for the upstream repository at vendoring time; keep this copy for attribution and agent context. When exact upstream wording matters, compare against the live README on GitHub.
+
+# Frontend Guidelines
+
+## HTML
+
+### Semantics
+
+HTML5 provides us with lots of semantic elements aimed to describe precisely the content. Make sure you benefit from its rich vocabulary.
+
+```html
+<!-- bad -->
+<div id=main>
+  <div class=article>
+    <div class=header>
+      <h1>Blog post</h1>
+      <p>Published: <span>21st Feb, 2015</span></p>
+    </div>
+    <p>…</p>
+  </div>
+</div>
+
+<!-- good -->
+<main>
+  <article>
+    <header>
+      <h1>Blog post</h1>
+      <p>Published: <time datetime=2015-02-21>21st Feb, 2015</time></p>
+    </header>
+    <p>…</p>
+  </article>
+</main>
+```
+
+Make sure you understand the semantics of the elements you're using. It's worse to use a semantic
+element in a wrong way than staying neutral.
+
+```html
+<!-- bad -->
+<h1>
+  <figure>
+    <img alt=Company src=logo.png>
+  </figure>
+</h1>
+
+<!-- good -->
+<h1>
+  <img alt=Company src=logo.png>
+</h1>
+```
+
+### Brevity
+
+Keep your code terse. Forget about your old XHTML habits.
+
+```html
+<!-- bad -->
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta http-equiv=Content-Type content="text/html; charset=utf-8" />
+    <title>Contact</title>
+    <link rel=stylesheet href=style.css type=text/css />
+  </head>
+  <body>
+    <h1>Contact me</h1>
+    <label>
+      Email address:
+      <input type=email placeholder=you@email.com required=required />
+    </label>
+    <script src=main.js type=text/javascript></script>
+  </body>
+</html>
+
+<!-- good -->
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>Contact</title>
+  <link rel=stylesheet href=style.css>
+
+  <h1>Contact me</h1>
+  <label>
+    Email address:
+    <input type=email placeholder=you@email.com required>
+  </label>
+  <script src=main.js></script>
+</html>
+```
+
+### Accessibility
+
+Accessibility shouldn't be an afterthought. You don't have to be a WCAG expert to improve your
+website, you can start immediately by fixing the little things that make a huge difference, such as:
+
+* learning to use the `alt` attribute properly
+* making sure your links and buttons are marked as such (no `<div class=button>` atrocities)
+* not relying exclusively on colors to communicate information
+* explicitly labelling form controls
+
+```html
+<!-- bad -->
+<h1><img alt=Logo src=logo.png></h1>
+
+<!-- good -->
+<h1><img alt=Company src=logo.png></h1>
+```
+
+### Language & character encoding
+
+While defining the language is optional, it's recommended to always declare
+it on the root element.
+
+The HTML standard requires that pages use the UTF-8 character encoding.
+It has to be declared, and although it can be declared in the Content-Type HTTP header,
+it is recommended to always declare it at the document level.
+
+```html
+<!-- bad -->
+<!doctype html>
+<title>Hello, world.</title>
+
+<!-- good -->
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>Hello, world.</title>
+</html>
+```
+
+### Performance
+
+Unless there's a valid reason for loading your scripts before your content, don't block the
+rendering of your page. If your style sheet is heavy, isolate the styles that are absolutely
+required initially and defer the loading of the secondary declarations in a separate style sheet.
+Two HTTP requests is significantly slower than one, but the perception of speed is the most
+important factor.
+
+```html
+<!-- bad -->
+<!doctype html>
+<meta charset=utf-8>
+<script src=analytics.js></script>
+<title>Hello, world.</title>
+<p>...</p>
+
+<!-- good -->
+<!doctype html>
+<meta charset=utf-8>
+<title>Hello, world.</title>
+<p>...</p>
+<script src=analytics.js></script>
+```
+
+## CSS
+
+### Semicolons
+
+While the semicolon is technically a separator in CSS, always treat it as a terminator.
+
+```css
+/* bad */
+div {
+  color: red
+}
+
+/* good */
+div {
+  color: red;
+}
+```
+
+### Box model
+
+The box model should ideally be the same for the entire document. A global
+`* { box-sizing: border-box; }` is fine, but don't change the default box model
+on specific elements if you can avoid it.
+
+```css
+/* bad */
+div {
+  width: 100%;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+/* good */
+div {
+  padding: 10px;
+}
+```
+
+### Flow
+
+Don't change the default behavior of an element if you can avoid it. Keep elements in the
+natural document flow as much as you can. For example, removing the white-space below an
+image shouldn't make you change its default display:
+
+```css
+/* bad */
+img {
+  display: block;
+}
+
+/* good */
+img {
+  vertical-align: middle;
+}
+```
+
+Similarly, don't take an element off the flow if you can avoid it.
+
+```css
+/* bad */
+div {
+  width: 100px;
+  position: absolute;
+  right: 0;
+}
+
+/* good */
+div {
+  width: 100px;
+  margin-left: auto;
+}
+```
+
+### Positioning
+
+There are many ways to position elements in CSS. Favor modern layout specifications
+such as Flexbox and Grid, and avoid removing elements from the normal document flow, for example
+with `position: absolute`.
+
+### Selectors
+
+Minimize selectors tightly coupled to the DOM. Consider adding a class to the elements
+you want to match when your selector exceeds 3 structural pseudo-classes, descendant or
+sibling combinators.
+
+```css
+/* bad */
+div:first-of-type :last-child > p ~ *
+
+/* good */
+div:first-of-type .info
+```
+
+Avoid overloading your selectors when you don't need to.
+
+```css
+/* bad */
+img[src$=svg], ul > li:first-child {
+  opacity: 0;
+}
+
+/* good */
+[src$=svg], ul > :first-child {
+  opacity: 0;
+}
+```
+
+### Specificity
+
+Don't make values and selectors hard to override. Minimize the use of `id`'s
+and avoid `!important`.
+
+```css
+/* bad */
+.bar {
+  color: green !important;
+}
+.foo {
+  color: red;
+}
+
+/* good */
+.foo.bar {
+  color: green;
+}
+.foo {
+  color: red;
+}
+```
+
+### Overriding
+
+Overriding styles makes selectors and debugging harder. Avoid it when possible.
+
+```css
+/* bad */
+li {
+  visibility: hidden;
+}
+li:first-child {
+  visibility: visible;
+}
+
+/* good */
+li + li {
+  visibility: hidden;
+}
+```
+
+### Inheritance
+
+Don't duplicate style declarations that can be inherited.
+
+```css
+/* bad */
+div h1, div p {
+  text-shadow: 0 1px 0 #fff;
+}
+
+/* good */
+div {
+  text-shadow: 0 1px 0 #fff;
+}
+```
+
+### Brevity
+
+Keep your code terse. Use shorthand properties and avoid using multiple properties when
+it's not needed.
+
+```css
+/* bad */
+div {
+  transition: all 1s;
+  top: 50%;
+  margin-top: -10px;
+  padding-top: 5px;
+  padding-right: 10px;
+  padding-bottom: 20px;
+  padding-left: 10px;
+}
+
+/* good */
+div {
+  transition: 1s;
+  top: calc(50% - 10px);
+  padding: 5px 10px 20px;
+}
+```
+
+### Language
+
+Prefer English over math.
+
+```css
+/* bad */
+:nth-child(2n + 1) {
+  transform: rotate(360deg);
+}
+
+/* good */
+:nth-child(odd) {
+  transform: rotate(1turn);
+}
+```
+
+### Vendor prefixes
+
+Kill obsolete vendor prefixes aggressively. If you need to use them, insert them before the
+standard property.
+
+```css
+/* bad */
+div {
+  transform: scale(2);
+  -webkit-transform: scale(2);
+  -moz-transform: scale(2);
+  -ms-transform: scale(2);
+  transition: 1s;
+  -webkit-transition: 1s;
+  -moz-transition: 1s;
+  -ms-transition: 1s;
+}
+
+/* good */
+div {
+  -webkit-transform: scale(2);
+  transform: scale(2);
+  transition: 1s;
+}
+```
+
+### Animations
+
+Favor transitions over animations. Avoid animating other properties than
+`opacity` and `transform`.
+
+```css
+/* bad */
+div:hover {
+  animation: move 1s forwards;
+}
+@keyframes move {
+  100% {
+    margin-left: 100px;
+  }
+}
+
+/* good */
+div:hover {
+  transition: 1s;
+  transform: translateX(100px);
+}
+```
+
+### Units
+
+Use unitless values when you can. Favor `rem` if you use relative units. Prefer seconds over
+milliseconds.
+
+```css
+/* bad */
+div {
+  margin: 0px;
+  font-size: .9em;
+  line-height: 22px;
+  transition: 500ms;
+}
+
+/* good */
+div {
+  margin: 0;
+  font-size: .9rem;
+  line-height: 1.5;
+  transition: .5s;
+}
+```
+
+### Colors
+
+If you need transparency, use `rgba`. Otherwise, always use the hexadecimal format.
+
+```css
+/* bad */
+div {
+  color: hsl(103, 54%, 43%);
+}
+
+/* good */
+div {
+  color: #5a3;
+}
+```
+
+### Drawing
+
+Avoid HTTP requests when the resources are easily replicable with CSS.
+
+```css
+/* bad */
+div::before {
+  content: url(white-circle.svg);
+}
+
+/* good */
+div::before {
+  content: "";
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+}
+```
+
+### Hacks
+
+Don't use them.
+
+```css
+/* bad */
+div {
+  // position: relative;
+  transform: translateZ(0);
+}
+
+/* good */
+div {
+  /* position: relative; */
+  will-change: transform;
+}
+```
+
+## JavaScript
+
+### Performance
+
+Favor readability, correctness and expressiveness over performance. JavaScript will basically never
+be your performance bottleneck. Optimize things like image compression, network access and DOM
+reflows instead. If you remember just one guideline from this document, choose this one.
+
+```javascript
+// bad (albeit way faster)
+const arr = [1, 2, 3, 4];
+const len = arr.length;
+var i = -1;
+var result = [];
+while (++i < len) {
+  var n = arr[i];
+  if (n % 2 > 0) continue;
+  result.push(n * n);
+}
+
+// good
+const arr = [1, 2, 3, 4];
+const isEven = n => n % 2 == 0;
+const square = n => n * n;
+
+const result = arr.filter(isEven).map(square);
+```
+
+### Statelessness
+
+Try to keep your functions pure. All functions should ideally produce no side-effects, use no outside data and return new objects instead of mutating existing ones.
+
+```javascript
+// bad
+const merge = (target, ...sources) => Object.assign(target, ...sources);
+merge({ foo: "foo" }, { bar: "bar" }); // => { foo: "foo", bar: "bar" }
+
+// good
+const merge = (...sources) => Object.assign({}, ...sources);
+merge({ foo: "foo" }, { bar: "bar" }); // => { foo: "foo", bar: "bar" }
+```
+
+### Natives
+
+Rely on native methods as much as possible.
+
+```javascript
+// bad
+const toArray = obj => [].slice.call(obj);
+
+// good
+const toArray = (() =>
+  Array.from ? Array.from : obj => [].slice.call(obj)
+)();
+```
+
+### Coercion
+
+Embrace implicit coercion when it makes sense. Avoid it otherwise. Don't cargo-cult.
+
+```javascript
+// bad
+if (x === undefined || x === null) { ... }
+
+// good
+if (x == undefined) { ... }
+```
+
+### Loops
+
+Don't use loops as they force you to use mutable objects. Rely on `array.prototype` methods.
+
+```javascript
+// bad
+const sum = arr => {
+  var sum = 0;
+  var i = -1;
+  for (;arr[++i];) {
+    sum += arr[i];
+  }
+  return sum;
+};
+
+sum([1, 2, 3]); // => 6
+
+// good
+const sum = arr =>
+  arr.reduce((x, y) => x + y);
+
+sum([1, 2, 3]); // => 6
+```
+If you can't, or if using `array.prototype` methods is arguably abusive, use recursion.
+
+```javascript
+// bad
+const createDivs = howMany => {
+  while (howMany--) {
+    document.body.insertAdjacentHTML("beforeend", "<div></div>");
+  }
+};
+createDivs(5);
+
+// bad
+const createDivs = howMany =>
+  [...Array(howMany)].forEach(() =>
+    document.body.insertAdjacentHTML("beforeend", "<div></div>")
+  );
+createDivs(5);
+
+// good
+const createDivs = howMany => {
+  if (!howMany) return;
+  document.body.insertAdjacentHTML("beforeend", "<div></div>");
+  return createDivs(howMany - 1);
+};
+createDivs(5);
+```
+
+Here's a [generic loop function](https://gist.github.com/bendc/6cb2db4a44ec30208e86) making recursion easier to use.
+
+### Arguments
+
+Forget about the `arguments` object. The rest parameter is always a better option because:
+
+1. it's named, so it gives you a better idea of the arguments the function is expecting
+2. it's a real array, which makes it easier to use.
+
+```javascript
+// bad
+const sortNumbers = () =>
+  Array.prototype.slice.call(arguments).sort();
+
+// good
+const sortNumbers = (...numbers) => numbers.sort();
+```
+
+### Apply
+
+Forget about `apply()`. Use the spread operator instead.
+
+```javascript
+const greet = (first, last) => `Hi ${first} ${last}`;
+const person = ["John", "Doe"];
+
+// bad
+greet.apply(null, person);
+
+// good
+greet(...person);
+```
+
+### Bind
+
+Don't `bind()` when there's a more idiomatic approach.
+
+```javascript
+// bad
+["foo", "bar"].forEach(func.bind(this));
+
+// good
+["foo", "bar"].forEach(func, this);
+```
+```javascript
+// bad
+const person = {
+  first: "John",
+  last: "Doe",
+  greet() {
+    const full = function() {
+      return `${this.first} ${this.last}`;
+    }.bind(this);
+    return `Hello ${full()}`;
+  }
+}
+
+// good
+const person = {
+  first: "John",
+  last: "Doe",
+  greet() {
+    const full = () => `${this.first} ${this.last}`;
+    return `Hello ${full()}`;
+  }
+}
+```
+
+### Higher-order functions
+
+Avoid nesting functions when you don't have to.
+
+```javascript
+// bad
+[1, 2, 3].map(num => String(num));
+
+// good
+[1, 2, 3].map(String);
+```
+
+### Composition
+
+Avoid multiple nested function calls. Use composition instead.
+
+```javascript
+const plus1 = a => a + 1;
+const mult2 = a => a * 2;
+
+// bad
+mult2(plus1(5)); // => 12
+
+// good
+const pipeline = (...funcs) => val => funcs.reduce((a, b) => b(a), val);
+const addThenMult = pipeline(plus1, mult2);
+addThenMult(5); // => 12
+```
+
+### Caching
+
+Cache feature tests, large data structures and any expensive operation.
+
+```javascript
+// bad
+const contains = (arr, value) =>
+  Array.prototype.includes
+    ? arr.includes(value)
+    : arr.some(el => el === value);
+contains(["foo", "bar"], "baz"); // => false
+
+// good
+const contains = (() =>
+  Array.prototype.includes
+    ? (arr, value) => arr.includes(value)
+    : (arr, value) => arr.some(el => el === value)
+)();
+contains(["foo", "bar"], "baz"); // => false
+```
+
+### Variables
+
+Favor `const` over `let` and `let` over `var`.
+
+```javascript
+// bad
+var me = new Map();
+me.set("name", "Ben").set("country", "Belgium");
+
+// good
+const me = new Map();
+me.set("name", "Ben").set("country", "Belgium");
+```
+
+### Conditions
+
+Favor IIFE's and return statements over if, else if, else and switch statements.
+
+```javascript
+// bad
+var grade;
+if (result < 50)
+  grade = "bad";
+else if (result < 90)
+  grade = "good";
+else
+  grade = "excellent";
+
+// good
+const grade = (() => {
+  if (result < 50)
+    return "bad";
+  if (result < 90)
+    return "good";
+  return "excellent";
+})();
+```
+
+### Object iteration
+
+Avoid `for...in` when you can.
+
+```javascript
+const shared = { foo: "foo" };
+const obj = Object.create(shared, {
+  bar: {
+    value: "bar",
+    enumerable: true
+  }
+});
+
+// bad
+for (var prop in obj) {
+  if (obj.hasOwnProperty(prop))
+    console.log(prop);
+}
+
+// good
+Object.keys(obj).forEach(prop => console.log(prop));
+```
+
+### Objects as Maps
+
+While objects have legitimate use cases, maps are usually a better, more powerful choice. When in
+doubt, use a `Map`.
+
+```javascript
+// bad
+const me = {
+  name: "Ben",
+  age: 30
+};
+var meSize = Object.keys(me).length;
+meSize; // => 2
+me.country = "Belgium";
+meSize++;
+meSize; // => 3
+
+// good
+const me = new Map();
+me.set("name", "Ben");
+me.set("age", 30);
+me.size; // => 2
+me.set("country", "Belgium");
+me.size; // => 3
+```
+
+### Curry
+
+Currying is a powerful but foreign paradigm for many developers. Don't abuse it as its appropriate
+use cases are fairly unusual.
+
+```javascript
+// bad
+const sum = a => b => a + b;
+sum(5)(3); // => 8
+
+// good
+const sum = (a, b) => a + b;
+sum(5, 3); // => 8
+```
+
+### Readability
+
+Don't obfuscate the intent of your code by using seemingly smart tricks.
+
+```javascript
+// bad
+foo || doSomething();
+
+// good
+if (!foo) doSomething();
+```
+```javascript
+// bad
+void function() { /* IIFE */ }();
+
+// good
+(function() { /* IIFE */ }());
+```
+```javascript
+// bad
+const n = ~~3.14;
+
+// good
+const n = Math.floor(3.14);
+```
+
+### Code reuse
+
+Don't be afraid of creating lots of small, highly composable and reusable functions.
+
+```javascript
+// bad
+arr[arr.length - 1];
+
+// good
+const first = arr => arr[0];
+const last = arr => first(arr.slice(-1));
+last(arr);
+```
+```javascript
+// bad
+const product = (a, b) => a * b;
+const triple = n => n * 3;
+
+// good
+const product = (a, b) => a * b;
+const triple = product.bind(null, 3);
+```
+
+### Dependencies
+
+Minimize dependencies. Third-party is code you don't know. Don't load an entire library for just a couple of methods easily replicable:
+
+```javascript
+// bad
+var _ = require("underscore");
+_.compact(["foo", 0]));
+_.unique(["foo", "foo"]);
+_.union(["foo"], ["bar"], ["foo"]);
+
+// good
+const compact = arr => arr.filter(el => el);
+const unique = arr => [...new Set(arr)];
+const union = (...arr) => unique([].concat(...arr));
+
+compact(["foo", 0]);
+unique(["foo", "foo"]);
+union(["foo"], ["bar"], ["foo"]);
+```

--- a/.agents/skills/bendc-frontend-guidelines/references/readme-original.md
+++ b/.agents/skills/bendc-frontend-guidelines/references/readme-original.md
@@ -12,9 +12,9 @@ HTML5 provides us with lots of semantic elements aimed to describe precisely the
 
 ```html
 <!-- bad -->
-<div id=main>
-  <div class=article>
-    <div class=header>
+<div id="main">
+  <div class="article">
+    <div class="header">
       <h1>Blog post</h1>
       <p>Published: <span>21st Feb, 2015</span></p>
     </div>
@@ -27,7 +27,7 @@ HTML5 provides us with lots of semantic elements aimed to describe precisely the
   <article>
     <header>
       <h1>Blog post</h1>
-      <p>Published: <time datetime=2015-02-21>21st Feb, 2015</time></p>
+      <p>Published: <time datetime="2015-02-21">21st Feb, 2015</time></p>
     </header>
     <p>…</p>
   </article>
@@ -41,13 +41,13 @@ element in a wrong way than staying neutral.
 <!-- bad -->
 <h1>
   <figure>
-    <img alt=Company src=logo.png>
+    <img alt="Company" src="logo.png" />
   </figure>
 </h1>
 
 <!-- good -->
 <h1>
-  <img alt=Company src=logo.png>
+  <img alt="Company" src="logo.png" />
 </h1>
 ```
 
@@ -95,17 +95,17 @@ Keep your code terse. Forget about your old XHTML habits.
 Accessibility shouldn't be an afterthought. You don't have to be a WCAG expert to improve your
 website, you can start immediately by fixing the little things that make a huge difference, such as:
 
-* learning to use the `alt` attribute properly
-* making sure your links and buttons are marked as such (no `<div class=button>` atrocities)
-* not relying exclusively on colors to communicate information
-* explicitly labelling form controls
+- learning to use the `alt` attribute properly
+- making sure your links and buttons are marked as such (no `<div class=button>` atrocities)
+- not relying exclusively on colors to communicate information
+- explicitly labelling form controls
 
 ```html
 <!-- bad -->
-<h1><img alt=Logo src=logo.png></h1>
+<h1><img alt="Logo" src="logo.png" /></h1>
 
 <!-- good -->
-<h1><img alt=Company src=logo.png></h1>
+<h1><img alt="Company" src="logo.png" /></h1>
 ```
 
 ### Language & character encoding
@@ -124,8 +124,8 @@ it is recommended to always declare it at the document level.
 
 <!-- good -->
 <!doctype html>
-<html lang=en>
-  <meta charset=utf-8>
+<html lang="en">
+  <meta charset="utf-8" />
   <title>Hello, world.</title>
 </html>
 ```
@@ -141,17 +141,17 @@ important factor.
 ```html
 <!-- bad -->
 <!doctype html>
-<meta charset=utf-8>
-<script src=analytics.js></script>
+<meta charset="utf-8" />
+<script src="analytics.js"></script>
 <title>Hello, world.</title>
 <p>...</p>
 
 <!-- good -->
 <!doctype html>
-<meta charset=utf-8>
+<meta charset="utf-8" />
 <title>Hello, world.</title>
 <p>...</p>
-<script src=analytics.js></script>
+<script src="analytics.js"></script>
 ```
 
 ## CSS
@@ -163,7 +163,7 @@ While the semicolon is technically a separator in CSS, always treat it as a term
 ```css
 /* bad */
 div {
-  color: red
+  color: red;
 }
 
 /* good */
@@ -251,12 +251,14 @@ Avoid overloading your selectors when you don't need to.
 
 ```css
 /* bad */
-img[src$=svg], ul > li:first-child {
+img[src$="svg"],
+ul > li:first-child {
   opacity: 0;
 }
 
 /* good */
-[src$=svg], ul > :first-child {
+[src$="svg"],
+ul > :first-child {
   opacity: 0;
 }
 ```
@@ -309,7 +311,8 @@ Don't duplicate style declarations that can be inherited.
 
 ```css
 /* bad */
-div h1, div p {
+div h1,
+div p {
   text-shadow: 0 1px 0 #fff;
 }
 
@@ -418,7 +421,7 @@ milliseconds.
 /* bad */
 div {
   margin: 0px;
-  font-size: .9em;
+  font-size: 0.9em;
   line-height: 22px;
   transition: 500ms;
 }
@@ -426,9 +429,9 @@ div {
 /* good */
 div {
   margin: 0;
-  font-size: .9rem;
+  font-size: 0.9rem;
   line-height: 1.5;
-  transition: .5s;
+  transition: 0.5s;
 }
 ```
 
@@ -509,8 +512,8 @@ while (++i < len) {
 
 // good
 const arr = [1, 2, 3, 4];
-const isEven = n => n % 2 == 0;
-const square = n => n * n;
+const isEven = (n) => n % 2 == 0;
+const square = (n) => n * n;
 
 const result = arr.filter(isEven).map(square);
 ```
@@ -535,12 +538,11 @@ Rely on native methods as much as possible.
 
 ```javascript
 // bad
-const toArray = obj => [].slice.call(obj);
+const toArray = (obj) => [].slice.call(obj);
 
 // good
 const toArray = (() =>
-  Array.from ? Array.from : obj => [].slice.call(obj)
-)();
+  Array.from ? Array.from : (obj) => [].slice.call(obj))();
 ```
 
 ### Coercion
@@ -561,10 +563,10 @@ Don't use loops as they force you to use mutable objects. Rely on `array.prototy
 
 ```javascript
 // bad
-const sum = arr => {
+const sum = (arr) => {
   var sum = 0;
   var i = -1;
-  for (;arr[++i];) {
+  for (; arr[++i]; ) {
     sum += arr[i];
   }
   return sum;
@@ -573,16 +575,16 @@ const sum = arr => {
 sum([1, 2, 3]); // => 6
 
 // good
-const sum = arr =>
-  arr.reduce((x, y) => x + y);
+const sum = (arr) => arr.reduce((x, y) => x + y);
 
 sum([1, 2, 3]); // => 6
 ```
+
 If you can't, or if using `array.prototype` methods is arguably abusive, use recursion.
 
 ```javascript
 // bad
-const createDivs = howMany => {
+const createDivs = (howMany) => {
   while (howMany--) {
     document.body.insertAdjacentHTML("beforeend", "<div></div>");
   }
@@ -590,14 +592,14 @@ const createDivs = howMany => {
 createDivs(5);
 
 // bad
-const createDivs = howMany =>
+const createDivs = (howMany) =>
   [...Array(howMany)].forEach(() =>
-    document.body.insertAdjacentHTML("beforeend", "<div></div>")
+    document.body.insertAdjacentHTML("beforeend", "<div></div>"),
   );
 createDivs(5);
 
 // good
-const createDivs = howMany => {
+const createDivs = (howMany) => {
   if (!howMany) return;
   document.body.insertAdjacentHTML("beforeend", "<div></div>");
   return createDivs(howMany - 1);
@@ -616,8 +618,7 @@ Forget about the `arguments` object. The rest parameter is always a better optio
 
 ```javascript
 // bad
-const sortNumbers = () =>
-  Array.prototype.slice.call(arguments).sort();
+const sortNumbers = () => Array.prototype.slice.call(arguments).sort();
 
 // good
 const sortNumbers = (...numbers) => numbers.sort();
@@ -649,18 +650,19 @@ Don't `bind()` when there's a more idiomatic approach.
 // good
 ["foo", "bar"].forEach(func, this);
 ```
+
 ```javascript
 // bad
 const person = {
   first: "John",
   last: "Doe",
   greet() {
-    const full = function() {
+    const full = function () {
       return `${this.first} ${this.last}`;
     }.bind(this);
     return `Hello ${full()}`;
-  }
-}
+  },
+};
 
 // good
 const person = {
@@ -669,8 +671,8 @@ const person = {
   greet() {
     const full = () => `${this.first} ${this.last}`;
     return `Hello ${full()}`;
-  }
-}
+  },
+};
 ```
 
 ### Higher-order functions
@@ -679,7 +681,7 @@ Avoid nesting functions when you don't have to.
 
 ```javascript
 // bad
-[1, 2, 3].map(num => String(num));
+[1, 2, 3].map((num) => String(num));
 
 // good
 [1, 2, 3].map(String);
@@ -690,14 +692,17 @@ Avoid nesting functions when you don't have to.
 Avoid multiple nested function calls. Use composition instead.
 
 ```javascript
-const plus1 = a => a + 1;
-const mult2 = a => a * 2;
+const plus1 = (a) => a + 1;
+const mult2 = (a) => a * 2;
 
 // bad
 mult2(plus1(5)); // => 12
 
 // good
-const pipeline = (...funcs) => val => funcs.reduce((a, b) => b(a), val);
+const pipeline =
+  (...funcs) =>
+  (val) =>
+    funcs.reduce((a, b) => b(a), val);
 const addThenMult = pipeline(plus1, mult2);
 addThenMult(5); // => 12
 ```
@@ -711,15 +716,14 @@ Cache feature tests, large data structures and any expensive operation.
 const contains = (arr, value) =>
   Array.prototype.includes
     ? arr.includes(value)
-    : arr.some(el => el === value);
+    : arr.some((el) => el === value);
 contains(["foo", "bar"], "baz"); // => false
 
 // good
 const contains = (() =>
   Array.prototype.includes
     ? (arr, value) => arr.includes(value)
-    : (arr, value) => arr.some(el => el === value)
-)();
+    : (arr, value) => arr.some((el) => el === value))();
 contains(["foo", "bar"], "baz"); // => false
 ```
 
@@ -744,19 +748,14 @@ Favor IIFE's and return statements over if, else if, else and switch statements.
 ```javascript
 // bad
 var grade;
-if (result < 50)
-  grade = "bad";
-else if (result < 90)
-  grade = "good";
-else
-  grade = "excellent";
+if (result < 50) grade = "bad";
+else if (result < 90) grade = "good";
+else grade = "excellent";
 
 // good
 const grade = (() => {
-  if (result < 50)
-    return "bad";
-  if (result < 90)
-    return "good";
+  if (result < 50) return "bad";
+  if (result < 90) return "good";
   return "excellent";
 })();
 ```
@@ -770,18 +769,17 @@ const shared = { foo: "foo" };
 const obj = Object.create(shared, {
   bar: {
     value: "bar",
-    enumerable: true
-  }
+    enumerable: true,
+  },
 });
 
 // bad
 for (var prop in obj) {
-  if (obj.hasOwnProperty(prop))
-    console.log(prop);
+  if (obj.hasOwnProperty(prop)) console.log(prop);
 }
 
 // good
-Object.keys(obj).forEach(prop => console.log(prop));
+Object.keys(obj).forEach((prop) => console.log(prop));
 ```
 
 ### Objects as Maps
@@ -793,7 +791,7 @@ doubt, use a `Map`.
 // bad
 const me = {
   name: "Ben",
-  age: 30
+  age: 30,
 };
 var meSize = Object.keys(me).length;
 meSize; // => 2
@@ -817,7 +815,7 @@ use cases are fairly unusual.
 
 ```javascript
 // bad
-const sum = a => b => a + b;
+const sum = (a) => (b) => a + b;
 sum(5)(3); // => 8
 
 // good
@@ -836,13 +834,19 @@ foo || doSomething();
 // good
 if (!foo) doSomething();
 ```
+
 ```javascript
 // bad
-void function() { /* IIFE */ }();
+void (function () {
+  /* IIFE */
+})();
 
 // good
-(function() { /* IIFE */ }());
+(function () {
+  /* IIFE */
+})();
 ```
+
 ```javascript
 // bad
 const n = ~~3.14;
@@ -860,14 +864,15 @@ Don't be afraid of creating lots of small, highly composable and reusable functi
 arr[arr.length - 1];
 
 // good
-const first = arr => arr[0];
-const last = arr => first(arr.slice(-1));
+const first = (arr) => arr[0];
+const last = (arr) => first(arr.slice(-1));
 last(arr);
 ```
+
 ```javascript
 // bad
 const product = (a, b) => a * b;
-const triple = n => n * 3;
+const triple = (n) => n * 3;
 
 // good
 const product = (a, b) => a * b;

--- a/.agents/skills/bendc-frontend-guidelines/references/upstream.md
+++ b/.agents/skills/bendc-frontend-guidelines/references/upstream.md
@@ -1,0 +1,29 @@
+---
+source_name: bendc/frontend-guidelines
+source_url: https://github.com/bendc/frontend-guidelines
+license: unknown
+last_reviewed: 2026-05-15
+---
+
+# Upstream: bendc frontend guidelines
+
+Canonical skill in this repo: `docs/ai/skills/bendc-frontend-guidelines/` (mirrored to `.cursor/skills/` and `.agents/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/bendc/frontend-guidelines
+- **Primary upstream doc:** `README.md` on the default branch (`master` at last refresh)
+- **Vendored copy:** `references/readme-original.md` (plus the short attribution block prepended there)
+
+## Refresh from upstream
+
+This skill is **not** installed via the Skills CLI and is **not** updated by `bun run skills:refresh-upstream`.
+
+1. Download the current `README.md` from https://raw.githubusercontent.com/bendc/frontend-guidelines/master/README.md
+2. Replace `references/readme-original.md` body with upstream content, preserving (or re-adding) the short **Vendored reference** block at the top of that file
+3. Re-read upstream for substantive changes; update `SKILL.md` **Precedence** or workflow bullets if guidance diverges from this repo
+4. Bump `last_reviewed` in this file
+5. Run `bun run skills:sync` and `bun run skills:verify`
+
+## Notes for maintainers
+
+- Do not copy secrets or environment-specific values into skill content.
+- The skill’s `SKILL.md` is the router: it tells agents when to use bendc guidance and when repo rules (`docs/ai/rules/frontend.md`, motion skills, TypeScript/ESLint) take precedence.

--- a/.agents/skills/bendc-frontend-guidelines/references/upstream.md
+++ b/.agents/skills/bendc-frontend-guidelines/references/upstream.md
@@ -27,3 +27,4 @@ This skill is **not** installed via the Skills CLI and is **not** updated by `bu
 
 - Do not copy secrets or environment-specific values into skill content.
 - The skill’s `SKILL.md` is the router: it tells agents when to use bendc guidance and when repo rules (`docs/ai/rules/frontend.md`, motion skills, TypeScript/ESLint) take precedence.
+- Before refreshing or expanding the vendored copy, re-check upstream license or permission and keep the attribution block. If the license is still unknown, preserve `license: unknown` metadata and do not present the vendored text as licensed source material.

--- a/.agents/skills/find-skills/SKILL.md
+++ b/.agents/skills/find-skills/SKILL.md
@@ -51,6 +51,8 @@ Some extra ecosystem or tool-specific skills may exist only in `.cursor/skills/`
 
 **Example — Resend app integration:** app-level Resend integration in this monorepo is documented in `docs/guides/features/resend-integration.md`.
 
+**Example — bendc frontend guidelines:** semantic HTML, CSS discipline, and vanilla JS readability patterns from [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) are covered by `docs/ai/skills/bendc-frontend-guidelines/SKILL.md` (vendored `README.md` under `references/`); maintainer refresh notes are in `docs/ai/skills/bendc-frontend-guidelines/references/upstream.md`. Use **`docs/ai/rules/frontend.md`** first for `apps/*` and `packages/ui` work.
+
 ## How to Help Users Find Skills
 
 ### Step 1: Understand What They Need

--- a/.cursor/skills/.repo-canonical-skills.json
+++ b/.cursor/skills/.repo-canonical-skills.json
@@ -3,6 +3,7 @@
   "canonicalSkills": [
     "anim",
     "base-ui",
+    "bendc-frontend-guidelines",
     "cache-components",
     "commit",
     "components-build",

--- a/.cursor/skills/bendc-frontend-guidelines/SKILL.md
+++ b/.cursor/skills/bendc-frontend-guidelines/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bendc-frontend-guidelines
+description: "HTML, CSS, and JavaScript craft guidelines from bendc/frontend-guidelines — semantics, a11y basics, selector discipline, motion-friendly CSS, and readable JS. Use for markup review, static HTML/CSS, email HTML, or general front-end hygiene; pair with repo frontend rules and TypeScript lint policy."
+metadata:
+  owner: core
+  last_updated: 2026-05-15
+  status: active
+  version: "1.0.0"
+---
+
+# bendc Frontend Guidelines (repo skill)
+
+## Triggers
+
+Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from Benjamin De Cock’s widely referenced checklist ([`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)), including:
+
+- Semantic HTML, document structure, `lang`, charset, and meaningful elements (`main`, `article`, `time`, etc.)
+- Accessibility basics called out upstream: `alt` text, real links and buttons, not relying on color alone, labelling controls
+- CSS structure: selector weight, avoiding unnecessary `!important`, inheritance, shorthand, flow and layout (flex/grid over absolute positioning when appropriate)
+- CSS performance habits: prefer `opacity` / `transform` for animation; avoid animating layout-heavy properties (aligns with repo motion rules)
+- Vanilla or legacy JS style: readability, native APIs, avoiding foot-guns called out in the upstream doc
+
+**Also load** `docs/ai/rules/frontend.md` for any **`apps/*` or `packages/ui`** work in this monorepo.
+
+## Do not use when
+
+- The task is strictly backend, migrations, or database-only work.
+- You only need **React / Next.js / App Router** patterns — prefer `docs/ai/skills/nextjs-app-router/SKILL.md` and framework docs.
+- You only need **Tailwind, design tokens, or shared `@asym/ui` primitives** — the upstream doc is not Tailwind-specific; follow `docs/ai/rules/frontend.md` first.
+
+## Precedence (this repo wins)
+
+The full text of the upstream guide lives in **`references/readme-original.md`**. When anything below disagrees with that file, **follow this section**.
+
+| Topic | Authoritative in this repo |
+| ----- | -------------------------- |
+| Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components | `docs/ai/rules/frontend.md` |
+| Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md` |
+| TypeScript types, `strict`, equality (`===`), linted patterns | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
+| React component structure, Server Components, hooks | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md` |
+
+Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS — not as a reason to weaken types, tokens, or repo motion policy.
+
+## Workflow
+
+1. Confirm the surface is in scope (markup, styles, or JS where the upstream checklist applies).
+2. Load **`references/readme-original.md`** (or skim the sections you need: HTML, CSS, JavaScript).
+3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, or TS types.
+4. For shared UI or app routes, reconcile recommendations with **`docs/ai/rules/frontend.md`** and nearby components.
+5. Prefer small, evidence-based edits; do not rewrite large areas solely to match upstream brevity examples if repo style differs.
+
+## Checklist
+
+- [ ] Confirmed triggers match (HTML/CSS/JS craft vs pure React/Next/backend).
+- [ ] Read the relevant sections of `references/readme-original.md` or the live upstream README.
+- [ ] Applied **Precedence**: repo frontend rules, motion skills, and TypeScript lint are satisfied.
+- [ ] Did not strip accessibility or semantics for brevity.
+- [ ] If you edited files under `docs/ai/skills/bendc-frontend-guidelines/`, ran `bun run skills:sync` and `bun run skills:verify` before committing.
+
+## See also
+
+- **Repo UI policy:** `docs/ai/rules/frontend.md`
+- **Motion craft:** `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md`
+- **React component patterns:** `docs/ai/skills/react-component-dev/SKILL.md`
+- **Maintainer refresh notes:** `references/upstream.md`

--- a/.cursor/skills/bendc-frontend-guidelines/SKILL.md
+++ b/.cursor/skills/bendc-frontend-guidelines/SKILL.md
@@ -8,11 +8,11 @@ metadata:
   version: "1.0.0"
 ---
 
-# bendc Frontend Guidelines (repo skill)
+# bendc Frontend Guidelines
 
 ## Triggers
 
-Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from Benjamin De Cock’s widely referenced checklist ([`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)), including:
+Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from the vendored [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) checklist, including:
 
 - Semantic HTML, document structure, `lang`, charset, and meaningful elements (`main`, `article`, `time`, etc.)
 - Accessibility basics called out upstream: `alt` text, real links and buttons, not relying on color alone, labelling controls
@@ -30,22 +30,23 @@ Use this skill when the task benefits from **foundational HTML, CSS, and vanilla
 
 ## Precedence (this repo wins)
 
-The full text of the upstream guide lives in **`references/readme-original.md`**. When anything below disagrees with that file, **follow this section**.
+The full text of the upstream guide lives in **`references/readme-original.md`**. When that reference conflicts with the **Precedence** table below, **follow the table**.
 
-| Topic | Authoritative in this repo |
-| ----- | -------------------------- |
-| Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components | `docs/ai/rules/frontend.md` |
-| Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md` |
-| TypeScript types, `strict`, equality (`===`), linted patterns | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
-| React component structure, Server Components, hooks | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md` |
+| Topic                                                                               | Authoritative in this repo                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components                  | `docs/ai/rules/frontend.md`                                                                                                                 |
+| Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md`                              |
+| General JavaScript / TypeScript code shape, control flow, helper extraction         | Root `AGENTS.md` code style — prefer explicit, straightforward code over upstream terseness, loop avoidance, recursion, or shorthand        |
+| TypeScript types, `strict`, equality (`===`), linted patterns                       | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
+| React component structure, Server Components, hooks                                 | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md`                                                                              |
 
-Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS — not as a reason to weaken types, tokens, or repo motion policy.
+Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS. Do not copy upstream JavaScript advice about terseness, avoiding loops, recursion, composition, or shorthand unless it improves clarity under this repo's `AGENTS.md` conventions.
 
 ## Workflow
 
 1. Confirm the surface is in scope (markup, styles, or JS where the upstream checklist applies).
 2. Load **`references/readme-original.md`** (or skim the sections you need: HTML, CSS, JavaScript).
-3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, or TS types.
+3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, JS/TS code shape, or TS types.
 4. For shared UI or app routes, reconcile recommendations with **`docs/ai/rules/frontend.md`** and nearby components.
 5. Prefer small, evidence-based edits; do not rewrite large areas solely to match upstream brevity examples if repo style differs.
 
@@ -53,7 +54,7 @@ Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS disci
 
 - [ ] Confirmed triggers match (HTML/CSS/JS craft vs pure React/Next/backend).
 - [ ] Read the relevant sections of `references/readme-original.md` or the live upstream README.
-- [ ] Applied **Precedence**: repo frontend rules, motion skills, and TypeScript lint are satisfied.
+- [ ] Applied **Precedence**: repo frontend rules, motion skills, `AGENTS.md` code style, and TypeScript lint are satisfied.
 - [ ] Did not strip accessibility or semantics for brevity.
 - [ ] If you edited files under `docs/ai/skills/bendc-frontend-guidelines/`, ran `bun run skills:sync` and `bun run skills:verify` before committing.
 

--- a/.cursor/skills/bendc-frontend-guidelines/references/readme-original.md
+++ b/.cursor/skills/bendc-frontend-guidelines/references/readme-original.md
@@ -1,0 +1,896 @@
+> **Vendored reference:** [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) — `README.md` on branch `master`, snapshot 2026-05-15.
+>
+> GitHub did not report an SPDX license for the upstream repository at vendoring time; keep this copy for attribution and agent context. When exact upstream wording matters, compare against the live README on GitHub.
+
+# Frontend Guidelines
+
+## HTML
+
+### Semantics
+
+HTML5 provides us with lots of semantic elements aimed to describe precisely the content. Make sure you benefit from its rich vocabulary.
+
+```html
+<!-- bad -->
+<div id=main>
+  <div class=article>
+    <div class=header>
+      <h1>Blog post</h1>
+      <p>Published: <span>21st Feb, 2015</span></p>
+    </div>
+    <p>…</p>
+  </div>
+</div>
+
+<!-- good -->
+<main>
+  <article>
+    <header>
+      <h1>Blog post</h1>
+      <p>Published: <time datetime=2015-02-21>21st Feb, 2015</time></p>
+    </header>
+    <p>…</p>
+  </article>
+</main>
+```
+
+Make sure you understand the semantics of the elements you're using. It's worse to use a semantic
+element in a wrong way than staying neutral.
+
+```html
+<!-- bad -->
+<h1>
+  <figure>
+    <img alt=Company src=logo.png>
+  </figure>
+</h1>
+
+<!-- good -->
+<h1>
+  <img alt=Company src=logo.png>
+</h1>
+```
+
+### Brevity
+
+Keep your code terse. Forget about your old XHTML habits.
+
+```html
+<!-- bad -->
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta http-equiv=Content-Type content="text/html; charset=utf-8" />
+    <title>Contact</title>
+    <link rel=stylesheet href=style.css type=text/css />
+  </head>
+  <body>
+    <h1>Contact me</h1>
+    <label>
+      Email address:
+      <input type=email placeholder=you@email.com required=required />
+    </label>
+    <script src=main.js type=text/javascript></script>
+  </body>
+</html>
+
+<!-- good -->
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>Contact</title>
+  <link rel=stylesheet href=style.css>
+
+  <h1>Contact me</h1>
+  <label>
+    Email address:
+    <input type=email placeholder=you@email.com required>
+  </label>
+  <script src=main.js></script>
+</html>
+```
+
+### Accessibility
+
+Accessibility shouldn't be an afterthought. You don't have to be a WCAG expert to improve your
+website, you can start immediately by fixing the little things that make a huge difference, such as:
+
+* learning to use the `alt` attribute properly
+* making sure your links and buttons are marked as such (no `<div class=button>` atrocities)
+* not relying exclusively on colors to communicate information
+* explicitly labelling form controls
+
+```html
+<!-- bad -->
+<h1><img alt=Logo src=logo.png></h1>
+
+<!-- good -->
+<h1><img alt=Company src=logo.png></h1>
+```
+
+### Language & character encoding
+
+While defining the language is optional, it's recommended to always declare
+it on the root element.
+
+The HTML standard requires that pages use the UTF-8 character encoding.
+It has to be declared, and although it can be declared in the Content-Type HTTP header,
+it is recommended to always declare it at the document level.
+
+```html
+<!-- bad -->
+<!doctype html>
+<title>Hello, world.</title>
+
+<!-- good -->
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>Hello, world.</title>
+</html>
+```
+
+### Performance
+
+Unless there's a valid reason for loading your scripts before your content, don't block the
+rendering of your page. If your style sheet is heavy, isolate the styles that are absolutely
+required initially and defer the loading of the secondary declarations in a separate style sheet.
+Two HTTP requests is significantly slower than one, but the perception of speed is the most
+important factor.
+
+```html
+<!-- bad -->
+<!doctype html>
+<meta charset=utf-8>
+<script src=analytics.js></script>
+<title>Hello, world.</title>
+<p>...</p>
+
+<!-- good -->
+<!doctype html>
+<meta charset=utf-8>
+<title>Hello, world.</title>
+<p>...</p>
+<script src=analytics.js></script>
+```
+
+## CSS
+
+### Semicolons
+
+While the semicolon is technically a separator in CSS, always treat it as a terminator.
+
+```css
+/* bad */
+div {
+  color: red
+}
+
+/* good */
+div {
+  color: red;
+}
+```
+
+### Box model
+
+The box model should ideally be the same for the entire document. A global
+`* { box-sizing: border-box; }` is fine, but don't change the default box model
+on specific elements if you can avoid it.
+
+```css
+/* bad */
+div {
+  width: 100%;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+/* good */
+div {
+  padding: 10px;
+}
+```
+
+### Flow
+
+Don't change the default behavior of an element if you can avoid it. Keep elements in the
+natural document flow as much as you can. For example, removing the white-space below an
+image shouldn't make you change its default display:
+
+```css
+/* bad */
+img {
+  display: block;
+}
+
+/* good */
+img {
+  vertical-align: middle;
+}
+```
+
+Similarly, don't take an element off the flow if you can avoid it.
+
+```css
+/* bad */
+div {
+  width: 100px;
+  position: absolute;
+  right: 0;
+}
+
+/* good */
+div {
+  width: 100px;
+  margin-left: auto;
+}
+```
+
+### Positioning
+
+There are many ways to position elements in CSS. Favor modern layout specifications
+such as Flexbox and Grid, and avoid removing elements from the normal document flow, for example
+with `position: absolute`.
+
+### Selectors
+
+Minimize selectors tightly coupled to the DOM. Consider adding a class to the elements
+you want to match when your selector exceeds 3 structural pseudo-classes, descendant or
+sibling combinators.
+
+```css
+/* bad */
+div:first-of-type :last-child > p ~ *
+
+/* good */
+div:first-of-type .info
+```
+
+Avoid overloading your selectors when you don't need to.
+
+```css
+/* bad */
+img[src$=svg], ul > li:first-child {
+  opacity: 0;
+}
+
+/* good */
+[src$=svg], ul > :first-child {
+  opacity: 0;
+}
+```
+
+### Specificity
+
+Don't make values and selectors hard to override. Minimize the use of `id`'s
+and avoid `!important`.
+
+```css
+/* bad */
+.bar {
+  color: green !important;
+}
+.foo {
+  color: red;
+}
+
+/* good */
+.foo.bar {
+  color: green;
+}
+.foo {
+  color: red;
+}
+```
+
+### Overriding
+
+Overriding styles makes selectors and debugging harder. Avoid it when possible.
+
+```css
+/* bad */
+li {
+  visibility: hidden;
+}
+li:first-child {
+  visibility: visible;
+}
+
+/* good */
+li + li {
+  visibility: hidden;
+}
+```
+
+### Inheritance
+
+Don't duplicate style declarations that can be inherited.
+
+```css
+/* bad */
+div h1, div p {
+  text-shadow: 0 1px 0 #fff;
+}
+
+/* good */
+div {
+  text-shadow: 0 1px 0 #fff;
+}
+```
+
+### Brevity
+
+Keep your code terse. Use shorthand properties and avoid using multiple properties when
+it's not needed.
+
+```css
+/* bad */
+div {
+  transition: all 1s;
+  top: 50%;
+  margin-top: -10px;
+  padding-top: 5px;
+  padding-right: 10px;
+  padding-bottom: 20px;
+  padding-left: 10px;
+}
+
+/* good */
+div {
+  transition: 1s;
+  top: calc(50% - 10px);
+  padding: 5px 10px 20px;
+}
+```
+
+### Language
+
+Prefer English over math.
+
+```css
+/* bad */
+:nth-child(2n + 1) {
+  transform: rotate(360deg);
+}
+
+/* good */
+:nth-child(odd) {
+  transform: rotate(1turn);
+}
+```
+
+### Vendor prefixes
+
+Kill obsolete vendor prefixes aggressively. If you need to use them, insert them before the
+standard property.
+
+```css
+/* bad */
+div {
+  transform: scale(2);
+  -webkit-transform: scale(2);
+  -moz-transform: scale(2);
+  -ms-transform: scale(2);
+  transition: 1s;
+  -webkit-transition: 1s;
+  -moz-transition: 1s;
+  -ms-transition: 1s;
+}
+
+/* good */
+div {
+  -webkit-transform: scale(2);
+  transform: scale(2);
+  transition: 1s;
+}
+```
+
+### Animations
+
+Favor transitions over animations. Avoid animating other properties than
+`opacity` and `transform`.
+
+```css
+/* bad */
+div:hover {
+  animation: move 1s forwards;
+}
+@keyframes move {
+  100% {
+    margin-left: 100px;
+  }
+}
+
+/* good */
+div:hover {
+  transition: 1s;
+  transform: translateX(100px);
+}
+```
+
+### Units
+
+Use unitless values when you can. Favor `rem` if you use relative units. Prefer seconds over
+milliseconds.
+
+```css
+/* bad */
+div {
+  margin: 0px;
+  font-size: .9em;
+  line-height: 22px;
+  transition: 500ms;
+}
+
+/* good */
+div {
+  margin: 0;
+  font-size: .9rem;
+  line-height: 1.5;
+  transition: .5s;
+}
+```
+
+### Colors
+
+If you need transparency, use `rgba`. Otherwise, always use the hexadecimal format.
+
+```css
+/* bad */
+div {
+  color: hsl(103, 54%, 43%);
+}
+
+/* good */
+div {
+  color: #5a3;
+}
+```
+
+### Drawing
+
+Avoid HTTP requests when the resources are easily replicable with CSS.
+
+```css
+/* bad */
+div::before {
+  content: url(white-circle.svg);
+}
+
+/* good */
+div::before {
+  content: "";
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+}
+```
+
+### Hacks
+
+Don't use them.
+
+```css
+/* bad */
+div {
+  // position: relative;
+  transform: translateZ(0);
+}
+
+/* good */
+div {
+  /* position: relative; */
+  will-change: transform;
+}
+```
+
+## JavaScript
+
+### Performance
+
+Favor readability, correctness and expressiveness over performance. JavaScript will basically never
+be your performance bottleneck. Optimize things like image compression, network access and DOM
+reflows instead. If you remember just one guideline from this document, choose this one.
+
+```javascript
+// bad (albeit way faster)
+const arr = [1, 2, 3, 4];
+const len = arr.length;
+var i = -1;
+var result = [];
+while (++i < len) {
+  var n = arr[i];
+  if (n % 2 > 0) continue;
+  result.push(n * n);
+}
+
+// good
+const arr = [1, 2, 3, 4];
+const isEven = n => n % 2 == 0;
+const square = n => n * n;
+
+const result = arr.filter(isEven).map(square);
+```
+
+### Statelessness
+
+Try to keep your functions pure. All functions should ideally produce no side-effects, use no outside data and return new objects instead of mutating existing ones.
+
+```javascript
+// bad
+const merge = (target, ...sources) => Object.assign(target, ...sources);
+merge({ foo: "foo" }, { bar: "bar" }); // => { foo: "foo", bar: "bar" }
+
+// good
+const merge = (...sources) => Object.assign({}, ...sources);
+merge({ foo: "foo" }, { bar: "bar" }); // => { foo: "foo", bar: "bar" }
+```
+
+### Natives
+
+Rely on native methods as much as possible.
+
+```javascript
+// bad
+const toArray = obj => [].slice.call(obj);
+
+// good
+const toArray = (() =>
+  Array.from ? Array.from : obj => [].slice.call(obj)
+)();
+```
+
+### Coercion
+
+Embrace implicit coercion when it makes sense. Avoid it otherwise. Don't cargo-cult.
+
+```javascript
+// bad
+if (x === undefined || x === null) { ... }
+
+// good
+if (x == undefined) { ... }
+```
+
+### Loops
+
+Don't use loops as they force you to use mutable objects. Rely on `array.prototype` methods.
+
+```javascript
+// bad
+const sum = arr => {
+  var sum = 0;
+  var i = -1;
+  for (;arr[++i];) {
+    sum += arr[i];
+  }
+  return sum;
+};
+
+sum([1, 2, 3]); // => 6
+
+// good
+const sum = arr =>
+  arr.reduce((x, y) => x + y);
+
+sum([1, 2, 3]); // => 6
+```
+If you can't, or if using `array.prototype` methods is arguably abusive, use recursion.
+
+```javascript
+// bad
+const createDivs = howMany => {
+  while (howMany--) {
+    document.body.insertAdjacentHTML("beforeend", "<div></div>");
+  }
+};
+createDivs(5);
+
+// bad
+const createDivs = howMany =>
+  [...Array(howMany)].forEach(() =>
+    document.body.insertAdjacentHTML("beforeend", "<div></div>")
+  );
+createDivs(5);
+
+// good
+const createDivs = howMany => {
+  if (!howMany) return;
+  document.body.insertAdjacentHTML("beforeend", "<div></div>");
+  return createDivs(howMany - 1);
+};
+createDivs(5);
+```
+
+Here's a [generic loop function](https://gist.github.com/bendc/6cb2db4a44ec30208e86) making recursion easier to use.
+
+### Arguments
+
+Forget about the `arguments` object. The rest parameter is always a better option because:
+
+1. it's named, so it gives you a better idea of the arguments the function is expecting
+2. it's a real array, which makes it easier to use.
+
+```javascript
+// bad
+const sortNumbers = () =>
+  Array.prototype.slice.call(arguments).sort();
+
+// good
+const sortNumbers = (...numbers) => numbers.sort();
+```
+
+### Apply
+
+Forget about `apply()`. Use the spread operator instead.
+
+```javascript
+const greet = (first, last) => `Hi ${first} ${last}`;
+const person = ["John", "Doe"];
+
+// bad
+greet.apply(null, person);
+
+// good
+greet(...person);
+```
+
+### Bind
+
+Don't `bind()` when there's a more idiomatic approach.
+
+```javascript
+// bad
+["foo", "bar"].forEach(func.bind(this));
+
+// good
+["foo", "bar"].forEach(func, this);
+```
+```javascript
+// bad
+const person = {
+  first: "John",
+  last: "Doe",
+  greet() {
+    const full = function() {
+      return `${this.first} ${this.last}`;
+    }.bind(this);
+    return `Hello ${full()}`;
+  }
+}
+
+// good
+const person = {
+  first: "John",
+  last: "Doe",
+  greet() {
+    const full = () => `${this.first} ${this.last}`;
+    return `Hello ${full()}`;
+  }
+}
+```
+
+### Higher-order functions
+
+Avoid nesting functions when you don't have to.
+
+```javascript
+// bad
+[1, 2, 3].map(num => String(num));
+
+// good
+[1, 2, 3].map(String);
+```
+
+### Composition
+
+Avoid multiple nested function calls. Use composition instead.
+
+```javascript
+const plus1 = a => a + 1;
+const mult2 = a => a * 2;
+
+// bad
+mult2(plus1(5)); // => 12
+
+// good
+const pipeline = (...funcs) => val => funcs.reduce((a, b) => b(a), val);
+const addThenMult = pipeline(plus1, mult2);
+addThenMult(5); // => 12
+```
+
+### Caching
+
+Cache feature tests, large data structures and any expensive operation.
+
+```javascript
+// bad
+const contains = (arr, value) =>
+  Array.prototype.includes
+    ? arr.includes(value)
+    : arr.some(el => el === value);
+contains(["foo", "bar"], "baz"); // => false
+
+// good
+const contains = (() =>
+  Array.prototype.includes
+    ? (arr, value) => arr.includes(value)
+    : (arr, value) => arr.some(el => el === value)
+)();
+contains(["foo", "bar"], "baz"); // => false
+```
+
+### Variables
+
+Favor `const` over `let` and `let` over `var`.
+
+```javascript
+// bad
+var me = new Map();
+me.set("name", "Ben").set("country", "Belgium");
+
+// good
+const me = new Map();
+me.set("name", "Ben").set("country", "Belgium");
+```
+
+### Conditions
+
+Favor IIFE's and return statements over if, else if, else and switch statements.
+
+```javascript
+// bad
+var grade;
+if (result < 50)
+  grade = "bad";
+else if (result < 90)
+  grade = "good";
+else
+  grade = "excellent";
+
+// good
+const grade = (() => {
+  if (result < 50)
+    return "bad";
+  if (result < 90)
+    return "good";
+  return "excellent";
+})();
+```
+
+### Object iteration
+
+Avoid `for...in` when you can.
+
+```javascript
+const shared = { foo: "foo" };
+const obj = Object.create(shared, {
+  bar: {
+    value: "bar",
+    enumerable: true
+  }
+});
+
+// bad
+for (var prop in obj) {
+  if (obj.hasOwnProperty(prop))
+    console.log(prop);
+}
+
+// good
+Object.keys(obj).forEach(prop => console.log(prop));
+```
+
+### Objects as Maps
+
+While objects have legitimate use cases, maps are usually a better, more powerful choice. When in
+doubt, use a `Map`.
+
+```javascript
+// bad
+const me = {
+  name: "Ben",
+  age: 30
+};
+var meSize = Object.keys(me).length;
+meSize; // => 2
+me.country = "Belgium";
+meSize++;
+meSize; // => 3
+
+// good
+const me = new Map();
+me.set("name", "Ben");
+me.set("age", 30);
+me.size; // => 2
+me.set("country", "Belgium");
+me.size; // => 3
+```
+
+### Curry
+
+Currying is a powerful but foreign paradigm for many developers. Don't abuse it as its appropriate
+use cases are fairly unusual.
+
+```javascript
+// bad
+const sum = a => b => a + b;
+sum(5)(3); // => 8
+
+// good
+const sum = (a, b) => a + b;
+sum(5, 3); // => 8
+```
+
+### Readability
+
+Don't obfuscate the intent of your code by using seemingly smart tricks.
+
+```javascript
+// bad
+foo || doSomething();
+
+// good
+if (!foo) doSomething();
+```
+```javascript
+// bad
+void function() { /* IIFE */ }();
+
+// good
+(function() { /* IIFE */ }());
+```
+```javascript
+// bad
+const n = ~~3.14;
+
+// good
+const n = Math.floor(3.14);
+```
+
+### Code reuse
+
+Don't be afraid of creating lots of small, highly composable and reusable functions.
+
+```javascript
+// bad
+arr[arr.length - 1];
+
+// good
+const first = arr => arr[0];
+const last = arr => first(arr.slice(-1));
+last(arr);
+```
+```javascript
+// bad
+const product = (a, b) => a * b;
+const triple = n => n * 3;
+
+// good
+const product = (a, b) => a * b;
+const triple = product.bind(null, 3);
+```
+
+### Dependencies
+
+Minimize dependencies. Third-party is code you don't know. Don't load an entire library for just a couple of methods easily replicable:
+
+```javascript
+// bad
+var _ = require("underscore");
+_.compact(["foo", 0]));
+_.unique(["foo", "foo"]);
+_.union(["foo"], ["bar"], ["foo"]);
+
+// good
+const compact = arr => arr.filter(el => el);
+const unique = arr => [...new Set(arr)];
+const union = (...arr) => unique([].concat(...arr));
+
+compact(["foo", 0]);
+unique(["foo", "foo"]);
+union(["foo"], ["bar"], ["foo"]);
+```

--- a/.cursor/skills/bendc-frontend-guidelines/references/readme-original.md
+++ b/.cursor/skills/bendc-frontend-guidelines/references/readme-original.md
@@ -12,9 +12,9 @@ HTML5 provides us with lots of semantic elements aimed to describe precisely the
 
 ```html
 <!-- bad -->
-<div id=main>
-  <div class=article>
-    <div class=header>
+<div id="main">
+  <div class="article">
+    <div class="header">
       <h1>Blog post</h1>
       <p>Published: <span>21st Feb, 2015</span></p>
     </div>
@@ -27,7 +27,7 @@ HTML5 provides us with lots of semantic elements aimed to describe precisely the
   <article>
     <header>
       <h1>Blog post</h1>
-      <p>Published: <time datetime=2015-02-21>21st Feb, 2015</time></p>
+      <p>Published: <time datetime="2015-02-21">21st Feb, 2015</time></p>
     </header>
     <p>…</p>
   </article>
@@ -41,13 +41,13 @@ element in a wrong way than staying neutral.
 <!-- bad -->
 <h1>
   <figure>
-    <img alt=Company src=logo.png>
+    <img alt="Company" src="logo.png" />
   </figure>
 </h1>
 
 <!-- good -->
 <h1>
-  <img alt=Company src=logo.png>
+  <img alt="Company" src="logo.png" />
 </h1>
 ```
 
@@ -95,17 +95,17 @@ Keep your code terse. Forget about your old XHTML habits.
 Accessibility shouldn't be an afterthought. You don't have to be a WCAG expert to improve your
 website, you can start immediately by fixing the little things that make a huge difference, such as:
 
-* learning to use the `alt` attribute properly
-* making sure your links and buttons are marked as such (no `<div class=button>` atrocities)
-* not relying exclusively on colors to communicate information
-* explicitly labelling form controls
+- learning to use the `alt` attribute properly
+- making sure your links and buttons are marked as such (no `<div class=button>` atrocities)
+- not relying exclusively on colors to communicate information
+- explicitly labelling form controls
 
 ```html
 <!-- bad -->
-<h1><img alt=Logo src=logo.png></h1>
+<h1><img alt="Logo" src="logo.png" /></h1>
 
 <!-- good -->
-<h1><img alt=Company src=logo.png></h1>
+<h1><img alt="Company" src="logo.png" /></h1>
 ```
 
 ### Language & character encoding
@@ -124,8 +124,8 @@ it is recommended to always declare it at the document level.
 
 <!-- good -->
 <!doctype html>
-<html lang=en>
-  <meta charset=utf-8>
+<html lang="en">
+  <meta charset="utf-8" />
   <title>Hello, world.</title>
 </html>
 ```
@@ -141,17 +141,17 @@ important factor.
 ```html
 <!-- bad -->
 <!doctype html>
-<meta charset=utf-8>
-<script src=analytics.js></script>
+<meta charset="utf-8" />
+<script src="analytics.js"></script>
 <title>Hello, world.</title>
 <p>...</p>
 
 <!-- good -->
 <!doctype html>
-<meta charset=utf-8>
+<meta charset="utf-8" />
 <title>Hello, world.</title>
 <p>...</p>
-<script src=analytics.js></script>
+<script src="analytics.js"></script>
 ```
 
 ## CSS
@@ -163,7 +163,7 @@ While the semicolon is technically a separator in CSS, always treat it as a term
 ```css
 /* bad */
 div {
-  color: red
+  color: red;
 }
 
 /* good */
@@ -251,12 +251,14 @@ Avoid overloading your selectors when you don't need to.
 
 ```css
 /* bad */
-img[src$=svg], ul > li:first-child {
+img[src$="svg"],
+ul > li:first-child {
   opacity: 0;
 }
 
 /* good */
-[src$=svg], ul > :first-child {
+[src$="svg"],
+ul > :first-child {
   opacity: 0;
 }
 ```
@@ -309,7 +311,8 @@ Don't duplicate style declarations that can be inherited.
 
 ```css
 /* bad */
-div h1, div p {
+div h1,
+div p {
   text-shadow: 0 1px 0 #fff;
 }
 
@@ -418,7 +421,7 @@ milliseconds.
 /* bad */
 div {
   margin: 0px;
-  font-size: .9em;
+  font-size: 0.9em;
   line-height: 22px;
   transition: 500ms;
 }
@@ -426,9 +429,9 @@ div {
 /* good */
 div {
   margin: 0;
-  font-size: .9rem;
+  font-size: 0.9rem;
   line-height: 1.5;
-  transition: .5s;
+  transition: 0.5s;
 }
 ```
 
@@ -509,8 +512,8 @@ while (++i < len) {
 
 // good
 const arr = [1, 2, 3, 4];
-const isEven = n => n % 2 == 0;
-const square = n => n * n;
+const isEven = (n) => n % 2 == 0;
+const square = (n) => n * n;
 
 const result = arr.filter(isEven).map(square);
 ```
@@ -535,12 +538,11 @@ Rely on native methods as much as possible.
 
 ```javascript
 // bad
-const toArray = obj => [].slice.call(obj);
+const toArray = (obj) => [].slice.call(obj);
 
 // good
 const toArray = (() =>
-  Array.from ? Array.from : obj => [].slice.call(obj)
-)();
+  Array.from ? Array.from : (obj) => [].slice.call(obj))();
 ```
 
 ### Coercion
@@ -561,10 +563,10 @@ Don't use loops as they force you to use mutable objects. Rely on `array.prototy
 
 ```javascript
 // bad
-const sum = arr => {
+const sum = (arr) => {
   var sum = 0;
   var i = -1;
-  for (;arr[++i];) {
+  for (; arr[++i]; ) {
     sum += arr[i];
   }
   return sum;
@@ -573,16 +575,16 @@ const sum = arr => {
 sum([1, 2, 3]); // => 6
 
 // good
-const sum = arr =>
-  arr.reduce((x, y) => x + y);
+const sum = (arr) => arr.reduce((x, y) => x + y);
 
 sum([1, 2, 3]); // => 6
 ```
+
 If you can't, or if using `array.prototype` methods is arguably abusive, use recursion.
 
 ```javascript
 // bad
-const createDivs = howMany => {
+const createDivs = (howMany) => {
   while (howMany--) {
     document.body.insertAdjacentHTML("beforeend", "<div></div>");
   }
@@ -590,14 +592,14 @@ const createDivs = howMany => {
 createDivs(5);
 
 // bad
-const createDivs = howMany =>
+const createDivs = (howMany) =>
   [...Array(howMany)].forEach(() =>
-    document.body.insertAdjacentHTML("beforeend", "<div></div>")
+    document.body.insertAdjacentHTML("beforeend", "<div></div>"),
   );
 createDivs(5);
 
 // good
-const createDivs = howMany => {
+const createDivs = (howMany) => {
   if (!howMany) return;
   document.body.insertAdjacentHTML("beforeend", "<div></div>");
   return createDivs(howMany - 1);
@@ -616,8 +618,7 @@ Forget about the `arguments` object. The rest parameter is always a better optio
 
 ```javascript
 // bad
-const sortNumbers = () =>
-  Array.prototype.slice.call(arguments).sort();
+const sortNumbers = () => Array.prototype.slice.call(arguments).sort();
 
 // good
 const sortNumbers = (...numbers) => numbers.sort();
@@ -649,18 +650,19 @@ Don't `bind()` when there's a more idiomatic approach.
 // good
 ["foo", "bar"].forEach(func, this);
 ```
+
 ```javascript
 // bad
 const person = {
   first: "John",
   last: "Doe",
   greet() {
-    const full = function() {
+    const full = function () {
       return `${this.first} ${this.last}`;
     }.bind(this);
     return `Hello ${full()}`;
-  }
-}
+  },
+};
 
 // good
 const person = {
@@ -669,8 +671,8 @@ const person = {
   greet() {
     const full = () => `${this.first} ${this.last}`;
     return `Hello ${full()}`;
-  }
-}
+  },
+};
 ```
 
 ### Higher-order functions
@@ -679,7 +681,7 @@ Avoid nesting functions when you don't have to.
 
 ```javascript
 // bad
-[1, 2, 3].map(num => String(num));
+[1, 2, 3].map((num) => String(num));
 
 // good
 [1, 2, 3].map(String);
@@ -690,14 +692,17 @@ Avoid nesting functions when you don't have to.
 Avoid multiple nested function calls. Use composition instead.
 
 ```javascript
-const plus1 = a => a + 1;
-const mult2 = a => a * 2;
+const plus1 = (a) => a + 1;
+const mult2 = (a) => a * 2;
 
 // bad
 mult2(plus1(5)); // => 12
 
 // good
-const pipeline = (...funcs) => val => funcs.reduce((a, b) => b(a), val);
+const pipeline =
+  (...funcs) =>
+  (val) =>
+    funcs.reduce((a, b) => b(a), val);
 const addThenMult = pipeline(plus1, mult2);
 addThenMult(5); // => 12
 ```
@@ -711,15 +716,14 @@ Cache feature tests, large data structures and any expensive operation.
 const contains = (arr, value) =>
   Array.prototype.includes
     ? arr.includes(value)
-    : arr.some(el => el === value);
+    : arr.some((el) => el === value);
 contains(["foo", "bar"], "baz"); // => false
 
 // good
 const contains = (() =>
   Array.prototype.includes
     ? (arr, value) => arr.includes(value)
-    : (arr, value) => arr.some(el => el === value)
-)();
+    : (arr, value) => arr.some((el) => el === value))();
 contains(["foo", "bar"], "baz"); // => false
 ```
 
@@ -744,19 +748,14 @@ Favor IIFE's and return statements over if, else if, else and switch statements.
 ```javascript
 // bad
 var grade;
-if (result < 50)
-  grade = "bad";
-else if (result < 90)
-  grade = "good";
-else
-  grade = "excellent";
+if (result < 50) grade = "bad";
+else if (result < 90) grade = "good";
+else grade = "excellent";
 
 // good
 const grade = (() => {
-  if (result < 50)
-    return "bad";
-  if (result < 90)
-    return "good";
+  if (result < 50) return "bad";
+  if (result < 90) return "good";
   return "excellent";
 })();
 ```
@@ -770,18 +769,17 @@ const shared = { foo: "foo" };
 const obj = Object.create(shared, {
   bar: {
     value: "bar",
-    enumerable: true
-  }
+    enumerable: true,
+  },
 });
 
 // bad
 for (var prop in obj) {
-  if (obj.hasOwnProperty(prop))
-    console.log(prop);
+  if (obj.hasOwnProperty(prop)) console.log(prop);
 }
 
 // good
-Object.keys(obj).forEach(prop => console.log(prop));
+Object.keys(obj).forEach((prop) => console.log(prop));
 ```
 
 ### Objects as Maps
@@ -793,7 +791,7 @@ doubt, use a `Map`.
 // bad
 const me = {
   name: "Ben",
-  age: 30
+  age: 30,
 };
 var meSize = Object.keys(me).length;
 meSize; // => 2
@@ -817,7 +815,7 @@ use cases are fairly unusual.
 
 ```javascript
 // bad
-const sum = a => b => a + b;
+const sum = (a) => (b) => a + b;
 sum(5)(3); // => 8
 
 // good
@@ -836,13 +834,19 @@ foo || doSomething();
 // good
 if (!foo) doSomething();
 ```
+
 ```javascript
 // bad
-void function() { /* IIFE */ }();
+void (function () {
+  /* IIFE */
+})();
 
 // good
-(function() { /* IIFE */ }());
+(function () {
+  /* IIFE */
+})();
 ```
+
 ```javascript
 // bad
 const n = ~~3.14;
@@ -860,14 +864,15 @@ Don't be afraid of creating lots of small, highly composable and reusable functi
 arr[arr.length - 1];
 
 // good
-const first = arr => arr[0];
-const last = arr => first(arr.slice(-1));
+const first = (arr) => arr[0];
+const last = (arr) => first(arr.slice(-1));
 last(arr);
 ```
+
 ```javascript
 // bad
 const product = (a, b) => a * b;
-const triple = n => n * 3;
+const triple = (n) => n * 3;
 
 // good
 const product = (a, b) => a * b;

--- a/.cursor/skills/bendc-frontend-guidelines/references/upstream.md
+++ b/.cursor/skills/bendc-frontend-guidelines/references/upstream.md
@@ -1,0 +1,29 @@
+---
+source_name: bendc/frontend-guidelines
+source_url: https://github.com/bendc/frontend-guidelines
+license: unknown
+last_reviewed: 2026-05-15
+---
+
+# Upstream: bendc frontend guidelines
+
+Canonical skill in this repo: `docs/ai/skills/bendc-frontend-guidelines/` (mirrored to `.cursor/skills/` and `.agents/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/bendc/frontend-guidelines
+- **Primary upstream doc:** `README.md` on the default branch (`master` at last refresh)
+- **Vendored copy:** `references/readme-original.md` (plus the short attribution block prepended there)
+
+## Refresh from upstream
+
+This skill is **not** installed via the Skills CLI and is **not** updated by `bun run skills:refresh-upstream`.
+
+1. Download the current `README.md` from https://raw.githubusercontent.com/bendc/frontend-guidelines/master/README.md
+2. Replace `references/readme-original.md` body with upstream content, preserving (or re-adding) the short **Vendored reference** block at the top of that file
+3. Re-read upstream for substantive changes; update `SKILL.md` **Precedence** or workflow bullets if guidance diverges from this repo
+4. Bump `last_reviewed` in this file
+5. Run `bun run skills:sync` and `bun run skills:verify`
+
+## Notes for maintainers
+
+- Do not copy secrets or environment-specific values into skill content.
+- The skill’s `SKILL.md` is the router: it tells agents when to use bendc guidance and when repo rules (`docs/ai/rules/frontend.md`, motion skills, TypeScript/ESLint) take precedence.

--- a/.cursor/skills/bendc-frontend-guidelines/references/upstream.md
+++ b/.cursor/skills/bendc-frontend-guidelines/references/upstream.md
@@ -27,3 +27,4 @@ This skill is **not** installed via the Skills CLI and is **not** updated by `bu
 
 - Do not copy secrets or environment-specific values into skill content.
 - The skill’s `SKILL.md` is the router: it tells agents when to use bendc guidance and when repo rules (`docs/ai/rules/frontend.md`, motion skills, TypeScript/ESLint) take precedence.
+- Before refreshing or expanding the vendored copy, re-check upstream license or permission and keep the attribution block. If the license is still unknown, preserve `license: unknown` metadata and do not present the vendored text as licensed source material.

--- a/.cursor/skills/find-skills/SKILL.md
+++ b/.cursor/skills/find-skills/SKILL.md
@@ -51,6 +51,8 @@ Some extra ecosystem or tool-specific skills may exist only in `.cursor/skills/`
 
 **Example — Resend app integration:** app-level Resend integration in this monorepo is documented in `docs/guides/features/resend-integration.md`.
 
+**Example — bendc frontend guidelines:** semantic HTML, CSS discipline, and vanilla JS readability patterns from [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) are covered by `docs/ai/skills/bendc-frontend-guidelines/SKILL.md` (vendored `README.md` under `references/`); maintainer refresh notes are in `docs/ai/skills/bendc-frontend-guidelines/references/upstream.md`. Use **`docs/ai/rules/frontend.md`** first for `apps/*` and `packages/ui` work.
+
 ## How to Help Users Find Skills
 
 ### Step 1: Understand What They Need

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,8 @@ To **pull newer upstream** content for Supabase: `npx skills add supabase/agent-
 
 **Resend CLI** (`docs/ai/skills/resend-cli/`) is vendored from the tagged [`resend/resend-cli`](https://github.com/resend/resend-cli) tree (`skills/resend-cli/`). Refresh steps live in `docs/ai/skills/resend-cli/references/upstream.md`; it is **not** updated by `bun run skills:refresh-upstream` today.
 
+**`bendc-frontend-guidelines`** (`docs/ai/skills/bendc-frontend-guidelines/`) vendors [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) `README.md`. Refresh steps live in `docs/ai/skills/bendc-frontend-guidelines/references/upstream.md`; it is **not** updated by `bun run skills:refresh-upstream` today.
+
 - **Next.js App Router structure, rendering, data fetching:** `docs/ai/skills/nextjs-app-router/SKILL.md`
 - **Cache Components / PPR / cacheTag & invalidation:** `docs/ai/skills/cache-components/SKILL.md`
 - **React component design/refactor:** `docs/ai/skills/react-component-dev/SKILL.md`
@@ -271,6 +273,7 @@ To **pull newer upstream** content for Supabase: `npx skills add supabase/agent-
 - **Composable, accessible UI components (components.build spec):** `docs/ai/skills/components-build/SKILL.md`
 - **shadcn/ui system usage:** `docs/ai/skills/moai-library-shadcn/SKILL.md`
 - **Base UI:** `docs/ai/skills/base-ui/SKILL.md`
+- **Semantic HTML, CSS discipline, and vanilla JS readability ([bendc/frontend-guidelines](https://github.com/bendc/frontend-guidelines)):** `docs/ai/skills/bendc-frontend-guidelines/SKILL.md` (vendored upstream text under `references/`; subordinate to `docs/ai/rules/frontend.md`, motion skills, and TypeScript lint)
 - **Animation work, transitions, micro-interactions, or motion polish:** load `docs/ai/skills/emil-design-engineering/SKILL.md` first. Pair with `docs/ai/skills/motion/SKILL.md` only when `motion/react` API details are needed.
 - **Motion animations (`motion/react`) implementation details:** `docs/ai/skills/motion/SKILL.md`
 - **Tasteful UI animation (timing, easing, CSS/Motion patterns):** `docs/ai/skills/anim/SKILL.md`

--- a/docs/ai/rules/frontend.md
+++ b/docs/ai/rules/frontend.md
@@ -11,6 +11,7 @@ Use this before changing anything in `apps/*` or `packages/ui` that affects UI.
 
 ### Architecture and organization
 
+- Foundational HTML, CSS, and vanilla JS craft (semantics, selector discipline, a11y hygiene, readable JS) are summarized for agents in **`docs/ai/skills/bendc-frontend-guidelines/SKILL.md`** (vendored from [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)). That skill is **subordinate to this file** and to motion skills when they conflict (tokens, Tailwind, TypeScript strictness, and motion gates in this doc always win).
 - Shared UI primitives live in `packages/ui`. Apps should consume them via `@asym/ui`.
 - Do not generate shadcn components inside `apps/*`.
 - Keep existing Radix-based shared components working while migration continues.

--- a/docs/ai/rules/frontend.md
+++ b/docs/ai/rules/frontend.md
@@ -11,7 +11,7 @@ Use this before changing anything in `apps/*` or `packages/ui` that affects UI.
 
 ### Architecture and organization
 
-- Foundational HTML, CSS, and vanilla JS craft (semantics, selector discipline, a11y hygiene, readable JS) are summarized for agents in **`docs/ai/skills/bendc-frontend-guidelines/SKILL.md`** (vendored from [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)). That skill is **subordinate to this file** and to motion skills when they conflict (tokens, Tailwind, TypeScript strictness, and motion gates in this doc always win).
+- Foundational HTML, CSS, and vanilla JS craft (semantics, selector discipline, a11y hygiene, readable JS) are summarized for agents in **`docs/ai/skills/bendc-frontend-guidelines/SKILL.md`** (vendored from [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)). That skill is **subordinate to this file** and to motion skills when they conflict. Tokens, Tailwind, TypeScript strictness, and motion gates in this doc always win.
 - Shared UI primitives live in `packages/ui`. Apps should consume them via `@asym/ui`.
 - Do not generate shadcn components inside `apps/*`.
 - Keep existing Radix-based shared components working while migration continues.

--- a/docs/ai/skills/bendc-frontend-guidelines/SKILL.md
+++ b/docs/ai/skills/bendc-frontend-guidelines/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bendc-frontend-guidelines
+description: "HTML, CSS, and JavaScript craft guidelines from bendc/frontend-guidelines — semantics, a11y basics, selector discipline, motion-friendly CSS, and readable JS. Use for markup review, static HTML/CSS, email HTML, or general front-end hygiene; pair with repo frontend rules and TypeScript lint policy."
+metadata:
+  owner: core
+  last_updated: 2026-05-15
+  status: active
+  version: "1.0.0"
+---
+
+# bendc Frontend Guidelines (repo skill)
+
+## Triggers
+
+Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from Benjamin De Cock’s widely referenced checklist ([`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)), including:
+
+- Semantic HTML, document structure, `lang`, charset, and meaningful elements (`main`, `article`, `time`, etc.)
+- Accessibility basics called out upstream: `alt` text, real links and buttons, not relying on color alone, labelling controls
+- CSS structure: selector weight, avoiding unnecessary `!important`, inheritance, shorthand, flow and layout (flex/grid over absolute positioning when appropriate)
+- CSS performance habits: prefer `opacity` / `transform` for animation; avoid animating layout-heavy properties (aligns with repo motion rules)
+- Vanilla or legacy JS style: readability, native APIs, avoiding foot-guns called out in the upstream doc
+
+**Also load** `docs/ai/rules/frontend.md` for any **`apps/*` or `packages/ui`** work in this monorepo.
+
+## Do not use when
+
+- The task is strictly backend, migrations, or database-only work.
+- You only need **React / Next.js / App Router** patterns — prefer `docs/ai/skills/nextjs-app-router/SKILL.md` and framework docs.
+- You only need **Tailwind, design tokens, or shared `@asym/ui` primitives** — the upstream doc is not Tailwind-specific; follow `docs/ai/rules/frontend.md` first.
+
+## Precedence (this repo wins)
+
+The full text of the upstream guide lives in **`references/readme-original.md`**. When anything below disagrees with that file, **follow this section**.
+
+| Topic                                                                               | Authoritative in this repo                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components                  | `docs/ai/rules/frontend.md`                                                                                                                 |
+| Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md`                              |
+| TypeScript types, `strict`, equality (`===`), linted patterns                       | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
+| React component structure, Server Components, hooks                                 | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md`                                                                              |
+
+Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS — not as a reason to weaken types, tokens, or repo motion policy.
+
+## Workflow
+
+1. Confirm the surface is in scope (markup, styles, or JS where the upstream checklist applies).
+2. Load **`references/readme-original.md`** (or skim the sections you need: HTML, CSS, JavaScript).
+3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, or TS types.
+4. For shared UI or app routes, reconcile recommendations with **`docs/ai/rules/frontend.md`** and nearby components.
+5. Prefer small, evidence-based edits; do not rewrite large areas solely to match upstream brevity examples if repo style differs.
+
+## Checklist
+
+- [ ] Confirmed triggers match (HTML/CSS/JS craft vs pure React/Next/backend).
+- [ ] Read the relevant sections of `references/readme-original.md` or the live upstream README.
+- [ ] Applied **Precedence**: repo frontend rules, motion skills, and TypeScript lint are satisfied.
+- [ ] Did not strip accessibility or semantics for brevity.
+- [ ] If you edited files under `docs/ai/skills/bendc-frontend-guidelines/`, ran `bun run skills:sync` and `bun run skills:verify` before committing.
+
+## See also
+
+- **Repo UI policy:** `docs/ai/rules/frontend.md`
+- **Motion craft:** `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md`
+- **React component patterns:** `docs/ai/skills/react-component-dev/SKILL.md`
+- **Maintainer refresh notes:** `references/upstream.md`

--- a/docs/ai/skills/bendc-frontend-guidelines/SKILL.md
+++ b/docs/ai/skills/bendc-frontend-guidelines/SKILL.md
@@ -8,11 +8,11 @@ metadata:
   version: "1.0.0"
 ---
 
-# bendc Frontend Guidelines (repo skill)
+# bendc Frontend Guidelines
 
 ## Triggers
 
-Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from Benjamin De Cock’s widely referenced checklist ([`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines)), including:
+Use this skill when the task benefits from **foundational HTML, CSS, and vanilla JS** craft guidance from the vendored [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) checklist, including:
 
 - Semantic HTML, document structure, `lang`, charset, and meaningful elements (`main`, `article`, `time`, etc.)
 - Accessibility basics called out upstream: `alt` text, real links and buttons, not relying on color alone, labelling controls
@@ -30,22 +30,23 @@ Use this skill when the task benefits from **foundational HTML, CSS, and vanilla
 
 ## Precedence (this repo wins)
 
-The full text of the upstream guide lives in **`references/readme-original.md`**. When anything below disagrees with that file, **follow this section**.
+The full text of the upstream guide lives in **`references/readme-original.md`**. When that reference conflicts with the **Precedence** table below, **follow the table**.
 
 | Topic                                                                               | Authoritative in this repo                                                                                                                  |
 | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | Tailwind, Maia/Zinc tokens, `cn()`, no arbitrary hex in components                  | `docs/ai/rules/frontend.md`                                                                                                                 |
 | Motion timing, tokens, reduced motion, `transition-all` ban, route view transitions | `docs/ai/rules/frontend.md`, `docs/ai/skills/emil-design-engineering/SKILL.md`, `docs/ai/skills/anim/SKILL.md`                              |
+| General JavaScript / TypeScript code shape, control flow, helper extraction         | Root `AGENTS.md` code style — prefer explicit, straightforward code over upstream terseness, loop avoidance, recursion, or shorthand        |
 | TypeScript types, `strict`, equality (`===`), linted patterns                       | ESLint / TS config and existing code style — **do not** adopt upstream examples that rely on loose equality or patterns that fail lint here |
 | React component structure, Server Components, hooks                                 | Next.js docs and `docs/ai/skills/react-component-dev/SKILL.md`                                                                              |
 
-Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS — not as a reason to weaken types, tokens, or repo motion policy.
+Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS discipline, and readable JS. Do not copy upstream JavaScript advice about terseness, avoiding loops, recursion, composition, or shorthand unless it improves clarity under this repo's `AGENTS.md` conventions.
 
 ## Workflow
 
 1. Confirm the surface is in scope (markup, styles, or JS where the upstream checklist applies).
 2. Load **`references/readme-original.md`** (or skim the sections you need: HTML, CSS, JavaScript).
-3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, or TS types.
+3. Cross-check **Precedence** above before recommending a change that touches tokens, Tailwind, motion, JS/TS code shape, or TS types.
 4. For shared UI or app routes, reconcile recommendations with **`docs/ai/rules/frontend.md`** and nearby components.
 5. Prefer small, evidence-based edits; do not rewrite large areas solely to match upstream brevity examples if repo style differs.
 
@@ -53,7 +54,7 @@ Use the bendc guide as **a second opinion** on semantics, DOM clarity, CSS disci
 
 - [ ] Confirmed triggers match (HTML/CSS/JS craft vs pure React/Next/backend).
 - [ ] Read the relevant sections of `references/readme-original.md` or the live upstream README.
-- [ ] Applied **Precedence**: repo frontend rules, motion skills, and TypeScript lint are satisfied.
+- [ ] Applied **Precedence**: repo frontend rules, motion skills, `AGENTS.md` code style, and TypeScript lint are satisfied.
 - [ ] Did not strip accessibility or semantics for brevity.
 - [ ] If you edited files under `docs/ai/skills/bendc-frontend-guidelines/`, ran `bun run skills:sync` and `bun run skills:verify` before committing.
 

--- a/docs/ai/skills/bendc-frontend-guidelines/references/readme-original.md
+++ b/docs/ai/skills/bendc-frontend-guidelines/references/readme-original.md
@@ -1,0 +1,901 @@
+> **Vendored reference:** [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) — `README.md` on branch `master`, snapshot 2026-05-15.
+>
+> GitHub did not report an SPDX license for the upstream repository at vendoring time; keep this copy for attribution and agent context. When exact upstream wording matters, compare against the live README on GitHub.
+
+# Frontend Guidelines
+
+## HTML
+
+### Semantics
+
+HTML5 provides us with lots of semantic elements aimed to describe precisely the content. Make sure you benefit from its rich vocabulary.
+
+```html
+<!-- bad -->
+<div id="main">
+  <div class="article">
+    <div class="header">
+      <h1>Blog post</h1>
+      <p>Published: <span>21st Feb, 2015</span></p>
+    </div>
+    <p>…</p>
+  </div>
+</div>
+
+<!-- good -->
+<main>
+  <article>
+    <header>
+      <h1>Blog post</h1>
+      <p>Published: <time datetime="2015-02-21">21st Feb, 2015</time></p>
+    </header>
+    <p>…</p>
+  </article>
+</main>
+```
+
+Make sure you understand the semantics of the elements you're using. It's worse to use a semantic
+element in a wrong way than staying neutral.
+
+```html
+<!-- bad -->
+<h1>
+  <figure>
+    <img alt="Company" src="logo.png" />
+  </figure>
+</h1>
+
+<!-- good -->
+<h1>
+  <img alt="Company" src="logo.png" />
+</h1>
+```
+
+### Brevity
+
+Keep your code terse. Forget about your old XHTML habits.
+
+```html
+<!-- bad -->
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta http-equiv=Content-Type content="text/html; charset=utf-8" />
+    <title>Contact</title>
+    <link rel=stylesheet href=style.css type=text/css />
+  </head>
+  <body>
+    <h1>Contact me</h1>
+    <label>
+      Email address:
+      <input type=email placeholder=you@email.com required=required />
+    </label>
+    <script src=main.js type=text/javascript></script>
+  </body>
+</html>
+
+<!-- good -->
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>Contact</title>
+  <link rel=stylesheet href=style.css>
+
+  <h1>Contact me</h1>
+  <label>
+    Email address:
+    <input type=email placeholder=you@email.com required>
+  </label>
+  <script src=main.js></script>
+</html>
+```
+
+### Accessibility
+
+Accessibility shouldn't be an afterthought. You don't have to be a WCAG expert to improve your
+website, you can start immediately by fixing the little things that make a huge difference, such as:
+
+- learning to use the `alt` attribute properly
+- making sure your links and buttons are marked as such (no `<div class=button>` atrocities)
+- not relying exclusively on colors to communicate information
+- explicitly labelling form controls
+
+```html
+<!-- bad -->
+<h1><img alt="Logo" src="logo.png" /></h1>
+
+<!-- good -->
+<h1><img alt="Company" src="logo.png" /></h1>
+```
+
+### Language & character encoding
+
+While defining the language is optional, it's recommended to always declare
+it on the root element.
+
+The HTML standard requires that pages use the UTF-8 character encoding.
+It has to be declared, and although it can be declared in the Content-Type HTTP header,
+it is recommended to always declare it at the document level.
+
+```html
+<!-- bad -->
+<!doctype html>
+<title>Hello, world.</title>
+
+<!-- good -->
+<!doctype html>
+<html lang="en">
+  <meta charset="utf-8" />
+  <title>Hello, world.</title>
+</html>
+```
+
+### Performance
+
+Unless there's a valid reason for loading your scripts before your content, don't block the
+rendering of your page. If your style sheet is heavy, isolate the styles that are absolutely
+required initially and defer the loading of the secondary declarations in a separate style sheet.
+Two HTTP requests is significantly slower than one, but the perception of speed is the most
+important factor.
+
+```html
+<!-- bad -->
+<!doctype html>
+<meta charset="utf-8" />
+<script src="analytics.js"></script>
+<title>Hello, world.</title>
+<p>...</p>
+
+<!-- good -->
+<!doctype html>
+<meta charset="utf-8" />
+<title>Hello, world.</title>
+<p>...</p>
+<script src="analytics.js"></script>
+```
+
+## CSS
+
+### Semicolons
+
+While the semicolon is technically a separator in CSS, always treat it as a terminator.
+
+```css
+/* bad */
+div {
+  color: red;
+}
+
+/* good */
+div {
+  color: red;
+}
+```
+
+### Box model
+
+The box model should ideally be the same for the entire document. A global
+`* { box-sizing: border-box; }` is fine, but don't change the default box model
+on specific elements if you can avoid it.
+
+```css
+/* bad */
+div {
+  width: 100%;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+/* good */
+div {
+  padding: 10px;
+}
+```
+
+### Flow
+
+Don't change the default behavior of an element if you can avoid it. Keep elements in the
+natural document flow as much as you can. For example, removing the white-space below an
+image shouldn't make you change its default display:
+
+```css
+/* bad */
+img {
+  display: block;
+}
+
+/* good */
+img {
+  vertical-align: middle;
+}
+```
+
+Similarly, don't take an element off the flow if you can avoid it.
+
+```css
+/* bad */
+div {
+  width: 100px;
+  position: absolute;
+  right: 0;
+}
+
+/* good */
+div {
+  width: 100px;
+  margin-left: auto;
+}
+```
+
+### Positioning
+
+There are many ways to position elements in CSS. Favor modern layout specifications
+such as Flexbox and Grid, and avoid removing elements from the normal document flow, for example
+with `position: absolute`.
+
+### Selectors
+
+Minimize selectors tightly coupled to the DOM. Consider adding a class to the elements
+you want to match when your selector exceeds 3 structural pseudo-classes, descendant or
+sibling combinators.
+
+```css
+/* bad */
+div:first-of-type :last-child > p ~ *
+
+/* good */
+div:first-of-type .info
+```
+
+Avoid overloading your selectors when you don't need to.
+
+```css
+/* bad */
+img[src$="svg"],
+ul > li:first-child {
+  opacity: 0;
+}
+
+/* good */
+[src$="svg"],
+ul > :first-child {
+  opacity: 0;
+}
+```
+
+### Specificity
+
+Don't make values and selectors hard to override. Minimize the use of `id`'s
+and avoid `!important`.
+
+```css
+/* bad */
+.bar {
+  color: green !important;
+}
+.foo {
+  color: red;
+}
+
+/* good */
+.foo.bar {
+  color: green;
+}
+.foo {
+  color: red;
+}
+```
+
+### Overriding
+
+Overriding styles makes selectors and debugging harder. Avoid it when possible.
+
+```css
+/* bad */
+li {
+  visibility: hidden;
+}
+li:first-child {
+  visibility: visible;
+}
+
+/* good */
+li + li {
+  visibility: hidden;
+}
+```
+
+### Inheritance
+
+Don't duplicate style declarations that can be inherited.
+
+```css
+/* bad */
+div h1,
+div p {
+  text-shadow: 0 1px 0 #fff;
+}
+
+/* good */
+div {
+  text-shadow: 0 1px 0 #fff;
+}
+```
+
+### Brevity
+
+Keep your code terse. Use shorthand properties and avoid using multiple properties when
+it's not needed.
+
+```css
+/* bad */
+div {
+  transition: all 1s;
+  top: 50%;
+  margin-top: -10px;
+  padding-top: 5px;
+  padding-right: 10px;
+  padding-bottom: 20px;
+  padding-left: 10px;
+}
+
+/* good */
+div {
+  transition: 1s;
+  top: calc(50% - 10px);
+  padding: 5px 10px 20px;
+}
+```
+
+### Language
+
+Prefer English over math.
+
+```css
+/* bad */
+:nth-child(2n + 1) {
+  transform: rotate(360deg);
+}
+
+/* good */
+:nth-child(odd) {
+  transform: rotate(1turn);
+}
+```
+
+### Vendor prefixes
+
+Kill obsolete vendor prefixes aggressively. If you need to use them, insert them before the
+standard property.
+
+```css
+/* bad */
+div {
+  transform: scale(2);
+  -webkit-transform: scale(2);
+  -moz-transform: scale(2);
+  -ms-transform: scale(2);
+  transition: 1s;
+  -webkit-transition: 1s;
+  -moz-transition: 1s;
+  -ms-transition: 1s;
+}
+
+/* good */
+div {
+  -webkit-transform: scale(2);
+  transform: scale(2);
+  transition: 1s;
+}
+```
+
+### Animations
+
+Favor transitions over animations. Avoid animating other properties than
+`opacity` and `transform`.
+
+```css
+/* bad */
+div:hover {
+  animation: move 1s forwards;
+}
+@keyframes move {
+  100% {
+    margin-left: 100px;
+  }
+}
+
+/* good */
+div:hover {
+  transition: 1s;
+  transform: translateX(100px);
+}
+```
+
+### Units
+
+Use unitless values when you can. Favor `rem` if you use relative units. Prefer seconds over
+milliseconds.
+
+```css
+/* bad */
+div {
+  margin: 0px;
+  font-size: 0.9em;
+  line-height: 22px;
+  transition: 500ms;
+}
+
+/* good */
+div {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  transition: 0.5s;
+}
+```
+
+### Colors
+
+If you need transparency, use `rgba`. Otherwise, always use the hexadecimal format.
+
+```css
+/* bad */
+div {
+  color: hsl(103, 54%, 43%);
+}
+
+/* good */
+div {
+  color: #5a3;
+}
+```
+
+### Drawing
+
+Avoid HTTP requests when the resources are easily replicable with CSS.
+
+```css
+/* bad */
+div::before {
+  content: url(white-circle.svg);
+}
+
+/* good */
+div::before {
+  content: "";
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+}
+```
+
+### Hacks
+
+Don't use them.
+
+```css
+/* bad */
+div {
+  // position: relative;
+  transform: translateZ(0);
+}
+
+/* good */
+div {
+  /* position: relative; */
+  will-change: transform;
+}
+```
+
+## JavaScript
+
+### Performance
+
+Favor readability, correctness and expressiveness over performance. JavaScript will basically never
+be your performance bottleneck. Optimize things like image compression, network access and DOM
+reflows instead. If you remember just one guideline from this document, choose this one.
+
+```javascript
+// bad (albeit way faster)
+const arr = [1, 2, 3, 4];
+const len = arr.length;
+var i = -1;
+var result = [];
+while (++i < len) {
+  var n = arr[i];
+  if (n % 2 > 0) continue;
+  result.push(n * n);
+}
+
+// good
+const arr = [1, 2, 3, 4];
+const isEven = (n) => n % 2 == 0;
+const square = (n) => n * n;
+
+const result = arr.filter(isEven).map(square);
+```
+
+### Statelessness
+
+Try to keep your functions pure. All functions should ideally produce no side-effects, use no outside data and return new objects instead of mutating existing ones.
+
+```javascript
+// bad
+const merge = (target, ...sources) => Object.assign(target, ...sources);
+merge({ foo: "foo" }, { bar: "bar" }); // => { foo: "foo", bar: "bar" }
+
+// good
+const merge = (...sources) => Object.assign({}, ...sources);
+merge({ foo: "foo" }, { bar: "bar" }); // => { foo: "foo", bar: "bar" }
+```
+
+### Natives
+
+Rely on native methods as much as possible.
+
+```javascript
+// bad
+const toArray = (obj) => [].slice.call(obj);
+
+// good
+const toArray = (() =>
+  Array.from ? Array.from : (obj) => [].slice.call(obj))();
+```
+
+### Coercion
+
+Embrace implicit coercion when it makes sense. Avoid it otherwise. Don't cargo-cult.
+
+```javascript
+// bad
+if (x === undefined || x === null) { ... }
+
+// good
+if (x == undefined) { ... }
+```
+
+### Loops
+
+Don't use loops as they force you to use mutable objects. Rely on `array.prototype` methods.
+
+```javascript
+// bad
+const sum = (arr) => {
+  var sum = 0;
+  var i = -1;
+  for (; arr[++i]; ) {
+    sum += arr[i];
+  }
+  return sum;
+};
+
+sum([1, 2, 3]); // => 6
+
+// good
+const sum = (arr) => arr.reduce((x, y) => x + y);
+
+sum([1, 2, 3]); // => 6
+```
+
+If you can't, or if using `array.prototype` methods is arguably abusive, use recursion.
+
+```javascript
+// bad
+const createDivs = (howMany) => {
+  while (howMany--) {
+    document.body.insertAdjacentHTML("beforeend", "<div></div>");
+  }
+};
+createDivs(5);
+
+// bad
+const createDivs = (howMany) =>
+  [...Array(howMany)].forEach(() =>
+    document.body.insertAdjacentHTML("beforeend", "<div></div>"),
+  );
+createDivs(5);
+
+// good
+const createDivs = (howMany) => {
+  if (!howMany) return;
+  document.body.insertAdjacentHTML("beforeend", "<div></div>");
+  return createDivs(howMany - 1);
+};
+createDivs(5);
+```
+
+Here's a [generic loop function](https://gist.github.com/bendc/6cb2db4a44ec30208e86) making recursion easier to use.
+
+### Arguments
+
+Forget about the `arguments` object. The rest parameter is always a better option because:
+
+1. it's named, so it gives you a better idea of the arguments the function is expecting
+2. it's a real array, which makes it easier to use.
+
+```javascript
+// bad
+const sortNumbers = () => Array.prototype.slice.call(arguments).sort();
+
+// good
+const sortNumbers = (...numbers) => numbers.sort();
+```
+
+### Apply
+
+Forget about `apply()`. Use the spread operator instead.
+
+```javascript
+const greet = (first, last) => `Hi ${first} ${last}`;
+const person = ["John", "Doe"];
+
+// bad
+greet.apply(null, person);
+
+// good
+greet(...person);
+```
+
+### Bind
+
+Don't `bind()` when there's a more idiomatic approach.
+
+```javascript
+// bad
+["foo", "bar"].forEach(func.bind(this));
+
+// good
+["foo", "bar"].forEach(func, this);
+```
+
+```javascript
+// bad
+const person = {
+  first: "John",
+  last: "Doe",
+  greet() {
+    const full = function () {
+      return `${this.first} ${this.last}`;
+    }.bind(this);
+    return `Hello ${full()}`;
+  },
+};
+
+// good
+const person = {
+  first: "John",
+  last: "Doe",
+  greet() {
+    const full = () => `${this.first} ${this.last}`;
+    return `Hello ${full()}`;
+  },
+};
+```
+
+### Higher-order functions
+
+Avoid nesting functions when you don't have to.
+
+```javascript
+// bad
+[1, 2, 3].map((num) => String(num));
+
+// good
+[1, 2, 3].map(String);
+```
+
+### Composition
+
+Avoid multiple nested function calls. Use composition instead.
+
+```javascript
+const plus1 = (a) => a + 1;
+const mult2 = (a) => a * 2;
+
+// bad
+mult2(plus1(5)); // => 12
+
+// good
+const pipeline =
+  (...funcs) =>
+  (val) =>
+    funcs.reduce((a, b) => b(a), val);
+const addThenMult = pipeline(plus1, mult2);
+addThenMult(5); // => 12
+```
+
+### Caching
+
+Cache feature tests, large data structures and any expensive operation.
+
+```javascript
+// bad
+const contains = (arr, value) =>
+  Array.prototype.includes
+    ? arr.includes(value)
+    : arr.some((el) => el === value);
+contains(["foo", "bar"], "baz"); // => false
+
+// good
+const contains = (() =>
+  Array.prototype.includes
+    ? (arr, value) => arr.includes(value)
+    : (arr, value) => arr.some((el) => el === value))();
+contains(["foo", "bar"], "baz"); // => false
+```
+
+### Variables
+
+Favor `const` over `let` and `let` over `var`.
+
+```javascript
+// bad
+var me = new Map();
+me.set("name", "Ben").set("country", "Belgium");
+
+// good
+const me = new Map();
+me.set("name", "Ben").set("country", "Belgium");
+```
+
+### Conditions
+
+Favor IIFE's and return statements over if, else if, else and switch statements.
+
+```javascript
+// bad
+var grade;
+if (result < 50) grade = "bad";
+else if (result < 90) grade = "good";
+else grade = "excellent";
+
+// good
+const grade = (() => {
+  if (result < 50) return "bad";
+  if (result < 90) return "good";
+  return "excellent";
+})();
+```
+
+### Object iteration
+
+Avoid `for...in` when you can.
+
+```javascript
+const shared = { foo: "foo" };
+const obj = Object.create(shared, {
+  bar: {
+    value: "bar",
+    enumerable: true,
+  },
+});
+
+// bad
+for (var prop in obj) {
+  if (obj.hasOwnProperty(prop)) console.log(prop);
+}
+
+// good
+Object.keys(obj).forEach((prop) => console.log(prop));
+```
+
+### Objects as Maps
+
+While objects have legitimate use cases, maps are usually a better, more powerful choice. When in
+doubt, use a `Map`.
+
+```javascript
+// bad
+const me = {
+  name: "Ben",
+  age: 30,
+};
+var meSize = Object.keys(me).length;
+meSize; // => 2
+me.country = "Belgium";
+meSize++;
+meSize; // => 3
+
+// good
+const me = new Map();
+me.set("name", "Ben");
+me.set("age", 30);
+me.size; // => 2
+me.set("country", "Belgium");
+me.size; // => 3
+```
+
+### Curry
+
+Currying is a powerful but foreign paradigm for many developers. Don't abuse it as its appropriate
+use cases are fairly unusual.
+
+```javascript
+// bad
+const sum = (a) => (b) => a + b;
+sum(5)(3); // => 8
+
+// good
+const sum = (a, b) => a + b;
+sum(5, 3); // => 8
+```
+
+### Readability
+
+Don't obfuscate the intent of your code by using seemingly smart tricks.
+
+```javascript
+// bad
+foo || doSomething();
+
+// good
+if (!foo) doSomething();
+```
+
+```javascript
+// bad
+void (function () {
+  /* IIFE */
+})();
+
+// good
+(function () {
+  /* IIFE */
+})();
+```
+
+```javascript
+// bad
+const n = ~~3.14;
+
+// good
+const n = Math.floor(3.14);
+```
+
+### Code reuse
+
+Don't be afraid of creating lots of small, highly composable and reusable functions.
+
+```javascript
+// bad
+arr[arr.length - 1];
+
+// good
+const first = (arr) => arr[0];
+const last = (arr) => first(arr.slice(-1));
+last(arr);
+```
+
+```javascript
+// bad
+const product = (a, b) => a * b;
+const triple = (n) => n * 3;
+
+// good
+const product = (a, b) => a * b;
+const triple = product.bind(null, 3);
+```
+
+### Dependencies
+
+Minimize dependencies. Third-party is code you don't know. Don't load an entire library for just a couple of methods easily replicable:
+
+```javascript
+// bad
+var _ = require("underscore");
+_.compact(["foo", 0]));
+_.unique(["foo", "foo"]);
+_.union(["foo"], ["bar"], ["foo"]);
+
+// good
+const compact = arr => arr.filter(el => el);
+const unique = arr => [...new Set(arr)];
+const union = (...arr) => unique([].concat(...arr));
+
+compact(["foo", 0]);
+unique(["foo", "foo"]);
+union(["foo"], ["bar"], ["foo"]);
+```

--- a/docs/ai/skills/bendc-frontend-guidelines/references/upstream.md
+++ b/docs/ai/skills/bendc-frontend-guidelines/references/upstream.md
@@ -1,0 +1,29 @@
+---
+source_name: bendc/frontend-guidelines
+source_url: https://github.com/bendc/frontend-guidelines
+license: unknown
+last_reviewed: 2026-05-15
+---
+
+# Upstream: bendc frontend guidelines
+
+Canonical skill in this repo: `docs/ai/skills/bendc-frontend-guidelines/` (mirrored to `.cursor/skills/` and `.agents/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/bendc/frontend-guidelines
+- **Primary upstream doc:** `README.md` on the default branch (`master` at last refresh)
+- **Vendored copy:** `references/readme-original.md` (plus the short attribution block prepended there)
+
+## Refresh from upstream
+
+This skill is **not** installed via the Skills CLI and is **not** updated by `bun run skills:refresh-upstream`.
+
+1. Download the current `README.md` from https://raw.githubusercontent.com/bendc/frontend-guidelines/master/README.md
+2. Replace `references/readme-original.md` body with upstream content, preserving (or re-adding) the short **Vendored reference** block at the top of that file
+3. Re-read upstream for substantive changes; update `SKILL.md` **Precedence** or workflow bullets if guidance diverges from this repo
+4. Bump `last_reviewed` in this file
+5. Run `bun run skills:sync` and `bun run skills:verify`
+
+## Notes for maintainers
+
+- Do not copy secrets or environment-specific values into skill content.
+- The skill’s `SKILL.md` is the router: it tells agents when to use bendc guidance and when repo rules (`docs/ai/rules/frontend.md`, motion skills, TypeScript/ESLint) take precedence.

--- a/docs/ai/skills/bendc-frontend-guidelines/references/upstream.md
+++ b/docs/ai/skills/bendc-frontend-guidelines/references/upstream.md
@@ -27,3 +27,4 @@ This skill is **not** installed via the Skills CLI and is **not** updated by `bu
 
 - Do not copy secrets or environment-specific values into skill content.
 - The skill’s `SKILL.md` is the router: it tells agents when to use bendc guidance and when repo rules (`docs/ai/rules/frontend.md`, motion skills, TypeScript/ESLint) take precedence.
+- Before refreshing or expanding the vendored copy, re-check upstream license or permission and keep the attribution block. If the license is still unknown, preserve `license: unknown` metadata and do not present the vendored text as licensed source material.

--- a/docs/ai/skills/find-skills/SKILL.md
+++ b/docs/ai/skills/find-skills/SKILL.md
@@ -51,6 +51,8 @@ Some extra ecosystem or tool-specific skills may exist only in `.cursor/skills/`
 
 **Example — Resend app integration:** app-level Resend integration in this monorepo is documented in `docs/guides/features/resend-integration.md`.
 
+**Example — bendc frontend guidelines:** semantic HTML, CSS discipline, and vanilla JS readability patterns from [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) are covered by `docs/ai/skills/bendc-frontend-guidelines/SKILL.md` (vendored `README.md` under `references/`); maintainer refresh notes are in `docs/ai/skills/bendc-frontend-guidelines/references/upstream.md`. Use **`docs/ai/rules/frontend.md`** first for `apps/*` and `packages/ui` work.
+
 ## How to Help Users Find Skills
 
 ### Step 1: Understand What They Need


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds [bendc/frontend-guidelines](https://github.com/bendc/frontend-guidelines) as a **canonical** repo skill under `docs/ai/skills/bendc-frontend-guidelines/`, following the same pattern as other vendored references (for example `resend-cli`): `SKILL.md` for triggers, workflow, checklist, and explicit **precedence** over upstream when repo rules conflict; `references/readme-original.md` as a vendored copy of upstream `README.md` with attribution; `references/upstream.md` for maintainer refresh steps.

## Routing

- `AGENTS.md` — new Skill Routing bullet and note in the ecosystem refresh paragraph.
- `docs/ai/rules/frontend.md` — points agents at the skill for foundational HTML/CSS/JS craft while keeping this rulebook primary for app UI.
- `docs/ai/skills/find-skills/SKILL.md` — discovery example for repo-local canonical skills.

## Mirrors

`bun run skills:sync` and `bun run skills:verify` were run; `.agents/skills/` and `.cursor/skills/` include `bendc-frontend-guidelines` and updated `.repo-canonical-skills.json`.

## Verification

- `bun run skills:verify`

Follow-up: trigger wording avoids attributing a full legal name to the upstream author when only the GitHub org/user handle is required for navigation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28e1d69c-f13d-488c-bd02-f64d1a2242e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28e1d69c-f13d-488c-bd02-f64d1a2242e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR vendors [`bendc/frontend-guidelines`](https://github.com/bendc/frontend-guidelines) as a canonical AI agent skill, following the same established pattern used for the `resend-cli` skill: a `SKILL.md` router with triggers, precedence table, and workflow; a vendored `references/readme-original.md` with attribution; and a `references/upstream.md` with maintainer refresh steps.

- `AGENTS.md` and `docs/ai/rules/frontend.md` are updated to route agents to the new skill, with explicit precedence rules ensuring repo-local conventions (Tailwind tokens, motion rules, TypeScript strictness) always win over upstream guidance.
- The skill is mirrored consistently to `docs/ai/skills/`, `.agents/skills/`, and `.cursor/skills/`, and `bendc-frontend-guidelines` is registered in alphabetical order in both `.repo-canonical-skills.json` files.
- The `find-skills/SKILL.md` discovery example is updated across all three locations.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no executable code; follows the established vendored-skill pattern exactly.

All changes are AI-guidance documents (SKILL.md, upstream.md, vendored README, AGENTS.md routing bullets, frontend rule pointer). No runtime code, migrations, auth logic, or configuration is touched. The license-unknown status of the upstream content is explicitly acknowledged in both the vendored file's attribution block and the upstream.md maintainer notes, which advise against presenting it as licensed source material.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/ai/skills/bendc-frontend-guidelines/SKILL.md | New canonical skill file; triggers, precedence table, workflow, and checklist are well-structured and consistent with the resend-cli pattern. |
| docs/ai/skills/bendc-frontend-guidelines/references/upstream.md | Refresh instructions and maintainer notes; explicitly acknowledges unknown license and instructs maintainers not to present the vendored copy as licensed source material. |
| docs/ai/skills/bendc-frontend-guidelines/references/readme-original.md | Vendored copy of upstream README with attribution block; license is noted as unknown, consistent with upstream.md guidance. |
| AGENTS.md | Adds ecosystem-refresh paragraph and skill-routing bullet for bendc-frontend-guidelines, mirroring the pattern used for resend-cli. |
| docs/ai/rules/frontend.md | Single-line addition that points agents at the new skill while clearly establishing subordination to this rulebook. |
| docs/ai/skills/find-skills/SKILL.md | Discovery example for the new skill added; correctly notes frontend.md takes precedence for apps/* and packages/ui work. |
| .agents/skills/.repo-canonical-skills.json | bendc-frontend-guidelines added in alphabetical order; mirrors the change in .cursor/skills/. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent receives frontend task] --> B{Task type?}
    B -->|apps/* or packages/ui| C[Load docs/ai/rules/frontend.md FIRST]
    B -->|Semantic HTML / CSS / vanilla JS| D[Load bendc-frontend-guidelines SKILL.md]
    B -->|React / Next.js patterns| E[nextjs-app-router SKILL.md]
    C --> D
    D --> F[Load references/readme-original.md]
    F --> G{Conflict with repo rules?}
    G -->|Yes| H[Repo rules win: frontend.md, motion skills, TS lint, AGENTS.md]
    G -->|No| I[Apply bendc guidance]
    H --> J[Produce output]
    I --> J
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: remove uncertain author wording fro..."](https://github.com/asymmetric-al/core/commit/a9d48d30b0d99276b2f7026941252e8653f49c64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33011739)</sub>

<!-- /greptile_comment -->