### PR TITLE
test(ci): Phases 1–3 test quality — unit harness, e2e smoke gate, Resend contracts

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -159,9 +159,13 @@ jobs:
         run: |
           nohup bun run --cwd apps/donor dev -- --port 3005 --hostname 127.0.0.1 > /tmp/donor-dev.log 2>&1 &
           echo $! > /tmp/donor-dev.pid
+      - name: Start admin app
+        run: |
+          nohup bun run --cwd apps/admin dev -- --port 3030 --hostname 127.0.0.1 > /tmp/admin-dev.log 2>&1 &
+          echo $! > /tmp/admin-dev.pid
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
-      - name: Wait for health endpoint
+      - name: Wait for donor health endpoint
         run: |
           for i in $(seq 1 120); do
             if curl -sf http://127.0.0.1:3005/api/health >/dev/null; then
@@ -179,11 +183,31 @@ jobs:
             fi
             sleep 1
           done
+      - name: Wait for admin health endpoint
+        run: |
+          for i in $(seq 1 120); do
+            if curl -sf http://127.0.0.1:3030/api/health >/dev/null; then
+              echo "Admin health endpoint ready after ${i}s"
+              exit 0
+            fi
+            if [ "$i" -eq 120 ]; then
+              echo "Timed out waiting for admin health endpoint"
+              echo "--- admin dev log (tail) ---"
+              tail -n 100 /tmp/admin-dev.log || true
+              echo "--- curl verbose ---"
+              curl -v http://127.0.0.1:3030/api/health || true
+              kill "$(cat /tmp/admin-dev.pid)" 2>/dev/null || true
+              exit 1
+            fi
+            sleep 1
+          done
       - name: Run Playwright smoke suite
         timeout-minutes: 15
         env:
           CI: "1"
           PLAYWRIGHT_BASE_URL: "http://127.0.0.1:3005"
+          PLAYWRIGHT_ADMIN_BASE_URL: "http://127.0.0.1:3030"
+          PLAYWRIGHT_INCLUDE_ADMIN: "1"
         run: bun run test:e2e:smoke
       - name: Upload artifact on failure
         if: failure()
@@ -249,29 +273,45 @@ jobs:
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
       - name: Start donor app
-        run: bun run --cwd apps/donor dev -- --port 3005 --hostname 127.0.0.1 &
-      - name: Wait for health endpoint
         run: |
-          for i in $(seq 1 60); do
+          nohup bun run --cwd apps/donor dev -- --port 3005 --hostname 127.0.0.1 > /tmp/donor-dev.log 2>&1 &
+          echo $! > /tmp/donor-dev.pid
+      - name: Wait for donor health endpoint
+        run: |
+          for i in $(seq 1 120); do
             if curl -sf http://127.0.0.1:3005/api/health >/dev/null; then
+              echo "Health endpoint ready after ${i}s"
               exit 0
             fi
-            if [ "$i" -eq 60 ]; then
+            if [ "$i" -eq 120 ]; then
               echo "Timed out waiting for health endpoint"
+              echo "--- donor dev log (tail) ---"
+              tail -n 100 /tmp/donor-dev.log || true
+              echo "--- curl verbose ---"
+              curl -v http://127.0.0.1:3005/api/health || true
+              kill "$(cat /tmp/donor-dev.pid)" 2>/dev/null || true
               exit 1
             fi
             sleep 1
           done
       - name: Start admin app
-        run: bun run --cwd apps/admin dev -- --port 3030 --hostname 127.0.0.1 &
+        run: |
+          nohup bun run --cwd apps/admin dev -- --port 3030 --hostname 127.0.0.1 > /tmp/admin-dev.log 2>&1 &
+          echo $! > /tmp/admin-dev.pid
       - name: Wait for admin health endpoint
         run: |
-          for i in $(seq 1 60); do
+          for i in $(seq 1 120); do
             if curl -sf http://127.0.0.1:3030/api/health >/dev/null; then
+              echo "Admin health endpoint ready after ${i}s"
               exit 0
             fi
-            if [ "$i" -eq 60 ]; then
+            if [ "$i" -eq 120 ]; then
               echo "Timed out waiting for admin health endpoint"
+              echo "--- admin dev log (tail) ---"
+              tail -n 100 /tmp/admin-dev.log || true
+              echo "--- curl verbose ---"
+              curl -v http://127.0.0.1:3030/api/health || true
+              kill "$(cat /tmp/admin-dev.pid)" 2>/dev/null || true
               exit 1
             fi
             sleep 1

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -112,7 +112,7 @@ jobs:
   test-e2e-smoke:
     needs: smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     services:
       postgres:
         image: postgres:15-alpine
@@ -155,18 +155,26 @@ jobs:
         run: bun run cms:migrate:status
       - name: Apply demo seed
         run: psql "$DATABASE_URL" -f supabase/seed.sql -v ON_ERROR_STOP=1
+      - name: Start donor app
+        run: |
+          nohup bun run --cwd apps/donor dev -- --port 3005 --hostname 127.0.0.1 > /tmp/donor-dev.log 2>&1 &
+          echo $! > /tmp/donor-dev.pid
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
-      - name: Start donor app
-        run: bun run --cwd apps/donor dev -- --port 3005 --hostname 127.0.0.1 &
       - name: Wait for health endpoint
         run: |
-          for i in $(seq 1 60); do
+          for i in $(seq 1 120); do
             if curl -sf http://127.0.0.1:3005/api/health >/dev/null; then
+              echo "Health endpoint ready after ${i}s"
               exit 0
             fi
-            if [ "$i" -eq 60 ]; then
+            if [ "$i" -eq 120 ]; then
               echo "Timed out waiting for health endpoint"
+              echo "--- donor dev log (tail) ---"
+              tail -n 100 /tmp/donor-dev.log || true
+              echo "--- curl verbose ---"
+              curl -v http://127.0.0.1:3005/api/health || true
+              kill "$(cat /tmp/donor-dev.pid)" 2>/dev/null || true
               exit 1
             fi
             sleep 1

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -24,7 +24,7 @@ jobs:
         image: postgres:15-alpine
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: postgres # pragma: allowlist secret
           POSTGRES_DB: asymmetrical_test
         ports:
           - 5432:5432
@@ -69,7 +69,7 @@ jobs:
         image: postgres:15-alpine
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: postgres # pragma: allowlist secret
           POSTGRES_DB: asymmetrical_test
         ports:
           - 5432:5432
@@ -109,6 +109,82 @@ jobs:
           response=$(curl -sf http://127.0.0.1:3005/api/health)
           echo "$response" | grep -q '"status":"ok"'
 
+  test-e2e-smoke:
+    needs: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres # pragma: allowlist secret
+          POSTGRES_DB: asymmetrical_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/asymmetrical_test
+      PAYLOAD_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/asymmetrical_test
+      PAYLOAD_SECRET: ci-payload-secret
+      SKIP_ENV_VALIDATION: "1"
+      E2E_AUTH_BYPASS: "true"
+      PLAYWRIGHT_REUSE_EXISTING_SERVER: "1"
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: example-anon-key
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+      - name: Apply migrations
+        run: node scripts/verify/supabase-migrations.mjs
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.4"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Apply Payload migrations
+        run: bun run cms:migrate
+      - name: Verify Payload migration status
+        run: bun run cms:migrate:status
+      - name: Apply demo seed
+        run: psql "$DATABASE_URL" -f supabase/seed.sql -v ON_ERROR_STOP=1
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+      - name: Start donor app
+        run: bun run --cwd apps/donor dev -- --port 3005 --hostname 127.0.0.1 &
+      - name: Wait for health endpoint
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:3005/api/health >/dev/null; then
+              exit 0
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Timed out waiting for health endpoint"
+              exit 1
+            fi
+            sleep 1
+          done
+      - name: Run Playwright smoke suite
+        timeout-minutes: 15
+        env:
+          CI: "1"
+          PLAYWRIGHT_BASE_URL: "http://127.0.0.1:3005"
+        run: bun run test:e2e:smoke
+      - name: Upload artifact on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-smoke-report
+          path: playwright-report/
+          retention-days: 7
+
   test-e2e:
     needs: smoke
     continue-on-error: ${{ (github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name == 'push' && github.ref == 'refs/heads/develop') }}
@@ -119,7 +195,7 @@ jobs:
         image: postgres:15-alpine
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: postgres # pragma: allowlist secret
           POSTGRES_DB: asymmetrical_test
         ports:
           - 5432:5432
@@ -236,20 +312,36 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  e2e-smoke-gate:
+    if: always()
+    needs: [test-e2e-smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if E2E smoke failed
+        run: |
+          echo "test-e2e-smoke: ${{ needs['test-e2e-smoke'].result }}"
+
+          if [ "${{ needs['test-e2e-smoke'].result }}" != "success" ]; then
+            echo "E2E smoke gate failed."
+            exit 1
+          fi
+
   integration-gate:
     if: always()
-    needs: [migrate, smoke]
+    needs: [migrate, smoke, e2e-smoke-gate]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if integration prerequisites failed
         run: |
           echo "migrate: ${{ needs.migrate.result }}"
           echo "smoke: ${{ needs.smoke.result }}"
+          echo "e2e-smoke-gate: ${{ needs['e2e-smoke-gate'].result }}"
 
           failed=0
           for result in \
             "${{ needs.migrate.result }}" \
-            "${{ needs.smoke.result }}"
+            "${{ needs.smoke.result }}" \
+            "${{ needs['e2e-smoke-gate'].result }}"
           do
             if [ "$result" != "success" ]; then
               failed=1

--- a/GOAL_LOG.md
+++ b/GOAL_LOG.md
@@ -1,0 +1,65 @@
+# PR 241 Review Docket
+
+## Goal
+
+Babysit PR 241 through review feedback and merge-readiness checks without
+merging it. Work directly on `cursor/test-quality-phases-1-3-24c3`.
+
+## Merge Readiness
+
+- PR: https://github.com/Asymmetric-al/core/pull/241
+- Base: `develop`
+- Head: `cursor/test-quality-phases-1-3-24c3`
+- Local branch state before fixes: clean and tracking
+  `origin/cursor/test-quality-phases-1-3-24c3`
+- Current remote checks before fixes: required checks green, `e2e-gate` skipped
+  as expected for `develop`
+- Mergeability before fixes: `MERGEABLE`, but `mergeStateStatus` is `BEHIND`
+- Review state before fixes: `REVIEW_REQUIRED`
+- Unresolved review threads before fixes: 31
+
+## Docket
+
+| ID  | Summary                                                                                                         | Source         | File / line                                                                | Severity | Confidence | Why it matters                                                                                        | Proposed fix                                                                                                                                                                         | Effort   | Status  | Verification                                                                              |
+| --- | --------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- | ----------------------------------------------------------------------------------------- |
+| D1  | Smoke gate claims Support Hub/admin coverage but the job only explicitly starts donor.                          | Cursor reviews | `.github/workflows/ci-integration.yml` lines 158, 182-187                  | blocker  | confirmed  | Required `develop` gate can pass while admin Support Hub tests skip or never run.                     | Start admin explicitly and health-check it in `test-e2e-smoke`, or narrow smoke to donor-only and document it. Preferred: align implementation with documented Support Hub coverage. | moderate | fixed   | Workflow contract tests passed; Playwright list passed; CI smoke gate after push          |
+| D2  | Smoke command uses `--project=chromium`, but `upload-crop.spec.ts` is ignored by that project.                  | Cursor reviews | `package.json` script, `.github/workflows/ci-integration.yml` line 187     | blocker  | confirmed  | Required smoke gate overstates upload/crop coverage.                                                  | Adjust `test:e2e:smoke` project selection so upload-crop runs under `chromium-donor`, likely by splitting smoke into two Playwright invocations or adding a dedicated script.        | moderate | fixed   | Playwright list confirms `chromium` excludes upload-crop and `chromium-donor` includes it |
+| D3  | Workflow contract tests assert YAML substrings instead of resolved smoke behavior.                              | Cursor reviews | `tests/unit/scripts/ci-integration-workflow.contract.test.ts` lines 37, 61 | high     | confirmed  | Current contract stayed green while smoke inventory was wrong.                                        | Add a behavior-level contract around package script / Playwright project mapping or a deterministic script inventory parser.                                                         | moderate | fixed   | Targeted Vitest contract test passed                                                      |
+| D4  | Deployment discipline verifier allows extra required checks on `develop`.                                       | Cursor review  | `tests/unit/scripts/deployment-discipline.test.ts` line 52                 | high     | confirmed  | The verifier would miss branch-protection drift where broad `e2e-gate` remains required on `develop`. | Make `validateGitHubBranchProtection` reject unexpected required contexts for branch-specific policy, with tests.                                                                    | moderate | fixed   | Targeted Vitest deployment-discipline test passed                                         |
+| D5  | `docs/ci.md` says smoke job has a 20-minute cap while workflow uses 25 minutes and a 15-minute Playwright step. | Cursor reviews | `docs/ci.md` line 213                                                      | medium   | confirmed  | Runbook timeout guidance is stale.                                                                    | Update docs to 25-minute job cap and mention 15-minute Playwright step cap.                                                                                                          | quick    | fixed   | Prettier check passed                                                                     |
+| D6  | Docs imply smoke is enough for a11y/hydration/manual confidence.                                                | Cursor reviews | `docs/ai/rules/testing.md`, `docs/ci.md`                                   | medium   | confirmed  | Teams may confuse smoke gate with axe/hydration/perf coverage.                                        | Add explicit smoke-not-a11y/hydration wording and point to `test:a11y` / perf/full E2E signals.                                                                                      | quick    | fixed   | Prettier check passed                                                                     |
+| D7  | Donor/missionary smoke contract reads another test file as source text to assert mock syntax.                   | Cursor reviews | `tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts` line 63     | medium   | confirmed  | Brittle meta-test fails on formatting and naming changes.                                             | Move assertion into `connect.test.ts` or remove it if behavior is already covered by route + snapshot tests.                                                                         | quick    | fixed   | Removed brittle source-text check; targeted Vitest passed                                 |
+| D8  | Donor/missionary smoke contract only checks file existence, not test discovery/execution.                       | Cursor review  | `tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts` line 23     | medium   | likely     | File existence is weaker than discovery but still catches accidental deletion.                        | Strengthen if cheap by asserting vitest include coverage and avoiding brittle source checks; otherwise document as low-signal follow-up.                                             | moderate | fixed   | Added path-shape guard plus existing Vitest include guard; targeted Vitest passed         |
+| D9  | Resend validation fixtures are duplicated across snapshot and route tests.                                      | Cursor review  | `tests/unit/packages/api/email/resend-snapshot-contract.test.ts` line 12   | medium   | likely     | Three copies of the same SPF/DKIM example add maintenance cost.                                       | Extract shared test fixture if small and clean.                                                                                                                                      | moderate | fixed   | Shared fixture added; email unit tests passed                                             |
+| D10 | Redundant `vi.useRealTimers()` inside a test duplicates `afterEach`.                                            | Cursor review  | `tests/unit/packages/api/email/connect.test.ts` line 165                   | low      | confirmed  | Minor cleanup.                                                                                        | Remove the inner reset; keep `afterEach`.                                                                                                                                            | quick    | fixed   | Email connect test passed                                                                 |
+| D11 | `EXPECTED_STAGES` duplicates `ci-preflight.mjs` stage source.                                                   | Cursor review  | `tests/unit/scripts/ci-preflight.contract.test.ts` line 7                  | low      | likely     | Drift risk, but fixing requires exporting script internals.                                           | Defer unless simple; current regex check intentionally avoids executing preflight.                                                                                                   | larger   | skipped | Low-value follow-up; not needed for PR merge safety                                       |
+| D12 | `test-e2e` and `test-e2e-smoke` have divergent donor health wait/debug behavior.                                | Cursor review  | `.github/workflows/ci-integration.yml` line 166                            | medium   | confirmed  | CI flake diagnostics differ between similar jobs.                                                     | If touching workflow, copy log-tail/PID cleanup pattern to full E2E or document as follow-up.                                                                                        | moderate | fixed   | Full E2E donor/admin waits now use log-tail/PID diagnostics                               |
+| D13 | Readiness signal change in auth specs may need condition-based waits if it flakes.                              | Cursor review  | `tests/e2e/auth-session-guards.spec.ts` line 30                            | low      | likely     | Pathname polling is better than sleeps but not visual readiness.                                      | No code change unless tests fail; monitor `test-e2e`.                                                                                                                                | quick    | fixed   | Current remote `test-e2e` was green before this fix pass                                  |
+
+## Initial Fix Plan
+
+1. Fix merge-gate correctness first: admin startup/health for Support Hub,
+   upload-crop project selection, and behavior-level contracts.
+2. Fix branch-protection verifier semantics so `develop` cannot silently keep
+   broad `e2e-gate` required.
+3. Align docs with the actual bounded smoke signal, timeout caps, and a11y /
+   hydration non-coverage.
+4. Apply small test hygiene fixes that are safe and directly actionable.
+5. Validate targeted tests first, then run broader checks appropriate to CI and
+   docs changes.
+
+## Validation Log
+
+- `bunx vitest run tests/unit/scripts/ci-integration-workflow.contract.test.ts tests/unit/scripts/deployment-discipline.test.ts tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts tests/unit/packages/api/email/connect.test.ts tests/unit/packages/api/email/resend-snapshot-contract.test.ts`
+  passed, 5 files / 29 tests.
+- `node node_modules/@playwright/test/cli.js test tests/e2e/demo-auth-preflight.spec.ts tests/e2e/usability-smoke.spec.ts tests/e2e/donate.spec.ts tests/e2e/support-hub.smoke.spec.ts --project=chromium --workers=1 --list`
+  passed, 12 tests in 4 files.
+- `node node_modules/@playwright/test/cli.js test tests/e2e/upload-crop.spec.ts --project=chromium-donor --workers=1 --list`
+  passed, 14 tests in 1 file.
+- `bunx prettier --check <edited files>` passed after formatting.
+- `git diff --check` passed.
+- Initial `bun run check` failed on the new Playwright inventory contract timeout
+  and a pre-existing Windows path separator issue in
+  `get-auth-context-request-propagation.test.ts`; both were fixed.
+- Second `bun run check` passed: lint/typecheck succeeded and Vitest reported
+  248 files passed, 1081 tests passed, 2 skipped.

--- a/GOAL_LOG.md
+++ b/GOAL_LOG.md
@@ -63,3 +63,10 @@ merging it. Work directly on `cursor/test-quality-phases-1-3-24c3`.
   `get-auth-context-request-propagation.test.ts`; both were fixed.
 - Second `bun run check` passed: lint/typecheck succeeded and Vitest reported
   248 files passed, 1081 tests passed, 2 skipped.
+- After merging `origin/develop`, targeted review tests passed again: 7 files /
+  32 tests.
+- After merging `origin/develop`, smoke inventory list checks passed with
+  `--reporter=list`: 12 chromium smoke tests and 14 `chromium-donor`
+  upload-crop tests.
+- Post-merge `bun run check` passed: lint/typecheck succeeded and Vitest
+  reported 253 files passed, 1101 tests passed, 2 skipped.

--- a/docs/ai/rules/testing.md
+++ b/docs/ai/rules/testing.md
@@ -121,9 +121,21 @@ bun run test:e2e --debug
 npx playwright show-report
 ```
 
+## E2E stability (required)
+
+- Prefer `expect.poll`, `page.waitForURL`, or `page.waitForLoadState` over
+  `page.waitForTimeout` fixed sleeps. Fixed sleeps hide race conditions and
+  slow CI without improving signal.
+- After an assertion already polls for readiness, do not add a redundant sleep.
+- CI enables Playwright retries (`retries: 2` when `CI=1`); keep specs
+  idempotent so retries remain meaningful.
+- `tests/unit/e2e/e2e-flake-guards.test.ts` fails if `waitForTimeout` re-enters
+  `tests/e2e/**/*.spec.ts`.
+
 ## Common mistakes / pitfalls
 
 - Adding Jest/Vitest without a request
 - Ignoring a11y failures
 - Writing brittle selectors or XPath
 - Allowing tests to depend on each other
+- Using `page.waitForTimeout` instead of polling for real UI or URL state

--- a/docs/ai/rules/testing.md
+++ b/docs/ai/rules/testing.md
@@ -15,15 +15,20 @@ Use this when adding tests, modifying critical flows, or verifying changes.
 - **Accessibility:** `@axe-core/playwright`.
 - **Performance:** Playwright-based Web Vitals assertions.
 - **Local CI parity:** Run `bun run ci:preflight` before push/PR-ready to mirror blocking GitHub checks.
+- **Fast local gate:** `bun run check` runs `lint`, `typecheck`, and `test:unit` only. Use it for tight iteration loops.
+- **Pre-push mirror:** `bun run ci:preflight` runs the broader verifier in `scripts/verify/ci-preflight.mjs` (format, lint, typecheck, unit tests, deployment discipline, and other repo scripts). Prefer `ci:preflight` when you changed CI workflows, branch protection expectations, or cross-package integration surfaces.
 
 ## Branch protection (required)
 
 - **Required PR checks on `epic`:** `ci-gate`, `integration-gate`, and
   `e2e-gate`.
-- **Required PR checks on `develop`:** `ci-gate` and `integration-gate`.
+- **Required PR checks on `develop`:** `ci-gate`, `integration-gate`, and
+  `e2e-smoke-gate`.
 - **Non-blocking informational checks:** raw `CI Integration / test-e2e` on
   `develop` must **not** be required; use the gate jobs as branch protection
   requirements. `e2e-gate` is production-only and is required for `epic`.
+  `e2e-smoke-gate` enforces the bounded `test-e2e-smoke` Playwright suite on
+  `develop`.
 - **Repo admins:** Settings → Branches → Branch protection rules → Require status checks to pass:
   - Require the checks above.
   - Disable force pushes on `epic` and `develop`.
@@ -34,7 +39,11 @@ See `docs/ci.md` for the full CI gate reference (what each check does, how to de
 
 ## Production E2E scope
 
-- The required `e2e-gate` must run a bounded production-release suite, not the
+- The required `e2e-smoke-gate` on `develop` runs `bun run test:e2e:smoke`
+  (demo auth preflight paths, usability smoke, donate, upload-crop, and Support
+  Hub smoke). It blocks merges without running the full broad Playwright
+  inventory.
+- The required `e2e-gate` on `epic` must run a bounded production-release suite, not the
   full broad local Playwright inventory. Use `bun run test:e2e:production-gate`
   for the release gate and keep local-seed-only CMS proof under
   `bun run test:e2e:cms:local`.

--- a/docs/ai/rules/testing.md
+++ b/docs/ai/rules/testing.md
@@ -16,7 +16,7 @@ Use this when adding tests, modifying critical flows, or verifying changes.
 - **Performance:** Playwright-based Web Vitals assertions.
 - **Local CI parity:** Run `bun run ci:preflight` before push/PR-ready to mirror blocking GitHub checks.
 - **Fast local gate:** `bun run check` runs `lint`, `typecheck`, and `test:unit` only. Use it for tight iteration loops.
-- **Pre-push mirror:** `bun run ci:preflight` runs the broader verifier in `scripts/verify/ci-preflight.mjs` (format, lint, typecheck, unit tests, deployment discipline, and other repo scripts). Prefer `ci:preflight` when you changed CI workflows, branch protection expectations, or cross-package integration surfaces.
+- **Pre-push mirror:** `bun run ci:preflight` runs `scripts/verify/ci-preflight.mjs`, which mirrors the blocking stages in `.github/workflows/ci.yml` (through `test:unit`). It does **not** run `verify:deployment-discipline`; use `bun run verify:deployment-discipline` or `bun run release:production` when branch-protection or Vercel release posture changes.
 
 ## Branch protection (required)
 
@@ -131,6 +131,24 @@ npx playwright show-report
   idempotent so retries remain meaningful.
 - `tests/unit/e2e/e2e-flake-guards.test.ts` fails if `waitForTimeout` re-enters
   `tests/e2e/**/*.spec.ts`.
+
+## Unit and gate regression guards (required)
+
+- `tests/unit/scripts/ci-preflight.contract.test.ts` locks `ci:preflight` stage
+  order against `docs/ci.md` and ensures deployment discipline stays out of
+  preflight.
+- `tests/unit/scripts/local-gates.contract.test.ts` locks `bun run check` and
+  per-app `lint:*` / `typecheck:*` scripts for donor and missionary.
+- `tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts` keeps baseline
+  donor/missionary unit smoke files, `tests/setup/unit-env.ts`, and the
+  `importOriginal` `@asym/email` mock pattern in `connect.test.ts`.
+- `tests/unit/packages/api/email/resend-snapshot-contract.test.ts` guards the
+  Resend snapshot helpers used by `packages/api` email connect flows.
+- `tests/unit/scripts/deployment-discipline.test.ts` and
+  `scripts/verify/deployment-discipline.mjs` enforce `e2e-smoke-gate` on
+  `develop` and `e2e-gate` on `epic`.
+- `tests/unit/unit-test-harness.test.ts` and `tests/setup/unit-env.ts` keep unit
+  tests off live secrets (`SUPABASE_SERVICE_ROLE_KEY` cleared globally).
 
 ## Common mistakes / pitfalls
 

--- a/docs/ai/rules/testing.md
+++ b/docs/ai/rules/testing.md
@@ -43,6 +43,9 @@ See `docs/ci.md` for the full CI gate reference (what each check does, how to de
   (demo auth preflight paths, usability smoke, donate, upload-crop, and Support
   Hub smoke). It blocks merges without running the full broad Playwright
   inventory.
+- The smoke gate is not an accessibility, hydration, performance, or full auth
+  gate. Changes in those areas still need the relevant command, such as
+  `bun run test:a11y`, `bun run test:perf`, or the broader `bun run test:e2e`.
 - The required `e2e-gate` on `epic` must run a bounded production-release suite, not the
   full broad local Playwright inventory. Use `bun run test:e2e:production-gate`
   for the release gate and keep local-seed-only CMS proof under

--- a/docs/ai/working-set.md
+++ b/docs/ai/working-set.md
@@ -1,5 +1,38 @@
 # Working Set
 
+## 2026-05-23 (PR 241 babysit review feedback)
+
+- Date: 2026-05-23
+- Repo: Asymmetric-al/core
+- Goal: Babysit PR 241 through review feedback by triaging all review threads,
+  CI state, mergeability, and confirmed fixes before pushing directly to
+  `cursor/test-quality-phases-1-3-24c3`.
+- Primary area:
+  - `.github/workflows/ci-integration.yml`
+  - `package.json`
+  - `playwright.config.ts`
+  - `docs/ai/rules/testing.md`
+  - `docs/ci.md`
+  - `tests/e2e/**`
+  - `tests/unit/scripts/**`
+  - `tests/unit/apps/**`
+  - `tests/unit/packages/api/email/**`
+- Stack:
+  - GitHub Actions
+  - Playwright
+  - Vitest
+  - Bun
+  - Turborepo
+  - TypeScript
+  - Next.js 16 App Router
+- Constraints:
+  - Work only on PR 241 head branch.
+  - Commit and push fixes directly to PR 241; do not open a new PR or merge.
+  - Build a PR Review Docket before code fixes.
+  - Keep changes surgical and tied to actionable review feedback.
+  - Confirm CI, mergeability, unresolved threads, branch freshness, and conflicts
+    after the latest push.
+
 ## 2026-05-16 (Monorepo Vercel build controls)
 
 - Date: 2026-05-16

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -209,6 +209,7 @@ Current coverage caveat: the repo's custom raw V8 fallback provider writes cover
 - _What it does:_ Re-applies SQL migrations against a fresh Postgres container through `node scripts/verify/supabase-migrations.mjs`, runs Payload migrations + status checks, then applies seed data, starts `apps/donor` on port 3005 with `E2E_AUTH_BYPASS=true`, waits for `/api/health`, and runs the bounded Playwright smoke suite via `bun run test:e2e:smoke` (demo auth preflight, usability smoke, donate, upload-crop, Support Hub smoke). The job has a 20-minute cap and uploads `playwright-smoke-report/` on failure.
 - _Branch behavior:_ Blocking on `develop` through `e2e-smoke-gate` and `integration-gate`.
 - _Debug locally:_ Run `bun run test:e2e:smoke` after `bun run test:e2e:auth-preflight` with donor on port 3005.
+- _Regression guards (unit):_ `tests/unit/scripts/ci-integration-workflow.contract.test.ts` locks `integration-gate` / `e2e-smoke-gate` / `e2e-gate` wiring; `tests/unit/e2e/e2e-flake-guards.test.ts` forbids `waitForTimeout` in `tests/e2e/**/*.spec.ts`.
 
 ### `test-e2e` (needs: `smoke`)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -44,6 +44,10 @@ bun run ci:preflight
 10. `build` (with CI-compatible env defaults for local parity)
 11. `test:unit`
 
+Regression guards: `tests/unit/scripts/ci-preflight.contract.test.ts` (stage order),
+`tests/unit/scripts/local-gates.contract.test.ts` (`bun run check`), and
+`tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts` (app unit smoke paths).
+
 This command is wired into `.husky/pre-push` so pushes fail fast when a blocking CI gate would fail in GitHub.
 
 `verify:git-attribution` blocks local pushes when Git is configured as
@@ -209,7 +213,7 @@ Current coverage caveat: the repo's custom raw V8 fallback provider writes cover
 - _What it does:_ Re-applies SQL migrations against a fresh Postgres container through `node scripts/verify/supabase-migrations.mjs`, runs Payload migrations + status checks, then applies seed data, starts `apps/donor` on port 3005 with `E2E_AUTH_BYPASS=true`, waits for `/api/health`, and runs the bounded Playwright smoke suite via `bun run test:e2e:smoke` (demo auth preflight, usability smoke, donate, upload-crop, Support Hub smoke). The job has a 20-minute cap and uploads `playwright-smoke-report/` on failure.
 - _Branch behavior:_ Blocking on `develop` through `e2e-smoke-gate` and `integration-gate`.
 - _Debug locally:_ Run `bun run test:e2e:smoke` after `bun run test:e2e:auth-preflight` with donor on port 3005.
-- _Regression guards (unit):_ `tests/unit/scripts/ci-integration-workflow.contract.test.ts` locks `integration-gate` / `e2e-smoke-gate` / `e2e-gate` wiring; `tests/unit/e2e/e2e-flake-guards.test.ts` forbids `waitForTimeout` in `tests/e2e/**/*.spec.ts`.
+- _Regression guards (unit):_ `tests/unit/scripts/ci-integration-workflow.contract.test.ts` locks `integration-gate` / `e2e-smoke-gate` / `e2e-gate` wiring; `tests/unit/e2e/e2e-flake-guards.test.ts` forbids `waitForTimeout` in `tests/e2e/**/*.spec.ts`; `tests/unit/scripts/ci-preflight.contract.test.ts` locks `ci:preflight` stage order; `tests/unit/scripts/local-gates.contract.test.ts` locks `bun run check`; `tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts` keeps donor/missionary unit smoke coverage and API email mock posture.
 
 ### `test-e2e` (needs: `smoke`)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,12 +8,13 @@ Two workflow files run on every PR to `develop` and `epic`, and on every push to
 | Workflow          | File                                   | Branches                          | Jobs                                            | Target time               |
 | ----------------- | -------------------------------------- | --------------------------------- | ----------------------------------------------- | ------------------------- |
 | Fast checks       | `.github/workflows/ci.yml`             | PRs + pushes on `develop`, `epic` | `format → lint → typecheck → build → test-unit` | < 4 min with remote cache |
-| Integration + E2E | `.github/workflows/ci-integration.yml` | PRs + pushes on `develop`, `epic` | `migrate → smoke → test-e2e`                    | ~5 min                    |
+| Integration + E2E | `.github/workflows/ci-integration.yml` | PRs + pushes on `develop`, `epic` | `migrate → smoke → test-e2e-smoke → test-e2e`   | ~5–25 min                 |
 
 Current workflow semantics:
 
 - `ci.yml` is the always-on fast gate for the active long-lived branches (`develop`, `epic`).
 - `ci-integration.yml` runs on the same active long-lived branches.
+- `test-e2e-smoke` is **blocking on `develop`** through `e2e-smoke-gate` and `integration-gate`.
 - `test-e2e` is **informational on `develop`** (`continue-on-error: true` there).
 - `test-e2e` is enforced on `epic` through the workflow's `e2e-gate`, and
   branch protection must require `ci-gate`, `integration-gate`, and `e2e-gate`
@@ -203,6 +204,12 @@ Current coverage caveat: the repo's custom raw V8 fallback provider writes cover
 - _Why it matters:_ Verifies the app boots without a crash — catches missing imports, broken middleware, and startup-time errors that build alone cannot catch.
 - _Debug locally:_ Run `bun run test:e2e` (default CI-equivalent env) or `bun run dev:donor` with real `.env.local` values, then `curl http://localhost:3005/api/health`. Expect `{"status":"ok","checks":{"supabase":"ok"},"observability":{"surface":"donor",...}}`; `observability.release` carries the commit/ref/environment metadata when the deployment provides it.
 
+### `test-e2e-smoke` (needs: `smoke`)
+
+- _What it does:_ Re-applies SQL migrations against a fresh Postgres container through `node scripts/verify/supabase-migrations.mjs`, runs Payload migrations + status checks, then applies seed data, starts `apps/donor` on port 3005 with `E2E_AUTH_BYPASS=true`, waits for `/api/health`, and runs the bounded Playwright smoke suite via `bun run test:e2e:smoke` (demo auth preflight, usability smoke, donate, upload-crop, Support Hub smoke). The job has a 20-minute cap and uploads `playwright-smoke-report/` on failure.
+- _Branch behavior:_ Blocking on `develop` through `e2e-smoke-gate` and `integration-gate`.
+- _Debug locally:_ Run `bun run test:e2e:smoke` after `bun run test:e2e:auth-preflight` with donor on port 3005.
+
 ### `test-e2e` (needs: `smoke`)
 
 - _What it does:_ Re-applies SQL migrations against a fresh Postgres container through `node scripts/verify/supabase-migrations.mjs`, runs Payload migrations + status checks, then applies seed data, starts `apps/donor` on port 3005 and `apps/admin` on port 3030, enables deterministic test auth mode (`E2E_AUTH_BYPASS=true`) for Playwright web servers, and sets `PLAYWRIGHT_REUSE_EXISTING_SERVER=1` so Playwright reuses the already-started servers instead of trying to bind those ports again. It executes demo-auth preflight (`bun run test:e2e:auth-preflight`), then runs bounded production-release suites:
@@ -221,7 +228,7 @@ The workflow files are the source of truth for execution. Branch protection shou
 
 ### Required checks by branch
 
-- `develop`: `ci-gate` and `integration-gate` are enforced; `CI Integration / test-e2e` is visible but intentionally non-blocking.
+- `develop`: `ci-gate`, `integration-gate`, and `e2e-smoke-gate` are enforced; the full `CI Integration / test-e2e` job remains visible but intentionally non-blocking.
 - `epic`: `ci-gate`, `integration-gate`, and `e2e-gate` are enforced; production release is handled by `bun run release:production`.
 - `main`: retired/protected historical branch only; do not treat it as production or staging in this repo.
 
@@ -231,7 +238,7 @@ The workflow files are the source of truth for execution. Branch protection shou
 2. Keep rules for `epic` and `develop`.
 3. Enable **Require status checks to pass before merging**.
 4. Require `ci-gate`, `integration-gate`, and `e2e-gate` on `epic`.
-5. Require `ci-gate` and `integration-gate` on `develop`.
+5. Require `ci-gate`, `integration-gate`, and `e2e-smoke-gate` on `develop`.
 6. Disable force pushes on both branches.
 7. For `develop`, leave `CI Integration / test-e2e` optional if you want the current "signal, not blocker" behavior to remain intact.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -210,9 +210,10 @@ Current coverage caveat: the repo's custom raw V8 fallback provider writes cover
 
 ### `test-e2e-smoke` (needs: `smoke`)
 
-- _What it does:_ Re-applies SQL migrations against a fresh Postgres container through `node scripts/verify/supabase-migrations.mjs`, runs Payload migrations + status checks, then applies seed data, starts `apps/donor` on port 3005 with `E2E_AUTH_BYPASS=true`, waits for `/api/health`, and runs the bounded Playwright smoke suite via `bun run test:e2e:smoke` (demo auth preflight, usability smoke, donate, upload-crop, Support Hub smoke). The job has a 20-minute cap and uploads `playwright-smoke-report/` on failure.
+- _What it does:_ Re-applies SQL migrations against a fresh Postgres container through `node scripts/verify/supabase-migrations.mjs`, runs Payload migrations + status checks, then applies seed data, starts `apps/donor` on port 3005 and `apps/admin` on port 3030 with `E2E_AUTH_BYPASS=true`, waits for both `/api/health` endpoints, and runs the bounded Playwright smoke suite via `bun run test:e2e:smoke` (demo auth preflight, usability smoke, donate, upload-crop under the donor-auth project, and Support Hub smoke). The job has a 25-minute cap, the Playwright smoke step has a 15-minute cap, and failures upload `playwright-smoke-report/`.
 - _Branch behavior:_ Blocking on `develop` through `e2e-smoke-gate` and `integration-gate`.
 - _Debug locally:_ Run `bun run test:e2e:smoke` after `bun run test:e2e:auth-preflight` with donor on port 3005.
+- _Coverage note:_ This bounded smoke gate is not the a11y, hydration, perf, or full auth signal. Run `bun run test:a11y`, `bun run test:perf`, or the broader `bun run test:e2e` when a change affects those contracts.
 - _Regression guards (unit):_ `tests/unit/scripts/ci-integration-workflow.contract.test.ts` locks `integration-gate` / `e2e-smoke-gate` / `e2e-gate` wiring; `tests/unit/e2e/e2e-flake-guards.test.ts` forbids `waitForTimeout` in `tests/e2e/**/*.spec.ts`; `tests/unit/scripts/ci-preflight.contract.test.ts` locks `ci:preflight` stage order; `tests/unit/scripts/local-gates.contract.test.ts` locks `bun run check`; `tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts` keeps donor/missionary unit smoke coverage and API email mock posture.
 
 ### `test-e2e` (needs: `smoke`)

--- a/docs/guides/development/code-review-and-ownership.md
+++ b/docs/guides/development/code-review-and-ownership.md
@@ -27,6 +27,7 @@ The repo uses gate jobs as merge controls. Gate jobs are summary checks that fai
 - `develop` requires:
   - `ci-gate`
   - `integration-gate`
+  - `e2e-smoke-gate`
 - `main` is retired/protected historical history and is not an active PR or
   deploy target.
 
@@ -41,13 +42,17 @@ The repo uses gate jobs as merge controls. Gate jobs are summary checks that fai
 - `integration-gate` covers:
   - `migrate` (DB migrations + seed verification)
   - `smoke` (app boot + health check)
+  - `e2e-smoke-gate` (summary gate for `test-e2e-smoke`)
+- `e2e-smoke-gate` covers:
+  - `test-e2e-smoke` (`bun run test:e2e:smoke`)
 - `e2e-gate` covers:
   - bounded production-release Playwright coverage through
     `bun run test:e2e:production-gate`
   - app-specific boneyard smoke checks
   - portable `@cms` coverage; local-seed-only `@cms-local` proof stays in
     `bun run test:e2e:cms:local`
-  - On `develop`, E2E remains informational (non-blocking)
+  - On `develop`, the full `test-e2e` job remains informational (non-blocking);
+    bounded smoke is enforced separately through `e2e-smoke-gate`
 
 ## Contributor PR Checklist
 

--- a/docs/guides/development/contributing.md
+++ b/docs/guides/development/contributing.md
@@ -77,7 +77,7 @@ bun run test:e2e
 This repo uses gate jobs as required checks. Gate jobs summarize multiple underlying jobs.
 
 - **`epic` required:** `ci-gate`
-- **`develop` required:** `ci-gate`, `integration-gate`
+- **`develop` required:** `ci-gate`, `integration-gate`, `e2e-smoke-gate`
 - **`main`:** retired/protected historical branch; do not open active PRs to it.
 
 For ownership and full review policy, see `docs/guides/development/code-review-and-ownership.md`.

--- a/docs/ops/deploy-checklist.md
+++ b/docs/ops/deploy-checklist.md
@@ -15,8 +15,8 @@ is not a deploy target.
       `bun run verify:deployment-discipline`
 - [ ] Monorepo build-control verifier passes:
       `bun run verify:vercel-build-controls`
-- [ ] GitHub branch protection requires `ci-gate` on `epic`; `ci-gate` and
-      `integration-gate` on `develop`
+- [ ] GitHub branch protection requires `ci-gate` on `epic`; `ci-gate`,
+      `integration-gate`, and `e2e-smoke-gate` on `develop`
 - [ ] Migrations reviewed (additive-only, or expand-then-contract followed)
 - [ ] Migrations tested on staging first
 - [ ] Vercel project Production Branch matches the intended release branch for all 3 projects

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:e2e:cms": "node scripts/run-with-ci-env.mjs -- node node_modules/@playwright/test/cli.js test --grep \"@cms\" --grep-invert \"@manual|@cms-local\"",
     "test:e2e:cms:strict": "node node_modules/@playwright/test/cli.js test --grep \"@cms\" --grep-invert \"@manual|@cms-local\"",
     "test:e2e:auth-preflight": "node scripts/run-with-ci-env.mjs -- node node_modules/@playwright/test/cli.js test tests/e2e/demo-auth-preflight.spec.ts --project=chromium",
-    "test:e2e:smoke": "node scripts/run-with-ci-env.mjs -- node node_modules/@playwright/test/cli.js test tests/e2e/demo-auth-preflight.spec.ts tests/e2e/usability-smoke.spec.ts tests/e2e/donate.spec.ts tests/e2e/upload-crop.spec.ts tests/e2e/support-hub.smoke.spec.ts --project=chromium --workers=1",
+    "test:e2e:smoke": "node scripts/run-with-ci-env.mjs -- node node_modules/@playwright/test/cli.js test tests/e2e/demo-auth-preflight.spec.ts tests/e2e/usability-smoke.spec.ts tests/e2e/donate.spec.ts tests/e2e/support-hub.smoke.spec.ts --project=chromium --workers=1 && node scripts/run-with-ci-env.mjs -- node node_modules/@playwright/test/cli.js test tests/e2e/upload-crop.spec.ts --project=chromium-donor --workers=1",
     "test:e2e:smoke:cms": "CMS_WEB_STUDIO_NATIVE_PAGES=true node scripts/run-with-ci-env.mjs -- node node_modules/@playwright/test/cli.js test tests/e2e/cms-admin-redirect.spec.ts tests/e2e/cms-publish-flow.spec.ts tests/e2e/cms-tenant-isolation.spec.ts tests/e2e/cms-ministry-updates.spec.ts tests/e2e/cms-web-studio-native.spec.ts tests/e2e/cms-templates-gallery.spec.ts",
     "test:e2e:cms:local": "node scripts/cms/run-local-e2e.mjs",
     "test:e2e:ui": "node node_modules/@playwright/test/cli.js test --ui",

--- a/scripts/verify/deployment-discipline.mjs
+++ b/scripts/verify/deployment-discipline.mjs
@@ -383,7 +383,7 @@ async function main() {
         branch: STAGING_BRANCH,
         protection: readGitHubProtection(args.repo, STAGING_BRANCH),
         branchRule: readGitHubBranchProtectionRule(args.repo, STAGING_BRANCH),
-        requiredContexts: ["ci-gate", "integration-gate"],
+        requiredContexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
       }),
     );
 

--- a/scripts/verify/deployment-discipline.mjs
+++ b/scripts/verify/deployment-discipline.mjs
@@ -135,6 +135,7 @@ export function validateGitHubBranchProtection({
   protection,
   branchRule,
   requiredContexts,
+  forbiddenContexts = [],
 }) {
   const checks = [];
   const contexts = contextNames(protection);
@@ -169,6 +170,14 @@ export function validateGitHubBranchProtection({
       checks,
       contexts.includes(context),
       `${branch} requires ${context}`,
+      contexts.join(", ") || "<none>",
+    );
+  }
+  for (const context of forbiddenContexts) {
+    requireCheck(
+      checks,
+      !contexts.includes(context),
+      `${branch} does not require ${context}`,
       contexts.join(", ") || "<none>",
     );
   }
@@ -376,6 +385,7 @@ async function main() {
           PRODUCTION_BRANCH,
         ),
         requiredContexts: ["ci-gate", "integration-gate", "e2e-gate"],
+        forbiddenContexts: ["e2e-smoke-gate"],
       }),
     );
     checks.push(
@@ -384,6 +394,7 @@ async function main() {
         protection: readGitHubProtection(args.repo, STAGING_BRANCH),
         branchRule: readGitHubBranchProtectionRule(args.repo, STAGING_BRANCH),
         requiredContexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
+        forbiddenContexts: ["e2e-gate"],
       }),
     );
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -34,7 +34,9 @@ Playwright config sets this automatically when `ASYM_USE_CI_ENV_DEFAULTS=1` (see
 
 ## CI behavior
 
-The `test-e2e` job in `.github/workflows/ci-integration.yml` is configured with `continue-on-error: true`, so failures are informational and do not block merges. On failure, CI uploads `playwright-report/` as an artifact for debugging.
+- `test-e2e-smoke` runs `bun run test:e2e:smoke` and is **blocking** on `develop` through the `e2e-smoke-gate` required check.
+- `test-e2e` remains configured with `continue-on-error: true` on `develop`, so the full broad suite is informational there. On `epic`, `e2e-gate` makes the bounded production-release path required.
+- On failure, CI uploads `playwright-smoke-report/` (smoke job) or `playwright-report/` (full job) as artifacts for debugging.
 
 ## Growth plan - future tests to add
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -35,6 +35,11 @@ Playwright config sets this automatically when `ASYM_USE_CI_ENV_DEFAULTS=1` (see
 ## CI behavior
 
 - `test-e2e-smoke` runs `bun run test:e2e:smoke` and is **blocking** on `develop` through the `e2e-smoke-gate` required check.
+- Smoke starts donor and admin, then runs a bounded inventory: donor auth
+  preflight/usability/donate, admin Support Hub, and upload-crop under the
+  donor-auth Playwright project. It is not a substitute for `bun run test:a11y`,
+  `bun run test:perf`, or the broader `bun run test:e2e` when those contracts
+  are touched.
 
 ## Deterministic waits
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -35,6 +35,12 @@ Playwright config sets this automatically when `ASYM_USE_CI_ENV_DEFAULTS=1` (see
 ## CI behavior
 
 - `test-e2e-smoke` runs `bun run test:e2e:smoke` and is **blocking** on `develop` through the `e2e-smoke-gate` required check.
+
+## Deterministic waits
+
+- Prefer `expect.poll` or `page.waitForURL` over `page.waitForTimeout`.
+- Do not stack a fixed sleep after a poll that already waited for the same condition.
+- Unit guard: `tests/unit/e2e/e2e-flake-guards.test.ts` rejects `waitForTimeout` in `tests/e2e/**/*.spec.ts`.
 - `test-e2e` remains configured with `continue-on-error: true` on `develop`, so the full broad suite is informational there. On `epic`, `e2e-gate` makes the bounded production-release path required.
 - On failure, CI uploads `playwright-smoke-report/` (smoke job) or `playwright-report/` (full job) as artifacts for debugging.
 

--- a/tests/e2e/auth-permissions.spec.ts
+++ b/tests/e2e/auth-permissions.spec.ts
@@ -24,13 +24,11 @@ test("permissions guard flow", async ({ page }) => {
   await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
     timeout: 20000,
   });
-  await page.waitForTimeout(1500);
   await expect
     .poll(() => new URL(page.url()).pathname, { timeout: 20000 })
     .toBe(expectedPostLoginPath!);
 
   await page.goto(protectedPath!, { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(1500);
   await expect
     .poll(() => new URL(page.url()).pathname, { timeout: 20000 })
     .toBe(expectedProtectedPath!);

--- a/tests/e2e/auth-session-guards.spec.ts
+++ b/tests/e2e/auth-session-guards.spec.ts
@@ -27,13 +27,11 @@ test("session guard flow: login, persistence, /login redirect, sign out", async 
     .toBe(expectedHomePath!);
 
   await page.reload({ waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(1500);
   await expect
     .poll(() => new URL(page.url()).pathname, { timeout: 20000 })
     .toBe(expectedHomePath!);
 
   await page.goto("/login");
-  await page.waitForTimeout(1500);
   await expect
     .poll(() => new URL(page.url()).pathname, { timeout: 20000 })
     .toBe(expectedHomePath!);

--- a/tests/setup/unit-env.ts
+++ b/tests/setup/unit-env.ts
@@ -3,6 +3,9 @@ process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "example-anon-key";
 process.env.PAYLOAD_SECRET ??= "unit-test-payload-secret";
 
+/** Prevent CMS/auth unit tests from opening real Supabase when .env.local sets a service role key. */
+delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
 const localStorageDescriptor = Object.getOwnPropertyDescriptor(
   globalThis,
   "localStorage",

--- a/tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts
+++ b/tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts
@@ -66,8 +66,12 @@ describe("donor and missionary unit smoke contract", () => {
       "utf8",
     );
 
-    expect(connectSource).toContain('vi.mock("@asym/email", async (importOriginal)');
-    expect(connectSource).toContain("validateResendApiKey: validateResendApiKeyMock");
+    expect(connectSource).toContain(
+      'vi.mock("@asym/email", async (importOriginal)',
+    );
+    expect(connectSource).toContain(
+      "validateResendApiKey: validateResendApiKeyMock",
+    );
     expect(connectSource).not.toMatch(
       /vi\.mock\("@asym\/email"\s*,\s*\(\)\s*=>\s*\(\{/,
     );

--- a/tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts
+++ b/tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts
@@ -1,0 +1,75 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import vitestConfig from "../../../vitest.config";
+
+const repoRoot = process.cwd();
+
+const DONOR_UNIT_SMOKE_FILES = [
+  "tests/unit/apps/donor/donor-dashboard-bootstrap.test.ts",
+  "tests/unit/apps/donor/donor-history-tanstack.test.ts",
+  "tests/unit/apps/donor/next-config-images.test.ts",
+] as const;
+
+const MISSIONARY_UNIT_SMOKE_FILES = [
+  "tests/unit/apps/missionary/donors-page-view-model-contract.test.ts",
+  "tests/unit/apps/missionary/donors-tanstack.test.ts",
+  "tests/unit/apps/missionary/app/access.test.ts",
+] as const;
+
+describe("donor and missionary unit smoke contract", () => {
+  it("keeps baseline donor app unit smoke files on disk", () => {
+    for (const relativePath of DONOR_UNIT_SMOKE_FILES) {
+      expect(existsSync(path.join(repoRoot, relativePath))).toBe(true);
+    }
+  });
+
+  it("keeps baseline missionary app unit smoke files on disk", () => {
+    for (const relativePath of MISSIONARY_UNIT_SMOKE_FILES) {
+      expect(existsSync(path.join(repoRoot, relativePath))).toBe(true);
+    }
+  });
+
+  it("includes tests/unit in vitest discovery", () => {
+    const testConfig = vitestConfig.test;
+    const include =
+      testConfig && typeof testConfig === "object" && "include" in testConfig
+        ? testConfig.include
+        : undefined;
+
+    expect(include).toEqual(
+      expect.arrayContaining([
+        "tests/unit/**/*.test.ts",
+        "tests/unit/**/*.test.tsx",
+      ]),
+    );
+  });
+
+  it("loads unit-env setup before app unit tests run", () => {
+    const testConfig = vitestConfig.test;
+    const setupFiles =
+      testConfig && typeof testConfig === "object" && "setupFiles" in testConfig
+        ? testConfig.setupFiles
+        : undefined;
+
+    expect(setupFiles).toContain("./tests/setup/unit-env.ts");
+    expect(existsSync(path.join(repoRoot, "tests/setup/unit-env.ts"))).toBe(
+      true,
+    );
+  });
+
+  it("mocks Resend validation in connect tests without replacing @asym/email", () => {
+    const connectSource = readFileSync(
+      path.join(repoRoot, "tests/unit/packages/api/email/connect.test.ts"),
+      "utf8",
+    );
+
+    expect(connectSource).toContain('vi.mock("@asym/email", async (importOriginal)');
+    expect(connectSource).toContain("validateResendApiKey: validateResendApiKeyMock");
+    expect(connectSource).not.toMatch(
+      /vi\.mock\("@asym\/email"\s*,\s*\(\)\s*=>\s*\(\{/,
+    );
+  });
+});

--- a/tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts
+++ b/tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -19,16 +19,21 @@ const MISSIONARY_UNIT_SMOKE_FILES = [
   "tests/unit/apps/missionary/app/access.test.ts",
 ] as const;
 
+function expectUnitSmokeFile(relativePath: string) {
+  expect(relativePath).toMatch(/^tests\/unit\/.+\.test\.tsx?$/);
+  expect(existsSync(path.join(repoRoot, relativePath))).toBe(true);
+}
+
 describe("donor and missionary unit smoke contract", () => {
   it("keeps baseline donor app unit smoke files on disk", () => {
     for (const relativePath of DONOR_UNIT_SMOKE_FILES) {
-      expect(existsSync(path.join(repoRoot, relativePath))).toBe(true);
+      expectUnitSmokeFile(relativePath);
     }
   });
 
   it("keeps baseline missionary app unit smoke files on disk", () => {
     for (const relativePath of MISSIONARY_UNIT_SMOKE_FILES) {
-      expect(existsSync(path.join(repoRoot, relativePath))).toBe(true);
+      expectUnitSmokeFile(relativePath);
     }
   });
 
@@ -57,23 +62,6 @@ describe("donor and missionary unit smoke contract", () => {
     expect(setupFiles).toContain("./tests/setup/unit-env.ts");
     expect(existsSync(path.join(repoRoot, "tests/setup/unit-env.ts"))).toBe(
       true,
-    );
-  });
-
-  it("mocks Resend validation in connect tests without replacing @asym/email", () => {
-    const connectSource = readFileSync(
-      path.join(repoRoot, "tests/unit/packages/api/email/connect.test.ts"),
-      "utf8",
-    );
-
-    expect(connectSource).toContain(
-      'vi.mock("@asym/email", async (importOriginal)',
-    );
-    expect(connectSource).toContain(
-      "validateResendApiKey: validateResendApiKeyMock",
-    );
-    expect(connectSource).not.toMatch(
-      /vi\.mock\("@asym\/email"\s*,\s*\(\)\s*=>\s*\(\{/,
     );
   });
 });

--- a/tests/unit/apps/donor/next-config-images.test.ts
+++ b/tests/unit/apps/donor/next-config-images.test.ts
@@ -15,5 +15,5 @@ describe("apps/donor next.config images", () => {
     const qualities = mod.default.images?.qualities;
     expect(qualities).toBeDefined();
     expect(qualities).toContain(85);
-  });
+  }, 10_000);
 });

--- a/tests/unit/cms/supabase-strategy.test.ts
+++ b/tests/unit/cms/supabase-strategy.test.ts
@@ -180,7 +180,10 @@ function createPayloadMock({
 
 function createStrategyWithMocks(
   mock: ReturnType<typeof createSupabaseClientMock>,
-  extra?: Omit<Parameters<SupabaseAuthStrategyFactory>[0], "createSupabaseClient">,
+  extra?: Omit<
+    Parameters<SupabaseAuthStrategyFactory>[0],
+    "createSupabaseClient"
+  >,
 ) {
   const dataClient = {
     from: mock.from,

--- a/tests/unit/cms/supabase-strategy.test.ts
+++ b/tests/unit/cms/supabase-strategy.test.ts
@@ -178,12 +178,29 @@ function createPayloadMock({
   return { create, find, update };
 }
 
+function createStrategyWithMocks(
+  mock: ReturnType<typeof createSupabaseClientMock>,
+  extra?: Omit<Parameters<SupabaseAuthStrategyFactory>[0], "createSupabaseClient">,
+) {
+  const dataClient = {
+    from: mock.from,
+    schema: mock.schema,
+  };
+
+  return createSupabaseAuthStrategy({
+    createSupabaseClient: mock.createServerClientMock as never,
+    createSupabaseDataClient: vi.fn(() => dataClient) as never,
+    ...extra,
+  });
+}
+
 describe("createSupabaseAuthStrategy", () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
     delete process.env.E2E_AUTH_BYPASS;
     delete process.env.ASYM_E2E_AUTH_SURFACE;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
   });
 
   it("returns null when Supabase env is missing", async () => {
@@ -203,7 +220,7 @@ describe("createSupabaseAuthStrategy", () => {
 
   it("authenticates admin E2E bypass cookies through normal Payload users", async () => {
     process.env.E2E_AUTH_BYPASS = "true";
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       userId: "",
     });
     const e2eCookie = createE2EAuthCookieValue({
@@ -212,9 +229,7 @@ describe("createSupabaseAuthStrategy", () => {
       userId: "e2e-admin-user",
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock();
 
     const result = await strategy.authenticate({
@@ -247,7 +262,7 @@ describe("createSupabaseAuthStrategy", () => {
 
   it("rejects donor E2E bypass cookies for the Payload admin surface", async () => {
     process.env.E2E_AUTH_BYPASS = "true";
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       userId: "",
     });
     const e2eCookie = createE2EAuthCookieValue({
@@ -256,9 +271,7 @@ describe("createSupabaseAuthStrategy", () => {
       userId: "e2e-donor-user",
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock();
 
     const result = await strategy.authenticate({
@@ -276,14 +289,12 @@ describe("createSupabaseAuthStrategy", () => {
   });
 
   it("creates a CMS user against the mirrored Payload tenant", async () => {
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       role: "donor",
       staffMembershipRole: "member_care",
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock();
 
     const result = await strategy.authenticate({
@@ -291,7 +302,7 @@ describe("createSupabaseAuthStrategy", () => {
       payload,
     } as never);
 
-    expect(createServerClientMock).toHaveBeenCalledTimes(1);
+    expect(supabaseMock.createServerClientMock).toHaveBeenCalledTimes(1);
     expect(payload.create).toHaveBeenCalledWith(
       expect.objectContaining({
         collection: "cms-users",
@@ -312,14 +323,12 @@ describe("createSupabaseAuthStrategy", () => {
   });
 
   it("skips write operations when the existing user is already in sync", async () => {
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       role: "donor",
       staffMembershipRole: "member_care",
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock({
       existingUser: {
         email: "staff@example.org",
@@ -346,7 +355,7 @@ describe("createSupabaseAuthStrategy", () => {
   });
 
   it("updates the CMS user when Supabase profile data changes tenant", async () => {
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       role: "donor",
       tenantId: "tenant_2",
       staffMembershipRole: "finance",
@@ -357,9 +366,7 @@ describe("createSupabaseAuthStrategy", () => {
       },
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock({
       cmsTenant: { id: 22, name: "Tenant Two", slug: "tenant-two" },
       existingUser: {
@@ -390,13 +397,11 @@ describe("createSupabaseAuthStrategy", () => {
   });
 
   it("rejects non-staff profile roles", async () => {
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       role: "donor",
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock();
 
     const result = await strategy.authenticate({
@@ -409,14 +414,12 @@ describe("createSupabaseAuthStrategy", () => {
   });
 
   it("accepts active staff membership even when profile role is donor", async () => {
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       role: "donor",
       staffMembershipRole: "finance",
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock();
 
     const result = await strategy.authenticate({
@@ -433,14 +436,12 @@ describe("createSupabaseAuthStrategy", () => {
   });
 
   it("accepts admin profile roles without giving them CRM ownership", async () => {
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       role: "admin",
       staffMembershipRole: null,
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock();
 
     const result = await strategy.authenticate({
@@ -496,7 +497,7 @@ describe("createSupabaseAuthStrategy", () => {
   });
 
   it("accepts tenantless super admins using the default tenant context", async () => {
-    const { createServerClientMock } = createSupabaseClientMock({
+    const supabaseMock = createSupabaseClientMock({
       role: "super_admin",
       tenantId: null,
       publicTenant: {
@@ -506,9 +507,7 @@ describe("createSupabaseAuthStrategy", () => {
       },
     });
 
-    const strategy = createSupabaseAuthStrategy({
-      createSupabaseClient: createServerClientMock as never,
-    });
+    const strategy = createStrategyWithMocks(supabaseMock);
     const payload = createPayloadMock({
       cmsTenant: { id: 17, name: "Default Tenant", slug: "default" },
     });

--- a/tests/unit/e2e/e2e-flake-guards.test.ts
+++ b/tests/unit/e2e/e2e-flake-guards.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const E2E_ROOT = path.join(process.cwd(), "tests", "e2e");
+
+function listSpecFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listSpecFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".spec.ts")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe("e2e flake guards", () => {
+  it("avoids fixed sleep waits in Playwright specs", () => {
+    const offenders: string[] = [];
+
+    for (const filePath of listSpecFiles(E2E_ROOT)) {
+      const contents = readFileSync(filePath, "utf8");
+      if (contents.includes("waitForTimeout(")) {
+        offenders.push(path.relative(process.cwd(), filePath));
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps CI Playwright retries enabled for transient navigation flakes", () => {
+    const config = readFileSync(
+      path.join(process.cwd(), "playwright.config.ts"),
+      "utf8",
+    );
+
+    expect(config).toContain("retries: process.env.CI ? 2 : 0");
+  });
+});

--- a/tests/unit/packages/api/auth/get-auth-context-request-propagation.test.ts
+++ b/tests/unit/packages/api/auth/get-auth-context-request-propagation.test.ts
@@ -16,7 +16,9 @@ function sourceFilesUnder(relativeDir: string): string[] {
   const files: string[] = [];
 
   for (const entry of entries) {
-    const relativePath = path.join(relativeDir, entry.name);
+    const relativePath = path
+      .join(relativeDir, entry.name)
+      .replaceAll("\\", "/");
     if (entry.isDirectory()) {
       files.push(...sourceFilesUnder(relativePath));
       continue;

--- a/tests/unit/packages/api/email/connect.test.ts
+++ b/tests/unit/packages/api/email/connect.test.ts
@@ -61,6 +61,10 @@ import {
   GET,
   POST,
 } from "../../../../../packages/api/src/email/connect";
+import {
+  FIXED_RESEND_VALIDATED_AT,
+  verifiedResendValidationResult,
+} from "./resend-validation-fixtures";
 
 function createPostRequest(body: unknown): NextRequest {
   return new Request("https://example.com/api/email/connect", {
@@ -87,47 +91,11 @@ describe("api/email/connect", () => {
 
   it("persists validated Resend connection settings", async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-02T12:00:00.000Z"));
+    vi.setSystemTime(new Date(FIXED_RESEND_VALIDATED_AT));
 
-    validateResendApiKeyMock.mockResolvedValueOnce({
-      valid: true,
-      senderIdentities: [
-        {
-          id: 1,
-          nickname: "default",
-          from_email: "a@b.com",
-          from_name: "A",
-          reply_to_email: null,
-          verified: true,
-        },
-      ],
-      domainAuthentication: [
-        {
-          id: 1,
-          domain: "example.com",
-          subdomain: null,
-          valid: true,
-          records: [
-            {
-              record: "SPF",
-              type: "TXT",
-              name: "send",
-              value: '"v=spf1 include:amazonses.com ~all"',
-              status: "verified",
-            },
-            {
-              record: "DKIM",
-              type: "TXT",
-              name: "resend._domainkey",
-              value: "p=abc123",
-              status: "verified",
-            },
-          ],
-        },
-      ],
-      deliverabilityScore: 100,
-      warnings: [],
-    });
+    validateResendApiKeyMock.mockResolvedValueOnce(
+      verifiedResendValidationResult(),
+    );
     encryptResendApiKeyMock.mockReturnValueOnce("encrypted-key");
     upsertTenantEmailSettingsMock.mockResolvedValueOnce({});
 
@@ -143,7 +111,7 @@ describe("api/email/connect", () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.sendReady).toBe(true);
-    expect(body.validatedAt).toBe("2026-04-02T12:00:00.000Z");
+    expect(body.validatedAt).toBe(FIXED_RESEND_VALIDATED_AT);
     expect(upsertTenantEmailSettingsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         tenantId: "tenant_1",
@@ -161,8 +129,6 @@ describe("api/email/connect", () => {
         }),
       }),
     );
-
-    vi.useRealTimers();
   });
 
   it("hydrates disconnected state when settings do not exist", async () => {

--- a/tests/unit/packages/api/email/connect.test.ts
+++ b/tests/unit/packages/api/email/connect.test.ts
@@ -1,14 +1,10 @@
 import { type NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   getAuthContextMock,
   requireRoleMock,
   validateResendApiKeyMock,
-  createResendValidationSnapshotMock,
-  parseResendValidationSnapshotMock,
-  isResendValidationSendReadyMock,
-  getFirstBlockingDeliverabilityWarningMock,
   encryptResendApiKeyMock,
   decryptResendApiKeyMock,
   readTenantEmailSettingsMock,
@@ -19,70 +15,6 @@ const {
   getAuthContextMock: vi.fn(),
   requireRoleMock: vi.fn(),
   validateResendApiKeyMock: vi.fn(),
-  createResendValidationSnapshotMock: vi.fn(
-    (validation: {
-      senderIdentities?: unknown[];
-      domainAuthentication?: Array<{
-        valid?: boolean;
-        records?: Array<{
-          record?: string;
-          type?: string;
-          status?: string;
-        }>;
-      }>;
-      warnings?: Array<{ severity?: string }>;
-      deliverabilityScore?: number;
-    }) => {
-      const domainAuthentication = validation.domainAuthentication ?? [];
-
-      return {
-        senderIdentities: validation.senderIdentities ?? [],
-        domainAuthentication,
-        warnings: validation.warnings ?? [],
-        deliverabilityScore: validation.deliverabilityScore ?? 0,
-        validatedAt: "2026-04-02T12:00:00.000Z",
-        domainAuthenticated: domainAuthentication.some(
-          (domain) => domain.valid,
-        ),
-        dkimVerified: domainAuthentication.some((domain) =>
-          (domain.records ?? []).some(
-            (record) =>
-              record.record === "DKIM" && record.status === "verified",
-          ),
-        ),
-        spfVerified: domainAuthentication.some((domain) =>
-          (domain.records ?? []).some(
-            (record) =>
-              record.record === "SPF" &&
-              record.type === "TXT" &&
-              record.status === "verified",
-          ),
-        ),
-      };
-    },
-  ),
-  parseResendValidationSnapshotMock: vi.fn(
-    (snapshot: unknown) => snapshot ?? null,
-  ),
-  isResendValidationSendReadyMock: vi.fn(
-    (snapshot: {
-      domainAuthenticated?: boolean;
-      warnings?: Array<{ severity?: string }>;
-    }) =>
-      Boolean(snapshot.domainAuthenticated) &&
-      !(snapshot.warnings ?? []).some(
-        (warning) => warning.severity === "error",
-      ),
-  ),
-  getFirstBlockingDeliverabilityWarningMock: vi.fn(
-    (
-      warnings:
-        | Array<{
-            severity?: "info" | "warning" | "error";
-          }>
-        | undefined,
-    ) => warnings?.find((warning) => warning.severity === "error"),
-  ),
   encryptResendApiKeyMock: vi.fn(),
   decryptResendApiKeyMock: vi.fn(),
   readTenantEmailSettingsMock: vi.fn(),
@@ -102,23 +34,14 @@ vi.mock("@asym/auth/context", () => ({
   requireRole: requireRoleMock,
 }));
 
-vi.mock("@asym/email", () => ({
-  RESEND_ERROR_CODES: {
-    UNAUTHORIZED: "unauthorized",
-    FORBIDDEN: "forbidden",
-    RATE_LIMITED: "rate_limited",
-    CONFLICT: "conflict",
-    INVALID_API_KEY: "invalid_api_key",
-    VALIDATION_ERROR: "validation_error",
-    SERVER_ERROR: "server_error",
-  },
-  validateResendApiKey: validateResendApiKeyMock,
-  createResendValidationSnapshot: createResendValidationSnapshotMock,
-  parseResendValidationSnapshot: parseResendValidationSnapshotMock,
-  isResendValidationSendReady: isResendValidationSendReadyMock,
-  getFirstBlockingDeliverabilityWarning:
-    getFirstBlockingDeliverabilityWarningMock,
-}));
+vi.mock("@asym/email", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@asym/email")>();
+
+  return {
+    ...actual,
+    validateResendApiKey: validateResendApiKeyMock,
+  };
+});
 
 vi.mock("../../../../../packages/api/src/email/crypto", () => ({
   encryptResendApiKey: encryptResendApiKeyMock,
@@ -150,6 +73,7 @@ function createPostRequest(body: unknown): NextRequest {
 describe("api/email/connect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     getAuthContextMock.mockResolvedValue({
       tenantId: "tenant_1",
       role: "admin",
@@ -157,7 +81,14 @@ describe("api/email/connect", () => {
     requireRoleMock.mockReturnValue(undefined);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("persists validated Resend connection settings", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T12:00:00.000Z"));
+
     validateResendApiKeyMock.mockResolvedValueOnce({
       valid: true,
       senderIdentities: [
@@ -230,6 +161,8 @@ describe("api/email/connect", () => {
         }),
       }),
     );
+
+    vi.useRealTimers();
   });
 
   it("hydrates disconnected state when settings do not exist", async () => {

--- a/tests/unit/packages/api/email/resend-snapshot-contract.test.ts
+++ b/tests/unit/packages/api/email/resend-snapshot-contract.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createResendValidationSnapshot,
+  isResendValidationSendReady,
+  parseResendValidationSnapshot,
+} from "@asym/email/resend";
+
+const FIXED_VALIDATED_AT = "2026-04-02T12:00:00.000Z";
+
+describe("@asym/email Resend validation snapshot contract", () => {
+  it("maps domain record evidence to snapshot flags used by api/email/connect", () => {
+    const snapshot = createResendValidationSnapshot(
+      {
+        senderIdentities: [],
+        domainAuthentication: [
+          {
+            id: 1,
+            domain: "example.com",
+            subdomain: null,
+            valid: true,
+            records: [
+              {
+                record: "SPF",
+                type: "TXT",
+                name: "send",
+                value: '"v=spf1 include:amazonses.com ~all"',
+                status: "verified",
+              },
+              {
+                record: "DKIM",
+                type: "TXT",
+                name: "resend._domainkey",
+                value: "p=abc123",
+                status: "verified",
+              },
+            ],
+          },
+        ],
+        deliverabilityScore: 100,
+        warnings: [],
+      },
+      FIXED_VALIDATED_AT,
+    );
+
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        validatedAt: FIXED_VALIDATED_AT,
+        domainAuthenticated: true,
+        dkimVerified: true,
+        spfVerified: true,
+        deliverabilityScore: 100,
+      }),
+    );
+    expect(isResendValidationSendReady(snapshot)).toBe(true);
+  });
+
+  it("round-trips snapshots through parseResendValidationSnapshot", () => {
+    const snapshot = createResendValidationSnapshot(
+      {
+        senderIdentities: [
+          {
+            id: 1,
+            nickname: "default",
+            from_email: "from@example.com",
+            from_name: "From Team",
+            reply_to_email: null,
+            verified: true,
+          },
+        ],
+        domainAuthentication: [
+          {
+            id: 1,
+            domain: "example.com",
+            subdomain: null,
+            valid: true,
+            records: [
+              {
+                record: "SPF",
+                type: "TXT",
+                name: "send",
+                value: '"v=spf1 include:amazonses.com ~all"',
+                status: "verified",
+              },
+            ],
+          },
+        ],
+        deliverabilityScore: 91,
+        warnings: [],
+      },
+      FIXED_VALIDATED_AT,
+    );
+
+    const parsed = parseResendValidationSnapshot(snapshot);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        validatedAt: FIXED_VALIDATED_AT,
+        domainAuthenticated: true,
+        deliverabilityScore: 91,
+        senderIdentities: [
+          expect.objectContaining({
+            from_email: "from@example.com",
+            verified: true,
+          }),
+        ],
+      }),
+    );
+    expect(isResendValidationSendReady(snapshot)).toBe(true);
+    expect(isResendValidationSendReady(parsed)).toBe(true);
+  });
+
+  it("marks send as blocked when deliverability warnings include errors", () => {
+    const snapshot = createResendValidationSnapshot(
+      {
+        senderIdentities: [],
+        domainAuthentication: [
+          { id: 1, domain: "example.com", subdomain: null, valid: true },
+        ],
+        deliverabilityScore: 100,
+        warnings: [
+          {
+            code: "DEFAULT_FROM_EMAIL_DOMAIN_NOT_VERIFIED",
+            severity: "error",
+            message: "Sender domain is not verified.",
+          },
+        ],
+      },
+      FIXED_VALIDATED_AT,
+    );
+
+    expect(snapshot.domainAuthenticated).toBe(true);
+    expect(isResendValidationSendReady(snapshot)).toBe(false);
+  });
+});

--- a/tests/unit/packages/api/email/resend-snapshot-contract.test.ts
+++ b/tests/unit/packages/api/email/resend-snapshot-contract.test.ts
@@ -6,46 +6,21 @@ import {
   parseResendValidationSnapshot,
 } from "@asym/email/resend";
 
-const FIXED_VALIDATED_AT = "2026-04-02T12:00:00.000Z";
+import {
+  FIXED_RESEND_VALIDATED_AT,
+  verifiedResendValidationResult,
+} from "./resend-validation-fixtures";
 
 describe("@asym/email Resend validation snapshot contract", () => {
   it("maps domain record evidence to snapshot flags used by api/email/connect", () => {
     const snapshot = createResendValidationSnapshot(
-      {
-        senderIdentities: [],
-        domainAuthentication: [
-          {
-            id: 1,
-            domain: "example.com",
-            subdomain: null,
-            valid: true,
-            records: [
-              {
-                record: "SPF",
-                type: "TXT",
-                name: "send",
-                value: '"v=spf1 include:amazonses.com ~all"',
-                status: "verified",
-              },
-              {
-                record: "DKIM",
-                type: "TXT",
-                name: "resend._domainkey",
-                value: "p=abc123",
-                status: "verified",
-              },
-            ],
-          },
-        ],
-        deliverabilityScore: 100,
-        warnings: [],
-      },
-      FIXED_VALIDATED_AT,
+      verifiedResendValidationResult({ senderIdentities: [] }),
+      FIXED_RESEND_VALIDATED_AT,
     );
 
     expect(snapshot).toEqual(
       expect.objectContaining({
-        validatedAt: FIXED_VALIDATED_AT,
+        validatedAt: FIXED_RESEND_VALIDATED_AT,
         domainAuthenticated: true,
         dkimVerified: true,
         spfVerified: true,
@@ -57,17 +32,7 @@ describe("@asym/email Resend validation snapshot contract", () => {
 
   it("round-trips snapshots through parseResendValidationSnapshot", () => {
     const snapshot = createResendValidationSnapshot(
-      {
-        senderIdentities: [
-          {
-            id: 1,
-            nickname: "default",
-            from_email: "from@example.com",
-            from_name: "From Team",
-            reply_to_email: null,
-            verified: true,
-          },
-        ],
+      verifiedResendValidationResult({
         domainAuthentication: [
           {
             id: 1,
@@ -86,9 +51,8 @@ describe("@asym/email Resend validation snapshot contract", () => {
           },
         ],
         deliverabilityScore: 91,
-        warnings: [],
-      },
-      FIXED_VALIDATED_AT,
+      }),
+      FIXED_RESEND_VALIDATED_AT,
     );
 
     const parsed = parseResendValidationSnapshot(snapshot);
@@ -96,7 +60,7 @@ describe("@asym/email Resend validation snapshot contract", () => {
     expect(parsed).not.toBeNull();
     expect(parsed).toEqual(
       expect.objectContaining({
-        validatedAt: FIXED_VALIDATED_AT,
+        validatedAt: FIXED_RESEND_VALIDATED_AT,
         domainAuthenticated: true,
         deliverabilityScore: 91,
         senderIdentities: [
@@ -113,7 +77,7 @@ describe("@asym/email Resend validation snapshot contract", () => {
 
   it("marks send as blocked when deliverability warnings include errors", () => {
     const snapshot = createResendValidationSnapshot(
-      {
+      verifiedResendValidationResult({
         senderIdentities: [],
         domainAuthentication: [
           { id: 1, domain: "example.com", subdomain: null, valid: true },
@@ -126,8 +90,8 @@ describe("@asym/email Resend validation snapshot contract", () => {
             message: "Sender domain is not verified.",
           },
         ],
-      },
-      FIXED_VALIDATED_AT,
+      }),
+      FIXED_RESEND_VALIDATED_AT,
     );
 
     expect(snapshot.domainAuthenticated).toBe(true);

--- a/tests/unit/packages/api/email/resend-validation-fixtures.ts
+++ b/tests/unit/packages/api/email/resend-validation-fixtures.ts
@@ -1,0 +1,48 @@
+import type { ResendValidationResult } from "@asym/email";
+
+export const FIXED_RESEND_VALIDATED_AT = "2026-04-02T12:00:00.000Z";
+
+export function verifiedResendValidationResult(
+  overrides: Partial<ResendValidationResult> = {},
+): ResendValidationResult {
+  return {
+    valid: true,
+    senderIdentities: [
+      {
+        id: 1,
+        nickname: "default",
+        from_email: "from@example.com",
+        from_name: "From Team",
+        reply_to_email: null,
+        verified: true,
+      },
+    ],
+    domainAuthentication: [
+      {
+        id: 1,
+        domain: "example.com",
+        subdomain: null,
+        valid: true,
+        records: [
+          {
+            record: "SPF",
+            type: "TXT",
+            name: "send",
+            value: '"v=spf1 include:amazonses.com ~all"',
+            status: "verified",
+          },
+          {
+            record: "DKIM",
+            type: "TXT",
+            name: "resend._domainkey",
+            value: "p=abc123",
+            status: "verified",
+          },
+        ],
+      },
+    ],
+    deliverabilityScore: 100,
+    warnings: [],
+    ...overrides,
+  };
+}

--- a/tests/unit/placeholder.test.ts
+++ b/tests/unit/placeholder.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("placeholder", () => {
-  it("passes — replace with real tests", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/tests/unit/scripts/ci-integration-workflow.contract.test.ts
+++ b/tests/unit/scripts/ci-integration-workflow.contract.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const WORKFLOW_PATH = ".github/workflows/ci-integration.yml";
+
+function readWorkflow(): string {
+  return readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+function jobBlock(workflow: string, jobId: string): string {
+  const jobsStart = workflow.indexOf("jobs:\n");
+  expect(jobsStart).toBeGreaterThanOrEqual(0);
+
+  const jobsYaml = workflow.slice(jobsStart);
+  const headers = [...jobsYaml.matchAll(/^  ([a-z0-9][a-z0-9-]*):/gm)];
+  const index = headers.findIndex((match) => match[1] === jobId);
+  expect(index).toBeGreaterThanOrEqual(0);
+
+  const blockStart = headers[index].index!;
+  const blockEnd =
+    index + 1 < headers.length ? headers[index + 1].index! : jobsYaml.length;
+
+  return jobsYaml.slice(blockStart, blockEnd);
+}
+
+describe("ci-integration workflow contract", () => {
+  const workflow = readWorkflow();
+
+  it("keeps develop merges gated by smoke while full E2E stays informational", () => {
+    const testE2e = jobBlock(workflow, "test-e2e");
+    const testE2eSmoke = jobBlock(workflow, "test-e2e-smoke");
+    const integrationGate = jobBlock(workflow, "integration-gate");
+    const e2eSmokeGate = jobBlock(workflow, "e2e-smoke-gate");
+    const e2eGate = jobBlock(workflow, "e2e-gate");
+
+    expect(testE2eSmoke).toContain("needs: smoke");
+    expect(testE2eSmoke).toContain('E2E_AUTH_BYPASS: "true"');
+    expect(testE2eSmoke).toContain('PLAYWRIGHT_REUSE_EXISTING_SERVER: "1"');
+    expect(testE2eSmoke).toContain("run: bun run test:e2e:smoke");
+    expect(testE2eSmoke).toContain("playwright-smoke-report");
+
+    expect(testE2e).toContain("continue-on-error:");
+    expect(testE2e).toContain("github.base_ref == 'develop'");
+    expect(testE2e).toContain("refs/heads/develop");
+
+    expect(integrationGate).toContain("needs: [migrate, smoke, e2e-smoke-gate]");
+    expect(integrationGate).not.toContain("test-e2e");
+
+    expect(e2eSmokeGate).toContain("needs: [test-e2e-smoke]");
+    expect(e2eSmokeGate).toContain('!= "success"');
+
+    expect(e2eGate).toContain("needs: [test-e2e]");
+    expect(e2eGate).toContain("github.base_ref == 'epic'");
+    expect(e2eGate).toContain("refs/heads/epic");
+    expect(e2eGate).not.toContain("develop");
+  });
+
+  it("does not require the broad chromium inventory in CI integration", () => {
+    expect(workflow).not.toContain("run: bun run test:e2e --project=chromium");
+  });
+});

--- a/tests/unit/scripts/ci-integration-workflow.contract.test.ts
+++ b/tests/unit/scripts/ci-integration-workflow.contract.test.ts
@@ -44,7 +44,7 @@ function jobBlock(workflow: string, jobId: string): string {
 function listPlaywrightTests(args: string[]): string {
   const result = spawnSync(
     process.execPath,
-    [PLAYWRIGHT_CLI, "test", ...args],
+    [PLAYWRIGHT_CLI, "test", ...args, "--reporter=list"],
     {
       encoding: "utf8",
     },

--- a/tests/unit/scripts/ci-integration-workflow.contract.test.ts
+++ b/tests/unit/scripts/ci-integration-workflow.contract.test.ts
@@ -1,11 +1,28 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 const WORKFLOW_PATH = ".github/workflows/ci-integration.yml";
+const PACKAGE_JSON_PATH = "package.json";
+const PLAYWRIGHT_CLI = path.join(
+  "node_modules",
+  "@playwright",
+  "test",
+  "cli.js",
+);
 
 function readWorkflow(): string {
   return readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+function readPackageScripts(): Record<string, string> {
+  const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+
+  return packageJson.scripts ?? {};
 }
 
 function jobBlock(workflow: string, jobId: string): string {
@@ -24,8 +41,25 @@ function jobBlock(workflow: string, jobId: string): string {
   return jobsYaml.slice(blockStart, blockEnd);
 }
 
+function listPlaywrightTests(args: string[]): string {
+  const result = spawnSync(
+    process.execPath,
+    [PLAYWRIGHT_CLI, "test", ...args],
+    {
+      encoding: "utf8",
+    },
+  );
+  const output = `${result.stdout}\n${result.stderr}`;
+
+  expect(output).not.toContain("Error:");
+  expect(result.status).toBe(0);
+
+  return output;
+}
+
 describe("ci-integration workflow contract", () => {
   const workflow = readWorkflow();
+  const scripts = readPackageScripts();
 
   it("keeps develop merges gated by smoke while full E2E stays informational", () => {
     const testE2e = jobBlock(workflow, "test-e2e");
@@ -38,6 +72,12 @@ describe("ci-integration workflow contract", () => {
     expect(testE2eSmoke).toContain('E2E_AUTH_BYPASS: "true"');
     expect(testE2eSmoke).toContain('PLAYWRIGHT_REUSE_EXISTING_SERVER: "1"');
     expect(testE2eSmoke).toContain("run: bun run test:e2e:smoke");
+    expect(testE2eSmoke).toContain("Start admin app");
+    expect(testE2eSmoke).toContain("Wait for admin health endpoint");
+    expect(testE2eSmoke).toContain(
+      'PLAYWRIGHT_ADMIN_BASE_URL: "http://127.0.0.1:3030"',
+    );
+    expect(testE2eSmoke).toContain('PLAYWRIGHT_INCLUDE_ADMIN: "1"');
     expect(testE2eSmoke).toContain("playwright-smoke-report");
 
     expect(testE2e).toContain("continue-on-error:");
@@ -61,4 +101,30 @@ describe("ci-integration workflow contract", () => {
   it("does not require the broad chromium inventory in CI integration", () => {
     expect(workflow).not.toContain("run: bun run test:e2e --project=chromium");
   });
+
+  it("runs the resolved smoke inventory under projects that include each file", () => {
+    expect(scripts["test:e2e:smoke"]).toContain("--project=chromium");
+    expect(scripts["test:e2e:smoke"]).toContain("--project=chromium-donor");
+
+    const chromiumSmoke = listPlaywrightTests([
+      "tests/e2e/demo-auth-preflight.spec.ts",
+      "tests/e2e/usability-smoke.spec.ts",
+      "tests/e2e/donate.spec.ts",
+      "tests/e2e/support-hub.smoke.spec.ts",
+      "--project=chromium",
+      "--workers=1",
+      "--list",
+    ]);
+    expect(chromiumSmoke).toContain("support-hub.smoke.spec.ts");
+    expect(chromiumSmoke).not.toContain("upload-crop.spec.ts");
+
+    const donorSmoke = listPlaywrightTests([
+      "tests/e2e/upload-crop.spec.ts",
+      "--project=chromium-donor",
+      "--workers=1",
+      "--list",
+    ]);
+    expect(donorSmoke).toContain("[chromium-donor]");
+    expect(donorSmoke).toContain("upload-crop.spec.ts");
+  }, 20_000);
 });

--- a/tests/unit/scripts/ci-integration-workflow.contract.test.ts
+++ b/tests/unit/scripts/ci-integration-workflow.contract.test.ts
@@ -44,7 +44,9 @@ describe("ci-integration workflow contract", () => {
     expect(testE2e).toContain("github.base_ref == 'develop'");
     expect(testE2e).toContain("refs/heads/develop");
 
-    expect(integrationGate).toContain("needs: [migrate, smoke, e2e-smoke-gate]");
+    expect(integrationGate).toContain(
+      "needs: [migrate, smoke, e2e-smoke-gate]",
+    );
     expect(integrationGate).not.toContain("test-e2e");
 
     expect(e2eSmokeGate).toContain("needs: [test-e2e-smoke]");

--- a/tests/unit/scripts/ci-preflight.contract.test.ts
+++ b/tests/unit/scripts/ci-preflight.contract.test.ts
@@ -18,7 +18,9 @@ const EXPECTED_STAGES: Array<{ id: string; script: string }> = [
   { id: "test-unit", script: "test:unit" },
 ];
 
-function parsePreflightStages(source: string): Array<{ id: string; script: string }> {
+function parsePreflightStages(
+  source: string,
+): Array<{ id: string; script: string }> {
   const stages: Array<{ id: string; script: string }> = [];
 
   for (const match of source.matchAll(

--- a/tests/unit/scripts/ci-preflight.contract.test.ts
+++ b/tests/unit/scripts/ci-preflight.contract.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const PREFLIGHT_PATH = "scripts/verify/ci-preflight.mjs";
+
+const EXPECTED_STAGES: Array<{ id: string; script: string }> = [
+  { id: "verify-git-attribution", script: "verify:git-attribution" },
+  { id: "format", script: "format:check" },
+  { id: "skills-verify", script: "skills:verify" },
+  { id: "lint", script: "lint" },
+  { id: "verify-data-boundary", script: "verify:data-boundary" },
+  { id: "verify-workspace-contract", script: "verify:workspace-contract" },
+  { id: "verify-eslint", script: "verify:eslint" },
+  { id: "verify-shadcn-diff", script: "verify:shadcn-diff" },
+  { id: "typecheck", script: "typecheck" },
+  { id: "build", script: "build" },
+  { id: "test-unit", script: "test:unit" },
+];
+
+function parsePreflightStages(source: string): Array<{ id: string; script: string }> {
+  const stages: Array<{ id: string; script: string }> = [];
+
+  for (const match of source.matchAll(
+    /\{\s*id:\s*"([^"]+)",\s*script:\s*"([^"]+)"/g,
+  )) {
+    stages.push({ id: match[1], script: match[2] });
+  }
+
+  return stages;
+}
+
+describe("ci-preflight contract", () => {
+  const source = readFileSync(PREFLIGHT_PATH, "utf8");
+  const stages = parsePreflightStages(source);
+
+  it("mirrors blocking ci.yml stage order documented in docs/ci.md", () => {
+    expect(stages).toEqual(EXPECTED_STAGES);
+  });
+
+  it("does not run deployment-discipline inside preflight", () => {
+    expect(source).not.toContain("verify:deployment-discipline");
+    expect(stages.map((stage) => stage.script)).not.toContain(
+      "verify:deployment-discipline",
+    );
+  });
+
+  it("applies CI Supabase placeholders to build and unit tests", () => {
+    expect(source).toContain("const ciSupabasePublicEnv = {");
+    expect(source).toContain("NEXT_PUBLIC_SUPABASE_URL:");
+    expect(source).toContain("NEXT_PUBLIC_SUPABASE_ANON_KEY:");
+
+    const buildStage = source.slice(
+      source.indexOf('id: "build"'),
+      source.indexOf('id: "test-unit"'),
+    );
+    const testUnitStage = source.slice(source.indexOf('id: "test-unit"'));
+
+    expect(buildStage).toContain("SKIP_ENV_VALIDATION");
+    expect(buildStage).toContain("...ciSupabasePublicEnv");
+    expect(testUnitStage).toContain("env: ciSupabasePublicEnv");
+  });
+});

--- a/tests/unit/scripts/deployment-discipline.test.ts
+++ b/tests/unit/scripts/deployment-discipline.test.ts
@@ -49,12 +49,7 @@ const branchProtection = {
   allow_force_pushes: { enabled: true },
   required_status_checks: {
     strict: true,
-    contexts: [
-      "ci-gate",
-      "integration-gate",
-      "e2e-gate",
-      "e2e-smoke-gate",
-    ],
+    contexts: ["ci-gate", "integration-gate", "e2e-gate", "e2e-smoke-gate"],
   },
   required_pull_request_reviews: {
     required_approving_review_count: 1,

--- a/tests/unit/scripts/deployment-discipline.test.ts
+++ b/tests/unit/scripts/deployment-discipline.test.ts
@@ -91,7 +91,7 @@ describe("deployment discipline verifier", () => {
     expect(workflow).toContain("run: bun run test:e2e:production-gate");
     expect(workflow).not.toContain("run: bun run test:e2e --project=chromium");
     expect(workflow).toContain("timeout-minutes: 30");
-    expect(workflow).toContain("timeout-minutes: 20");
+    expect(workflow).toContain("timeout-minutes: 25");
     expect(workflow).toContain("timeout-minutes: 10");
     expect(packageJson.scripts["test:e2e:smoke"]).toContain(
       "tests/e2e/usability-smoke.spec.ts",

--- a/tests/unit/scripts/deployment-discipline.test.ts
+++ b/tests/unit/scripts/deployment-discipline.test.ts
@@ -49,7 +49,12 @@ const branchProtection = {
   allow_force_pushes: { enabled: true },
   required_status_checks: {
     strict: true,
-    contexts: ["ci-gate", "integration-gate", "e2e-gate"],
+    contexts: [
+      "ci-gate",
+      "integration-gate",
+      "e2e-gate",
+      "e2e-smoke-gate",
+    ],
   },
   required_pull_request_reviews: {
     required_approving_review_count: 1,
@@ -85,10 +90,20 @@ describe("deployment discipline verifier", () => {
       scripts: Record<string, string>;
     };
 
+    expect(workflow).toContain("test-e2e-smoke:");
+    expect(workflow).toContain("e2e-smoke-gate:");
+    expect(workflow).toContain("run: bun run test:e2e:smoke");
     expect(workflow).toContain("run: bun run test:e2e:production-gate");
     expect(workflow).not.toContain("run: bun run test:e2e --project=chromium");
     expect(workflow).toContain("timeout-minutes: 30");
+    expect(workflow).toContain("timeout-minutes: 20");
     expect(workflow).toContain("timeout-minutes: 10");
+    expect(packageJson.scripts["test:e2e:smoke"]).toContain(
+      "tests/e2e/usability-smoke.spec.ts",
+    );
+    expect(packageJson.scripts["test:e2e:smoke"]).toContain(
+      "tests/e2e/support-hub.smoke.spec.ts",
+    );
     expect(packageJson.scripts["test:e2e:production-gate"]).toContain(
       "tests/e2e/usability-smoke.spec.ts",
     );
@@ -141,7 +156,7 @@ describe("deployment discipline verifier", () => {
       branch: "develop",
       protection: branchProtection,
       branchRule: branchProtectionRule,
-      requiredContexts: ["ci-gate", "integration-gate"],
+      requiredContexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
     });
     const epicChecks = validateGitHubBranchProtection({
       branch: "epic",
@@ -191,7 +206,7 @@ describe("deployment discipline verifier", () => {
           "Preview – missionary",
         ],
       },
-      requiredContexts: ["ci-gate", "integration-gate"],
+      requiredContexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
     });
 
     expect(checks.filter((item) => !item.ok).map((item) => item.label)).toEqual(

--- a/tests/unit/scripts/deployment-discipline.test.ts
+++ b/tests/unit/scripts/deployment-discipline.test.ts
@@ -49,10 +49,18 @@ const branchProtection = {
   allow_force_pushes: { enabled: true },
   required_status_checks: {
     strict: true,
-    contexts: ["ci-gate", "integration-gate", "e2e-gate", "e2e-smoke-gate"],
+    contexts: ["ci-gate", "integration-gate", "e2e-gate"],
   },
   required_pull_request_reviews: {
     required_approving_review_count: 1,
+  },
+};
+
+const developBranchProtection = {
+  ...branchProtection,
+  required_status_checks: {
+    strict: true,
+    contexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
   },
 };
 
@@ -149,19 +157,46 @@ describe("deployment discipline verifier", () => {
   it("accepts protected GitHub branches with required checks and force pushes disabled", () => {
     const developChecks = validateGitHubBranchProtection({
       branch: "develop",
-      protection: branchProtection,
+      protection: developBranchProtection,
       branchRule: branchProtectionRule,
       requiredContexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
+      forbiddenContexts: ["e2e-gate"],
     });
     const epicChecks = validateGitHubBranchProtection({
       branch: "epic",
       protection: branchProtection,
       branchRule: branchProtectionRule,
       requiredContexts: ["ci-gate", "integration-gate", "e2e-gate"],
+      forbiddenContexts: ["e2e-smoke-gate"],
     });
 
     expect(developChecks.every((item) => item.ok)).toBe(true);
     expect(epicChecks.every((item) => item.ok)).toBe(true);
+  });
+
+  it("detects extra broad E2E requirements on develop branch protection", () => {
+    const checks = validateGitHubBranchProtection({
+      branch: "develop",
+      protection: {
+        ...developBranchProtection,
+        required_status_checks: {
+          strict: true,
+          contexts: [
+            "ci-gate",
+            "integration-gate",
+            "e2e-smoke-gate",
+            "e2e-gate",
+          ],
+        },
+      },
+      branchRule: branchProtectionRule,
+      requiredContexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
+      forbiddenContexts: ["e2e-gate"],
+    });
+
+    expect(checks.filter((item) => !item.ok).map((item) => item.label)).toEqual(
+      expect.arrayContaining(["develop does not require e2e-gate"]),
+    );
   });
 
   it("detects missing GitHub status checks and enabled force pushes", () => {
@@ -191,7 +226,7 @@ describe("deployment discipline verifier", () => {
   it("detects required deployments for disabled Vercel Preview environments", () => {
     const checks = validateGitHubBranchProtection({
       branch: "develop",
-      protection: branchProtection,
+      protection: developBranchProtection,
       branchRule: {
         ...branchProtectionRule,
         requiresDeployments: true,
@@ -202,6 +237,7 @@ describe("deployment discipline verifier", () => {
         ],
       },
       requiredContexts: ["ci-gate", "integration-gate", "e2e-smoke-gate"],
+      forbiddenContexts: ["e2e-gate"],
     });
 
     expect(checks.filter((item) => !item.ok).map((item) => item.label)).toEqual(

--- a/tests/unit/scripts/local-gates.contract.test.ts
+++ b/tests/unit/scripts/local-gates.contract.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const PACKAGE_JSON_PATH = "package.json";
+
+describe("local gates contract", () => {
+  const packageJson = JSON.parse(
+    readFileSync(PACKAGE_JSON_PATH, "utf8"),
+  ) as {
+    scripts: Record<string, string>;
+  };
+
+  it("keeps bun run check as lint, typecheck, then test:unit", () => {
+    expect(packageJson.scripts.check).toBe(
+      "bun run lint && bun run typecheck && bun run test:unit",
+    );
+  });
+
+  it("wires ci:preflight to the preflight verifier script", () => {
+    expect(packageJson.scripts["ci:preflight"]).toBe(
+      "node scripts/verify/ci-preflight.mjs",
+    );
+  });
+
+  it("exposes per-app lint and typecheck scripts for donor and missionary", () => {
+    expect(packageJson.scripts["lint:donor"]).toContain("@asym/donor");
+    expect(packageJson.scripts["lint:missionary"]).toContain(
+      "@asym/missionary-app",
+    );
+    expect(packageJson.scripts["typecheck:donor"]).toContain("@asym/donor");
+    expect(packageJson.scripts["typecheck:missionary"]).toContain(
+      "@asym/missionary-app",
+    );
+  });
+});

--- a/tests/unit/scripts/local-gates.contract.test.ts
+++ b/tests/unit/scripts/local-gates.contract.test.ts
@@ -5,9 +5,7 @@ import { describe, expect, it } from "vitest";
 const PACKAGE_JSON_PATH = "package.json";
 
 describe("local gates contract", () => {
-  const packageJson = JSON.parse(
-    readFileSync(PACKAGE_JSON_PATH, "utf8"),
-  ) as {
+  const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
     scripts: Record<string, string>;
   };
 

--- a/tests/unit/unit-test-harness.test.ts
+++ b/tests/unit/unit-test-harness.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import vitestConfig from "../../vitest.config";
+
+describe("unit test harness", () => {
+  it("applies SKIP_ENV_VALIDATION from vitest env defaults", () => {
+    expect(process.env.SKIP_ENV_VALIDATION).toBe("1");
+  });
+
+  it("uses placeholder Supabase URLs from vitest env (not .env.local)", () => {
+    expect(process.env.NEXT_PUBLIC_SUPABASE_URL).toBe("http://127.0.0.1:54321");
+    expect(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("test-anon-key");
+  });
+
+  it("clears SUPABASE_SERVICE_ROLE_KEY in unit-env setup", () => {
+    expect(process.env.SUPABASE_SERVICE_ROLE_KEY).toBeUndefined();
+  });
+
+  it("sets PAYLOAD_SECRET via unit-env setup", () => {
+    expect(process.env.PAYLOAD_SECRET).toBe("unit-test-payload-secret");
+  });
+
+  it("enables clearMocks in vitest config", () => {
+    const testConfig = vitestConfig.test;
+    const clearMocks =
+      testConfig && typeof testConfig === "object" && "clearMocks" in testConfig
+        ? testConfig.clearMocks
+        : undefined;
+
+    expect(clearMocks).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the test-quality audit **phases 1–3** on `develop`: unit harness hardening, develop E2E smoke gate policy, and regression contracts so gates cannot drift without failing unit tests.

### Phase 1 — Unit harness
- Global `SUPABASE_SERVICE_ROLE_KEY` clearing in `tests/setup/unit-env.ts`
- CMS strategy tests mock Supabase clients (no live network)
- `tests/unit/unit-test-harness.test.ts` replaces placeholder test

### Phase 2 — CI / E2E policy
- Blocking `test-e2e-smoke` + `e2e-smoke-gate` on `develop`; full `test-e2e` stays informational
- Removed redundant `waitForTimeout` after `expect.poll` in auth E2E specs
- Contract tests: `ci-integration-workflow.contract.test.ts`, `e2e-flake-guards.test.ts`

### Phase 3 — Gates, API email, app smoke (this commit)
- **`ci-preflight.contract.test.ts`** — locks `scripts/verify/ci-preflight.mjs` stage order vs `docs/ci.md`; asserts deployment discipline is **not** in preflight
- **`local-gates.contract.test.ts`** — locks `bun run check` and donor/missionary `lint:*` / `typecheck:*` scripts
- **`donor-missionary-unit-smoke.contract.test.ts`** — baseline donor/missionary unit files, vitest `include`/`setupFiles`, `importOriginal` `@asym/email` mock in `connect.test.ts`
- **`resend-snapshot-contract.test.ts`** + `connect.test.ts` mock fix (prior commits)
- **`deployment-discipline`** + tests require `e2e-smoke-gate` on `develop`
- **`testing.md`** corrected: `ci:preflight` mirrors `ci.yml`, not deployment discipline

## Verification

```bash
bunx vitest run tests/unit/scripts/ci-preflight.contract.test.ts \
  tests/unit/scripts/local-gates.contract.test.ts \
  tests/unit/apps/donor-missionary-unit-smoke.contract.test.ts
bun run test:unit   # 1081 passed
bun run check       # pass
```

`bun run ci:preflight` may still fail in cloud agents on `verify:git-attribution` (git identity), not application code.

## Docs

- `docs/ci.md`, `docs/ai/rules/testing.md`, `tests/e2e/README.md`, contributing/deploy checklists updated in earlier commits on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf359dce-140c-4548-99f8-341b00fd24c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf359dce-140c-4548-99f8-341b00fd24c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes test-quality audit phases 1–3: hardening the unit test harness (env isolation, Supabase client mocking), adding a blocking `test-e2e-smoke` + `e2e-smoke-gate` job to CI for `develop`, and locking CI structure and package.json scripts against drift with a new suite of contract tests.

- **Unit harness**: Globally deletes `SUPABASE_SERVICE_ROLE_KEY` in `unit-env.ts`, rebuilds CMS strategy tests to mock both Supabase client factories, and replaces the placeholder test with a live harness assertion.
- **CI workflow**: Introduces `test-e2e-smoke` (25 min, auth-bypass, runs both `chromium` and `chromium-donor` projects) gated by a new `e2e-smoke-gate` job; `integration-gate` now depends on this gate; `test-e2e` health-check wait extended to 120 s with debug output on timeout.
- **Contract tests**: Lock `ci-integration.yml` job topology, `ci-preflight.mjs` stage order, `package.json` scripts, baseline unit-smoke files, and Resend validation snapshot behaviour against real `@asym/email` functions.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the unit and contract test changes; the CI workflow change warrants a second look before landing on develop, as the concern raised in the prior thread about the smoke gate's blast radius through integration-gate has not yet been addressed in the code.

The unit harness hardening, mock quality improvements, and contract tests are well-implemented with no correctness issues. The CI workflow adds a new blocking job chain (test-e2e-smoke → e2e-smoke-gate → integration-gate) that runs on every workflow trigger regardless of target branch. Because integration-gate is a required status check for both develop and epic, a flaky smoke run on any branch can stall a production release. The deployment-discipline verifier correctly forbids e2e-smoke-gate from epic's direct branch protection, but that check does not account for the transitive dependency through integration-gate, leaving the protection gap intact.

.github/workflows/ci-integration.yml — the test-e2e-smoke job and its gate chain
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-integration.yml | Adds test-e2e-smoke job (no branch filter) and e2e-smoke-gate; integration-gate now depends on e2e-smoke-gate, which runs for both develop and epic workflows; the prior thread flagged that this transitively blocks epic merges through integration-gate despite epic branch protection listing e2e-smoke-gate as forbidden. |
| scripts/verify/deployment-discipline.mjs | Adds forbiddenContexts parameter to validateGitHubBranchProtection; production branch now forbids e2e-smoke-gate, staging branch requires it and forbids e2e-gate. Logic is correct. |
| tests/unit/packages/api/email/connect.test.ts | Switches @asym/email mock to importOriginal (only stubs validateResendApiKey), introduces vi.useFakeTimers in one test with proper beforeEach/afterEach cleanup; reduces over-mocking significantly. |
| tests/unit/packages/api/email/resend-snapshot-contract.test.ts | New contract test exercising real createResendValidationSnapshot, isResendValidationSendReady, and parseResendValidationSnapshot from @asym/email/resend against shared fixtures. |
| tests/unit/scripts/ci-integration-workflow.contract.test.ts | New contract test locking CI workflow job topology and smoke inventory; uses spawnSync to run Playwright --list within a 20 s test timeout. |
| tests/setup/unit-env.ts | Deletes SUPABASE_SERVICE_ROLE_KEY globally at harness setup time, preventing live Supabase connections when .env.local is present locally. |
| tests/unit/cms/supabase-strategy.test.ts | Adds createStrategyWithMocks helper that provides a mock for createSupabaseDataClient in addition to createSupabaseClient, eliminating remaining live-network paths from strategy tests. |
| tests/unit/scripts/deployment-discipline.test.ts | Updated to cover the new forbiddenContexts logic, including a positive test that detects e2e-gate being present on develop branch protection. |
| package.json | test:e2e:smoke now runs upload-crop.spec.ts under the chromium-donor project as a second chained command, separating it from the main chromium suite. |
| tests/unit/e2e/e2e-flake-guards.test.ts | New guard that fails if any spec file contains waitForTimeout() and verifies Playwright retries are configured for CI. |
| tests/unit/packages/api/auth/get-auth-context-request-propagation.test.ts | Fixes Windows path separator issue by normalising backslashes to forward slashes with replaceAll. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[migrate] --> B[smoke]
    B --> C[test-e2e-smoke]
    B --> D[test-e2e]
    C --> E[e2e-smoke-gate\nif: always]
    D --> F[e2e-gate\nif: epic only]
    E --> G[integration-gate\nif: always\nrequired on develop + epic]
    A --> G
    B --> G

    style E fill:#f90,color:#000
    style G fill:#d44,color:#fff
    style C fill:#f90,color:#000
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): stabilize post-merge smoke inv..."](https://github.com/asymmetric-al/core/commit/b165737a7f05cde492de4dba18642538edd8a1b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33479845)</sub>

<!-- /greptile_comment -->