### PR TITLE
chore: upgrade Bun pin and CI runtime

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  BUN_VERSION: "1.3.14"
+
 jobs:
   migrate:
     runs-on: ubuntu-latest
@@ -35,11 +38,13 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v6
+      - name: Install system dependencies (canvas)
+        run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun ci
       - name: Install PostgreSQL client
         run: |
           sudo apt-get update
@@ -85,11 +90,13 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: example-anon-key
     steps:
       - uses: actions/checkout@v6
+      - name: Install system dependencies (canvas)
+        run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun ci
       - name: Start donor app
         run: bun run --cwd apps/donor dev -- --port 3005 --hostname 127.0.0.1 &
       - name: Wait for health endpoint
@@ -151,11 +158,13 @@ jobs:
           sudo apt-get install -y postgresql-client
       - name: Apply migrations
         run: node scripts/verify/supabase-migrations.mjs
+      - name: Install system dependencies (canvas)
+        run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun ci
       - name: Apply Payload migrations
         run: bun run cms:migrate
       - name: Verify Payload migration status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  BUN_VERSION: "1.3.14"
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -22,13 +25,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v5
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
+          key: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+      - run: bun ci
       - run: bun run format:check
       - run: bun run skills:verify
 
@@ -43,13 +46,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v5
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
+          key: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+      - run: bun ci
       - run: bun run lint
       - name: Check data access boundary
         run: bun run verify:data-boundary
@@ -67,13 +70,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v5
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
+          key: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+      - run: bun ci
       - run: bun run typecheck
 
   build:
@@ -90,13 +93,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v5
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
+          key: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+      - run: bun ci
       - run: bun run build
 
   test-unit:
@@ -113,13 +116,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpixman-1-dev libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.4"
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v5
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
+          key: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
+      - run: bun ci
       - name: Run unit tests
         run: bun run test:unit
       - name: Upload coverage artifact (best effort)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for contributing to asymmetric.al. We welcome pull requests, bug reports,
 - **Base branches:** use `develop` for staging validation and `epic` only for
   an intentional production release. `main` is retired/protected historical
   history and is not an active deploy target.
-- **Package manager:** `bun` (see `package.json#packageManager`).
+- **Package manager:** `bun` pinned via `package.json#packageManager` (currently `bun@1.3.14`). `bun run setup` and `scripts/setup/*` call `bun run verify:bun-version` so a mismatched local Bun fails fast with upgrade instructions.
 - **Conventions:** `docs/conventions.md` (folder structure, code style, and pre-commit checklist).
 - **Setup (macOS/Linux):** `bun run setup` (creates/validates `.env.local`, installs deps, runs verification).
 - **Mission Control in Cursor Cloud:** `bun run setup:mission-control:cloud && bun run dev:mission-control` (writes gitignored dev placeholders only).

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Commit both the canonical files and any mirror updates.
 
 ### Package Manager
 
-This repo uses **Bun** (see root `package.json` `packageManager`, currently **1.3.x**). Prefer `bun` / `bunx` for scripts in this workspace.
+This repo uses **Bun** pinned in root `package.json` `packageManager` (currently **1.3.14**). Install that exact version locally (`bun run verify:bun-version` after setup). Prefer `bun` / `bunx` for scripts in this workspace; CI installs with `bun ci`.
 
 ### Monorepo Workspace Contract
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -21,6 +21,14 @@ Current workflow semantics:
 - `main` is retired and protected historical history; active workflows do not
   treat it as staging or production.
 
+### Bun toolchain
+
+- **Pinned version:** root `package.json` `packageManager` (currently `bun@1.3.14`).
+- **GitHub Actions:** both workflows set `env.BUN_VERSION` to that exact version; every `oven-sh/setup-bun@v2` step uses `bun-version: ${{ env.BUN_VERSION }}`.
+- **Install in CI:** `bun ci` (frozen lockfile install). Do not use `bun install --frozen-lockfile` in workflows unless a future Bun release documents a regression.
+- **Turbo cache keys** in `ci.yml` include `bun-${{ env.BUN_VERSION }}` so cache restores do not cross Bun upgrades.
+- **Local parity:** match the pin (`bun run verify:bun-version`); reproducible install from a clean tree is `bun ci` (same as CI).
+
 ## Local CI parity (pre-push)
 
 Use the local preflight command to mirror blocking GitHub checks before pushing:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
-  "packageManager": "bun@1.3.4",
+  "packageManager": "bun@1.3.14",
   "workspaces": [
     "apps/*",
     "packages/*",
@@ -89,6 +89,7 @@
     "verify:git-attribution": "node scripts/verify/git-attribution.mjs",
     "verify:shadcn-diff": "node scripts/verify/shadcn-diff.mjs",
     "tsconfig:future-audit": "node scripts/tsconfig-future-audit.mjs",
+    "verify:bun-version": "bash scripts/verify/bun-version.sh",
     "verify:data-boundary": "node scripts/verify/data-boundary-check.mjs",
     "verify:twenty-crm-health": "bun scripts/verify/twenty-crm-health.ts",
     "verify:workspace-contract": "node scripts/verify-workspace-contract.mjs",

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -131,6 +131,22 @@ try {
 Write-Log 'Checking prerequisites...'
 $ok = $true
 $ok = (Require-Command 'bun' 'Install Bun for Windows and ensure it is on PATH: https://bun.sh/docs/installation#windows') -and $ok
+if (-not $ok) { exit 1 }
+
+$bunVersionScript = Join-Path $rootDir 'scripts/verify/bun-version.sh'
+if (Test-Path -LiteralPath $bunVersionScript) {
+  $bashCommand = Get-Command 'bash' -ErrorAction SilentlyContinue
+  if ($bashCommand) {
+    & bash $bunVersionScript
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  } else {
+    Write-Log 'Skipping Bun version guard (bash not found). Run: bun run verify:bun-version'
+  }
+} else {
+  Write-Fail "Missing Bun version guard script: $bunVersionScript"
+  exit 1
+}
+
 $ok = (Require-Command 'git' 'Install Git for Windows and ensure it is on PATH: https://git-scm.com/download/win') -and $ok
 if (-not $ok) { exit 1 }
 Write-SupabaseCliGuidance

--- a/scripts/setup/index.sh
+++ b/scripts/setup/index.sh
@@ -54,6 +54,7 @@ has_env_value() {
 
 log "Checking prerequisites..."
 require_cmd bun
+bash "$ROOT_DIR/scripts/verify/bun-version.sh"
 require_cmd git
 supabase_cli_guidance
 

--- a/scripts/verify/bun-version.sh
+++ b/scripts/verify/bun-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "error: bun is not installed or not on PATH." >&2
+  echo "Install Bun from https://bun.sh/docs/installation" >&2
+  exit 1
+fi
+
+package_json="$REPO_ROOT/package.json"
+if [[ ! -f "$package_json" ]]; then
+  echo "error: missing root package.json at $package_json" >&2
+  exit 1
+fi
+
+expected_raw="$(bun -e "
+const fs = require('node:fs');
+const pkg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+const pm = pkg.packageManager;
+if (!pm || typeof pm !== 'string') {
+  process.stderr.write('error: package.json is missing packageManager\\n');
+  process.exit(2);
+}
+const match = pm.match(/^bun@(.+)$/);
+if (!match) {
+  process.stderr.write('error: packageManager must look like bun@<version>, got: ' + pm + '\\n');
+  process.exit(2);
+}
+process.stdout.write(match[1]);
+" "$package_json")"
+
+installed_raw="$(bun --version 2>/dev/null | tr -d '[:space:]')"
+installed="${installed_raw#v}"
+expected="${expected_raw#v}"
+
+if [[ "$installed" != "$expected" ]]; then
+  echo "error: Bun version mismatch." >&2
+  echo "  expected (package.json packageManager): bun@${expected}" >&2
+  echo "  installed (bun --version):              bun@${installed}" >&2
+  echo "" >&2
+  echo "Upgrade Bun to match the repo pin, for example:" >&2
+  echo "  curl -fsSL https://bun.sh/install | bash" >&2
+  echo "  # or: bun upgrade" >&2
+  exit 1
+fi
+
+echo "Bun version OK: bun@${installed}"

--- a/tests/unit/scripts/bun-version.test.ts
+++ b/tests/unit/scripts/bun-version.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const scriptPath = path.join(repoRoot, "scripts", "verify", "bun-version.sh");
+
+function runGuard(env: NodeJS.ProcessEnv = {}) {
+  return spawnSync("bash", [scriptPath], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+describe("bun version guard", () => {
+  it("accepts the installed Bun when it matches packageManager", () => {
+    const result = runGuard();
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Bun version OK: bun@1.3.14");
+    expect(result.stderr).toBe("");
+  });
+
+  it("fails fast when the Bun binary does not match packageManager", () => {
+    const fakeBinDir = mkdtempSync(path.join(tmpdir(), "fake-bun-"));
+    const realBun = process.execPath.includes("/bun")
+      ? process.execPath
+      : spawnSync("which", ["bun"], { encoding: "utf8" }).stdout.trim();
+
+    writeFileSync(
+      path.join(fakeBinDir, "bun"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'if [[ "${1:-}" == "--version" ]]; then',
+        '  echo "1.3.4"',
+        "  exit 0",
+        "fi",
+        'exec "$REAL_BUN" "$@"',
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = runGuard({
+      PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+      REAL_BUN: realBun,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("error: Bun version mismatch.");
+    expect(result.stderr).toContain(
+      "expected (package.json packageManager): bun@1.3.14",
+    );
+    expect(result.stderr).toContain(
+      "installed (bun --version):              bun@1.3.4",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Rebuilt the Bun upgrade on current production.
- Pin packageManager and GitHub workflow BUN_VERSION to bun@1.3.14.
- Switch CI installs to bun ci and include Bun version in Turbo cache keys.
- Add local setup/version guard plus Windows setup integration.
- Add unit coverage for the Bun version guard mismatch path.

## Validation
- Verified latest official Bun release via GitHub API: bun-v1.3.14 published 2026-05-13.
- bun --version => 1.3.14
- bun ci
- bun run verify:bun-version
- bunx vitest run tests/unit/scripts/bun-version.test.ts
- bun run format:check
- bun run ci:preflight
- git push preflight: bun run ci:preflight

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tooling-only bump from Bun 1.3.4 → 1.3.14 across the monorepo: `packageManager` in `package.json`, both CI workflows, and a new local version-guard script that fails fast when the installed Bun doesn't match the pin. No app dependencies or lockfile are changed.

- **CI workflows** (`ci.yml`, `ci-integration.yml`): single `BUN_VERSION` env var drives every `oven-sh/setup-bun@v2` step; `bun install --frozen-lockfile` replaced by `bun ci`; Turbo cache keys now include the Bun version to avoid cross-version cache hits; canvas apt deps added to all integration-test install jobs for parity.
- **Version guard** (`scripts/verify/bun-version.sh`): new script reads `packageManager` from `package.json` using `bun -e`, compares against `bun --version`, and exits non-zero with actionable instructions on mismatch; wired into both the Unix and PowerShell setup scripts.
- **Tests** (`tests/unit/scripts/bun-version.test.ts`): exercises the guard with a real Bun install and a fake wrapper that reports an old version.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no app code, no lockfile changes, and `bun ci` is a documented Bun 1.3 command equivalent to `--frozen-lockfile`.

All changes are confined to tooling: a version pin, CI workflow wiring, a shell version-guard script, and matching tests. The guard script logic is correct, `bun ci` is well-documented for Bun 1.3.x, and the Turbo cache key change appropriately invalidates stale cross-version caches. Two minor quality observations exist but neither affects runtime or CI correctness.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/verify/bun-version.sh | New version-guard script that compares installed Bun against packageManager field; logic is sound, but the upgrade hint suggests `bun upgrade` which installs latest, not the pinned version |
| tests/unit/scripts/bun-version.test.ts | Tests the version guard with a real and mocked bun binary; hardcodes "1.3.14" in both success and failure assertions, requiring manual updates on each future version bump |
| .github/workflows/ci.yml | Pins BUN_VERSION env var, switches `bun install --frozen-lockfile` to `bun ci`, and adds BUN_VERSION to Turbo cache keys to prevent cross-version cache hits — all correct |
| .github/workflows/ci-integration.yml | Adds BUN_VERSION env var, switches to `bun ci`, and adds canvas apt deps to all three install jobs for parity with ci.yml |
| scripts/setup/index.sh | Adds version guard call after confirming bun is on PATH; ordering and fail-fast behavior are correct |
| scripts/setup.ps1 | Adds early exit when bun is missing, then calls bun-version.sh via bash with graceful fallback if bash is unavailable on Windows |
| package.json | Bumps packageManager from bun@1.3.4 to bun@1.3.14 and adds verify:bun-version script entry |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun run setup / bun run verify:bun-version] --> B{bun on PATH?}
    B -- No --> C[error: bun not installed\nexit 1]
    B -- Yes --> D{package.json exists?}
    D -- No --> E[error: missing package.json\nexit 1]
    D -- Yes --> F["bun -e: read packageManager\nextract version after 'bun@'"]
    F --> G{packageManager valid?}
    G -- No --> H[error: missing / malformed\nexit 2]
    G -- Yes --> I[bun --version → installed]
    I --> J{installed == expected?}
    J -- Yes --> K[✓ Bun version OK: bun@X.Y.Z]
    J -- No --> L["error: version mismatch\ninstalled vs expected\nupgrade instructions\nexit 1"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: upgrade Bun pin and CI runtime"](https://github.com/asymmetric-al/core/commit/ecde21d183960b8d53ef1e6403db014fa37fb694) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33677319)</sub>

<!-- /greptile_comment -->