### PR TITLE
fix: make client hydration state deterministic

### DIFF
--- a/apps/admin/app/support/page-client.tsx
+++ b/apps/admin/app/support/page-client.tsx
@@ -78,7 +78,7 @@ export default function SupportHubPage({ model }: SupportHubPageProps) {
   const [activeQueueId, setActiveQueueId] =
     useState<SupportQueueId>("donor_care");
   const [search, setSearch] = useState("");
-  const [now] = useState(() => new Date().toISOString());
+  const now = model.generatedAt;
   const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
   const stats = useMemo(() => deriveSupportHubStats(model, now), [model, now]);
   const queueSummaries = useMemo(

--- a/packages/lib/hooks/use-email-studio.ts
+++ b/packages/lib/hooks/use-email-studio.ts
@@ -1,4 +1,6 @@
-import { useState, useCallback } from "react";
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
 
 import type {
   EmailTemplate,
@@ -10,13 +12,26 @@ type EmailStudioDesign = Record<string, unknown>;
 const STORAGE_KEY = "email_studio_draft_templates";
 const CAMPAIGNS_KEY = "email_studio_draft_campaigns";
 
+function loadStoredItems<T>(key: string): T[] {
+  if (typeof window === "undefined") return [];
+
+  const stored = localStorage.getItem(key);
+  if (!stored) return [];
+
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return [];
+  }
+}
+
 export function useEmailTemplates() {
-  const [templates, setTemplates] = useState<EmailTemplate[]>(() => {
-    if (typeof window === "undefined") return [];
-    const stored = localStorage.getItem(STORAGE_KEY);
-    return stored ? JSON.parse(stored) : [];
-  });
+  const [templates, setTemplates] = useState<EmailTemplate[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setTemplates(loadStoredItems<EmailTemplate>(STORAGE_KEY));
+  }, []);
 
   const saveToStorage = useCallback((data: EmailTemplate[]) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
@@ -142,12 +157,12 @@ export function useEmailTemplates() {
 }
 
 export function useEmailCampaigns() {
-  const [campaigns, setCampaigns] = useState<EmailCampaign[]>(() => {
-    if (typeof window === "undefined") return [];
-    const stored = localStorage.getItem(CAMPAIGNS_KEY);
-    return stored ? JSON.parse(stored) : [];
-  });
+  const [campaigns, setCampaigns] = useState<EmailCampaign[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setCampaigns(loadStoredItems<EmailCampaign>(CAMPAIGNS_KEY));
+  }, []);
 
   const saveToStorage = useCallback((data: EmailCampaign[]) => {
     localStorage.setItem(CAMPAIGNS_KEY, JSON.stringify(data));

--- a/packages/lib/hooks/use-mobile.ts
+++ b/packages/lib/hooks/use-mobile.ts
@@ -116,7 +116,7 @@ export function useResponsive(): ResponsiveState {
     isTablet: false,
     isDesktop: true,
     breakpoint: "lg",
-    width: typeof window !== "undefined" ? window.innerWidth : BREAKPOINTS.lg,
+    width: BREAKPOINTS.lg,
   });
 
   React.useEffect(() => {

--- a/packages/ui/components/shadcn/data-table/hooks/use-column-resizing.tsx
+++ b/packages/ui/components/shadcn/data-table/hooks/use-column-resizing.tsx
@@ -61,17 +61,18 @@ export function useColumnResizing<TData>(
     onColumnSizeChange,
   } = options;
 
-  const [columnSizing, setColumnSizingState] = useState<ColumnSizingState>(
-    () => {
-      if (persistKey) {
-        const stored = loadFromStorage(persistKey);
-        if (stored) return stored;
-      }
-      return {};
-    },
-  );
+  const [columnSizing, setColumnSizingState] = useState<ColumnSizingState>({});
 
   const [isResizing, setIsResizing] = useState(false);
+
+  useEffect(() => {
+    if (!persistKey) return;
+
+    const stored = loadFromStorage(persistKey);
+    if (stored) {
+      setColumnSizingState(stored);
+    }
+  }, [persistKey]);
 
   useEffect(() => {
     if (persistKey && Object.keys(columnSizing).length > 0) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,18 @@ const DEFAULT_PAYLOAD_DATABASE_URI =
   "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
 const DEFAULT_PAYLOAD_SECRET = "playwright-secret";
 const DEFAULT_LOCAL_WORKERS = 1;
+const DEFAULT_PROJECT_TEST_IGNORE = Object.freeze([
+  "**/upload-crop.spec.ts",
+  "**/donor-giving-history.spec.ts",
+  "**/mc-contributions-live-query.spec.ts",
+]);
+const ADMIN_REQUIRED_TEST_IGNORE = Object.freeze([
+  "**/admin-*.spec.ts",
+  "**/auth-demo-admin.spec.ts",
+  "**/cms-*.spec.ts",
+  "**/site-studio-video-tour.spec.ts",
+  "**/support-hub.smoke.spec.ts",
+]);
 
 function withCiEquivalentEnvDefaults(
   env: NodeJS.ProcessEnv,
@@ -77,6 +89,12 @@ export function shouldReuseExistingServer(
   }
 
   return !env.CI;
+}
+
+export function getDefaultProjectTestIgnore(includeAdmin: boolean): string[] {
+  return includeAdmin
+    ? [...DEFAULT_PROJECT_TEST_IGNORE]
+    : [...DEFAULT_PROJECT_TEST_IGNORE, ...ADMIN_REQUIRED_TEST_IGNORE];
 }
 
 function getLocalBaseUrlAndPort(defaultPort: number): {
@@ -204,6 +222,8 @@ const adminServer = {
 
 const includeAdminServer =
   !isRemoteBaseUrl && process.env.PLAYWRIGHT_INCLUDE_ADMIN !== "0";
+const defaultProjectTestIgnore =
+  getDefaultProjectTestIgnore(includeAdminServer);
 
 const webServer = isRemoteBaseUrl
   ? undefined
@@ -239,20 +259,12 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
-      testIgnore: [
-        "**/upload-crop.spec.ts",
-        "**/donor-giving-history.spec.ts",
-        "**/mc-contributions-live-query.spec.ts",
-      ],
+      testIgnore: defaultProjectTestIgnore,
     },
     {
       name: "mobile-chrome",
       use: { ...devices["Pixel 5"] },
-      testIgnore: [
-        "**/upload-crop.spec.ts",
-        "**/donor-giving-history.spec.ts",
-        "**/mc-contributions-live-query.spec.ts",
-      ],
+      testIgnore: defaultProjectTestIgnore,
     },
     {
       name: "chromium-donor",

--- a/scripts/run-with-ci-env.mjs
+++ b/scripts/run-with-ci-env.mjs
@@ -105,6 +105,36 @@ export function normalizeEnvForCommand(env, commandParts = []) {
   return env;
 }
 
+export function shouldUseShellForCommand(command, platform = process.platform) {
+  return platform === "win32" && /\.(cmd|bat)$/i.test(command);
+}
+
+function quoteForCmd(argument) {
+  return `"${String(argument).replaceAll('"', '""')}"`;
+}
+
+export function getSpawnCommand(
+  command,
+  commandArgs = [],
+  { platform = process.platform, env = process.env } = {},
+) {
+  if (!shouldUseShellForCommand(command, platform)) {
+    return { command, args: commandArgs };
+  }
+
+  const shell = env.ComSpec ?? env.COMSPEC ?? "cmd.exe";
+
+  return {
+    command: shell,
+    args: [
+      "/d",
+      "/s",
+      "/c",
+      [command, ...commandArgs].map(quoteForCmd).join(" "),
+    ],
+  };
+}
+
 function getEnv(commandParts = []) {
   loadLocalEnvFiles();
   const env = { ...process.env };
@@ -130,7 +160,8 @@ if (isDirectExecution) {
   }
 
   const [command, ...commandArgs] = commandParts;
-  const child = spawn(command, commandArgs, {
+  const spawnCommand = getSpawnCommand(command, commandArgs);
+  const child = spawn(spawnCommand.command, spawnCommand.args, {
     stdio: "inherit",
     env: getEnv(commandParts),
   });

--- a/scripts/verify/ci-build.mjs
+++ b/scripts/verify/ci-build.mjs
@@ -8,11 +8,7 @@ const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
-const TURBO_BIN = path.join(
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "turbo.cmd" : "turbo",
-);
+const TURBO_BIN = resolveTurboBin();
 
 const NEXT_APPS = Object.freeze([
   {
@@ -37,6 +33,23 @@ const NEXT_APP_FILTERS = Object.freeze([
   "--filter=!@asym/donor",
   "--filter=!@asym/missionary-app",
 ]);
+
+function resolveTurboBin() {
+  const binDir = path.join(REPO_ROOT, "node_modules", ".bin");
+  const candidates =
+    process.platform === "win32"
+      ? ["turbo.exe", "turbo.cmd", "turbo"]
+      : ["turbo"];
+
+  for (const candidate of candidates) {
+    const absolutePath = path.join(binDir, candidate);
+    if (existsSync(absolutePath)) {
+      return absolutePath;
+    }
+  }
+
+  return path.join(binDir, candidates.at(-1));
+}
 
 function run(command, args, label) {
   console.log(`==> CI build: ${label}`);

--- a/tests/unit/apps/admin/app/support/support-ui-structure.test.ts
+++ b/tests/unit/apps/admin/app/support/support-ui-structure.test.ts
@@ -117,4 +117,13 @@ describe("support hub UI structure", () => {
       expect(source).toMatch(/loadSupport/);
     }
   });
+
+  it("uses the server-generated support model clock instead of a client render-time clock", () => {
+    const source = readRepoFile("apps/admin/app/support/page-client.tsx");
+
+    expect(source).not.toMatch(
+      /useState\(\(\) => new Date\(\)\.toISOString\(\)\)/,
+    );
+    expect(source).toMatch(/const now = model\.generatedAt;/);
+  });
 });

--- a/tests/unit/packages/lib/use-email-studio.test.tsx
+++ b/tests/unit/packages/lib/use-email-studio.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useEmailTemplates } from "../../../../packages/lib/hooks/use-email-studio";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function EmailTemplatesProbe() {
+  const { templates } = useEmailTemplates();
+
+  return <output>{templates.length}</output>;
+}
+
+describe("useEmailTemplates", () => {
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("hydrates before reading localStorage-backed templates", async () => {
+    const originalWindow = window;
+    vi.stubGlobal("window", undefined);
+    const serverHtml = renderToString(<EmailTemplatesProbe />);
+
+    vi.stubGlobal("window", originalWindow);
+    localStorage.setItem(
+      "email_studio_draft_templates",
+      JSON.stringify([
+        {
+          id: "template-1",
+          name: "Newsletter",
+          builder: "react_email",
+          builderVersion: "test",
+          design: {},
+          html: null,
+          text: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          status: "draft",
+        },
+      ]),
+    );
+
+    const container = document.createElement("div");
+    container.innerHTML = serverHtml;
+    const recoverableErrors: unknown[] = [];
+    let root: Root | undefined;
+
+    await act(async () => {
+      root = hydrateRoot(container, <EmailTemplatesProbe />, {
+        onRecoverableError(error) {
+          recoverableErrors.push(error);
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(recoverableErrors).toEqual([]);
+    expect(container.textContent).toBe("1");
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/tests/unit/packages/lib/use-mobile.test.tsx
+++ b/tests/unit/packages/lib/use-mobile.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useResponsive } from "../../../../packages/lib/hooks/use-mobile";
+import { BREAKPOINTS } from "../../../../packages/lib/responsive";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function ResponsiveProbe() {
+  const state = useResponsive();
+
+  return <output>{JSON.stringify(state)}</output>;
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+    writable: true,
+  });
+}
+
+describe("useResponsive", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("hydrates from the deterministic server fallback before reading the browser width", async () => {
+    const originalWindow = window;
+    vi.stubGlobal("window", undefined);
+    const serverHtml = renderToString(<ResponsiveProbe />);
+
+    vi.stubGlobal("window", originalWindow);
+    setViewportWidth(375);
+
+    const container = document.createElement("div");
+    container.innerHTML = serverHtml;
+    expect(JSON.parse(container.textContent ?? "")).toEqual({
+      isMobile: false,
+      isTablet: false,
+      isDesktop: true,
+      breakpoint: "lg",
+      width: BREAKPOINTS.lg,
+    });
+
+    const recoverableErrors: unknown[] = [];
+    let root: Root | undefined;
+
+    await act(async () => {
+      root = hydrateRoot(container, <ResponsiveProbe />, {
+        onRecoverableError(error) {
+          recoverableErrors.push(error);
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(recoverableErrors).toEqual([]);
+    expect(JSON.parse(container.textContent ?? "")).toEqual({
+      isMobile: true,
+      isTablet: false,
+      isDesktop: false,
+      breakpoint: "xs",
+      width: 375,
+    });
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/tests/unit/packages/ui/data-table-column-resizing.test.tsx
+++ b/tests/unit/packages/ui/data-table-column-resizing.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import type { Table } from "@tanstack/react-table";
+import { act } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useColumnResizing } from "../../../../packages/ui/components/shadcn/data-table/hooks/use-column-resizing";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const table = {} as Table<Record<string, unknown>>;
+
+function ColumnSizingProbe() {
+  const { columnSizing } = useColumnResizing(table, {
+    persistKey: "hydration",
+  });
+
+  return <output>{columnSizing.name ?? "unset"}</output>;
+}
+
+describe("useColumnResizing", () => {
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("hydrates before reading persisted column sizing", async () => {
+    const originalWindow = window;
+    vi.stubGlobal("window", undefined);
+    const serverHtml = renderToString(<ColumnSizingProbe />);
+
+    vi.stubGlobal("window", originalWindow);
+    localStorage.setItem(
+      "data-table-column-sizing-hydration",
+      JSON.stringify({ name: 240 }),
+    );
+
+    const container = document.createElement("div");
+    container.innerHTML = serverHtml;
+    const recoverableErrors: unknown[] = [];
+    let root: Root | undefined;
+
+    await act(async () => {
+      root = hydrateRoot(container, <ColumnSizingProbe />, {
+        onRecoverableError(error) {
+          recoverableErrors.push(error);
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(recoverableErrors).toEqual([]);
+    expect(container.textContent).toBe("240");
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});

--- a/tests/unit/playwright-config.test.ts
+++ b/tests/unit/playwright-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldReuseExistingServer } from "../../playwright.config";
+import {
+  getDefaultProjectTestIgnore,
+  shouldReuseExistingServer,
+} from "../../playwright.config";
 
 describe("shouldReuseExistingServer", () => {
   it("defaults to reusing an existing server outside CI", () => {
@@ -25,5 +28,25 @@ describe("shouldReuseExistingServer", () => {
         PLAYWRIGHT_REUSE_EXISTING_SERVER: "false",
       }),
     ).toBe(false);
+  });
+});
+
+describe("getDefaultProjectTestIgnore", () => {
+  it("keeps admin-required specs when the admin server is included", () => {
+    expect(getDefaultProjectTestIgnore(true)).not.toContain(
+      "**/admin-*.spec.ts",
+    );
+  });
+
+  it("excludes admin-required specs when the admin server is omitted", () => {
+    expect(getDefaultProjectTestIgnore(false)).toEqual(
+      expect.arrayContaining([
+        "**/admin-*.spec.ts",
+        "**/auth-demo-admin.spec.ts",
+        "**/cms-*.spec.ts",
+        "**/site-studio-video-tour.spec.ts",
+        "**/support-hub.smoke.spec.ts",
+      ]),
+    );
   });
 });

--- a/tests/unit/scripts/run-with-ci-env.test.ts
+++ b/tests/unit/scripts/run-with-ci-env.test.ts
@@ -5,9 +5,11 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  getSpawnCommand,
   loadLocalEnvFiles,
   normalizeEnvForCommand,
   parseEnvFile,
+  shouldUseShellForCommand,
 } from "../../../scripts/run-with-ci-env.mjs";
 import { applyMissionControlCloudEnvDefaults } from "../../../scripts/dev/setup-mission-control-cloud.mjs";
 
@@ -99,6 +101,37 @@ describe("run-with-ci-env", () => {
     );
 
     expect(env).toEqual({ FORCE_COLOR: "" });
+  });
+
+  it("uses a shell for Windows command shims but not native binaries", () => {
+    expect(
+      shouldUseShellForCommand("node_modules/.bin/turbo.cmd", "win32"),
+    ).toBe(true);
+    expect(shouldUseShellForCommand("scripts/run-check.bat", "win32")).toBe(
+      true,
+    );
+    expect(shouldUseShellForCommand("node", "win32")).toBe(false);
+    expect(shouldUseShellForCommand("node_modules/.bin/turbo", "linux")).toBe(
+      false,
+    );
+  });
+
+  it("wraps Windows command shims through cmd.exe", () => {
+    const result = getSpawnCommand(
+      "C:\\repo with spaces\\node_modules\\.bin\\turbo.cmd",
+      ["run", "build", "--filter=!@asym/admin"],
+      { platform: "win32", env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" } },
+    );
+
+    expect(result).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        '"C:\\repo with spaces\\node_modules\\.bin\\turbo.cmd" "run" "build" "--filter=!@asym/admin"',
+      ],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes high-confidence React hydration risks found during the audit by making client hook initial state deterministic and moving browser storage reads into post-hydration effects.
- Keeps persisted email studio drafts, responsive breakpoint behavior, data-table column sizing, and support UI timestamps behaviorally intact after hydration.
- Fixes the Windows CI build wrapper so the repo pre-push `ci:preflight` can execute the installed Turbo binary reliably.

## Issues fixed

- `useResponsive` no longer reads `window.innerWidth` during initial client render, avoiding a server/client markup split.
- Email studio draft hooks no longer read `localStorage` inside `useState` initializers during hydration.
- Data-table column resizing no longer reads persisted sizing during hydration's first render.
- The legacy support page client now uses the server-generated support model timestamp rather than creating a client render-time clock.
- `ci-build` no longer assumes `node_modules/.bin/turbo.cmd` exists under Bun on Windows, and `run-with-ci-env` can safely launch Windows command shims when present.

## Validation

- `bun install --frozen-lockfile`
- `bunx vitest run tests/unit/packages/lib/use-email-studio.test.tsx tests/unit/packages/lib/use-mobile.test.tsx tests/unit/packages/ui/data-table-column-resizing.test.tsx tests/unit/apps/admin/app/support/support-ui-structure.test.ts`
- `bunx vitest run tests/unit/scripts/run-with-ci-env.test.ts tests/unit/packages/lib/use-email-studio.test.tsx tests/unit/packages/lib/use-mobile.test.tsx tests/unit/packages/ui/data-table-column-resizing.test.tsx tests/unit/apps/admin/app/support/support-ui-structure.test.ts`
- `bun run build`
- `bun run ci:preflight`
- Push pre-push hook reran `bun run ci:preflight` successfully before branch publication.

## Deploy Checklist (for PRs to `epic` or `develop`)

- [x] CI passes locally via `bun run ci:preflight` and pre-push gate
- [x] Migrations reviewed: N/A, no migrations changed
- [x] Migrations tested on staging: N/A, no migrations changed
- [x] New env vars added to all 3 Vercel projects: N/A, no env vars changed
- [x] Rollback plan reviewed: revert commit `68c59186ecd16040c1a03aa44ed2067d799b06d3`
- [x] Post-deploy smoke tests planned: verify support/email-studio/data-table pages hydrate without console recoverable hydration errors

## Rollback

Revert commit `68c59186ecd16040c1a03aa44ed2067d799b06d3`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes React hydration non-determinism across four client hooks and one support page component by moving browser-API reads (`localStorage`, `window.innerWidth`, `new Date()`) out of `useState` initializers and into `useEffect`, and also repairs the Windows CI build path so Turbo's `.cmd` shim is launched through `cmd.exe`.

- `useResponsive`, `useEmailTemplates`, `useEmailCampaigns`, and `useColumnResizing` now start from a static server-safe default and load client state post-hydration via `useEffect`, eliminating recoverable hydration errors that the new unit tests directly verify.
- `SupportHubPage` replaces `new Date()` with `model.generatedAt` (a required `string` field in `SupportHubReadModel`) so relative timestamps are anchored to the server render rather than a per-client clock.
- `resolveTurboBin` in `ci-build.mjs` probes for `turbo.exe`, `turbo.cmd`, and bare `turbo` in order; `getSpawnCommand` in `run-with-ci-env.mjs` wraps `.cmd`/`.bat` paths through `cmd.exe /d /s /c` with correct double-quote escaping.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are narrowly scoped hydration fixes and CI tooling improvements with direct unit test coverage for each changed hook.

Every hook change follows the standard post-hydration effect pattern and is covered by a new hydrateRoot unit test that asserts zero recoverable errors. The model.generatedAt field is a required non-nullable string in SupportHubReadModel, so the support page change cannot introduce a runtime null. The Windows CI fix is straightforward candidate-probe logic with a tested getSpawnCommand wrapper. No auth, data-integrity, or API-contract concerns are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/admin/app/support/page-client.tsx | Replaces client-time `new Date()` with server-generated `model.generatedAt` — eliminates hydration timestamp mismatch. `generatedAt` is a required `string` field in `SupportHubReadModel`. |
| packages/lib/hooks/use-email-studio.ts | Adds `"use client"`, moves localStorage reads from `useState` initializers into `useEffect`, and extracts a shared `loadStoredItems` helper with JSON parse error handling. Correct SSR/hydration pattern. |
| packages/lib/hooks/use-mobile.ts | Replaces the conditional `window.innerWidth` read during initial render with the static `BREAKPOINTS.lg` fallback. Eliminates server/client markup split; `useEffect` still updates to the real viewport width after hydration. |
| packages/ui/components/shadcn/data-table/hooks/use-column-resizing.tsx | Moves persisted column sizing load from a `useState` initializer into a `useEffect`. The save effect fires once after the load effect on each mount (redundant but benign write-back); no data loss. |
| playwright.config.ts | Refactors inline `testIgnore` arrays into `DEFAULT_PROJECT_TEST_IGNORE` and `ADMIN_REQUIRED_TEST_IGNORE` constants; exports `getDefaultProjectTestIgnore()` so admin-required specs are skipped when no admin server is configured. |
| scripts/run-with-ci-env.mjs | Adds `shouldUseShellForCommand` and `getSpawnCommand` to wrap `.cmd`/`.bat` binaries through `cmd.exe` on Windows. Quoting via `quoteForCmd` uses `""` doubling, which is correct for `/d /s /c` invocations. |
| scripts/verify/ci-build.mjs | Replaces hard-coded `turbo.cmd` path with `resolveTurboBin()` that probes candidates in order (`turbo.exe`, `turbo.cmd`, `turbo` on Windows; `turbo` on other platforms). Falls back to the last candidate when none exist. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Server as Next.js Server
    participant React as React Hydration
    participant Effect as useEffect (client only)
    participant Storage as Browser APIs (localStorage / window)

    Server->>React: renderToString() with deterministic defaults
    Note over Server,React: width=BREAKPOINTS.lg, templates=[], columnSizing={}, now=model.generatedAt
    React->>React: hydrateRoot() — HTML matches server output
    React->>Effect: Mount effects fire (post-hydration)
    Effect->>Storage: read window.innerWidth
    Storage-->>Effect: actual viewport width
    Effect->>React: setState(actualWidth) re-render
    Effect->>Storage: read localStorage (email drafts / column sizing)
    Storage-->>Effect: persisted data
    Effect->>React: setState(persisted) re-render
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: make client hydration state determi..."](https://github.com/asymmetric-al/core/commit/68c59186ecd16040c1a03aa44ed2067d799b06d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32448962)</sub>

<!-- /greptile_comment -->