### PR TITLE
fix(api): type admin PostgREST query builders

### DIFF
--- a/packages/api/src/admin/contributions/service.ts
+++ b/packages/api/src/admin/contributions/service.ts
@@ -10,7 +10,12 @@ import type {
   AdminContributionsListResponse,
   AdminContributionsSummary,
 } from "./types";
+import type {
+  AdminSupabaseFluentFilterBuilder,
+  SupabaseColumn,
+} from "../shared/supabase-filter-builder";
 import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+import type { Donation } from "@asym/database/types";
 
 type AdminSupabase = AdminSupabaseClient;
 
@@ -88,15 +93,16 @@ type StagedGiftRow = {
 };
 
 const PENDING_STATUSES = ["pending", "processing"] as const;
+type DonationColumn = SupabaseColumn<Donation>;
 
-const SORT_COLUMN_BY_FIELD: Record<ContributionSortField, string> = {
+const SORT_COLUMN_BY_FIELD = {
   giftDate: "gift_date",
   createdAt: "created_at",
   amount: "amount",
   status: "status",
   paymentMethod: "payment_method",
   source: "source",
-};
+} satisfies Record<ContributionSortField, DonationColumn>;
 
 function escapeSearchValue(value: string) {
   return value.replace(/[%(),]/g, " ");
@@ -169,14 +175,16 @@ async function resolveMatchingDonorIds(
   return Array.from(donorIds);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO(asym): narrow Postgrest builder typing without breaking dynamic filters
-type ContributionQueryBuilder = any;
+type ContributionQueryBuilder<TQuery> = AdminSupabaseFluentFilterBuilder<
+  Donation,
+  TQuery
+>;
 
-function applyBaseFilters(
-  query: ContributionQueryBuilder,
+function applyBaseFilters<TQuery extends ContributionQueryBuilder<TQuery>>(
+  query: TQuery,
   params: AdminContributionsParams,
   directSearchableDonorIds: string[],
-): ContributionQueryBuilder {
+): TQuery {
   const { filters, search } = params;
 
   if (filters.statuses.length > 0) {
@@ -263,10 +271,10 @@ function applyBaseFilters(
   return query;
 }
 
-function applyCursor(
-  query: ContributionQueryBuilder,
+function applyCursor<TQuery extends ContributionQueryBuilder<TQuery>>(
+  query: TQuery,
   params: AdminContributionsParams,
-): ContributionQueryBuilder {
+): TQuery {
   const { cursor, sort } = params;
   if (!cursor) {
     return query;

--- a/packages/api/src/admin/crm/service.ts
+++ b/packages/api/src/admin/crm/service.ts
@@ -7,13 +7,19 @@ import {
 import { ApiHttpError } from "../../shared/http-errors";
 
 import type { AdminCrmListResponse } from "./types";
+import type {
+  AdminSupabaseFluentFilterBuilder,
+  SupabaseColumn,
+} from "../shared/supabase-filter-builder";
 import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+import type { Donor } from "@asym/database/types";
 
 type AdminSupabase = AdminSupabaseClient;
 
 type DonorRow = Parameters<typeof buildCrmGridRow>[0];
+type DonorColumn = SupabaseColumn<Donor>;
 
-const SORT_COLUMN_BY_FIELD: Record<CrmSortField, string> = {
+const SORT_COLUMN_BY_FIELD = {
   updatedAt: "updated_at",
   createdAt: "created_at",
   name: "name",
@@ -21,7 +27,7 @@ const SORT_COLUMN_BY_FIELD: Record<CrmSortField, string> = {
   lifecycleStatus: "status",
   lifetimeGiving: "total_given",
   lastGiftAt: "last_gift_date",
-};
+} satisfies Record<CrmSortField, DonorColumn>;
 
 function escapeSearchValue(value: string) {
   return value.replace(/[%(),]/g, " ");
@@ -31,13 +37,15 @@ function normalizeIds(ids: Iterable<string>) {
   return Array.from(new Set(ids)).filter(Boolean);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO(crm-postgrest): narrow when donor query builder is fully typed
-type DonorQueryBuilder = any;
+type DonorQueryBuilder<TQuery> = AdminSupabaseFluentFilterBuilder<
+  Donor,
+  TQuery
+>;
 
-function applyBaseFilters(
-  query: DonorQueryBuilder,
+function applyBaseFilters<TQuery extends DonorQueryBuilder<TQuery>>(
+  query: TQuery,
   params: AdminCrmParams,
-): DonorQueryBuilder {
+): TQuery {
   const { filters, search } = params;
 
   if (filters.recordTypes.length > 0) {
@@ -68,10 +76,10 @@ function applyBaseFilters(
   return query;
 }
 
-function applyCursor(
-  query: DonorQueryBuilder,
+function applyCursor<TQuery extends DonorQueryBuilder<TQuery>>(
+  query: TQuery,
   params: AdminCrmParams,
-): DonorQueryBuilder {
+): TQuery {
   const { cursor, sort } = params;
   if (!cursor) {
     return query;

--- a/packages/api/src/admin/shared/supabase-filter-builder.ts
+++ b/packages/api/src/admin/shared/supabase-filter-builder.ts
@@ -1,0 +1,54 @@
+export type SupabaseColumn<TRow extends object> = Extract<keyof TRow, string>;
+
+export type SupabaseFilterValue = string | number | boolean | null;
+
+export interface SupabaseListResult<TRow extends object> {
+  data: TRow[] | null;
+  error: { message: string } | null;
+}
+
+export interface AdminSupabaseFilterBuilder<TRow extends object>
+  extends
+    PromiseLike<SupabaseListResult<TRow>>,
+    AdminSupabaseFilterMethods<TRow, AdminSupabaseFilterBuilder<TRow>> {}
+
+export type AdminSupabaseFluentFilterBuilder<
+  TRow extends object,
+  TSelf,
+> = AdminSupabaseFilterMethods<TRow, TSelf>;
+
+interface AdminSupabaseFilterMethods<TRow extends object, TSelf> {
+  eq(column: SupabaseColumn<TRow>, value: SupabaseFilterValue): TSelf;
+  neq(column: SupabaseColumn<TRow>, value: SupabaseFilterValue): TSelf;
+  gt(column: SupabaseColumn<TRow>, value: SupabaseFilterValue): TSelf;
+  lt(column: SupabaseColumn<TRow>, value: SupabaseFilterValue): TSelf;
+  gte(column: SupabaseColumn<TRow>, value: SupabaseFilterValue): TSelf;
+  lte(column: SupabaseColumn<TRow>, value: SupabaseFilterValue): TSelf;
+  in(
+    column: SupabaseColumn<TRow>,
+    values: readonly SupabaseFilterValue[],
+  ): TSelf;
+  is(column: SupabaseColumn<TRow>, value: null): TSelf;
+  not(
+    column: SupabaseColumn<TRow>,
+    operator: string,
+    value: SupabaseFilterValue,
+  ): TSelf;
+  overlaps(
+    column: SupabaseColumn<TRow>,
+    value: readonly SupabaseFilterValue[],
+  ): TSelf;
+  /**
+   * Raw PostgREST OR filter expression, for example:
+   * `name.ilike.%ada%,email.ilike.%ada%`.
+   */
+  or(filters: string): TSelf;
+  order(
+    column: SupabaseColumn<TRow>,
+    options?: {
+      ascending?: boolean;
+      nullsFirst?: boolean;
+    },
+  ): TSelf;
+  limit(count: number): TSelf;
+}

--- a/packages/api/tests/unit/supabase-filter-builder-types.test.ts
+++ b/packages/api/tests/unit/supabase-filter-builder-types.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import type {
+  AdminSupabaseFilterBuilder,
+  AdminSupabaseFluentFilterBuilder,
+  SupabaseColumn,
+} from "../../src/admin/shared/supabase-filter-builder";
+
+type ExampleRow = {
+  id: string;
+  tenant_id: string;
+  amount: number;
+  created_at: string;
+  profile_id: string | null;
+  tags: string[] | null;
+};
+
+// This suite is a compile-time regression guard. The assertions below are
+// enforced by TypeScript during `turbo typecheck`; Vitest only keeps the file
+// in the unit-test graph so the contract stays easy to run locally.
+function assertBuilderTypes(query: AdminSupabaseFilterBuilder<ExampleRow>) {
+  const chainedQuery = query
+    .eq("tenant_id", "tenant-1")
+    .neq("id", "excluded")
+    .gt("amount", 100)
+    .lt("created_at", "2026-01-01")
+    .gte("amount", 10)
+    .lte("amount", 1000)
+    .in("id", ["donation-1", "donation-2"])
+    .is("profile_id", null)
+    .not("profile_id", "is", null)
+    .overlaps("tags", ["major-donor"])
+    .or("id.eq.donation-1,id.eq.donation-2")
+    .order("created_at", { ascending: false, nullsFirst: false })
+    .limit(50);
+
+  expectTypeOf(chainedQuery).toEqualTypeOf<
+    AdminSupabaseFilterBuilder<ExampleRow>
+  >();
+
+  expectTypeOf<"created_at">().toMatchTypeOf<SupabaseColumn<ExampleRow>>();
+
+  // @ts-expect-error unknown table columns must not be accepted by filter helpers
+  query.eq("missing_column", "value");
+}
+
+void assertBuilderTypes;
+
+type TableRow = {
+  id: string;
+  tenant_id: string;
+  created_at: string;
+};
+
+type SelectedRow = {
+  id: string;
+  created_at: string;
+  display_name: string | null;
+};
+
+type SelectedQuery = {
+  selectedRows: SelectedRow[];
+};
+
+function assertSplitTableAndSelectedRows(
+  query: AdminSupabaseFluentFilterBuilder<TableRow, SelectedQuery>,
+) {
+  const selectedQuery = query.eq("tenant_id", "tenant-1");
+
+  expectTypeOf(selectedQuery).toMatchTypeOf<SelectedQuery>();
+
+  // @ts-expect-error selected-only fields must not become filterable columns
+  query.eq("display_name", "Ada");
+}
+
+void assertSplitTableAndSelectedRows;
+
+describe("supabase filter builder type contract", () => {
+  it("keeps compile-time admin list query contracts in the unit suite", () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Cleans up PR #245 to the actual type-only API fix and drops the stale `CODE_QUALITY_AUDIT.md` diff that was already handled by earlier audit PRs.

- Adds a narrow shared PostgREST fluent-filter builder type for admin API list queries.
- Replaces the `DonorQueryBuilder = any` and `ContributionQueryBuilder = any` aliases in CRM and contributions services.
- Constrains sort/filter columns to canonical `Donor` and `Donation` table keys while preserving selected response row shapes.
- Adds a type-regression test for known columns, unknown columns, and selected-row/table-row separation.
- Documents that the regression test is enforced by `turbo typecheck`, not Vitest runtime execution, and documents the raw PostgREST `.or()` filter grammar surface.

## Validation

Passed locally on the cleaned branch:

```bash
bunx vitest run packages/api/tests/unit/supabase-filter-builder-types.test.ts
bunx turbo run typecheck lint --filter=@asym/api
bun run verify:data-boundary
bun run format:check
git push --force-with-lease origin HEAD:cursor/audit-item-p2-a3ce
# pre-push ci:preflight passed: format, skills:verify, lint, data-boundary, workspace-contract, eslint config, shadcn diff, typecheck, build, and unit tests
# unit tests: 255 files passed, 1107 passed, 1 skipped
```

## Risk

Low runtime risk. The change is type-only and does not change emitted Supabase query strings, auth, tenant scope, route behavior, or response shaping.

## Rollback

Revert this PR, or remove the shared builder type/test and restore the old query-builder aliases in:

- `packages/api/src/admin/crm/service.ts`
- `packages/api/src/admin/contributions/service.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces `DonorQueryBuilder = any` and `ContributionQueryBuilder = any` (and their `eslint-disable` suppressors) with a narrow, F-bounded type seam that constrains PostgREST filter/order column parameters to the canonical `keyof Donor` and `keyof Donation` key sets. All changes are type-only; no runtime query strings, auth scope, or response shapes are affected.

- `supabase-filter-builder.ts` introduces a new `AdminSupabaseFilterMethods<TRow, TSelf>` interface covering the filter/order/limit methods used by the two admin list queries, with `SupabaseColumn<TRow>` enforcing valid column names at compile time.
- Both service files switch from `any` to the F-bounded `TQuery extends …FluentFilterBuilder<Table, TQuery>` pattern and apply `satisfies Record<SortField, Column>` on their sort-column maps, catching column typos statically.
- A new Vitest file serves as a compile-time regression guard; the `turbo typecheck` step is the real enforcement mechanism (acknowledged in the PR and in a previous review comment).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is entirely type-level with no emitted JavaScript differences

Every changed line is a type annotation, type alias, or `satisfies` expression. No runtime query strings, auth paths, response shapes, or API contracts are touched. The `turbo typecheck` gate already validated the new column constraints against the canonical database types, and the rollback plan is straightforward.

No files require special attention
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/shared/supabase-filter-builder.ts | New type-only seam that narrows PostgREST fluent builder column parameters to `keyof TRow`; interface coverage matches the methods actually used in both admin services |
| packages/api/src/admin/crm/service.ts | Replaced `DonorQueryBuilder = any` with F-bounded `DonorQueryBuilder<TQuery>` and applied `satisfies` on the sort-column map; no runtime logic changed |
| packages/api/src/admin/contributions/service.ts | Same pattern as CRM: replaced `ContributionQueryBuilder = any`, constrained sort columns to `DonationColumn`; no runtime changes |
| packages/api/tests/unit/supabase-filter-builder-types.test.ts | Compile-time regression guard for the new type seam; runtime test body is a trivial pass, real enforcement comes from `turbo typecheck` (noted in previous review) |

</details>

</details>

<details open><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class AdminSupabaseFilterMethods~TRow, TSelf~ {
        <<interface>>
        +eq(column: SupabaseColumn~TRow~, value): TSelf
        +neq(column, value): TSelf
        +gt(column, value): TSelf
        +lt(column, value): TSelf
        +gte(column, value): TSelf
        +lte(column, value): TSelf
        +in(column, values): TSelf
        +is(column, null): TSelf
        +not(column, op, value): TSelf
        +overlaps(column, values): TSelf
        +or(filters: string): TSelf
        +order(column, options?): TSelf
        +limit(count): TSelf
    }

    class AdminSupabaseFilterBuilder~TRow~ {
        <<interface>>
        PromiseLike~SupabaseListResult~TRow~~
    }

    class AdminSupabaseFluentFilterBuilder~TRow, TSelf~ {
        <<type alias>>
    }

    class DonorQueryBuilder~TQuery~ {
        <<type alias>>
        AdminSupabaseFluentFilterBuilder~Donor, TQuery~
    }

    class ContributionQueryBuilder~TQuery~ {
        <<type alias>>
        AdminSupabaseFluentFilterBuilder~Donation, TQuery~
    }

    AdminSupabaseFilterMethods <|-- AdminSupabaseFilterBuilder : implements
    AdminSupabaseFilterMethods <|.. AdminSupabaseFluentFilterBuilder : alias
    AdminSupabaseFluentFilterBuilder <|.. DonorQueryBuilder : specialises
    AdminSupabaseFluentFilterBuilder <|.. ContributionQueryBuilder : specialises
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): type admin PostgREST query bui..."](https://github.com/asymmetric-al/core/commit/6b2692b224a841545380f8ab05d33fee6cb4e4b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33595295)</sub>

<!-- /greptile_comment -->