### PR TITLE
chore(skills): add idempotency-handling skill

### DIFF
--- a/.agents/skills/.repo-canonical-skills.json
+++ b/.agents/skills/.repo-canonical-skills.json
@@ -14,6 +14,7 @@
     "find-skills",
     "grill-me",
     "grill-with-docs",
+    "idempotency-handling",
     "improve-codebase-architecture",
     "migrate-to-shoehorn",
     "moai-library-shadcn",

--- a/.agents/skills/idempotency-handling/SKILL.md
+++ b/.agents/skills/idempotency-handling/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: idempotency-handling
+description: >
+  Implement idempotency keys and handling to ensure operations can be safely
+  retried without duplicate effects. Use when building payment systems, APIs
+  with retries, or distributed transactions.
+---
+
+## This repository (Asymmetric-al/core)
+
+Subordinate to **`docs/ai/rules/backend.md`** and **`docs/guides/architecture/data-access-boundary.md`**. Pair with Stripe/payment work using ecosystem skills under `.agents/skills/` when installed.
+
+**Repo touchpoints:**
+
+- Donor API idempotency header validation: `packages/api/src/donate/idempotency.ts` (`idempotency-key` / `x-idempotency-key`).
+- Prefer existing monorepo patterns (Next.js route handlers, Supabase, Stripe) over copying generic Express/Redis examples from this skill verbatim.
+
+Refresh: `references/upstream.md`.
+
+# Idempotency Handling
+
+## Table of Contents
+
+- [Overview](#overview)
+- [When to Use](#when-to-use)
+- [Quick Start](#quick-start)
+- [Reference Guides](#reference-guides)
+- [Best Practices](#best-practices)
+
+## Overview
+
+Implement idempotency to ensure operations produce the same result regardless of how many times they're executed.
+
+## When to Use
+
+- Payment processing
+- API endpoints with retries
+- Webhooks and callbacks
+- Message queue consumers
+- Distributed transactions
+- Bank transfers
+- Order creation
+- Email sending
+- Resource creation
+
+## Quick Start
+
+Minimal working example:
+
+```typescript
+import express from "express";
+import Redis from "ioredis";
+import crypto from "crypto";
+
+interface IdempotentRequest {
+  key: string;
+  status: "processing" | "completed" | "failed";
+  response?: any;
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+class IdempotencyService {
+  private redis: Redis;
+  private ttl = 86400; // 24 hours
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl);
+  }
+
+  async getRequest(key: string): Promise<IdempotentRequest | null> {
+    const data = await this.redis.get(`idempotency:${key}`);
+    return data ? JSON.parse(data) : null;
+  }
+// ... (see reference guides for full implementation)
+```
+
+## Reference Guides
+
+Detailed implementations in the `references/` directory:
+
+| Guide | Contents |
+|---|---|
+| [Express Idempotency Middleware](references/express-idempotency-middleware.md) | Express Idempotency Middleware |
+| [Database-Based Idempotency](references/database-based-idempotency.md) | Database-Based Idempotency |
+| [Stripe-Style Idempotency](references/stripe-style-idempotency.md) | Stripe-Style Idempotency |
+| [Message Queue Idempotency](references/message-queue-idempotency.md) | Message Queue Idempotency |
+
+## Best Practices
+
+### ✅ DO
+
+- Require idempotency keys for mutations
+- Store request and response together
+- Set appropriate TTL for idempotency records
+- Validate request body matches stored request
+- Handle concurrent requests gracefully
+- Return same response for duplicate requests
+- Clean up old idempotency records
+- Use database constraints for atomicity
+
+### ❌ DON'T
+
+- Apply idempotency to GET requests
+- Store idempotency data forever
+- Skip validation of request body
+- Use non-unique idempotency keys
+- Process same request concurrently
+- Change response for duplicate requests

--- a/.agents/skills/idempotency-handling/references/database-based-idempotency.md
+++ b/.agents/skills/idempotency-handling/references/database-based-idempotency.md
@@ -1,0 +1,123 @@
+# Database-Based Idempotency
+
+## Database-Based Idempotency
+
+```typescript
+import { Pool } from "pg";
+
+interface IdempotencyRecord {
+  key: string;
+  request_body: any;
+  response_body?: any;
+  status: string;
+  error_message?: string;
+  created_at: Date;
+  completed_at?: Date;
+}
+
+class DatabaseIdempotency {
+  constructor(private db: Pool) {
+    this.createTable();
+  }
+
+  private async createTable(): Promise<void> {
+    await this.db.query(`
+      CREATE TABLE IF NOT EXISTS idempotency_keys (
+        key VARCHAR(255) PRIMARY KEY,
+        request_body JSONB NOT NULL,
+        response_body JSONB,
+        status VARCHAR(50) NOT NULL,
+        error_message TEXT,
+        created_at TIMESTAMP DEFAULT NOW(),
+        completed_at TIMESTAMP,
+        expires_at TIMESTAMP NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_idempotency_expires
+      ON idempotency_keys (expires_at);
+    `);
+  }
+
+  async checkIdempotency(
+    key: string,
+    requestBody: any,
+  ): Promise<IdempotencyRecord | null> {
+    const result = await this.db.query(
+      "SELECT * FROM idempotency_keys WHERE key = $1",
+      [key],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    const record = result.rows[0];
+
+    // Check if request body matches
+    if (JSON.stringify(record.request_body) !== JSON.stringify(requestBody)) {
+      throw new Error("Request body mismatch for idempotency key");
+    }
+
+    return record;
+  }
+
+  async startProcessing(key: string, requestBody: any): Promise<boolean> {
+    try {
+      const expiresAt = new Date(Date.now() + 86400 * 1000); // 24 hours
+
+      await this.db.query(
+        `
+        INSERT INTO idempotency_keys (key, request_body, status, expires_at)
+        VALUES ($1, $2, 'processing', $3)
+      `,
+        [key, requestBody, expiresAt],
+      );
+
+      return true;
+    } catch (error: any) {
+      if (error.code === "23505") {
+        // Unique violation
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async completeRequest(key: string, responseBody: any): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE idempotency_keys
+      SET
+        response_body = $1,
+        status = 'completed',
+        completed_at = NOW()
+      WHERE key = $2
+    `,
+      [responseBody, key],
+    );
+  }
+
+  async failRequest(key: string, errorMessage: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE idempotency_keys
+      SET
+        error_message = $1,
+        status = 'failed',
+        completed_at = NOW()
+      WHERE key = $2
+    `,
+      [errorMessage, key],
+    );
+  }
+
+  async cleanup(): Promise<number> {
+    const result = await this.db.query(`
+      DELETE FROM idempotency_keys
+      WHERE expires_at < NOW()
+    `);
+
+    return result.rowCount || 0;
+  }
+}
+```

--- a/.agents/skills/idempotency-handling/references/express-idempotency-middleware.md
+++ b/.agents/skills/idempotency-handling/references/express-idempotency-middleware.md
@@ -1,0 +1,186 @@
+# Express Idempotency Middleware
+
+## Express Idempotency Middleware
+
+```typescript
+import express from "express";
+import Redis from "ioredis";
+import crypto from "crypto";
+
+interface IdempotentRequest {
+  key: string;
+  status: "processing" | "completed" | "failed";
+  response?: any;
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+class IdempotencyService {
+  private redis: Redis;
+  private ttl = 86400; // 24 hours
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl);
+  }
+
+  async getRequest(key: string): Promise<IdempotentRequest | null> {
+    const data = await this.redis.get(`idempotency:${key}`);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async setRequest(key: string, request: IdempotentRequest): Promise<void> {
+    await this.redis.setex(
+      `idempotency:${key}`,
+      this.ttl,
+      JSON.stringify(request),
+    );
+  }
+
+  async startProcessing(key: string): Promise<boolean> {
+    const request: IdempotentRequest = {
+      key,
+      status: "processing",
+      createdAt: Date.now(),
+    };
+
+    // Use SET NX to ensure only one request processes
+    const result = await this.redis.set(
+      `idempotency:${key}`,
+      JSON.stringify(request),
+      "EX",
+      this.ttl,
+      "NX",
+    );
+
+    return result === "OK";
+  }
+
+  async completeRequest(key: string, response: any): Promise<void> {
+    const request: IdempotentRequest = {
+      key,
+      status: "completed",
+      response,
+      createdAt: Date.now(),
+      completedAt: Date.now(),
+    };
+
+    await this.setRequest(key, request);
+  }
+
+  async failRequest(key: string, error: string): Promise<void> {
+    const request: IdempotentRequest = {
+      key,
+      status: "failed",
+      error,
+      createdAt: Date.now(),
+      completedAt: Date.now(),
+    };
+
+    await this.setRequest(key, request);
+  }
+}
+
+function idempotencyMiddleware(idempotency: IdempotencyService) {
+  return async (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    // Only apply to POST, PUT, PATCH, DELETE
+    if (!["POST", "PUT", "PATCH", "DELETE"].includes(req.method)) {
+      return next();
+    }
+
+    const idempotencyKey = req.headers["idempotency-key"] as string;
+
+    if (!idempotencyKey) {
+      return res.status(400).json({
+        error: "Idempotency-Key header required",
+      });
+    }
+
+    // Check for existing request
+    const existing = await idempotency.getRequest(idempotencyKey);
+
+    if (existing) {
+      if (existing.status === "processing") {
+        return res.status(409).json({
+          error: "Request already processing",
+          message: "Please wait and retry",
+        });
+      }
+
+      if (existing.status === "completed") {
+        return res.status(200).json(existing.response);
+      }
+
+      if (existing.status === "failed") {
+        return res.status(500).json({
+          error: "Previous request failed",
+          message: existing.error,
+        });
+      }
+    }
+
+    // Start processing
+    const canProcess = await idempotency.startProcessing(idempotencyKey);
+
+    if (!canProcess) {
+      return res.status(409).json({
+        error: "Request already processing",
+      });
+    }
+
+    // Capture response
+    const originalSend = res.json.bind(res);
+    res.json = (body: any) => {
+      // Save response for future requests
+      idempotency.completeRequest(idempotencyKey, body).catch(console.error);
+      return originalSend(body);
+    };
+
+    // Handle errors
+    const originalNext = next;
+    next = (err?: any) => {
+      if (err) {
+        idempotency
+          .failRequest(idempotencyKey, err.message)
+          .catch(console.error);
+      }
+      return originalNext(err);
+    };
+
+    next();
+  };
+}
+
+// Usage
+const app = express();
+const redis = new Redis("redis://localhost:6379");
+const idempotency = new IdempotencyService("redis://localhost:6379");
+
+app.use(express.json());
+app.use(idempotencyMiddleware(idempotency));
+
+app.post("/api/payments", async (req, res) => {
+  const { amount, userId } = req.body;
+
+  // Process payment
+  const payment = await processPayment(amount, userId);
+
+  res.json(payment);
+});
+
+async function processPayment(amount: number, userId: string) {
+  // Payment processing logic
+  return {
+    id: crypto.randomUUID(),
+    amount,
+    userId,
+    status: "completed",
+  };
+}
+
+app.listen(3000);
+```

--- a/.agents/skills/idempotency-handling/references/message-queue-idempotency.md
+++ b/.agents/skills/idempotency-handling/references/message-queue-idempotency.md
@@ -1,0 +1,110 @@
+# Message Queue Idempotency
+
+## Message Queue Idempotency
+
+```typescript
+interface Message {
+  id: string;
+  data: any;
+  timestamp: number;
+}
+
+class IdempotentMessageProcessor {
+  private processedMessages = new Set<string>();
+  private db: Pool;
+
+  constructor(db: Pool) {
+    this.db = db;
+    this.loadProcessedMessages();
+  }
+
+  private async loadProcessedMessages(): Promise<void> {
+    // Load recent processed message IDs
+    const result = await this.db.query(`
+      SELECT message_id
+      FROM processed_messages
+      WHERE processed_at > NOW() - INTERVAL '24 hours'
+    `);
+
+    result.rows.forEach((row) => {
+      this.processedMessages.add(row.message_id);
+    });
+  }
+
+  async processMessage(message: Message): Promise<void> {
+    // Check if already processed
+    if (this.processedMessages.has(message.id)) {
+      console.log(`Message ${message.id} already processed, skipping`);
+      return;
+    }
+
+    // Mark as processing (atomic operation)
+    const wasInserted = await this.markAsProcessing(message.id);
+
+    if (!wasInserted) {
+      console.log(`Message ${message.id} already being processed`);
+      return;
+    }
+
+    try {
+      // Process message
+      await this.handleMessage(message);
+
+      // Mark as completed
+      await this.markAsCompleted(message.id);
+
+      this.processedMessages.add(message.id);
+    } catch (error) {
+      console.error(`Failed to process message ${message.id}:`, error);
+      await this.markAsFailed(message.id, (error as Error).message);
+      throw error;
+    }
+  }
+
+  private async markAsProcessing(messageId: string): Promise<boolean> {
+    try {
+      await this.db.query(
+        `
+        INSERT INTO processed_messages (message_id, status, processed_at)
+        VALUES ($1, 'processing', NOW())
+      `,
+        [messageId],
+      );
+
+      return true;
+    } catch (error: any) {
+      if (error.code === "23505") {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private async markAsCompleted(messageId: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE processed_messages
+      SET status = 'completed', completed_at = NOW()
+      WHERE message_id = $1
+    `,
+      [messageId],
+    );
+  }
+
+  private async markAsFailed(messageId: string, error: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE processed_messages
+      SET status = 'failed', error = $2, completed_at = NOW()
+      WHERE message_id = $1
+    `,
+      [messageId, error],
+    );
+  }
+
+  private async handleMessage(message: Message): Promise<void> {
+    // Actual message processing logic
+    console.log("Processing message:", message);
+  }
+}
+```

--- a/.agents/skills/idempotency-handling/references/stripe-style-idempotency.md
+++ b/.agents/skills/idempotency-handling/references/stripe-style-idempotency.md
@@ -1,0 +1,200 @@
+# Stripe-Style Idempotency
+
+## Stripe-Style Idempotency
+
+```python
+import hashlib
+import json
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+import psycopg2
+
+class IdempotencyManager:
+    def __init__(self, db_connection):
+        self.db = db_connection
+        self.ttl_days = 1
+
+    def process_request(
+        self,
+        idempotency_key: str,
+        request_data: Dict[str, Any],
+        process_fn: callable
+    ) -> Dict[str, Any]:
+        """
+        Process request with idempotency guarantee.
+
+        Args:
+            idempotency_key: Unique key for this request
+            request_data: Request payload
+            process_fn: Function to process the request
+
+        Returns:
+            Response data
+        """
+        # Check for existing request
+        existing = self.get_existing_request(
+            idempotency_key,
+            request_data
+        )
+
+        if existing:
+            if existing['status'] == 'processing':
+                raise ConflictError('Request already processing')
+
+            if existing['status'] == 'completed':
+                return existing['response']
+
+            if existing['status'] == 'failed':
+                raise ProcessingError(existing['error'])
+
+        # Start processing
+        if not self.start_processing(idempotency_key, request_data):
+            raise ConflictError('Request already processing')
+
+        try:
+            # Process request
+            result = process_fn(request_data)
+
+            # Store result
+            self.complete_request(idempotency_key, result)
+
+            return result
+
+        except Exception as e:
+            # Store error
+            self.fail_request(idempotency_key, str(e))
+            raise
+
+    def get_existing_request(
+        self,
+        key: str,
+        request_data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Get existing idempotent request."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            SELECT status, response, error, request_hash
+            FROM idempotency_requests
+            WHERE idempotency_key = %s
+            AND created_at > %s
+        """, (key, datetime.now() - timedelta(days=self.ttl_days)))
+
+        row = cursor.fetchone()
+        cursor.close()
+
+        if not row:
+            return None
+
+        # Verify request data matches
+        request_hash = self.hash_request(request_data)
+        if row[3] != request_hash:
+            raise ValueError(
+                'Request data does not match idempotency key'
+            )
+
+        return {
+            'status': row[0],
+            'response': row[1],
+            'error': row[2]
+        }
+
+    def start_processing(
+        self,
+        key: str,
+        request_data: Dict[str, Any]
+    ) -> bool:
+        """Mark request as processing."""
+        cursor = self.db.cursor()
+        request_hash = self.hash_request(request_data)
+
+        try:
+            cursor.execute("""
+                INSERT INTO idempotency_requests
+                (idempotency_key, request_hash, status, created_at)
+                VALUES (%s, %s, 'processing', NOW())
+            """, (key, request_hash))
+
+            self.db.commit()
+            cursor.close()
+            return True
+
+        except psycopg2.IntegrityError:
+            self.db.rollback()
+            cursor.close()
+            return False
+
+    def complete_request(
+        self,
+        key: str,
+        response: Dict[str, Any]
+    ):
+        """Mark request as completed."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            UPDATE idempotency_requests
+            SET
+                status = 'completed',
+                response = %s,
+                completed_at = NOW()
+            WHERE idempotency_key = %s
+        """, (json.dumps(response), key))
+
+        self.db.commit()
+        cursor.close()
+
+    def fail_request(self, key: str, error: str):
+        """Mark request as failed."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            UPDATE idempotency_requests
+            SET
+                status = 'failed',
+                error = %s,
+                completed_at = NOW()
+            WHERE idempotency_key = %s
+        """, (error, key))
+
+        self.db.commit()
+        cursor.close()
+
+    def hash_request(self, data: Dict[str, Any]) -> str:
+        """Create hash of request data."""
+        json_str = json.dumps(data, sort_keys=True)
+        return hashlib.sha256(json_str.encode()).hexdigest()
+
+
+class ConflictError(Exception):
+    pass
+
+
+class ProcessingError(Exception):
+    pass
+
+
+# Usage
+def process_payment(data):
+    # Process payment logic
+    return {
+        'payment_id': 'pay_123',
+        'amount': data['amount'],
+        'status': 'completed'
+    }
+
+# In your API handler
+idempotency = IdempotencyManager(db_connection)
+
+try:
+    result = idempotency.process_request(
+        idempotency_key='key_abc123',
+        request_data={'amount': 100, 'currency': 'USD'},
+        process_fn=process_payment
+    )
+    print(result)
+except ConflictError as e:
+    print(f"Conflict: {e}")
+except ProcessingError as e:
+    print(f"Processing error: {e}")
+```

--- a/.agents/skills/idempotency-handling/references/upstream.md
+++ b/.agents/skills/idempotency-handling/references/upstream.md
@@ -1,0 +1,25 @@
+---
+source_name: aj-geddes/useful-ai-prompts (idempotency-handling)
+source_url: https://github.com/aj-geddes/useful-ai-prompts
+source_type: github
+upstream_path: skills/idempotency-handling/SKILL.md
+skills_lock_hash: 282a4585f756e098318a3d778e7480cb61e90617c290b79d2fd206845e7f82b6
+last_reviewed: 2026-05-29
+---
+
+# Upstream: idempotency-handling
+
+Canonical copy in this repo: `docs/ai/skills/idempotency-handling/` (mirrored to `.cursor/skills/` and `.agents/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/aj-geddes/useful-ai-prompts
+- **Upstream path:** `skills/idempotency-handling/SKILL.md`
+- **Install via Skills CLI:** `npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y`
+
+## Refresh from ecosystem
+
+1. `npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y` updates `.agents/skills/idempotency-handling/` and `skills-lock.json`.
+2. Copy the skill tree into `docs/ai/skills/idempotency-handling/` if the canonical copy needs updating.
+3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+
+This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.agents/skills/idempotency-handling/scripts/validate-api.sh
+++ b/.agents/skills/idempotency-handling/scripts/validate-api.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# validate-api.sh - Validate API specification
+# Usage: ./validate-api.sh <openapi_spec>
+
+set -euo pipefail
+
+SPEC_FILE="${{1:?Usage: $0 <openapi_spec>}}"
+
+echo "Validating API spec: $SPEC_FILE"
+
+# TODO: Add API validation
+# - Validate OpenAPI/Swagger syntax
+# - Check endpoint naming conventions
+# - Verify response schemas
+# - Check for required headers
+# - Validate authentication definitions
+
+echo "API validation complete."

--- a/.agents/skills/idempotency-handling/scripts/validate-api.sh
+++ b/.agents/skills/idempotency-handling/scripts/validate-api.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-SPEC_FILE="${{1:?Usage: $0 <openapi_spec>}}"
+SPEC_FILE="${1:?Usage: $0 <openapi_spec>}"
 
 echo "Validating API spec: $SPEC_FILE"
 

--- a/.agents/skills/idempotency-handling/templates/api-scaffold.yaml
+++ b/.agents/skills/idempotency-handling/templates/api-scaffold.yaml
@@ -1,0 +1,22 @@
+# API Endpoint Scaffold
+# TODO: Customize for your API framework
+
+openapi: "3.0.3"
+info:
+  title: "API Service"
+  version: "1.0.0"
+
+paths:
+  /api/v1/resource:
+    get:
+      summary: "List resources"
+      # TODO: Define parameters and responses
+      responses:
+        "200":
+          description: "Success"
+    post:
+      summary: "Create resource"
+      # TODO: Define request body and responses
+      responses:
+        "201":
+          description: "Created"

--- a/.cursor/skills/.repo-canonical-skills.json
+++ b/.cursor/skills/.repo-canonical-skills.json
@@ -14,6 +14,7 @@
     "find-skills",
     "grill-me",
     "grill-with-docs",
+    "idempotency-handling",
     "improve-codebase-architecture",
     "migrate-to-shoehorn",
     "moai-library-shadcn",

--- a/.cursor/skills/idempotency-handling/SKILL.md
+++ b/.cursor/skills/idempotency-handling/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: idempotency-handling
+description: >
+  Implement idempotency keys and handling to ensure operations can be safely
+  retried without duplicate effects. Use when building payment systems, APIs
+  with retries, or distributed transactions.
+---
+
+## This repository (Asymmetric-al/core)
+
+Subordinate to **`docs/ai/rules/backend.md`** and **`docs/guides/architecture/data-access-boundary.md`**. Pair with Stripe/payment work using ecosystem skills under `.agents/skills/` when installed.
+
+**Repo touchpoints:**
+
+- Donor API idempotency header validation: `packages/api/src/donate/idempotency.ts` (`idempotency-key` / `x-idempotency-key`).
+- Prefer existing monorepo patterns (Next.js route handlers, Supabase, Stripe) over copying generic Express/Redis examples from this skill verbatim.
+
+Refresh: `references/upstream.md`.
+
+# Idempotency Handling
+
+## Table of Contents
+
+- [Overview](#overview)
+- [When to Use](#when-to-use)
+- [Quick Start](#quick-start)
+- [Reference Guides](#reference-guides)
+- [Best Practices](#best-practices)
+
+## Overview
+
+Implement idempotency to ensure operations produce the same result regardless of how many times they're executed.
+
+## When to Use
+
+- Payment processing
+- API endpoints with retries
+- Webhooks and callbacks
+- Message queue consumers
+- Distributed transactions
+- Bank transfers
+- Order creation
+- Email sending
+- Resource creation
+
+## Quick Start
+
+Minimal working example:
+
+```typescript
+import express from "express";
+import Redis from "ioredis";
+import crypto from "crypto";
+
+interface IdempotentRequest {
+  key: string;
+  status: "processing" | "completed" | "failed";
+  response?: any;
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+class IdempotencyService {
+  private redis: Redis;
+  private ttl = 86400; // 24 hours
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl);
+  }
+
+  async getRequest(key: string): Promise<IdempotentRequest | null> {
+    const data = await this.redis.get(`idempotency:${key}`);
+    return data ? JSON.parse(data) : null;
+  }
+// ... (see reference guides for full implementation)
+```
+
+## Reference Guides
+
+Detailed implementations in the `references/` directory:
+
+| Guide | Contents |
+|---|---|
+| [Express Idempotency Middleware](references/express-idempotency-middleware.md) | Express Idempotency Middleware |
+| [Database-Based Idempotency](references/database-based-idempotency.md) | Database-Based Idempotency |
+| [Stripe-Style Idempotency](references/stripe-style-idempotency.md) | Stripe-Style Idempotency |
+| [Message Queue Idempotency](references/message-queue-idempotency.md) | Message Queue Idempotency |
+
+## Best Practices
+
+### ✅ DO
+
+- Require idempotency keys for mutations
+- Store request and response together
+- Set appropriate TTL for idempotency records
+- Validate request body matches stored request
+- Handle concurrent requests gracefully
+- Return same response for duplicate requests
+- Clean up old idempotency records
+- Use database constraints for atomicity
+
+### ❌ DON'T
+
+- Apply idempotency to GET requests
+- Store idempotency data forever
+- Skip validation of request body
+- Use non-unique idempotency keys
+- Process same request concurrently
+- Change response for duplicate requests

--- a/.cursor/skills/idempotency-handling/references/database-based-idempotency.md
+++ b/.cursor/skills/idempotency-handling/references/database-based-idempotency.md
@@ -1,0 +1,123 @@
+# Database-Based Idempotency
+
+## Database-Based Idempotency
+
+```typescript
+import { Pool } from "pg";
+
+interface IdempotencyRecord {
+  key: string;
+  request_body: any;
+  response_body?: any;
+  status: string;
+  error_message?: string;
+  created_at: Date;
+  completed_at?: Date;
+}
+
+class DatabaseIdempotency {
+  constructor(private db: Pool) {
+    this.createTable();
+  }
+
+  private async createTable(): Promise<void> {
+    await this.db.query(`
+      CREATE TABLE IF NOT EXISTS idempotency_keys (
+        key VARCHAR(255) PRIMARY KEY,
+        request_body JSONB NOT NULL,
+        response_body JSONB,
+        status VARCHAR(50) NOT NULL,
+        error_message TEXT,
+        created_at TIMESTAMP DEFAULT NOW(),
+        completed_at TIMESTAMP,
+        expires_at TIMESTAMP NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_idempotency_expires
+      ON idempotency_keys (expires_at);
+    `);
+  }
+
+  async checkIdempotency(
+    key: string,
+    requestBody: any,
+  ): Promise<IdempotencyRecord | null> {
+    const result = await this.db.query(
+      "SELECT * FROM idempotency_keys WHERE key = $1",
+      [key],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    const record = result.rows[0];
+
+    // Check if request body matches
+    if (JSON.stringify(record.request_body) !== JSON.stringify(requestBody)) {
+      throw new Error("Request body mismatch for idempotency key");
+    }
+
+    return record;
+  }
+
+  async startProcessing(key: string, requestBody: any): Promise<boolean> {
+    try {
+      const expiresAt = new Date(Date.now() + 86400 * 1000); // 24 hours
+
+      await this.db.query(
+        `
+        INSERT INTO idempotency_keys (key, request_body, status, expires_at)
+        VALUES ($1, $2, 'processing', $3)
+      `,
+        [key, requestBody, expiresAt],
+      );
+
+      return true;
+    } catch (error: any) {
+      if (error.code === "23505") {
+        // Unique violation
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async completeRequest(key: string, responseBody: any): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE idempotency_keys
+      SET
+        response_body = $1,
+        status = 'completed',
+        completed_at = NOW()
+      WHERE key = $2
+    `,
+      [responseBody, key],
+    );
+  }
+
+  async failRequest(key: string, errorMessage: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE idempotency_keys
+      SET
+        error_message = $1,
+        status = 'failed',
+        completed_at = NOW()
+      WHERE key = $2
+    `,
+      [errorMessage, key],
+    );
+  }
+
+  async cleanup(): Promise<number> {
+    const result = await this.db.query(`
+      DELETE FROM idempotency_keys
+      WHERE expires_at < NOW()
+    `);
+
+    return result.rowCount || 0;
+  }
+}
+```

--- a/.cursor/skills/idempotency-handling/references/express-idempotency-middleware.md
+++ b/.cursor/skills/idempotency-handling/references/express-idempotency-middleware.md
@@ -1,0 +1,186 @@
+# Express Idempotency Middleware
+
+## Express Idempotency Middleware
+
+```typescript
+import express from "express";
+import Redis from "ioredis";
+import crypto from "crypto";
+
+interface IdempotentRequest {
+  key: string;
+  status: "processing" | "completed" | "failed";
+  response?: any;
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+class IdempotencyService {
+  private redis: Redis;
+  private ttl = 86400; // 24 hours
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl);
+  }
+
+  async getRequest(key: string): Promise<IdempotentRequest | null> {
+    const data = await this.redis.get(`idempotency:${key}`);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async setRequest(key: string, request: IdempotentRequest): Promise<void> {
+    await this.redis.setex(
+      `idempotency:${key}`,
+      this.ttl,
+      JSON.stringify(request),
+    );
+  }
+
+  async startProcessing(key: string): Promise<boolean> {
+    const request: IdempotentRequest = {
+      key,
+      status: "processing",
+      createdAt: Date.now(),
+    };
+
+    // Use SET NX to ensure only one request processes
+    const result = await this.redis.set(
+      `idempotency:${key}`,
+      JSON.stringify(request),
+      "EX",
+      this.ttl,
+      "NX",
+    );
+
+    return result === "OK";
+  }
+
+  async completeRequest(key: string, response: any): Promise<void> {
+    const request: IdempotentRequest = {
+      key,
+      status: "completed",
+      response,
+      createdAt: Date.now(),
+      completedAt: Date.now(),
+    };
+
+    await this.setRequest(key, request);
+  }
+
+  async failRequest(key: string, error: string): Promise<void> {
+    const request: IdempotentRequest = {
+      key,
+      status: "failed",
+      error,
+      createdAt: Date.now(),
+      completedAt: Date.now(),
+    };
+
+    await this.setRequest(key, request);
+  }
+}
+
+function idempotencyMiddleware(idempotency: IdempotencyService) {
+  return async (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    // Only apply to POST, PUT, PATCH, DELETE
+    if (!["POST", "PUT", "PATCH", "DELETE"].includes(req.method)) {
+      return next();
+    }
+
+    const idempotencyKey = req.headers["idempotency-key"] as string;
+
+    if (!idempotencyKey) {
+      return res.status(400).json({
+        error: "Idempotency-Key header required",
+      });
+    }
+
+    // Check for existing request
+    const existing = await idempotency.getRequest(idempotencyKey);
+
+    if (existing) {
+      if (existing.status === "processing") {
+        return res.status(409).json({
+          error: "Request already processing",
+          message: "Please wait and retry",
+        });
+      }
+
+      if (existing.status === "completed") {
+        return res.status(200).json(existing.response);
+      }
+
+      if (existing.status === "failed") {
+        return res.status(500).json({
+          error: "Previous request failed",
+          message: existing.error,
+        });
+      }
+    }
+
+    // Start processing
+    const canProcess = await idempotency.startProcessing(idempotencyKey);
+
+    if (!canProcess) {
+      return res.status(409).json({
+        error: "Request already processing",
+      });
+    }
+
+    // Capture response
+    const originalSend = res.json.bind(res);
+    res.json = (body: any) => {
+      // Save response for future requests
+      idempotency.completeRequest(idempotencyKey, body).catch(console.error);
+      return originalSend(body);
+    };
+
+    // Handle errors
+    const originalNext = next;
+    next = (err?: any) => {
+      if (err) {
+        idempotency
+          .failRequest(idempotencyKey, err.message)
+          .catch(console.error);
+      }
+      return originalNext(err);
+    };
+
+    next();
+  };
+}
+
+// Usage
+const app = express();
+const redis = new Redis("redis://localhost:6379");
+const idempotency = new IdempotencyService("redis://localhost:6379");
+
+app.use(express.json());
+app.use(idempotencyMiddleware(idempotency));
+
+app.post("/api/payments", async (req, res) => {
+  const { amount, userId } = req.body;
+
+  // Process payment
+  const payment = await processPayment(amount, userId);
+
+  res.json(payment);
+});
+
+async function processPayment(amount: number, userId: string) {
+  // Payment processing logic
+  return {
+    id: crypto.randomUUID(),
+    amount,
+    userId,
+    status: "completed",
+  };
+}
+
+app.listen(3000);
+```

--- a/.cursor/skills/idempotency-handling/references/message-queue-idempotency.md
+++ b/.cursor/skills/idempotency-handling/references/message-queue-idempotency.md
@@ -1,0 +1,110 @@
+# Message Queue Idempotency
+
+## Message Queue Idempotency
+
+```typescript
+interface Message {
+  id: string;
+  data: any;
+  timestamp: number;
+}
+
+class IdempotentMessageProcessor {
+  private processedMessages = new Set<string>();
+  private db: Pool;
+
+  constructor(db: Pool) {
+    this.db = db;
+    this.loadProcessedMessages();
+  }
+
+  private async loadProcessedMessages(): Promise<void> {
+    // Load recent processed message IDs
+    const result = await this.db.query(`
+      SELECT message_id
+      FROM processed_messages
+      WHERE processed_at > NOW() - INTERVAL '24 hours'
+    `);
+
+    result.rows.forEach((row) => {
+      this.processedMessages.add(row.message_id);
+    });
+  }
+
+  async processMessage(message: Message): Promise<void> {
+    // Check if already processed
+    if (this.processedMessages.has(message.id)) {
+      console.log(`Message ${message.id} already processed, skipping`);
+      return;
+    }
+
+    // Mark as processing (atomic operation)
+    const wasInserted = await this.markAsProcessing(message.id);
+
+    if (!wasInserted) {
+      console.log(`Message ${message.id} already being processed`);
+      return;
+    }
+
+    try {
+      // Process message
+      await this.handleMessage(message);
+
+      // Mark as completed
+      await this.markAsCompleted(message.id);
+
+      this.processedMessages.add(message.id);
+    } catch (error) {
+      console.error(`Failed to process message ${message.id}:`, error);
+      await this.markAsFailed(message.id, (error as Error).message);
+      throw error;
+    }
+  }
+
+  private async markAsProcessing(messageId: string): Promise<boolean> {
+    try {
+      await this.db.query(
+        `
+        INSERT INTO processed_messages (message_id, status, processed_at)
+        VALUES ($1, 'processing', NOW())
+      `,
+        [messageId],
+      );
+
+      return true;
+    } catch (error: any) {
+      if (error.code === "23505") {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private async markAsCompleted(messageId: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE processed_messages
+      SET status = 'completed', completed_at = NOW()
+      WHERE message_id = $1
+    `,
+      [messageId],
+    );
+  }
+
+  private async markAsFailed(messageId: string, error: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE processed_messages
+      SET status = 'failed', error = $2, completed_at = NOW()
+      WHERE message_id = $1
+    `,
+      [messageId, error],
+    );
+  }
+
+  private async handleMessage(message: Message): Promise<void> {
+    // Actual message processing logic
+    console.log("Processing message:", message);
+  }
+}
+```

--- a/.cursor/skills/idempotency-handling/references/stripe-style-idempotency.md
+++ b/.cursor/skills/idempotency-handling/references/stripe-style-idempotency.md
@@ -1,0 +1,200 @@
+# Stripe-Style Idempotency
+
+## Stripe-Style Idempotency
+
+```python
+import hashlib
+import json
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+import psycopg2
+
+class IdempotencyManager:
+    def __init__(self, db_connection):
+        self.db = db_connection
+        self.ttl_days = 1
+
+    def process_request(
+        self,
+        idempotency_key: str,
+        request_data: Dict[str, Any],
+        process_fn: callable
+    ) -> Dict[str, Any]:
+        """
+        Process request with idempotency guarantee.
+
+        Args:
+            idempotency_key: Unique key for this request
+            request_data: Request payload
+            process_fn: Function to process the request
+
+        Returns:
+            Response data
+        """
+        # Check for existing request
+        existing = self.get_existing_request(
+            idempotency_key,
+            request_data
+        )
+
+        if existing:
+            if existing['status'] == 'processing':
+                raise ConflictError('Request already processing')
+
+            if existing['status'] == 'completed':
+                return existing['response']
+
+            if existing['status'] == 'failed':
+                raise ProcessingError(existing['error'])
+
+        # Start processing
+        if not self.start_processing(idempotency_key, request_data):
+            raise ConflictError('Request already processing')
+
+        try:
+            # Process request
+            result = process_fn(request_data)
+
+            # Store result
+            self.complete_request(idempotency_key, result)
+
+            return result
+
+        except Exception as e:
+            # Store error
+            self.fail_request(idempotency_key, str(e))
+            raise
+
+    def get_existing_request(
+        self,
+        key: str,
+        request_data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Get existing idempotent request."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            SELECT status, response, error, request_hash
+            FROM idempotency_requests
+            WHERE idempotency_key = %s
+            AND created_at > %s
+        """, (key, datetime.now() - timedelta(days=self.ttl_days)))
+
+        row = cursor.fetchone()
+        cursor.close()
+
+        if not row:
+            return None
+
+        # Verify request data matches
+        request_hash = self.hash_request(request_data)
+        if row[3] != request_hash:
+            raise ValueError(
+                'Request data does not match idempotency key'
+            )
+
+        return {
+            'status': row[0],
+            'response': row[1],
+            'error': row[2]
+        }
+
+    def start_processing(
+        self,
+        key: str,
+        request_data: Dict[str, Any]
+    ) -> bool:
+        """Mark request as processing."""
+        cursor = self.db.cursor()
+        request_hash = self.hash_request(request_data)
+
+        try:
+            cursor.execute("""
+                INSERT INTO idempotency_requests
+                (idempotency_key, request_hash, status, created_at)
+                VALUES (%s, %s, 'processing', NOW())
+            """, (key, request_hash))
+
+            self.db.commit()
+            cursor.close()
+            return True
+
+        except psycopg2.IntegrityError:
+            self.db.rollback()
+            cursor.close()
+            return False
+
+    def complete_request(
+        self,
+        key: str,
+        response: Dict[str, Any]
+    ):
+        """Mark request as completed."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            UPDATE idempotency_requests
+            SET
+                status = 'completed',
+                response = %s,
+                completed_at = NOW()
+            WHERE idempotency_key = %s
+        """, (json.dumps(response), key))
+
+        self.db.commit()
+        cursor.close()
+
+    def fail_request(self, key: str, error: str):
+        """Mark request as failed."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            UPDATE idempotency_requests
+            SET
+                status = 'failed',
+                error = %s,
+                completed_at = NOW()
+            WHERE idempotency_key = %s
+        """, (error, key))
+
+        self.db.commit()
+        cursor.close()
+
+    def hash_request(self, data: Dict[str, Any]) -> str:
+        """Create hash of request data."""
+        json_str = json.dumps(data, sort_keys=True)
+        return hashlib.sha256(json_str.encode()).hexdigest()
+
+
+class ConflictError(Exception):
+    pass
+
+
+class ProcessingError(Exception):
+    pass
+
+
+# Usage
+def process_payment(data):
+    # Process payment logic
+    return {
+        'payment_id': 'pay_123',
+        'amount': data['amount'],
+        'status': 'completed'
+    }
+
+# In your API handler
+idempotency = IdempotencyManager(db_connection)
+
+try:
+    result = idempotency.process_request(
+        idempotency_key='key_abc123',
+        request_data={'amount': 100, 'currency': 'USD'},
+        process_fn=process_payment
+    )
+    print(result)
+except ConflictError as e:
+    print(f"Conflict: {e}")
+except ProcessingError as e:
+    print(f"Processing error: {e}")
+```

--- a/.cursor/skills/idempotency-handling/references/upstream.md
+++ b/.cursor/skills/idempotency-handling/references/upstream.md
@@ -1,0 +1,25 @@
+---
+source_name: aj-geddes/useful-ai-prompts (idempotency-handling)
+source_url: https://github.com/aj-geddes/useful-ai-prompts
+source_type: github
+upstream_path: skills/idempotency-handling/SKILL.md
+skills_lock_hash: 282a4585f756e098318a3d778e7480cb61e90617c290b79d2fd206845e7f82b6
+last_reviewed: 2026-05-29
+---
+
+# Upstream: idempotency-handling
+
+Canonical copy in this repo: `docs/ai/skills/idempotency-handling/` (mirrored to `.cursor/skills/` and `.agents/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/aj-geddes/useful-ai-prompts
+- **Upstream path:** `skills/idempotency-handling/SKILL.md`
+- **Install via Skills CLI:** `npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y`
+
+## Refresh from ecosystem
+
+1. `npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y` updates `.agents/skills/idempotency-handling/` and `skills-lock.json`.
+2. Copy the skill tree into `docs/ai/skills/idempotency-handling/` if the canonical copy needs updating.
+3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+
+This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.cursor/skills/idempotency-handling/scripts/validate-api.sh
+++ b/.cursor/skills/idempotency-handling/scripts/validate-api.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# validate-api.sh - Validate API specification
+# Usage: ./validate-api.sh <openapi_spec>
+
+set -euo pipefail
+
+SPEC_FILE="${{1:?Usage: $0 <openapi_spec>}}"
+
+echo "Validating API spec: $SPEC_FILE"
+
+# TODO: Add API validation
+# - Validate OpenAPI/Swagger syntax
+# - Check endpoint naming conventions
+# - Verify response schemas
+# - Check for required headers
+# - Validate authentication definitions
+
+echo "API validation complete."

--- a/.cursor/skills/idempotency-handling/scripts/validate-api.sh
+++ b/.cursor/skills/idempotency-handling/scripts/validate-api.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-SPEC_FILE="${{1:?Usage: $0 <openapi_spec>}}"
+SPEC_FILE="${1:?Usage: $0 <openapi_spec>}"
 
 echo "Validating API spec: $SPEC_FILE"
 

--- a/.cursor/skills/idempotency-handling/templates/api-scaffold.yaml
+++ b/.cursor/skills/idempotency-handling/templates/api-scaffold.yaml
@@ -1,0 +1,22 @@
+# API Endpoint Scaffold
+# TODO: Customize for your API framework
+
+openapi: "3.0.3"
+info:
+  title: "API Service"
+  version: "1.0.0"
+
+paths:
+  /api/v1/resource:
+    get:
+      summary: "List resources"
+      # TODO: Define parameters and responses
+      responses:
+        "200":
+          description: "Success"
+    post:
+      summary: "Create resource"
+      # TODO: Define request body and responses
+      responses:
+        "201":
+          description: "Created"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,8 @@ To **pull newer upstream** content for Supabase: `npx skills add supabase/agent-
 
 **Payload CMS** ([`payloadcms/skills`](https://github.com/payloadcms/skills)) is vendored into `docs/ai/skills/payloadcms-payload/` and `docs/ai/skills/payloadcms-cms-migration/`. Refresh steps live in each skill's `references/upstream.md`; optional Skills CLI install is `npx skills add payloadcms/skills`; these skills are **not** updated by `bun run skills:refresh-upstream` today.
 
+**`idempotency-handling`** ([`aj-geddes/useful-ai-prompts`](https://github.com/aj-geddes/useful-ai-prompts)) is in `docs/ai/skills/idempotency-handling/`. Refresh via `npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y`, reconcile into `docs/ai/skills/idempotency-handling/` if needed, then `bun run skills:sync` and `bun run skills:verify`. See `docs/ai/skills/idempotency-handling/references/upstream.md`; **not** updated by `bun run skills:refresh-upstream` today.
+
 - **Next.js App Router structure, rendering, data fetching:** `docs/ai/skills/nextjs-app-router/SKILL.md`
 - **Cache Components / PPR / cacheTag & invalidation:** `docs/ai/skills/cache-components/SKILL.md`
 - **React component design/refactor:** `docs/ai/skills/react-component-dev/SKILL.md`
@@ -295,6 +297,7 @@ To **pull newer upstream** content for Supabase: `npx skills add supabase/agent-
 - **Vercel React + Next performance patterns:** `docs/ai/skills/vercel-react-best-practices/SKILL.md`
 - **React View Transitions + Next.js route / shared-element continuity:** `docs/ai/skills/vercel-react-view-transitions/SKILL.md`
 - **Discover/install agent skills (skills.sh, repo canonical skills):** `docs/ai/skills/find-skills/SKILL.md`
+- **Idempotency keys, safe retries, webhooks, payments, queue consumers:** `docs/ai/skills/idempotency-handling/SKILL.md` (subordinate to `docs/ai/rules/backend.md`; see `packages/api/src/donate/idempotency.ts` for donor API header validation)
 - **Commit message creation:** `docs/ai/skills/commit/SKILL.md`
 
 **GitHub `AL-###` issue/PR workflow:** there are no `SKILL.md` files under `docs/ai/skills/` for those flows today; follow `docs/ai/rules/general.md`. Deprecated stubs live under `skills/*/DEPRECATED.md` only.

--- a/docs/ai/skills/idempotency-handling/SKILL.md
+++ b/docs/ai/skills/idempotency-handling/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: idempotency-handling
+description: >
+  Implement idempotency keys and handling to ensure operations can be safely
+  retried without duplicate effects. Use when building payment systems, APIs
+  with retries, or distributed transactions.
+---
+
+## This repository (Asymmetric-al/core)
+
+Subordinate to **`docs/ai/rules/backend.md`** and **`docs/guides/architecture/data-access-boundary.md`**. Pair with Stripe/payment work using ecosystem skills under `.agents/skills/` when installed.
+
+**Repo touchpoints:**
+
+- Donor API idempotency header validation: `packages/api/src/donate/idempotency.ts` (`idempotency-key` / `x-idempotency-key`).
+- Prefer existing monorepo patterns (Next.js route handlers, Supabase, Stripe) over copying generic Express/Redis examples from this skill verbatim.
+
+Refresh: `references/upstream.md`.
+
+# Idempotency Handling
+
+## Table of Contents
+
+- [Overview](#overview)
+- [When to Use](#when-to-use)
+- [Quick Start](#quick-start)
+- [Reference Guides](#reference-guides)
+- [Best Practices](#best-practices)
+
+## Overview
+
+Implement idempotency to ensure operations produce the same result regardless of how many times they're executed.
+
+## When to Use
+
+- Payment processing
+- API endpoints with retries
+- Webhooks and callbacks
+- Message queue consumers
+- Distributed transactions
+- Bank transfers
+- Order creation
+- Email sending
+- Resource creation
+
+## Quick Start
+
+Minimal working example:
+
+```typescript
+import express from "express";
+import Redis from "ioredis";
+import crypto from "crypto";
+
+interface IdempotentRequest {
+  key: string;
+  status: "processing" | "completed" | "failed";
+  response?: any;
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+class IdempotencyService {
+  private redis: Redis;
+  private ttl = 86400; // 24 hours
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl);
+  }
+
+  async getRequest(key: string): Promise<IdempotentRequest | null> {
+    const data = await this.redis.get(`idempotency:${key}`);
+    return data ? JSON.parse(data) : null;
+  }
+// ... (see reference guides for full implementation)
+```
+
+## Reference Guides
+
+Detailed implementations in the `references/` directory:
+
+| Guide | Contents |
+|---|---|
+| [Express Idempotency Middleware](references/express-idempotency-middleware.md) | Express Idempotency Middleware |
+| [Database-Based Idempotency](references/database-based-idempotency.md) | Database-Based Idempotency |
+| [Stripe-Style Idempotency](references/stripe-style-idempotency.md) | Stripe-Style Idempotency |
+| [Message Queue Idempotency](references/message-queue-idempotency.md) | Message Queue Idempotency |
+
+## Best Practices
+
+### ✅ DO
+
+- Require idempotency keys for mutations
+- Store request and response together
+- Set appropriate TTL for idempotency records
+- Validate request body matches stored request
+- Handle concurrent requests gracefully
+- Return same response for duplicate requests
+- Clean up old idempotency records
+- Use database constraints for atomicity
+
+### ❌ DON'T
+
+- Apply idempotency to GET requests
+- Store idempotency data forever
+- Skip validation of request body
+- Use non-unique idempotency keys
+- Process same request concurrently
+- Change response for duplicate requests

--- a/docs/ai/skills/idempotency-handling/references/database-based-idempotency.md
+++ b/docs/ai/skills/idempotency-handling/references/database-based-idempotency.md
@@ -1,0 +1,123 @@
+# Database-Based Idempotency
+
+## Database-Based Idempotency
+
+```typescript
+import { Pool } from "pg";
+
+interface IdempotencyRecord {
+  key: string;
+  request_body: any;
+  response_body?: any;
+  status: string;
+  error_message?: string;
+  created_at: Date;
+  completed_at?: Date;
+}
+
+class DatabaseIdempotency {
+  constructor(private db: Pool) {
+    this.createTable();
+  }
+
+  private async createTable(): Promise<void> {
+    await this.db.query(`
+      CREATE TABLE IF NOT EXISTS idempotency_keys (
+        key VARCHAR(255) PRIMARY KEY,
+        request_body JSONB NOT NULL,
+        response_body JSONB,
+        status VARCHAR(50) NOT NULL,
+        error_message TEXT,
+        created_at TIMESTAMP DEFAULT NOW(),
+        completed_at TIMESTAMP,
+        expires_at TIMESTAMP NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_idempotency_expires
+      ON idempotency_keys (expires_at);
+    `);
+  }
+
+  async checkIdempotency(
+    key: string,
+    requestBody: any,
+  ): Promise<IdempotencyRecord | null> {
+    const result = await this.db.query(
+      "SELECT * FROM idempotency_keys WHERE key = $1",
+      [key],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    const record = result.rows[0];
+
+    // Check if request body matches
+    if (JSON.stringify(record.request_body) !== JSON.stringify(requestBody)) {
+      throw new Error("Request body mismatch for idempotency key");
+    }
+
+    return record;
+  }
+
+  async startProcessing(key: string, requestBody: any): Promise<boolean> {
+    try {
+      const expiresAt = new Date(Date.now() + 86400 * 1000); // 24 hours
+
+      await this.db.query(
+        `
+        INSERT INTO idempotency_keys (key, request_body, status, expires_at)
+        VALUES ($1, $2, 'processing', $3)
+      `,
+        [key, requestBody, expiresAt],
+      );
+
+      return true;
+    } catch (error: any) {
+      if (error.code === "23505") {
+        // Unique violation
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async completeRequest(key: string, responseBody: any): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE idempotency_keys
+      SET
+        response_body = $1,
+        status = 'completed',
+        completed_at = NOW()
+      WHERE key = $2
+    `,
+      [responseBody, key],
+    );
+  }
+
+  async failRequest(key: string, errorMessage: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE idempotency_keys
+      SET
+        error_message = $1,
+        status = 'failed',
+        completed_at = NOW()
+      WHERE key = $2
+    `,
+      [errorMessage, key],
+    );
+  }
+
+  async cleanup(): Promise<number> {
+    const result = await this.db.query(`
+      DELETE FROM idempotency_keys
+      WHERE expires_at < NOW()
+    `);
+
+    return result.rowCount || 0;
+  }
+}
+```

--- a/docs/ai/skills/idempotency-handling/references/express-idempotency-middleware.md
+++ b/docs/ai/skills/idempotency-handling/references/express-idempotency-middleware.md
@@ -1,0 +1,186 @@
+# Express Idempotency Middleware
+
+## Express Idempotency Middleware
+
+```typescript
+import express from "express";
+import Redis from "ioredis";
+import crypto from "crypto";
+
+interface IdempotentRequest {
+  key: string;
+  status: "processing" | "completed" | "failed";
+  response?: any;
+  error?: string;
+  createdAt: number;
+  completedAt?: number;
+}
+
+class IdempotencyService {
+  private redis: Redis;
+  private ttl = 86400; // 24 hours
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl);
+  }
+
+  async getRequest(key: string): Promise<IdempotentRequest | null> {
+    const data = await this.redis.get(`idempotency:${key}`);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async setRequest(key: string, request: IdempotentRequest): Promise<void> {
+    await this.redis.setex(
+      `idempotency:${key}`,
+      this.ttl,
+      JSON.stringify(request),
+    );
+  }
+
+  async startProcessing(key: string): Promise<boolean> {
+    const request: IdempotentRequest = {
+      key,
+      status: "processing",
+      createdAt: Date.now(),
+    };
+
+    // Use SET NX to ensure only one request processes
+    const result = await this.redis.set(
+      `idempotency:${key}`,
+      JSON.stringify(request),
+      "EX",
+      this.ttl,
+      "NX",
+    );
+
+    return result === "OK";
+  }
+
+  async completeRequest(key: string, response: any): Promise<void> {
+    const request: IdempotentRequest = {
+      key,
+      status: "completed",
+      response,
+      createdAt: Date.now(),
+      completedAt: Date.now(),
+    };
+
+    await this.setRequest(key, request);
+  }
+
+  async failRequest(key: string, error: string): Promise<void> {
+    const request: IdempotentRequest = {
+      key,
+      status: "failed",
+      error,
+      createdAt: Date.now(),
+      completedAt: Date.now(),
+    };
+
+    await this.setRequest(key, request);
+  }
+}
+
+function idempotencyMiddleware(idempotency: IdempotencyService) {
+  return async (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    // Only apply to POST, PUT, PATCH, DELETE
+    if (!["POST", "PUT", "PATCH", "DELETE"].includes(req.method)) {
+      return next();
+    }
+
+    const idempotencyKey = req.headers["idempotency-key"] as string;
+
+    if (!idempotencyKey) {
+      return res.status(400).json({
+        error: "Idempotency-Key header required",
+      });
+    }
+
+    // Check for existing request
+    const existing = await idempotency.getRequest(idempotencyKey);
+
+    if (existing) {
+      if (existing.status === "processing") {
+        return res.status(409).json({
+          error: "Request already processing",
+          message: "Please wait and retry",
+        });
+      }
+
+      if (existing.status === "completed") {
+        return res.status(200).json(existing.response);
+      }
+
+      if (existing.status === "failed") {
+        return res.status(500).json({
+          error: "Previous request failed",
+          message: existing.error,
+        });
+      }
+    }
+
+    // Start processing
+    const canProcess = await idempotency.startProcessing(idempotencyKey);
+
+    if (!canProcess) {
+      return res.status(409).json({
+        error: "Request already processing",
+      });
+    }
+
+    // Capture response
+    const originalSend = res.json.bind(res);
+    res.json = (body: any) => {
+      // Save response for future requests
+      idempotency.completeRequest(idempotencyKey, body).catch(console.error);
+      return originalSend(body);
+    };
+
+    // Handle errors
+    const originalNext = next;
+    next = (err?: any) => {
+      if (err) {
+        idempotency
+          .failRequest(idempotencyKey, err.message)
+          .catch(console.error);
+      }
+      return originalNext(err);
+    };
+
+    next();
+  };
+}
+
+// Usage
+const app = express();
+const redis = new Redis("redis://localhost:6379");
+const idempotency = new IdempotencyService("redis://localhost:6379");
+
+app.use(express.json());
+app.use(idempotencyMiddleware(idempotency));
+
+app.post("/api/payments", async (req, res) => {
+  const { amount, userId } = req.body;
+
+  // Process payment
+  const payment = await processPayment(amount, userId);
+
+  res.json(payment);
+});
+
+async function processPayment(amount: number, userId: string) {
+  // Payment processing logic
+  return {
+    id: crypto.randomUUID(),
+    amount,
+    userId,
+    status: "completed",
+  };
+}
+
+app.listen(3000);
+```

--- a/docs/ai/skills/idempotency-handling/references/message-queue-idempotency.md
+++ b/docs/ai/skills/idempotency-handling/references/message-queue-idempotency.md
@@ -1,0 +1,110 @@
+# Message Queue Idempotency
+
+## Message Queue Idempotency
+
+```typescript
+interface Message {
+  id: string;
+  data: any;
+  timestamp: number;
+}
+
+class IdempotentMessageProcessor {
+  private processedMessages = new Set<string>();
+  private db: Pool;
+
+  constructor(db: Pool) {
+    this.db = db;
+    this.loadProcessedMessages();
+  }
+
+  private async loadProcessedMessages(): Promise<void> {
+    // Load recent processed message IDs
+    const result = await this.db.query(`
+      SELECT message_id
+      FROM processed_messages
+      WHERE processed_at > NOW() - INTERVAL '24 hours'
+    `);
+
+    result.rows.forEach((row) => {
+      this.processedMessages.add(row.message_id);
+    });
+  }
+
+  async processMessage(message: Message): Promise<void> {
+    // Check if already processed
+    if (this.processedMessages.has(message.id)) {
+      console.log(`Message ${message.id} already processed, skipping`);
+      return;
+    }
+
+    // Mark as processing (atomic operation)
+    const wasInserted = await this.markAsProcessing(message.id);
+
+    if (!wasInserted) {
+      console.log(`Message ${message.id} already being processed`);
+      return;
+    }
+
+    try {
+      // Process message
+      await this.handleMessage(message);
+
+      // Mark as completed
+      await this.markAsCompleted(message.id);
+
+      this.processedMessages.add(message.id);
+    } catch (error) {
+      console.error(`Failed to process message ${message.id}:`, error);
+      await this.markAsFailed(message.id, (error as Error).message);
+      throw error;
+    }
+  }
+
+  private async markAsProcessing(messageId: string): Promise<boolean> {
+    try {
+      await this.db.query(
+        `
+        INSERT INTO processed_messages (message_id, status, processed_at)
+        VALUES ($1, 'processing', NOW())
+      `,
+        [messageId],
+      );
+
+      return true;
+    } catch (error: any) {
+      if (error.code === "23505") {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private async markAsCompleted(messageId: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE processed_messages
+      SET status = 'completed', completed_at = NOW()
+      WHERE message_id = $1
+    `,
+      [messageId],
+    );
+  }
+
+  private async markAsFailed(messageId: string, error: string): Promise<void> {
+    await this.db.query(
+      `
+      UPDATE processed_messages
+      SET status = 'failed', error = $2, completed_at = NOW()
+      WHERE message_id = $1
+    `,
+      [messageId, error],
+    );
+  }
+
+  private async handleMessage(message: Message): Promise<void> {
+    // Actual message processing logic
+    console.log("Processing message:", message);
+  }
+}
+```

--- a/docs/ai/skills/idempotency-handling/references/stripe-style-idempotency.md
+++ b/docs/ai/skills/idempotency-handling/references/stripe-style-idempotency.md
@@ -1,0 +1,200 @@
+# Stripe-Style Idempotency
+
+## Stripe-Style Idempotency
+
+```python
+import hashlib
+import json
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+import psycopg2
+
+class IdempotencyManager:
+    def __init__(self, db_connection):
+        self.db = db_connection
+        self.ttl_days = 1
+
+    def process_request(
+        self,
+        idempotency_key: str,
+        request_data: Dict[str, Any],
+        process_fn: callable
+    ) -> Dict[str, Any]:
+        """
+        Process request with idempotency guarantee.
+
+        Args:
+            idempotency_key: Unique key for this request
+            request_data: Request payload
+            process_fn: Function to process the request
+
+        Returns:
+            Response data
+        """
+        # Check for existing request
+        existing = self.get_existing_request(
+            idempotency_key,
+            request_data
+        )
+
+        if existing:
+            if existing['status'] == 'processing':
+                raise ConflictError('Request already processing')
+
+            if existing['status'] == 'completed':
+                return existing['response']
+
+            if existing['status'] == 'failed':
+                raise ProcessingError(existing['error'])
+
+        # Start processing
+        if not self.start_processing(idempotency_key, request_data):
+            raise ConflictError('Request already processing')
+
+        try:
+            # Process request
+            result = process_fn(request_data)
+
+            # Store result
+            self.complete_request(idempotency_key, result)
+
+            return result
+
+        except Exception as e:
+            # Store error
+            self.fail_request(idempotency_key, str(e))
+            raise
+
+    def get_existing_request(
+        self,
+        key: str,
+        request_data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Get existing idempotent request."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            SELECT status, response, error, request_hash
+            FROM idempotency_requests
+            WHERE idempotency_key = %s
+            AND created_at > %s
+        """, (key, datetime.now() - timedelta(days=self.ttl_days)))
+
+        row = cursor.fetchone()
+        cursor.close()
+
+        if not row:
+            return None
+
+        # Verify request data matches
+        request_hash = self.hash_request(request_data)
+        if row[3] != request_hash:
+            raise ValueError(
+                'Request data does not match idempotency key'
+            )
+
+        return {
+            'status': row[0],
+            'response': row[1],
+            'error': row[2]
+        }
+
+    def start_processing(
+        self,
+        key: str,
+        request_data: Dict[str, Any]
+    ) -> bool:
+        """Mark request as processing."""
+        cursor = self.db.cursor()
+        request_hash = self.hash_request(request_data)
+
+        try:
+            cursor.execute("""
+                INSERT INTO idempotency_requests
+                (idempotency_key, request_hash, status, created_at)
+                VALUES (%s, %s, 'processing', NOW())
+            """, (key, request_hash))
+
+            self.db.commit()
+            cursor.close()
+            return True
+
+        except psycopg2.IntegrityError:
+            self.db.rollback()
+            cursor.close()
+            return False
+
+    def complete_request(
+        self,
+        key: str,
+        response: Dict[str, Any]
+    ):
+        """Mark request as completed."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            UPDATE idempotency_requests
+            SET
+                status = 'completed',
+                response = %s,
+                completed_at = NOW()
+            WHERE idempotency_key = %s
+        """, (json.dumps(response), key))
+
+        self.db.commit()
+        cursor.close()
+
+    def fail_request(self, key: str, error: str):
+        """Mark request as failed."""
+        cursor = self.db.cursor()
+
+        cursor.execute("""
+            UPDATE idempotency_requests
+            SET
+                status = 'failed',
+                error = %s,
+                completed_at = NOW()
+            WHERE idempotency_key = %s
+        """, (error, key))
+
+        self.db.commit()
+        cursor.close()
+
+    def hash_request(self, data: Dict[str, Any]) -> str:
+        """Create hash of request data."""
+        json_str = json.dumps(data, sort_keys=True)
+        return hashlib.sha256(json_str.encode()).hexdigest()
+
+
+class ConflictError(Exception):
+    pass
+
+
+class ProcessingError(Exception):
+    pass
+
+
+# Usage
+def process_payment(data):
+    # Process payment logic
+    return {
+        'payment_id': 'pay_123',
+        'amount': data['amount'],
+        'status': 'completed'
+    }
+
+# In your API handler
+idempotency = IdempotencyManager(db_connection)
+
+try:
+    result = idempotency.process_request(
+        idempotency_key='key_abc123',
+        request_data={'amount': 100, 'currency': 'USD'},
+        process_fn=process_payment
+    )
+    print(result)
+except ConflictError as e:
+    print(f"Conflict: {e}")
+except ProcessingError as e:
+    print(f"Processing error: {e}")
+```

--- a/docs/ai/skills/idempotency-handling/references/upstream.md
+++ b/docs/ai/skills/idempotency-handling/references/upstream.md
@@ -1,0 +1,25 @@
+---
+source_name: aj-geddes/useful-ai-prompts (idempotency-handling)
+source_url: https://github.com/aj-geddes/useful-ai-prompts
+source_type: github
+upstream_path: skills/idempotency-handling/SKILL.md
+skills_lock_hash: 282a4585f756e098318a3d778e7480cb61e90617c290b79d2fd206845e7f82b6
+last_reviewed: 2026-05-29
+---
+
+# Upstream: idempotency-handling
+
+Canonical copy in this repo: `docs/ai/skills/idempotency-handling/` (mirrored to `.cursor/skills/` and `.agents/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/aj-geddes/useful-ai-prompts
+- **Upstream path:** `skills/idempotency-handling/SKILL.md`
+- **Install via Skills CLI:** `npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y`
+
+## Refresh from ecosystem
+
+1. `npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y` updates `.agents/skills/idempotency-handling/` and `skills-lock.json`.
+2. Copy the skill tree into `docs/ai/skills/idempotency-handling/` if the canonical copy needs updating.
+3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+
+This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/docs/ai/skills/idempotency-handling/scripts/validate-api.sh
+++ b/docs/ai/skills/idempotency-handling/scripts/validate-api.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# validate-api.sh - Validate API specification
+# Usage: ./validate-api.sh <openapi_spec>
+
+set -euo pipefail
+
+SPEC_FILE="${{1:?Usage: $0 <openapi_spec>}}"
+
+echo "Validating API spec: $SPEC_FILE"
+
+# TODO: Add API validation
+# - Validate OpenAPI/Swagger syntax
+# - Check endpoint naming conventions
+# - Verify response schemas
+# - Check for required headers
+# - Validate authentication definitions
+
+echo "API validation complete."

--- a/docs/ai/skills/idempotency-handling/scripts/validate-api.sh
+++ b/docs/ai/skills/idempotency-handling/scripts/validate-api.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-SPEC_FILE="${{1:?Usage: $0 <openapi_spec>}}"
+SPEC_FILE="${1:?Usage: $0 <openapi_spec>}"
 
 echo "Validating API spec: $SPEC_FILE"
 

--- a/docs/ai/skills/idempotency-handling/templates/api-scaffold.yaml
+++ b/docs/ai/skills/idempotency-handling/templates/api-scaffold.yaml
@@ -1,0 +1,22 @@
+# API Endpoint Scaffold
+# TODO: Customize for your API framework
+
+openapi: "3.0.3"
+info:
+  title: "API Service"
+  version: "1.0.0"
+
+paths:
+  /api/v1/resource:
+    get:
+      summary: "List resources"
+      # TODO: Define parameters and responses
+      responses:
+        "200":
+          description: "Success"
+    post:
+      summary: "Create resource"
+      # TODO: Define request body and responses
+      responses:
+        "201":
+          description: "Created"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -73,6 +73,12 @@
       "skillPath": "skills/productivity/handoff/SKILL.md",
       "computedHash": "3fdffd9dce6fc3e9f9f756ba79d694c5f162e11c7e7fbc72a0958f204312e0b1"
     },
+    "idempotency-handling": {
+      "source": "aj-geddes/useful-ai-prompts",
+      "sourceType": "github",
+      "skillPath": "skills/idempotency-handling/SKILL.md",
+      "computedHash": "282a4585f756e098318a3d778e7480cb61e90617c290b79d2fd206845e7f82b6"
+    },
     "improve-codebase-architecture": {
       "source": "mattpocock/skills",
       "sourceType": "github",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **`idempotency-handling`** skill from [`aj-geddes/useful-ai-prompts`](https://github.com/aj-geddes/useful-ai-prompts) using this repo’s canonical skills workflow.

## Changes

- **Canonical:** `docs/ai/skills/idempotency-handling/` (SKILL.md, references, scripts, templates)
- **Upstream doc:** `docs/ai/skills/idempotency-handling/references/upstream.md` (refresh steps; not in `skills:refresh-upstream`)
- **Pin:** `skills-lock.json` entry for `idempotency-handling`
- **Mirrors:** synced to `.agents/skills/` and `.cursor/skills/` via `skills:sync`
- **Routing:** `AGENTS.md` vendored-skill note + skill routing bullet
- **Repo overlay:** SKILL.md “This repository” section points to `packages/api/src/donate/idempotency.ts` and subordinates to backend/data-access rules

## Verification

```bash
bun run skills:sync
bun run skills:verify
```

Both pass on this branch.

## Refresh (contributors)

```bash
npx skills add https://github.com/aj-geddes/useful-ai-prompts --skill idempotency-handling -y
# reconcile into docs/ai/skills/idempotency-handling/ if needed
bun run skills:sync && bun run skills:verify
```

See `docs/ai/skills/idempotency-handling/references/upstream.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20d5892e-537f-4860-a06e-b841f7703372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d5892e-537f-4860-a06e-b841f7703372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR vendors the `idempotency-handling` skill from `aj-geddes/useful-ai-prompts` into the repo's canonical skill system, following the same pattern used by other vendored skills (Payload CMS, resend-cli, bendc-frontend-guidelines, etc.).

- **Canonical skill** added under `docs/ai/skills/idempotency-handling/` with a repo-specific \"This repository\" section pointing at the real touchpoint `packages/api/src/donate/idempotency.ts`; properly subordinated to `docs/ai/rules/backend.md`.
- **`skills-lock.json`** entry added in alphabetical order with correct source, type, and content hash; **AGENTS.md** updated with both a vendored-skill vendor note and a deterministic skill-routing bullet referencing the same canonical path.
- **Mirrors** synced to `.agents/skills/` and `.cursor/skills/` via `bun run skills:sync`; `.repo-canonical-skills.json` updated in both mirror locations.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are documentation and skill tooling only with no runtime code paths affected.

The vendoring workflow is correctly executed — lockfile hash, AGENTS.md routing, canonical docs, and both mirror locations are all consistent. The only rough edge is the validate-api.sh stub, which captures its argument but never uses it and always exits successfully, so any agent that invokes it expecting a real gate will get a false positive.

docs/ai/skills/idempotency-handling/scripts/validate-api.sh (and its two mirror copies) — the validation body is entirely unimplemented.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/ai/skills/idempotency-handling/SKILL.md | Canonical skill SKILL.md; correctly adds a repo-specific "This repository" section referencing the real touchpoint at packages/api/src/donate/idempotency.ts and subordinating to backend rules. |
| docs/ai/skills/idempotency-handling/scripts/validate-api.sh | Stub script that always exits 0 and prints "API validation complete." — SPEC_FILE argument is captured but never actually used for validation; misleads any agent that runs it. |
| skills-lock.json | Adds idempotency-handling entry with correct source, sourceType, skillPath, and computedHash; insertion follows lockfile alphabetical ordering. |
| AGENTS.md | Adds a vendored-skill vendor note and a skill routing bullet; both entries correctly reference the canonical path and the real repo touchpoint. Referenced idempotency.ts file was verified to exist. |
| docs/ai/skills/idempotency-handling/templates/api-scaffold.yaml | Minimal OpenAPI 3.0.3 scaffold template with TODO placeholders; appropriate for a skill template. |
| docs/ai/skills/idempotency-handling/references/upstream.md | Correctly records upstream source, hash, last_reviewed date, and refresh steps; explicitly marks the skill as not updated by skills:refresh-upstream, consistent with other vendored skills. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[aj-geddes/useful-ai-prompts\nskills/idempotency-handling/] -->|npx skills add| B[skills-lock.json\ncomputedHash pinned]
    B --> C[docs/ai/skills/idempotency-handling/\nCANONICAL]
    C -->|bun run skills:sync| D[.agents/skills/idempotency-handling/]
    C -->|bun run skills:sync| E[.cursor/skills/idempotency-handling/]
    C --> F[AGENTS.md\nvendor note + routing bullet]
    C --> G[packages/api/src/donate/idempotency.ts\nrepo touchpoint referenced in SKILL.md]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(idempotency): correct validate-api p..."](https://github.com/asymmetric-al/core/commit/12e2353e6b4d5e190a1b814cef9426524f29bbb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34616612)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->