### PR TITLE
docs(agents): cloud VM dev env caveats for Bun and donor dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,6 +474,25 @@ bun run dev:mission-control
 
 Then open `http://localhost:3030`. The setup command only writes gitignored `.env.local` defaults (`SKIP_ENV_VALIDATION=1`, `E2E_AUTH_BYPASS=true`, placeholder public Supabase values, `PAYLOAD_SECRET`, and admin Playwright URL/port). Existing explicit `E2E_AUTH_BYPASS=false` values are preserved unless you pass `--force-bypass`. Replace placeholders with real Supabase/demo-account values before testing live auth, hosted data, Payload/CMS, or database-backed admin workflows.
 
+If `bun install` fails on `@asym/pdf-renderer` (`ENOENT` extracting the vendor tarball), run `bun run setup:mission-control:cloud --skip-install` after fixing the package manually (see **Bun install workaround** below).
+
+### Bun install workaround (`@asym/pdf-renderer`)
+
+On some Cloud Agent VMs, `bun install` exits non-zero when extracting `@asym/pdf-renderer` from `vendor/react-pdf-packages/asym-pdf-renderer-0.0.0.tgz` even though the tarball exists. If `node_modules/@asym/pdf-renderer/package.json` is missing after install:
+
+```bash
+rm -rf node_modules/@asym/pdf-renderer
+mkdir -p node_modules/@asym/pdf-renderer
+tar -xzf vendor/react-pdf-packages/asym-pdf-renderer-0.0.0.tgz -C node_modules/@asym/pdf-renderer --strip-components=1
+```
+
+Then rerun checks (`bun run lint`, `bun run typecheck`, `bun run test:unit`). The VM startup update script applies the same extract when needed.
+
+### Dev server env injection
+
+- **Mission Control / admin E2E builds:** `bun run dev:mission-control` wraps `dev:admin` with `scripts/run-with-ci-env.mjs`, which injects cloud/CI defaults even when `.env.local` is not exported into the shell.
+- **Donor (and missionary) via plain Turbo:** `bun run dev:donor` does **not** use that wrapper. If the app returns 500 with `Invalid environment variables`, either export root `.env.local` before starting (`set -a && source .env.local && set +a && bun run dev:donor`), use `bun run dev:all` (loads `--env-file=.env.local`), or symlink `.env.local` into `apps/donor/` (see **Environment variables**).
+
 ### Local Supabase startup
 
 Docker and Supabase CLI must be installed and running before starting local Supabase. After Docker is running (`sudo dockerd &`), run `supabase start` from the repo root.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents Cursor Cloud / VM setup gotchas discovered during dev environment setup so future agents can start services without guesswork.

## Changes

- **`AGENTS.md`** — adds under **Cursor Cloud specific instructions**:
  - `@asym/pdf-renderer` manual tarball extract workaround when `bun install` fails on that package
  - Dev server env injection: `dev:mission-control` uses `run-with-ci-env.mjs`; `dev:donor` / `dev:all` need sourced `.env.local` or app symlinks

## Verification

- Pre-push `ci:preflight` passed on push (format, skills:verify, lint, typecheck, admin/donor/missionary builds, 1100 unit tests)
- No application code changes

## Deploy Checklist (for PRs to `epic` or `develop`)

- [x] CI passes (local pre-push preflight)
- [x] Base branch confirmed: docs-only change targeting `production`
- [x] Migrations reviewed (N/A)
- [x] Migrations tested on staging (N/A)
- [x] New env vars added to all 3 Vercel projects (N/A)
- [x] Rollback plan reviewed (revert doc commit)
- [x] Production release will use `bun run release:production` (N/A)
- [x] Post-deploy smoke tests planned (N/A)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dab7fea3-7254-4cb0-a137-24412f219077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dab7fea3-7254-4cb0-a137-24412f219077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

