### PR TITLE
chore(deps): upgrade @base-ui/react to 1.5.0

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -28,7 +28,7 @@
     "@asym/pdf-renderer": "file:../../vendor/react-pdf-packages/asym-pdf-renderer-0.0.0.tgz",
     "@asym/pdf-template-schema": "file:../../vendor/react-pdf-packages/asym-pdf-template-schema-0.0.0.tgz",
     "@asym/ui": "workspace:*",
-    "@base-ui/react": "1.4.0",
+    "@base-ui/react": "1.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/apps/donor/package.json
+++ b/apps/donor/package.json
@@ -26,7 +26,7 @@
     "@asym/graphql": "workspace:*",
     "@asym/lib": "workspace:*",
     "@asym/ui": "workspace:*",
-    "@base-ui/react": "1.4.0",
+    "@base-ui/react": "1.5.0",
     "@openpolicy/react": "0.0.17",
     "@openpolicy/sdk": "0.0.17",
     "@next/env": "16.2.6",

--- a/apps/missionary/package.json
+++ b/apps/missionary/package.json
@@ -21,7 +21,7 @@
     "@asym/lib": "workspace:*",
     "@asym/missionary": "workspace:*",
     "@asym/ui": "workspace:*",
-    "@base-ui/react": "1.4.0",
+    "@base-ui/react": "1.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
         "@asym/pdf-renderer": "file:../../vendor/react-pdf-packages/asym-pdf-renderer-0.0.0.tgz",
         "@asym/pdf-template-schema": "file:../../vendor/react-pdf-packages/asym-pdf-template-schema-0.0.0.tgz",
         "@asym/ui": "workspace:*",
-        "@base-ui/react": "1.4.0",
+        "@base-ui/react": "1.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -141,7 +141,7 @@
         "@asym/graphql": "workspace:*",
         "@asym/lib": "workspace:*",
         "@asym/ui": "workspace:*",
-        "@base-ui/react": "1.4.0",
+        "@base-ui/react": "1.5.0",
         "@next/env": "16.2.6",
         "@openpolicy/react": "0.0.17",
         "@openpolicy/sdk": "0.0.17",
@@ -192,7 +192,7 @@
         "@asym/lib": "workspace:*",
         "@asym/missionary": "workspace:*",
         "@asym/ui": "workspace:*",
-        "@base-ui/react": "1.4.0",
+        "@base-ui/react": "1.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -399,7 +399,7 @@
         "@asym/auth": "workspace:*",
         "@asym/database": "workspace:*",
         "@asym/lib": "workspace:*",
-        "@base-ui/react": "1.3.0",
+        "@base-ui/react": "1.5.0",
         "@react-email/editor": "1.3.8",
         "@supabase/supabase-js": "^2.89.0",
         "@tanstack/db": "^0.6.4",
@@ -590,9 +590,9 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@base-ui/react": ["@base-ui/react@1.4.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.2.7", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg=="],
+    "@base-ui/react": ["@base-ui/react@1.5.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.2.9", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A=="],
 
-    "@base-ui/utils": ["@base-ui/utils@0.2.7", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA=="],
+    "@base-ui/utils": ["@base-ui/utils@0.2.9", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
@@ -616,7 +616,7 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
-    "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
+    "@date-fns/tz": ["@date-fns/tz@1.2.0", "", {}, "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg=="],
 
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 
@@ -3802,8 +3802,6 @@
 
     "@asym/pdf-editor/@react-email/editor": ["@react-email/editor@1.1.1", "", { "dependencies": { "@floating-ui/react-dom": "^2.1.8", "@radix-ui/react-popover": "^1.0.0", "@radix-ui/react-slot": "^1.2.3", "@tiptap/core": "^3.17.1", "@tiptap/extension-blockquote": "^3.17.1", "@tiptap/extension-bold": "^3.17.1", "@tiptap/extension-bullet-list": "^3.17.1", "@tiptap/extension-code": "^3.17.1", "@tiptap/extension-code-block": "^3.17.1", "@tiptap/extension-hard-break": "^3.17.1", "@tiptap/extension-heading": "^3.17.1", "@tiptap/extension-horizontal-rule": "^3.17.1", "@tiptap/extension-italic": "^3.17.1", "@tiptap/extension-link": "^3.17.1", "@tiptap/extension-list-item": "^3.17.1", "@tiptap/extension-mention": "^3.17.1", "@tiptap/extension-ordered-list": "^3.17.1", "@tiptap/extension-paragraph": "^3.17.1", "@tiptap/extension-placeholder": "^3.17.1", "@tiptap/extension-strike": "^3.17.1", "@tiptap/extension-superscript": "^3.17.1", "@tiptap/extension-text": "^3.17.1", "@tiptap/extension-underline": "^3.17.1", "@tiptap/extensions": "^3.17.1", "@tiptap/html": "^3.17.1", "@tiptap/pm": "^3.17.1", "@tiptap/react": "^3.17.1", "@tiptap/starter-kit": "^3.17.1", "@tiptap/suggestion": "^3.17.1", "hast-util-from-html": "^2.0.3", "prismjs": "^1.30.0", "react-email": "6.0.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jK7WRbI5nybW9iVuVatA47tD3MsPSFEHhvT96WP4KyFeG1zmUL3Lg5W+fmwZK2fYAXfQwEXMB+ht2JtJMpVw6Q=="],
 
-    "@asym/ui/@base-ui/react": ["@base-ui/react@1.3.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.6", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -3861,8 +3859,6 @@
     "@payloadcms/richtext-lexical/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "@payloadcms/richtext-lexical/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
-
-    "@payloadcms/ui/@date-fns/tz": ["@date-fns/tz@1.2.0", "", {}, "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg=="],
 
     "@payloadcms/ui/scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
 
@@ -4278,6 +4274,8 @@
 
     "react-datepicker/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
 
+    "react-day-picker/@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
+
     "react-email/@babel/parser": ["@babel/parser@7.27.0", "", { "dependencies": { "@babel/types": "^7.27.0" }, "bin": "./bin/babel-parser.js" }, "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg=="],
 
     "react-email/@babel/traverse": ["@babel/traverse@7.27.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "@babel/generator": "^7.27.0", "@babel/parser": "^7.27.0", "@babel/template": "^7.27.0", "@babel/types": "^7.27.0", "debug": "^4.3.1", "globals": "^11.1.0" } }, "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA=="],
@@ -4365,8 +4363,6 @@
     "@asym/eslint-config/eslint-config-next/@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.1", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA=="],
 
     "@asym/pdf-editor/@react-email/editor/react-email": ["react-email@6.0.0", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "@react-email/render": ">=2.0.7", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "css-tree": "3.2.1", "debounce": "^2.0.0", "esbuild": "0.27.5", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "marked": "^15.0.12", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.5", "ora": "^8.0.0", "prismjs": "^1.30.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tailwindcss": "^4.1.18", "tsconfig-paths": "4.2.0" }, "bin": { "email": "dist/cli/index.mjs" } }, "sha512-DZkFbOiSPjXz76GOuNj/9odFxO3zPd5eyNes+MTbya/8rpzmWFYjoF02d9wxbUV/y+TE96/Nc9IBPWYsht9KGQ=="],
-
-    "@asym/ui/@base-ui/react/@base-ui/utils": ["@base-ui/utils@0.2.6", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,7 +61,7 @@
     "@asym/auth": "workspace:*",
     "@asym/database": "workspace:*",
     "@asym/lib": "workspace:*",
-    "@base-ui/react": "1.3.0",
+    "@base-ui/react": "1.5.0",
     "@react-email/editor": "1.3.8",
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/db": "^0.6.4",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Updated `@base-ui/react` to exactly **1.5.0** across all declaring workspaces (`@asym/ui`, `@asym/admin`, `@asym/donor`, `@asym/missionary-app`).
- Regenerated `bun.lock` with a **single** resolved `@base-ui/react@1.5.0` (no duplicate 1.3.0 / 1.4.0 entries).
- Audited the full Base UI usage surface: **one** direct import (`packages/ui/components/shadcn/drawer.tsx`); apps consume Drawer via `@asym/ui` only.
- Compared the shared Drawer wrapper against Base UI 1.5.0 Drawer types — all used parts (`Root`, `Trigger`, `Portal`, `Backdrop`, `Viewport`, `Popup`, `Content`, `Title`, `Description`, `Close`) remain present; **no wrapper code changes** required.
- **OTPField breaking change (`sanitizeValue` → `normalizeValue`) is not applicable** — no repo usage of `OTPField` or Base UI `sanitizeValue`.
- Preserved legacy `direction` → `swipeDirection` mapping, `asChild` → `render` compatibility, animation data attributes, and existing MAIA/shadcn styling.

## Files Changed

- `packages/ui/package.json` — `1.3.0` → `1.5.0`
- `apps/admin/package.json` — `1.4.0` → `1.5.0`
- `apps/donor/package.json` — `1.4.0` → `1.5.0`
- `apps/missionary/package.json` — `1.4.0` → `1.5.0`
- `bun.lock` — single resolved `@base-ui/react@1.5.0`

No compatibility source changes (drawer wrapper, CSS, or tests) were required.

## Base UI Usage Audit

| Finding | Detail |
|--------|--------|
| Direct imports | **1 file:** `packages/ui/components/shadcn/drawer.tsx` (`@base-ui/react/drawer`) |
| App-level direct imports | **None** in `apps/admin`, `apps/donor`, `apps/missionary` |
| Popup primitives in repo | Drawer only (via shared wrapper) |
| `render` / `asChild` | `DrawerTrigger` and `DrawerClose` map `asChild` → `render={<SlotPrimitive.Root />}` — unchanged |
| `keepMounted` | Not used |
| Animation / state attrs | `data-[starting-style]`, `data-[ending-style]`, `data-[swipe-direction=*]` on drawer — unchanged |
| Other Base UI components | Not imported in product code |

## Drawer Compatibility

- **Parts verified (1.5.0 types):** `Root`, `Trigger`, `Portal`, `Backdrop`, `Viewport`, `Popup`, `Content`, `Title`, `Description`, `Close` (+ optional `SwipeArea` exists but not required by wrapper).
- **Legacy `direction`:** Still mapped via `packages/ui/lib/drawer-swipe-direction.ts`; `swipeDirection` wins when both set.
- **Placements:** top/bottom/left/right → up/down/left/right swipe directions; Tailwind `data-[swipe-direction=*]` classes unchanged.
- **Style forwarding:** Caller `style` / `className` on `DrawerContent` still flow to `DrawerPrimitive.Popup` only (Viewport has fixed layout classes) — same public API as before; no 1.5.0 change required.
- **Focus / Escape / backdrop / swipe:** Relies on Base UI 1.5.0 behavior improvements; no wrapper edits.
- **Nested drawers:** No dedicated product tests; no code changes.

## OTP Breaking Change

**Not applicable.** Searched repo for `OTPField`, `OTP Field`, and Base UI `sanitizeValue` — no matches outside vendored `vendor/payload-upstream` (unrelated).

## Setup and CSS Notes

- **`body { position: relative; isolation: isolate; }`** already in `packages/ui/styles/globals.css` (`@layer base`) — no CSS added.
- **No stacking-context / portal layout changes** — existing z-index and portal usage preserved.

## Checks Run

| Command | Result |
|---------|--------|
| `bun run typecheck` | **Pass** (13 packages) |
| `bun run lint` | **Pass** (13 packages) |
| `bun run build` | **Pass** (admin, donor, missionary + shared packages) |
| `bunx vitest run tests/unit/packages/ui/drawer-swipe-direction.test.ts` | **Pass** (3 tests) |
| `bun run test:unit` | **7 failures** in `tests/unit/cms/supabase-strategy.test.ts` (5000ms timeouts) — **unrelated** to Base UI; same failures when run in isolation |

## Checks Not Run

| Command | Reason |
|---------|--------|
| `bun run test:e2e:smoke` | Not run in cloud VM (Playwright + demo auth/env); dependency-only change with no drawer behavior edits |
| `bun run test:a11y` | Not run (same) |
| Manual drawer QA on listed routes | Dev server + credentials not exercised in this session |

**Follow-up risk:** Low for this diff (lockfile + version pins only). Recommend spot-checking drawer open/close/swipe on admin/donor/missionary routes in a preview environment.

## Revert

```bash
git revert 1a644d85   # or merge revert of this PR
bun install
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df585a9c-a01f-4629-bdcc-8e342c08f840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df585a9c-a01f-4629-bdcc-8e342c08f840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades `@base-ui/react` to `1.5.0` across all four declaring workspaces (`@asym/ui`, `@asym/admin`, `@asym/donor`, `@asym/missionary-app`), resolving a pre-existing version split (1.3.0 in the shared UI package vs. 1.4.0 in the apps) and regenerating `bun.lock` with a single resolved entry.

- **Version alignment**: `packages/ui` moves from `1.3.0` → `1.5.0`; all three apps move from `1.4.0` → `1.5.0`, eliminating the duplicate-resolution risk that previously existed in the lockfile.
- **No source changes required**: The sole direct consumer — `packages/ui/components/shadcn/drawer.tsx` — uses `Root`, `Trigger`, `Portal`, `Backdrop`, `Viewport`, `Popup`, `Content`, `Title`, `Description`, and `Close`, all of which remain stable in 1.5.0. The only breaking change between 1.3.0 and 1.5.0 (`OTPField.sanitizeValue` → `normalizeValue`) is not used anywhere in the repo.
- **Lockfile verified**: `bun.lock` now shows a single `@base-ui/react@1.5.0` resolution across all four declaring workspaces.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — pure dependency version bump with no source code changes, full typecheck/lint/build passes, and a thorough compatibility audit covering the one affected component.

The change is confined to four package.json version pins and the regenerated lockfile. The only direct consumer of @base-ui/react (drawer.tsx) uses APIs that are unchanged in 1.5.0, and the sole breaking change in the 1.3.0–1.5.0 range (OTPField) has no usage in the repo. Typecheck, lint, and build all pass.

No files require special attention. The bun.lock change is the largest diff but correctly reflects a single resolved version.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/package.json | Bumps @base-ui/react from 1.3.0 to 1.5.0, aligning the shared UI package with the app-level version that was already at 1.4.0 |
| apps/admin/package.json | Bumps @base-ui/react from 1.4.0 to 1.5.0; no direct source imports from @base-ui/react exist in the admin app |
| apps/donor/package.json | Bumps @base-ui/react from 1.4.0 to 1.5.0; no direct source imports from @base-ui/react exist in the donor app |
| apps/missionary/package.json | Bumps @base-ui/react from 1.4.0 to 1.5.0; no direct source imports from @base-ui/react exist in the missionary app |
| bun.lock | Regenerated lockfile resolves a single @base-ui/react@1.5.0 across all 4 declaring workspaces, eliminating previous 1.3.0/1.4.0 duplicates |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@asym/admin\n1.4.0 → 1.5.0"] --> R["@base-ui/react@1.5.0\n(single resolved)"]
    B["@asym/donor\n1.4.0 → 1.5.0"] --> R
    C["@asym/missionary\n1.4.0 → 1.5.0"] --> R
    D["@asym/ui\n1.3.0 → 1.5.0"] --> R
    R --> E["packages/ui/components/shadcn/drawer.tsx\n(only direct consumer)"]
    E --> F["DrawerPrimitive.Root / Trigger / Portal\nBackdrop / Viewport / Popup\nContent / Title / Description / Close\n✅ All stable in 1.5.0"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): upgrade @base-ui/react to 1..."](https://github.com/asymmetric-al/core/commit/e607758f1af5c06e7455b1d266c5e8785bbf07d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33000200)</sub>

<!-- /greptile_comment -->