### PR TITLE
test: cover CMS Supabase service-role injection

### DIFF
--- a/tests/unit/cms/supabase-strategy.test.ts
+++ b/tests/unit/cms/supabase-strategy.test.ts
@@ -203,6 +203,7 @@ describe("createSupabaseAuthStrategy", () => {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
     delete process.env.E2E_AUTH_BYPASS;
     delete process.env.ASYM_E2E_AUTH_SURFACE;
+    // Keep unit tests on injected clients even when a developer shell exports the service role key.
     delete process.env.SUPABASE_SERVICE_ROLE_KEY;
   });
 
@@ -496,6 +497,41 @@ describe("createSupabaseAuthStrategy", () => {
       publicTenantId: "tenant_1",
       role: "admin",
       tenantId: "17",
+    });
+  });
+
+  it("completes cookie auth when service role env is set if data client is injected", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "unit-test-service-role-key";
+    const sessionClient = createSupabaseClientMock({ role: "admin" });
+    const trustedDataClient = createSupabaseClientMock({
+      role: "admin",
+      publicTenant: {
+        id: "tenant_1",
+        name: "Tenant One",
+        slug: "tenant-one",
+      },
+    });
+    const createSupabaseDataClient = vi.fn(() => ({
+      from: trustedDataClient.from,
+      schema: trustedDataClient.schema,
+    }));
+
+    const strategy = createSupabaseAuthStrategy({
+      createSupabaseClient: sessionClient.createServerClientMock as never,
+      createSupabaseDataClient: createSupabaseDataClient as never,
+    });
+    const payload = createPayloadMock();
+
+    const result = await strategy.authenticate({
+      headers: new Headers({ cookie: "sb-access-token=test" }),
+      payload,
+    } as never);
+
+    expect(createSupabaseDataClient).toHaveBeenCalledTimes(1);
+    expect(result.user).toMatchObject({
+      collection: "cms-users",
+      role: "admin",
+      publicTenantId: "tenant_1",
     });
   });
 


### PR DESCRIPTION
## Summary

Narrow CMS auth unit-test regression coverage for the Supabase service-role path.

This PR now intentionally contains only `tests/unit/cms/supabase-strategy.test.ts`. The previously bundled `CODE_QUALITY_AUDIT.md` changes were removed from this branch because PR #242 already landed the audit document separately, and review feedback requested keeping this timeout/test fix focused.

## What changed

- Adds a regression test for cookie auth when `SUPABASE_SERVICE_ROLE_KEY` is present and `createSupabaseDataClient` is injected.
- Asserts the injected data-client factory is called, locking the intended test seam and avoiding accidental real trusted-client/network usage in unit tests.
- Keeps production auth behavior unchanged.

## Validation

- `bunx prettier --write tests/unit/cms/supabase-strategy.test.ts` — unchanged
- `bunx vitest run tests/unit/cms/supabase-strategy.test.ts` — pass, 12 tests
- `bun run ci:preflight` via pre-push — pass: lint, data-boundary, typecheck, builds, unit tests (253 files, 1103 passed, 1 skipped)

## Review feedback addressed

- Removed `CODE_QUALITY_AUDIT.md` from this PR scope.
- Final diff is test-only.
- Added the suggested explicit assertion that the injected data-client factory is called.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a P0 CI timeout in the CMS Supabase auth strategy unit tests caused by the strategy building a real Supabase trusted client (via `createTrustedSupabaseDataClient`) when `SUPABASE_SERVICE_ROLE_KEY` was exported in the developer shell, causing real network I/O and Vitest 5 s timeouts.

- **`beforeEach` guard**: adds `delete process.env.SUPABASE_SERVICE_ROLE_KEY` so all tests in this file default to the injected mock path, matching the existing `NEXT_PUBLIC_SUPABASE_URL` / anon key setup already present.
- **Regression test**: `"completes cookie auth when service role env is set if data client is injected"` sets the service-role key, injects a mock factory, and asserts `createSupabaseDataClient` was called once and auth completes correctly — documenting the opt-in pattern for future tests that need real service-role behaviour.
- No production code is changed; `apps/admin/src/cms/auth/supabase-strategy.ts` is untouched.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — test-only change with no production code modifications and correct env cleanup across all test cases.

The change is confined to test infrastructure: a one-line `beforeEach` guard and a new regression test. The `beforeEach` correctly mirrors the existing env-cleanup pattern already in place for `E2E_AUTH_BYPASS` and `ASYM_E2E_AUTH_SURFACE`. The regression test properly injects a mock factory, asserts it was called once, and verifies the full auth result — demonstrating isolation without leaking the service-role key to subsequent tests (the next `beforeEach` deletes it). Production auth behaviour is entirely unchanged.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/unit/cms/supabase-strategy.test.ts | Adds `delete process.env.SUPABASE_SERVICE_ROLE_KEY` to `beforeEach` to prevent real Supabase client initialization during unit tests, and adds a regression test verifying that injecting `createSupabaseDataClient` keeps tests isolated even when the service role key is present in the shell environment. No production code changes. |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["test: cover CMS supabase service-role in..."](https://github.com/asymmetric-al/core/commit/880afb4ec80d25f31fb28942e31a030aa22c3313) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33581094)</sub>

<!-- /greptile_comment -->