### PR TITLE
Add PR signal coordinator

### DIFF
--- a/.agents/skills/idempotency-handling/SKILL.md
+++ b/.agents/skills/idempotency-handling/SKILL.md
@@ -80,12 +80,12 @@ class IdempotencyService {
 
 Detailed implementations in the `references/` directory:
 
-| Guide | Contents |
-|---|---|
+| Guide                                                                          | Contents                       |
+| ------------------------------------------------------------------------------ | ------------------------------ |
 | [Express Idempotency Middleware](references/express-idempotency-middleware.md) | Express Idempotency Middleware |
-| [Database-Based Idempotency](references/database-based-idempotency.md) | Database-Based Idempotency |
-| [Stripe-Style Idempotency](references/stripe-style-idempotency.md) | Stripe-Style Idempotency |
-| [Message Queue Idempotency](references/message-queue-idempotency.md) | Message Queue Idempotency |
+| [Database-Based Idempotency](references/database-based-idempotency.md)         | Database-Based Idempotency     |
+| [Stripe-Style Idempotency](references/stripe-style-idempotency.md)             | Stripe-Style Idempotency       |
+| [Message Queue Idempotency](references/message-queue-idempotency.md)           | Message Queue Idempotency      |
 
 ## Best Practices
 

--- a/.cursor/skills/idempotency-handling/SKILL.md
+++ b/.cursor/skills/idempotency-handling/SKILL.md
@@ -80,12 +80,12 @@ class IdempotencyService {
 
 Detailed implementations in the `references/` directory:
 
-| Guide | Contents |
-|---|---|
+| Guide                                                                          | Contents                       |
+| ------------------------------------------------------------------------------ | ------------------------------ |
 | [Express Idempotency Middleware](references/express-idempotency-middleware.md) | Express Idempotency Middleware |
-| [Database-Based Idempotency](references/database-based-idempotency.md) | Database-Based Idempotency |
-| [Stripe-Style Idempotency](references/stripe-style-idempotency.md) | Stripe-Style Idempotency |
-| [Message Queue Idempotency](references/message-queue-idempotency.md) | Message Queue Idempotency |
+| [Database-Based Idempotency](references/database-based-idempotency.md)         | Database-Based Idempotency     |
+| [Stripe-Style Idempotency](references/stripe-style-idempotency.md)             | Stripe-Style Idempotency       |
+| [Message Queue Idempotency](references/message-queue-idempotency.md)           | Message Queue Idempotency      |
 
 ## Best Practices
 

--- a/.github/workflows/greptile-trigger-codex-review.yml
+++ b/.github/workflows/greptile-trigger-codex-review.yml
@@ -1,6 +1,8 @@
 name: Greptile Trigger Codex Review
 
 on:
+  check_run:
+    types: [completed]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-signal-coordinator.yml
+++ b/.github/workflows/pr-signal-coordinator.yml
@@ -1,0 +1,71 @@
+name: PR Signal Coordinator
+
+on:
+  pull_request:
+    branches: [develop, production]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  check_run:
+    types: [completed]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional pull request number to reconcile"
+        required: false
+        type: number
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  reconcile:
+    if: github.event_name != 'check_run' || github.event.check_run.pull_requests[0].number != null
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Reconcile PR automation labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
+          EVENT_LABEL_NAME: ${{ github.event.label.name || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.check_run.pull_requests[0].number || '' }}
+          PR_SIGNAL_GRACE_MINUTES: "20"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          args=(
+            --repo "${GITHUB_REPOSITORY}"
+            --event-name "${EVENT_NAME}"
+            --event-action "${EVENT_ACTION}"
+            --event-label "${EVENT_LABEL_NAME}"
+            --grace-minutes "${PR_SIGNAL_GRACE_MINUTES}"
+          )
+
+          pr_number="${INPUT_PR_NUMBER:-${EVENT_PR_NUMBER:-}}"
+
+          if [[ -n "${pr_number}" ]]; then
+            args+=(--pr-number "${pr_number}")
+          elif [[ "${EVENT_NAME}" == "schedule" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            args+=(--all-open)
+          else
+            echo "No pull request number is associated with this event; skipping."
+            exit 0
+          fi
+
+          node scripts/github/pr-signal-coordinator.mjs "${args[@]}"

--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -1,0 +1,49 @@
+name: Release Source Gate
+
+on:
+  pull_request:
+    branches: [production]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  push:
+    branches: [production]
+
+permissions:
+  contents: read
+
+jobs:
+  release-source-gate:
+    name: release-source-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require develop as production release source
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+            echo "Non-PR production branch event accepted."
+            exit 0
+          fi
+
+          if [[ "${BASE_REF}" != "production" ]]; then
+            echo "::error::release-source-gate only validates production PRs targeting production."
+            exit 1
+          fi
+
+          if [[ "${HEAD_REF}" != "develop" ]]; then
+            echo "::error::Production release PRs to production must come from develop; got ${HEAD_REF}."
+            exit 1
+          fi
+
+          if [[ "${HEAD_REPO}" != "${REPOSITORY}" ]]; then
+            echo "::error::Production release PRs to production must come from develop in ${REPOSITORY}; got ${HEAD_REPO}."
+            exit 1
+          fi
+
+          echo "Production release source accepted: ${HEAD_REPO}:${HEAD_REF} -> ${BASE_REF}."

--- a/docs/ai/rules/general.md
+++ b/docs/ai/rules/general.md
@@ -26,6 +26,27 @@ Use this as the default rulebook for any repo change or AL-### issue workflow.
 
 **Rule:** Exactly one label from each category. Do not mix multiple labels from the same category.
 
+### PR automation labels
+
+`automation:*` labels are machine-owned PR orchestration labels, not part of the
+issue taxonomy above. The PR Signal Coordinator owns these labels and may add or
+remove them when CI, review-bot, and security signals change:
+
+- `automation:signals-pending`
+- `automation:ci-settled`
+- `automation:ci-failed`
+- `automation:greptile-settled`
+- `automation:bugbot-settled`
+- `automation:security-settled`
+- `automation:security-failed`
+- `automation:review-findings`
+- `automation:signal-timeout`
+- `automation:pr-intake-ready`
+
+Do not manually maintain these labels except for emergency reruns or cleanup.
+`automation:pr-intake-ready` means the PR is ready for a settled intake snapshot;
+it does **not** mean the PR is ready to merge.
+
 ### CI gates (must pass before merge)
 
 - `bun run format:check`

--- a/docs/ai/skills/idempotency-handling/SKILL.md
+++ b/docs/ai/skills/idempotency-handling/SKILL.md
@@ -80,12 +80,12 @@ class IdempotencyService {
 
 Detailed implementations in the `references/` directory:
 
-| Guide | Contents |
-|---|---|
+| Guide                                                                          | Contents                       |
+| ------------------------------------------------------------------------------ | ------------------------------ |
 | [Express Idempotency Middleware](references/express-idempotency-middleware.md) | Express Idempotency Middleware |
-| [Database-Based Idempotency](references/database-based-idempotency.md) | Database-Based Idempotency |
-| [Stripe-Style Idempotency](references/stripe-style-idempotency.md) | Stripe-Style Idempotency |
-| [Message Queue Idempotency](references/message-queue-idempotency.md) | Message Queue Idempotency |
+| [Database-Based Idempotency](references/database-based-idempotency.md)         | Database-Based Idempotency     |
+| [Stripe-Style Idempotency](references/stripe-style-idempotency.md)             | Stripe-Style Idempotency       |
+| [Message Queue Idempotency](references/message-queue-idempotency.md)           | Message Queue Idempotency      |
 
 ## Best Practices
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,12 +3,16 @@
 ## Overview
 
 Two workflow files run on every PR to `develop` and `production`, and on every push to
-`develop` and `production`:
+`develop` and `production`. A third production-only workflow validates that
+release PRs into `production` come from `develop`. A fourth workflow coordinates
+PR automation labels after CI, review-bot, and security signals settle:
 
-| Workflow          | File                                   | Branches                                | Jobs                                            | Target time               |
-| ----------------- | -------------------------------------- | --------------------------------------- | ----------------------------------------------- | ------------------------- |
-| Fast checks       | `.github/workflows/ci.yml`             | PRs + pushes on `develop`, `production` | `format → lint → typecheck → build → test-unit` | < 4 min with remote cache |
-| Integration + E2E | `.github/workflows/ci-integration.yml` | PRs + pushes on `develop`, `production` | `migrate → smoke → test-e2e-smoke → test-e2e`   | ~5–25 min                 |
+| Workflow              | File                                          | Branches                                | Jobs                                            | Target time               |
+| --------------------- | --------------------------------------------- | --------------------------------------- | ----------------------------------------------- | ------------------------- |
+| Fast checks           | `.github/workflows/ci.yml`                    | PRs + pushes on `develop`, `production` | `format → lint → typecheck → build → test-unit` | < 4 min with remote cache |
+| Integration + E2E     | `.github/workflows/ci-integration.yml`        | PRs + pushes on `develop`, `production` | `migrate → smoke → test-e2e-smoke → test-e2e`   | ~5–25 min                 |
+| Release source        | `.github/workflows/release-source.yml`        | PRs to `production`                     | `release-source-gate`                           | < 1 min                   |
+| PR signal coordinator | `.github/workflows/pr-signal-coordinator.yml` | PR events + check/review/comment events | automation label reconciliation                 | < 1 min                   |
 
 Current workflow semantics:
 
@@ -17,10 +21,64 @@ Current workflow semantics:
 - `test-e2e-smoke` is **blocking on `develop`** through `e2e-smoke-gate` and `integration-gate`.
 - `test-e2e` is **informational on `develop`** (`continue-on-error: true` there).
 - `test-e2e` is enforced on `production` through the workflow's `e2e-gate`, and
-  branch protection must require `ci-gate`, `integration-gate`, and `e2e-gate`
-  before production release PRs can merge.
+  branch protection must require `release-source-gate`, `ci-gate`,
+  `integration-gate`, and `e2e-gate` before production release PRs can merge.
+- `release-source-gate` blocks production PRs to `production` unless the source branch
+  is `develop` in this repository.
+- `pr-signal-coordinator.yml` never checks out PR head code and never uses
+  `pull_request_target`. It only reads GitHub metadata from the trusted workflow
+  checkout and reconciles `automation:*` labels.
 - `main` is retired and protected historical history; active workflows do not
   treat it as staging or production.
+
+## PR signal coordinator
+
+`scripts/github/pr-signal-coordinator.mjs` is the source of truth for
+automation label decisions. The workflow runs on PR updates, completed check
+runs, review events, issue comments, a 10-minute schedule, and manual dispatch.
+
+Machine-owned labels:
+
+- `automation:signals-pending` — waiting for prerequisite PR automation signals.
+- `automation:ci-settled` — required checks reached terminal state.
+- `automation:ci-failed` — at least one required check failed.
+- `automation:greptile-settled` — Greptile signal settled or timed out.
+- `automation:bugbot-settled` — Cursor Bugbot signal settled or timed out.
+- `automation:security-settled` — Cursor Security Reviewer settled or timed out.
+- `automation:security-failed` — security reviewer failed, found issues, or timed out.
+- `automation:review-findings` — Greptile or Bugbot findings are present.
+- `automation:signal-timeout` — an expected bot signal did not arrive in time.
+- `automation:pr-intake-ready` — all prerequisite signals are terminal and the
+  Cursor PR Intake Coordinator may run.
+
+Required checks:
+
+- `develop`: `ci-gate`, `integration-gate`
+- `production`: `release-source-gate`, `ci-gate`, `integration-gate`, `e2e-gate`
+
+On `opened`, `reopened`, `synchronize`, and `ready_for_review`, the coordinator
+removes stale `automation:*` labels and reapplies `automation:signals-pending`.
+The default missing-signal grace window is 20 minutes. Missing Greptile or
+Bugbot marks the signal settled plus `automation:signal-timeout`; missing Cursor
+Security also applies `automation:security-failed`.
+
+Debug locally with a dry run:
+
+```bash
+node scripts/github/pr-signal-coordinator.mjs \
+  --repo Asymmetric-al/core \
+  --pr-number <number> \
+  --dry-run \
+  --json
+```
+
+To create or refresh the GitHub labels without processing a PR:
+
+```bash
+node scripts/github/pr-signal-coordinator.mjs \
+  --repo Asymmetric-al/core \
+  --ensure-labels-only
+```
 
 ### Bun toolchain
 
@@ -250,7 +308,7 @@ The workflow files are the source of truth for execution. Branch protection shou
 ### Required checks by branch
 
 - `develop`: `ci-gate`, `integration-gate`, and `e2e-smoke-gate` are enforced; the full `CI Integration / test-e2e` job remains visible but intentionally non-blocking.
-- `production`: `ci-gate`, `integration-gate`, and `e2e-gate` are enforced; production release is handled by `bun run release:production`.
+- `production`: `release-source-gate`, `ci-gate`, `integration-gate`, and `e2e-gate` are enforced; production release is handled by `bun run release:production`.
 - `main`: retired/protected historical branch only; do not treat it as production or staging in this repo.
 
 ### GitHub branch rule guidance
@@ -258,7 +316,7 @@ The workflow files are the source of truth for execution. Branch protection shou
 1. Go to _Settings → Branches → Branch protection rules_.
 2. Keep rules for `production` and `develop`.
 3. Enable **Require status checks to pass before merging**.
-4. Require `ci-gate`, `integration-gate`, and `e2e-gate` on `production`.
+4. Require `release-source-gate`, `ci-gate`, `integration-gate`, and `e2e-gate` on `production`.
 5. Require `ci-gate`, `integration-gate`, and `e2e-smoke-gate` on `develop`.
 6. Disable force pushes on both branches.
 7. For `develop`, leave `CI Integration / test-e2e` optional if you want the current "signal, not blocker" behavior to remain intact.

--- a/scripts/github/pr-signal-coordinator.mjs
+++ b/scripts/github/pr-signal-coordinator.mjs
@@ -1,0 +1,847 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_REPO = "Asymmetric-al/core";
+const DEFAULT_GRACE_MINUTES = 20;
+const SUPPORTED_BASE_REFS = new Set(["develop", "production"]);
+
+export const AUTOMATION_LABELS = Object.freeze({
+  signalsPending: "automation:signals-pending",
+  ciSettled: "automation:ci-settled",
+  ciFailed: "automation:ci-failed",
+  greptileSettled: "automation:greptile-settled",
+  bugbotSettled: "automation:bugbot-settled",
+  securitySettled: "automation:security-settled",
+  securityFailed: "automation:security-failed",
+  reviewFindings: "automation:review-findings",
+  signalTimeout: "automation:signal-timeout",
+  prIntakeReady: "automation:pr-intake-ready",
+});
+
+export const AUTOMATION_LABEL_DEFINITIONS = Object.freeze([
+  {
+    name: AUTOMATION_LABELS.signalsPending,
+    color: "D97706",
+    description: "Waiting for PR automation prerequisite signals.",
+  },
+  {
+    name: AUTOMATION_LABELS.ciSettled,
+    color: "0E8A16",
+    description: "Required PR CI checks have reached a terminal state.",
+  },
+  {
+    name: AUTOMATION_LABELS.ciFailed,
+    color: "B60205",
+    description: "At least one required PR CI check failed.",
+  },
+  {
+    name: AUTOMATION_LABELS.greptileSettled,
+    color: "5319E7",
+    description: "Greptile review signal has settled or timed out.",
+  },
+  {
+    name: AUTOMATION_LABELS.bugbotSettled,
+    color: "5319E7",
+    description: "Cursor Bugbot signal has settled or timed out.",
+  },
+  {
+    name: AUTOMATION_LABELS.securitySettled,
+    color: "0366D6",
+    description: "Cursor Security Reviewer signal has settled or timed out.",
+  },
+  {
+    name: AUTOMATION_LABELS.securityFailed,
+    color: "B60205",
+    description: "Security reviewer failed, found issues, or timed out.",
+  },
+  {
+    name: AUTOMATION_LABELS.reviewFindings,
+    color: "FBCA04",
+    description: "Automated review findings are present.",
+  },
+  {
+    name: AUTOMATION_LABELS.signalTimeout,
+    color: "D93F0B",
+    description: "An expected PR automation signal timed out.",
+  },
+  {
+    name: AUTOMATION_LABELS.prIntakeReady,
+    color: "0E8A16",
+    description: "Settled signals are ready for the PR Intake Coordinator.",
+  },
+]);
+
+const ALL_AUTOMATION_LABELS = Object.freeze(
+  AUTOMATION_LABEL_DEFINITIONS.map((label) => label.name),
+);
+
+const REQUIRED_CHECKS_BY_BASE = Object.freeze({
+  develop: Object.freeze(["ci-gate", "integration-gate"]),
+  production: Object.freeze([
+    "release-source-gate",
+    "ci-gate",
+    "integration-gate",
+    "e2e-gate",
+  ]),
+});
+
+const RESET_EVENTS = new Set([
+  "opened",
+  "reopened",
+  "synchronize",
+  "ready_for_review",
+]);
+
+export function requiredChecksForBase(baseRef) {
+  return [...(REQUIRED_CHECKS_BY_BASE[baseRef] ?? [])];
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function normalizeLabelSet(labels) {
+  return new Set(
+    labels
+      .map((label) => (typeof label === "string" ? label : label?.name))
+      .filter((label) => typeof label === "string" && label.length > 0),
+  );
+}
+
+function isResetEvent(context) {
+  return (
+    context.eventName === "pull_request" &&
+    RESET_EVENTS.has(context.eventAction)
+  );
+}
+
+function parseTime(value) {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function hasTimedOut({ now, signalStartedAt, graceMinutes }) {
+  const nowTimestamp = parseTime(now);
+  const signalTimestamp = parseTime(signalStartedAt);
+  const minutes =
+    typeof graceMinutes === "number" ? graceMinutes : DEFAULT_GRACE_MINUTES;
+
+  if (nowTimestamp === null || signalTimestamp === null) return false;
+
+  return nowTimestamp - signalTimestamp >= minutes * 60 * 1000;
+}
+
+function textFrom(value) {
+  if (!value) return "";
+
+  if (typeof value === "string") return value;
+
+  return [value.body, value.title, value.summary, value.text]
+    .filter((item) => typeof item === "string")
+    .join("\n");
+}
+
+function checkRunText(checkRun) {
+  return [checkRun?.name, textFrom(checkRun?.output)]
+    .filter((item) => typeof item === "string")
+    .join("\n");
+}
+
+function actorLogin(item) {
+  return item?.user?.login ?? item?.author?.login ?? "";
+}
+
+function itemTimestamp(item) {
+  return (
+    parseTime(item?.created_at) ??
+    parseTime(item?.createdAt) ??
+    parseTime(item?.submitted_at) ??
+    parseTime(item?.submittedAt) ??
+    parseTime(item?.updated_at) ??
+    parseTime(item?.updatedAt)
+  );
+}
+
+function isCurrentSignalItem(context, item) {
+  const signalTimestamp = parseTime(context.pr?.signalStartedAt);
+  const timestamp = itemTimestamp(item);
+
+  if (signalTimestamp === null || timestamp === null) return true;
+
+  return timestamp >= signalTimestamp;
+}
+
+function bodyTextItems(items) {
+  return items.map((item) => textFrom(item)).filter((body) => body.length > 0);
+}
+
+function collectBotItems(context, predicate) {
+  const allItems = [
+    ...(context.reviews ?? []),
+    ...(context.reviewComments ?? []),
+    ...(context.issueComments ?? []),
+  ];
+
+  return allItems.filter(
+    (item) =>
+      isCurrentSignalItem(context, item) &&
+      predicate(actorLogin(item), textFrom(item)),
+  );
+}
+
+function isIntakeSummaryBody(body) {
+  return (
+    body.includes("<!-- core-pr-intake-coordinator -->") ||
+    /no comments found by intake/i.test(body) ||
+    /PR Intake Snapshot/i.test(body)
+  );
+}
+
+function isCursorAutomationActor(login) {
+  return login.toLowerCase().includes("cursor");
+}
+
+function checkRunDate(checkRun) {
+  return (
+    parseTime(checkRun?.completedAt) ??
+    parseTime(checkRun?.completed_at) ??
+    parseTime(checkRun?.startedAt) ??
+    parseTime(checkRun?.started_at) ??
+    parseTime(checkRun?.updatedAt) ??
+    parseTime(checkRun?.updated_at) ??
+    0
+  );
+}
+
+function latestMatchingCheckRun(checkRuns, predicate) {
+  const matches = (checkRuns ?? []).filter(predicate);
+  if (matches.length === 0) return null;
+
+  return matches.reduce((latest, current) =>
+    checkRunDate(current) >= checkRunDate(latest) ? current : latest,
+  );
+}
+
+function checkName(checkRun) {
+  return String(checkRun?.name ?? "");
+}
+
+function checkAppName(checkRun) {
+  return String(checkRun?.app?.name ?? "");
+}
+
+function isCompleted(checkRun) {
+  return checkRun?.status === "completed" || checkRun?.status === "COMPLETED";
+}
+
+function evaluateRequiredChecks(context) {
+  const requiredChecks = requiredChecksForBase(context.pr?.baseRef);
+  const results = requiredChecks.map((name) => {
+    const checkRun = latestMatchingCheckRun(
+      context.checkRuns,
+      (candidate) => checkName(candidate) === name,
+    );
+
+    if (!checkRun || !isCompleted(checkRun)) {
+      return { name, state: "pending" };
+    }
+
+    if (
+      checkRun.conclusion === "success" ||
+      checkRun.conclusion === "SUCCESS"
+    ) {
+      return { name, state: "pass" };
+    }
+
+    return {
+      name,
+      state: "fail",
+      conclusion: checkRun.conclusion ?? "unknown",
+    };
+  });
+  const settled =
+    results.length > 0 && results.every((result) => result.state !== "pending");
+  const failed = settled && results.some((result) => result.state === "fail");
+
+  return { requiredChecks, results, settled, failed };
+}
+
+function evaluateGreptile(context, timedOut) {
+  const checkRun = latestMatchingCheckRun(context.checkRuns, (candidate) => {
+    const name = checkName(candidate).toLowerCase();
+    const app = checkAppName(candidate).toLowerCase();
+    return name.includes("greptile") || app.includes("greptile");
+  });
+  const botItems = collectBotItems(context, (login, body) => {
+    const normalizedLogin = login.toLowerCase();
+    return normalizedLogin.includes("greptile") && !isIntakeSummaryBody(body);
+  });
+  const bodies = bodyTextItems(botItems);
+  const observed = Boolean(checkRun) || botItems.length > 0;
+  const settled = observed || timedOut;
+  const hasInlineFinding = (context.reviewComments ?? []).some(
+    (item) =>
+      isCurrentSignalItem(context, item) &&
+      actorLogin(item).toLowerCase().includes("greptile"),
+  );
+  const findings =
+    hasInlineFinding ||
+    bodies.some((body) =>
+      /\b(P[0-3]|findings?\s+present|changes?\s+requested|safe\s+to\s+merge\s+after\s+fixing)\b/i.test(
+        body,
+      ),
+    );
+
+  return {
+    observed,
+    settled,
+    timedOut: !observed && timedOut,
+    findings,
+  };
+}
+
+function evaluateBugbot(context, timedOut) {
+  const checkRun = latestMatchingCheckRun(context.checkRuns, (candidate) =>
+    checkName(candidate).toLowerCase().includes("bugbot"),
+  );
+  const botItems = collectBotItems(
+    context,
+    (login, body) =>
+      isCursorAutomationActor(login) &&
+      /bugbot/i.test(body) &&
+      !isIntakeSummaryBody(body),
+  );
+  const bodies = bodyTextItems(botItems);
+  const observed = Boolean(checkRun) || botItems.length > 0;
+  const settled = observed || timedOut;
+  const findings =
+    (checkRun && checkRun.conclusion && checkRun.conclusion !== "success") ||
+    bodies.some((body) =>
+      /\b(P[0-3]|bug|finding|issue|regression|failure)\b/i.test(body),
+    );
+
+  return {
+    observed,
+    settled,
+    timedOut: !observed && timedOut,
+    findings: Boolean(findings),
+  };
+}
+
+function evaluateSecurity(context, timedOut) {
+  const checkRun = latestMatchingCheckRun(context.checkRuns, (candidate) => {
+    const name = checkName(candidate).toLowerCase();
+    return (
+      name.includes("cursor security") || name.includes("security reviewer")
+    );
+  });
+  const botItems = collectBotItems(
+    context,
+    (login, body) =>
+      isCursorAutomationActor(login) &&
+      /security reviewer|security review/i.test(body) &&
+      !isIntakeSummaryBody(body),
+  );
+  const bodies = bodyTextItems(botItems);
+  const observed = Boolean(checkRun) || botItems.length > 0;
+  const completed = !checkRun || isCompleted(checkRun);
+  const settled = (observed && completed) || timedOut;
+  const conclusion = String(checkRun?.conclusion ?? "").toLowerCase();
+  const runText = checkRunText(checkRun);
+  const failedToStart =
+    /failed to start|hard limit|unavailable|timed out|timeout/i.test(runText);
+  const findingText = [...bodies, runText].some((body) =>
+    /\b(P[0-3]|finding|vulnerability|injection|leak|secret|exploit)\b/i.test(
+      body,
+    ),
+  );
+  const failed =
+    (!observed && timedOut) ||
+    ["failure", "cancelled", "timed_out", "action_required"].includes(
+      conclusion,
+    ) ||
+    (conclusion === "neutral" && failedToStart) ||
+    findingText;
+
+  return {
+    observed,
+    settled,
+    timedOut: !observed && timedOut,
+    failed: Boolean(failed),
+  };
+}
+
+function diffLabels({ currentLabels, targetLabels }) {
+  const target = new Set(targetLabels);
+  const labelsToAdd = [...target].filter((label) => !currentLabels.has(label));
+  const labelsToRemove = ALL_AUTOMATION_LABELS.filter(
+    (label) => currentLabels.has(label) && !target.has(label),
+  );
+
+  return { labelsToAdd, labelsToRemove };
+}
+
+export function buildSignalDecision(context) {
+  const currentLabels = normalizeLabelSet(context.pr?.labels ?? []);
+
+  if (isResetEvent(context)) {
+    return {
+      readyForIntake: false,
+      targetLabels: [AUTOMATION_LABELS.signalsPending],
+      labelsToAdd: currentLabels.has(AUTOMATION_LABELS.signalsPending)
+        ? []
+        : [AUTOMATION_LABELS.signalsPending],
+      labelsToRemove: ALL_AUTOMATION_LABELS.filter(
+        (label) =>
+          label !== AUTOMATION_LABELS.signalsPending &&
+          currentLabels.has(label),
+      ),
+      ci: evaluateRequiredChecks(context),
+      greptile: {
+        observed: false,
+        settled: false,
+        timedOut: false,
+        findings: false,
+      },
+      bugbot: {
+        observed: false,
+        settled: false,
+        timedOut: false,
+        findings: false,
+      },
+      security: {
+        observed: false,
+        settled: false,
+        timedOut: false,
+        failed: false,
+      },
+      timedOut: false,
+      reason: "reset event",
+    };
+  }
+
+  const timedOut = hasTimedOut({
+    now: context.now,
+    signalStartedAt: context.pr?.signalStartedAt,
+    graceMinutes: context.graceMinutes,
+  });
+  const ci = evaluateRequiredChecks(context);
+  const greptile = evaluateGreptile(context, timedOut);
+  const bugbot = evaluateBugbot(context, timedOut);
+  const security = evaluateSecurity(context, timedOut);
+  const allSignalsSettled =
+    ci.settled && greptile.settled && bugbot.settled && security.settled;
+  const targetLabels = [];
+
+  if (!allSignalsSettled) {
+    targetLabels.push(AUTOMATION_LABELS.signalsPending);
+  }
+
+  if (ci.settled) targetLabels.push(AUTOMATION_LABELS.ciSettled);
+  if (ci.failed) targetLabels.push(AUTOMATION_LABELS.ciFailed);
+  if (greptile.settled) targetLabels.push(AUTOMATION_LABELS.greptileSettled);
+  if (bugbot.settled) targetLabels.push(AUTOMATION_LABELS.bugbotSettled);
+  if (security.settled) targetLabels.push(AUTOMATION_LABELS.securitySettled);
+  if (security.failed) targetLabels.push(AUTOMATION_LABELS.securityFailed);
+  if (greptile.findings || bugbot.findings) {
+    targetLabels.push(AUTOMATION_LABELS.reviewFindings);
+  }
+  if (greptile.timedOut || bugbot.timedOut || security.timedOut) {
+    targetLabels.push(AUTOMATION_LABELS.signalTimeout);
+  }
+  if (allSignalsSettled) targetLabels.push(AUTOMATION_LABELS.prIntakeReady);
+
+  const { labelsToAdd, labelsToRemove } = diffLabels({
+    currentLabels,
+    targetLabels: unique(targetLabels),
+  });
+
+  return {
+    readyForIntake: allSignalsSettled,
+    targetLabels: unique(targetLabels),
+    labelsToAdd,
+    labelsToRemove,
+    ci,
+    greptile,
+    bugbot,
+    security,
+    timedOut,
+    reason: allSignalsSettled ? "signals settled" : "signals pending",
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    repo: process.env.GITHUB_REPOSITORY || DEFAULT_REPO,
+    prNumber: "",
+    eventName: process.env.GITHUB_EVENT_NAME || "",
+    eventAction: process.env.GITHUB_EVENT_ACTION || "",
+    eventLabel: process.env.GITHUB_EVENT_LABEL || "",
+    graceMinutes: Number(
+      process.env.PR_SIGNAL_GRACE_MINUTES || DEFAULT_GRACE_MINUTES,
+    ),
+    dryRun: false,
+    json: false,
+    allOpen: false,
+    ensureLabelsOnly: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo") {
+      args.repo = argv.at(index + 1) ?? args.repo;
+      index += 1;
+    } else if (arg === "--pr-number") {
+      args.prNumber = argv.at(index + 1) ?? args.prNumber;
+      index += 1;
+    } else if (arg === "--event-name") {
+      args.eventName = argv.at(index + 1) ?? args.eventName;
+      index += 1;
+    } else if (arg === "--event-action") {
+      args.eventAction = argv.at(index + 1) ?? args.eventAction;
+      index += 1;
+    } else if (arg === "--event-label") {
+      args.eventLabel = argv.at(index + 1) ?? args.eventLabel;
+      index += 1;
+    } else if (arg === "--grace-minutes") {
+      args.graceMinutes = Number(argv.at(index + 1) ?? args.graceMinutes);
+      index += 1;
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--all-open") {
+      args.allOpen = true;
+    } else if (arg === "--ensure-labels-only") {
+      args.ensureLabelsOnly = true;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    }
+  }
+
+  if (!Number.isFinite(args.graceMinutes) || args.graceMinutes < 1) {
+    args.graceMinutes = DEFAULT_GRACE_MINUTES;
+  }
+
+  return args;
+}
+
+function usage() {
+  return `Usage: node scripts/github/pr-signal-coordinator.mjs [options]
+
+Options:
+  --repo <owner/repo>       Repository. Default: ${DEFAULT_REPO}
+  --pr-number <number>      Process one pull request.
+  --all-open                Process all open develop/production pull requests.
+  --event-name <name>       GitHub event name.
+  --event-action <action>   GitHub event action.
+  --event-label <label>     GitHub event label name.
+  --grace-minutes <number>  Missing-signal grace window. Default: ${DEFAULT_GRACE_MINUTES}
+  --dry-run                 Print decisions without changing labels.
+  --json                    Print machine-readable JSON.
+  --ensure-labels-only      Create/update automation labels and exit.
+`;
+}
+
+function gh(args, options = {}) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", options.ignoreStderr ? "ignore" : "pipe"],
+  });
+}
+
+function ghJson(args, fallback = null) {
+  try {
+    return JSON.parse(gh(["api", ...args]));
+  } catch (error) {
+    if (fallback !== null) return fallback;
+    throw error;
+  }
+}
+
+function ghApi(args, options = {}) {
+  try {
+    return gh(["api", ...args], options);
+  } catch (error) {
+    if (options.ignoreError) return "";
+    throw error;
+  }
+}
+
+function isPermissionDenied(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Resource not accessible by integration") ||
+    message.includes("HTTP 403")
+  );
+}
+
+function warnPermissionDenied(action, error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(
+    `Warning: skipped ${action} because GitHub denied token access: ${message}`,
+  );
+}
+
+function encodePathPart(value) {
+  return encodeURIComponent(value).replace(/%20/g, "+");
+}
+
+function labelApiPath(repo, labelName) {
+  return `/repos/${repo}/labels/${encodePathPart(labelName)}`;
+}
+
+export function ensureAutomationLabels({ repo, dryRun = false } = {}) {
+  const results = [];
+
+  for (const label of AUTOMATION_LABEL_DEFINITIONS) {
+    const existing = ghJson([labelApiPath(repo, label.name)], {});
+    const exists = existing && existing.name === label.name;
+    const action = exists ? "update" : "create";
+    results.push({ name: label.name, action });
+
+    if (dryRun) continue;
+
+    if (exists) {
+      try {
+        ghApi([
+          "--method",
+          "PATCH",
+          labelApiPath(repo, label.name),
+          "-f",
+          `color=${label.color}`,
+          "-f",
+          `description=${label.description}`,
+        ]);
+      } catch (error) {
+        if (!isPermissionDenied(error)) throw error;
+        warnPermissionDenied(`updating ${label.name}`, error);
+      }
+    } else {
+      try {
+        ghApi([
+          "--method",
+          "POST",
+          `/repos/${repo}/labels`,
+          "-f",
+          `name=${label.name}`,
+          "-f",
+          `color=${label.color}`,
+          "-f",
+          `description=${label.description}`,
+        ]);
+      } catch (error) {
+        if (!isPermissionDenied(error)) throw error;
+        warnPermissionDenied(`creating ${label.name}`, error);
+      }
+    }
+  }
+
+  return results;
+}
+
+function listOpenPullRequests(repo) {
+  const seen = new Map();
+
+  for (const base of SUPPORTED_BASE_REFS) {
+    const prs = ghJson(
+      [
+        `/repos/${repo}/pulls?state=open&base=${base}&per_page=100`,
+        "--paginate",
+      ],
+      [],
+    );
+
+    for (const pr of prs) {
+      seen.set(String(pr.number), pr.number);
+    }
+  }
+
+  return [...seen.values()];
+}
+
+function fetchPullRequestContext({
+  repo,
+  prNumber,
+  eventName,
+  eventAction,
+  graceMinutes,
+}) {
+  const pr = ghJson([`/repos/${repo}/pulls/${prNumber}`], null);
+  if (!pr || pr.message === "Not Found") return null;
+  if (pr.state !== "open") return null;
+  if (!SUPPORTED_BASE_REFS.has(pr.base?.ref)) return null;
+
+  const issue = ghJson([`/repos/${repo}/issues/${prNumber}`], {});
+  const commit = ghJson([`/repos/${repo}/commits/${pr.head?.sha}`], {});
+  const checkRuns = ghJson(
+    [`/repos/${repo}/commits/${pr.head?.sha}/check-runs?per_page=100`],
+    { check_runs: [] },
+  );
+  const reviews = ghJson(
+    [`/repos/${repo}/pulls/${prNumber}/reviews?per_page=100`, "--paginate"],
+    [],
+  );
+  const reviewComments = ghJson(
+    [`/repos/${repo}/pulls/${prNumber}/comments?per_page=100`, "--paginate"],
+    [],
+  );
+  const issueComments = ghJson(
+    [`/repos/${repo}/issues/${prNumber}/comments?per_page=100`, "--paginate"],
+    [],
+  );
+  const signalStartedAt =
+    commit?.commit?.committer?.date ??
+    commit?.commit?.author?.date ??
+    pr.updated_at ??
+    pr.created_at;
+
+  return {
+    pr: {
+      number: pr.number,
+      baseRef: pr.base?.ref,
+      labels: issue.labels ?? [],
+      signalStartedAt,
+    },
+    checkRuns: checkRuns.check_runs ?? [],
+    reviews,
+    reviewComments,
+    issueComments,
+    now: new Date().toISOString(),
+    graceMinutes,
+    eventName,
+    eventAction,
+  };
+}
+
+function removeLabel({ repo, prNumber, label }) {
+  ghApi(
+    [
+      "--method",
+      "DELETE",
+      `/repos/${repo}/issues/${prNumber}/labels/${encodePathPart(label)}`,
+    ],
+    { ignoreError: true, ignoreStderr: true },
+  );
+}
+
+function addLabels({ repo, prNumber, labels }) {
+  if (labels.length === 0) return;
+
+  const fields = labels.flatMap((label) => ["-f", `labels[]=${label}`]);
+  try {
+    ghApi([
+      "--method",
+      "POST",
+      `/repos/${repo}/issues/${prNumber}/labels`,
+      ...fields,
+    ]);
+  } catch (error) {
+    if (!isPermissionDenied(error)) throw error;
+    warnPermissionDenied(`adding labels to PR #${prNumber}`, error);
+  }
+}
+
+function applyDecision({ repo, prNumber, decision, dryRun }) {
+  if (dryRun) return;
+
+  for (const label of decision.labelsToRemove) {
+    removeLabel({ repo, prNumber, label });
+  }
+  addLabels({ repo, prNumber, labels: decision.labelsToAdd });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const labelResults = ensureAutomationLabels({
+    repo: args.repo,
+    dryRun: args.dryRun,
+  });
+
+  if (args.ensureLabelsOnly) {
+    const payload = { labels: labelResults, dryRun: args.dryRun };
+    console.log(
+      args.json
+        ? JSON.stringify(payload, null, 2)
+        : "Automation labels ensured.",
+    );
+    return;
+  }
+
+  const prNumbers = args.prNumber
+    ? [Number(args.prNumber)]
+    : args.allOpen
+      ? listOpenPullRequests(args.repo)
+      : [];
+
+  if (prNumbers.length === 0) {
+    console.log("No pull requests to process.");
+    return;
+  }
+
+  const results = [];
+
+  for (const prNumber of prNumbers) {
+    const context = fetchPullRequestContext({
+      repo: args.repo,
+      prNumber,
+      eventName: args.eventName,
+      eventAction: args.eventAction,
+      graceMinutes: args.graceMinutes,
+    });
+
+    if (!context) {
+      results.push({ prNumber, skipped: true });
+      continue;
+    }
+
+    const decision = buildSignalDecision(context);
+    applyDecision({
+      repo: args.repo,
+      prNumber,
+      decision,
+      dryRun: args.dryRun,
+    });
+    results.push({
+      prNumber,
+      skipped: false,
+      readyForIntake: decision.readyForIntake,
+      reason: decision.reason,
+      labelsToAdd: decision.labelsToAdd,
+      labelsToRemove: decision.labelsToRemove,
+      targetLabels: decision.targetLabels,
+    });
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({ dryRun: args.dryRun, results }, null, 2));
+    return;
+  }
+
+  for (const result of results) {
+    if (result.skipped) {
+      console.log(`PR #${result.prNumber}: skipped`);
+      continue;
+    }
+
+    console.log(
+      `PR #${result.prNumber}: ${result.reason}; add=[${result.labelsToAdd.join(
+        ", ",
+      )}], remove=[${result.labelsToRemove.join(", ")}]`,
+    );
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/tests/unit/scripts/pr-signal-coordinator.test.ts
+++ b/tests/unit/scripts/pr-signal-coordinator.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOMATION_LABELS,
+  buildSignalDecision,
+  requiredChecksForBase,
+} from "../../../scripts/github/pr-signal-coordinator.mjs";
+
+const BASE_NOW = "2026-06-11T17:00:00.000Z";
+const RECENT_SIGNAL_START = "2026-06-11T16:55:00.000Z";
+const STALE_SIGNAL_START = "2026-06-11T16:00:00.000Z";
+
+function checkRun(name: string, conclusion = "success") {
+  return {
+    name,
+    status: "completed",
+    conclusion,
+    app: { name: "GitHub Actions" },
+  };
+}
+
+function baseContext(overrides = {}) {
+  return {
+    pr: {
+      number: 304,
+      baseRef: "develop",
+      labels: [],
+      signalStartedAt: RECENT_SIGNAL_START,
+    },
+    checkRuns: [],
+    reviews: [],
+    reviewComments: [],
+    issueComments: [],
+    now: BASE_NOW,
+    graceMinutes: 20,
+    eventName: "pull_request",
+    eventAction: "labeled",
+    ...overrides,
+  };
+}
+
+describe("PR signal coordinator", () => {
+  it("resets stale automation labels when a PR receives a new push", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        eventName: "pull_request",
+        eventAction: "synchronize",
+        pr: {
+          number: 304,
+          baseRef: "develop",
+          labels: [
+            AUTOMATION_LABELS.ciSettled,
+            AUTOMATION_LABELS.prIntakeReady,
+          ],
+          signalStartedAt: BASE_NOW,
+        },
+      }),
+    );
+
+    expect(decision.labelsToAdd).toContain(AUTOMATION_LABELS.signalsPending);
+    expect(decision.labelsToRemove).toEqual(
+      expect.arrayContaining([
+        AUTOMATION_LABELS.ciSettled,
+        AUTOMATION_LABELS.prIntakeReady,
+      ]),
+    );
+    expect(decision.readyForIntake).toBe(false);
+  });
+
+  it("requires only ci-gate and integration-gate for develop PRs", () => {
+    expect(requiredChecksForBase("develop")).toEqual([
+      "ci-gate",
+      "integration-gate",
+    ]);
+  });
+
+  it("requires release and e2e gates for production PRs", () => {
+    expect(requiredChecksForBase("production")).toEqual([
+      "release-source-gate",
+      "ci-gate",
+      "integration-gate",
+      "e2e-gate",
+    ]);
+  });
+
+  it("settles CI and marks failed required checks", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        checkRuns: [
+          checkRun("ci-gate", "success"),
+          checkRun("integration-gate", "failure"),
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).toEqual(
+      expect.arrayContaining([
+        AUTOMATION_LABELS.ciSettled,
+        AUTOMATION_LABELS.ciFailed,
+      ]),
+    );
+    expect(decision.readyForIntake).toBe(false);
+  });
+
+  it("marks Greptile findings from inline review comments", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        reviewComments: [
+          {
+            user: { login: "greptile-apps[bot]" },
+            body: "P1: existence check is allocation-type-agnostic",
+          },
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).toEqual(
+      expect.arrayContaining([
+        AUTOMATION_LABELS.greptileSettled,
+        AUTOMATION_LABELS.reviewFindings,
+      ]),
+    );
+  });
+
+  it("does not treat an intake snapshot mentioning pending bots as settled bot evidence", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        issueComments: [
+          {
+            user: { login: "cursor[bot]" },
+            body: [
+              "<!-- core-pr-intake-coordinator -->",
+              "Greptile: pending / no comments found by intake",
+              "Cursor Bugbot: pending / no comments found by intake",
+            ].join("\n"),
+          },
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).not.toContain(
+      AUTOMATION_LABELS.greptileSettled,
+    );
+    expect(decision.labelsToAdd).not.toContain(AUTOMATION_LABELS.bugbotSettled);
+    expect(decision.readyForIntake).toBe(false);
+  });
+
+  it("does not settle Bugbot from human comments mentioning bugbot", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        issueComments: [
+          {
+            user: { login: "human-reviewer" },
+            body: "Waiting for bugbot before we decide whether this issue is real.",
+          },
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).not.toContain(AUTOMATION_LABELS.bugbotSettled);
+    expect(decision.labelsToAdd).not.toContain(
+      AUTOMATION_LABELS.reviewFindings,
+    );
+    expect(decision.readyForIntake).toBe(false);
+  });
+
+  it("does not settle Cursor Security from human comments mentioning security review", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        issueComments: [
+          {
+            user: { login: "human-reviewer" },
+            body: "I finished my security review and found no issues.",
+          },
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).not.toContain(
+      AUTOMATION_LABELS.securitySettled,
+    );
+    expect(decision.labelsToAdd).not.toContain(
+      AUTOMATION_LABELS.securityFailed,
+    );
+    expect(decision.readyForIntake).toBe(false);
+  });
+
+  it("ignores stale bot comments created before the current head signal window", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        pr: {
+          number: 304,
+          baseRef: "develop",
+          labels: [],
+          signalStartedAt: RECENT_SIGNAL_START,
+        },
+        issueComments: [
+          {
+            user: { login: "cursor[bot]" },
+            created_at: "2026-06-11T16:30:00.000Z",
+            body: "Cursor Bugbot found a P1 issue before the latest push.",
+          },
+        ],
+        reviewComments: [
+          {
+            user: { login: "greptile-apps[bot]" },
+            created_at: "2026-06-11T16:30:00.000Z",
+            body: "P1: finding from the previous head.",
+          },
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).not.toContain(
+      AUTOMATION_LABELS.greptileSettled,
+    );
+    expect(decision.labelsToAdd).not.toContain(AUTOMATION_LABELS.bugbotSettled);
+    expect(decision.labelsToAdd).not.toContain(
+      AUTOMATION_LABELS.reviewFindings,
+    );
+  });
+
+  it("treats Cursor Security neutral failed-to-start as security failed", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        checkRuns: [
+          {
+            name: "Cursor Security Agent: Security Reviewer",
+            status: "completed",
+            conclusion: "neutral",
+            output: {
+              summary:
+                "Security Review run failed to start: team hard limit needs at least $2 remaining.",
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).toEqual(
+      expect.arrayContaining([
+        AUTOMATION_LABELS.securitySettled,
+        AUTOMATION_LABELS.securityFailed,
+      ]),
+    );
+  });
+
+  it("marks missing bot signals after the grace window as timed out", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        pr: {
+          number: 304,
+          baseRef: "develop",
+          labels: [],
+          signalStartedAt: STALE_SIGNAL_START,
+        },
+        checkRuns: [
+          checkRun("ci-gate", "success"),
+          checkRun("integration-gate", "success"),
+        ],
+      }),
+    );
+
+    expect(decision.labelsToAdd).toEqual(
+      expect.arrayContaining([
+        AUTOMATION_LABELS.greptileSettled,
+        AUTOMATION_LABELS.bugbotSettled,
+        AUTOMATION_LABELS.securitySettled,
+        AUTOMATION_LABELS.securityFailed,
+        AUTOMATION_LABELS.signalTimeout,
+      ]),
+    );
+  });
+
+  it("applies the intake-ready label once every prerequisite signal is terminal", () => {
+    const decision = buildSignalDecision(
+      baseContext({
+        checkRuns: [
+          checkRun("ci-gate", "success"),
+          checkRun("integration-gate", "success"),
+          {
+            name: "Greptile Review",
+            status: "completed",
+            conclusion: "success",
+            app: { name: "Greptile Apps" },
+          },
+          {
+            name: "Cursor Bugbot",
+            status: "completed",
+            conclusion: "success",
+          },
+          {
+            name: "Cursor Security Agent: Security Reviewer",
+            status: "completed",
+            conclusion: "success",
+          },
+        ],
+      }),
+    );
+
+    expect(decision.readyForIntake).toBe(true);
+    expect(decision.labelsToAdd).toEqual(
+      expect.arrayContaining([
+        AUTOMATION_LABELS.ciSettled,
+        AUTOMATION_LABELS.greptileSettled,
+        AUTOMATION_LABELS.bugbotSettled,
+        AUTOMATION_LABELS.securitySettled,
+        AUTOMATION_LABELS.prIntakeReady,
+      ]),
+    );
+    expect(decision.labelsToAdd).not.toContain(AUTOMATION_LABELS.ciFailed);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a PR signal coordinator workflow that applies `automation:pr-intake-ready` only after CI, Greptile, Bugbot, and Cursor Security signals settle.
- Add a tested coordinator decision module with dry-run and label-upsert support.
- Add the production release-source gate required by the coordinator's production check matrix.
- Fix the Greptile trigger workflow so its `check_run` condition can actually run.
- Document the automation label contract and CI debugging flow.

## Validation
- `bun run format:check`
- `bun run skills:verify`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test:unit`
- `bunx vitest run tests/unit/scripts/pr-signal-coordinator.test.ts`
- `node scripts/github/pr-signal-coordinator.mjs --repo Asymmetric-al/core --pr-number 304 --event-name workflow_dispatch --dry-run --json`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the PR Signal Coordinator: a new workflow and decision script that applies `automation:pr-intake-ready` only after CI, Greptile, Bugbot, and Cursor Security signals all reach a terminal state. It also adds a `release-source-gate` workflow enforcing that production release PRs originate from `develop`, fixes the Greptile trigger workflow by adding the missing `check_run` event, and documents the automation label contract.

- **`scripts/github/pr-signal-coordinator.mjs`** — new 847-line decision module with actor-login guards on all bot-item evaluations, grace-window timeout, idempotent label diffing, and dry-run/JSON modes. The `--event-label` arg is parsed and forwarded from the workflow but is dead code — it is never passed into the context object consumed by `buildSignalDecision`.
- **`pr-signal-coordinator.yml`** — new workflow covering PR, check_run, review, comment, schedule, and dispatch triggers; the `check_run` path has a correct job-level guard preventing unnecessary runner spin-ups for check runs with no associated PR.
- **`release-source.yml`** — new gate blocking production PRs unless the source branch is `develop` in the same repository; push events pass unconditionally, safe under branch protection semantics.
- **`greptile-trigger-codex-review.yml`** — the missing `check_run` trigger is added so the existing job `if` guard can now match; test coverage in the new test file is solid across reset, CI, bot, timeout, and full intake-ready paths.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The coordinator is safe to merge: it only reads GitHub metadata and writes automation labels, uses no pull_request_target, and all bot-item evaluations are correctly gated on actor login.

The core decision logic, actor guards, timeout handling, label diffing, and reset-event behavior are all correctly implemented and covered by tests. The greptile trigger fix is minimal and correct. The one dead-code nit (--event-label never reaching the context object) has no effect on runtime behavior.

No files require special attention. The dead eventLabel field in parseArgs is the only observation and has no correctness impact.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/github/pr-signal-coordinator.mjs | New 847-line decision module; correctly guards all bot-item evaluations on actor login, handles reset events, timeout logic, and label diffing. One dead code nit: --event-label is parsed and forwarded but never consumed in the decision context. |
| .github/workflows/pr-signal-coordinator.yml | New workflow with correct job-level guard filtering check_run events to those with an associated PR; env vars are properly isolated from expressions, preventing injection. |
| .github/workflows/greptile-trigger-codex-review.yml | Adds missing check_run trigger so the existing job-level if-guard (Greptile app + review name + success + PR present) can now actually fire; the workflow_dispatch path remains a no-op by design since the if condition requires check_run context. |
| .github/workflows/release-source.yml | New gate that blocks production PRs not sourced from develop in the same repository; push events exit 0 unconditionally, which is safe since branch protection requires the check only for PRs. |
| tests/unit/scripts/pr-signal-coordinator.test.ts | Good coverage across reset events, CI settling/failing, bot actor guards, stale signal filtering, timeout behavior, and the full intake-ready path. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Event\npull_request / check_run\nreview / comment / schedule] --> B{check_run with\nno PR?}
    B -- yes --> Z[Job skipped]
    B -- no --> C[pr-signal-coordinator.mjs]

    C --> D{Reset event?\nopened/synchronize\nreopened/ready_for_review}
    D -- yes --> E[Remove stale labels\nApply signals-pending]

    D -- no --> F[evaluateRequiredChecks\nci-gate / integration-gate\ne2e-gate / release-source-gate]
    F --> G[evaluateGreptile\ncheck run + bot comments\nactor login guard]
    G --> H[evaluateBugbot\ncheck run + cursor actor comments]
    H --> I[evaluateSecurity\ncheck run + cursor actor comments]

    I --> J{All signals\nsettled?}
    J -- no --> K[automation:signals-pending\n+ individual settled labels]
    J -- yes --> L[automation:pr-intake-ready\n+ all settled labels]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/github/pr-signal-coordinator.mjs`, line 1028-1031 ([link](https://github.com/asymmetric-al/core/blob/98179d20203cfad709995461c83eb567ed739679/scripts/github/pr-signal-coordinator.mjs#L1028-L1031)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Check-runs fetch lacks pagination — required checks may be silently missed**

   The reviews and comments calls all pass `"--paginate"`, but the check-runs call uses only `per_page=100` with no pagination flag. If a commit accumulates more than 100 check runs (possible on active PRs with many matrix jobs or retries), the required-checks like `ci-gate` or `e2e-gate` may fall outside the first page and be treated as `pending` indefinitely. The coordinator would then never apply `automation:pr-intake-ready` for those PRs without timing out. Adding `"--paginate"` keeps parity with the other API calls.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fgithub%2Fpr-signal-coordinator.mjs%0ALine%3A%201028-1031%0A%0AComment%3A%0A**Check-runs%20fetch%20lacks%20pagination%20%E2%80%94%20required%20checks%20may%20be%20silently%20missed**%0A%0AThe%20reviews%20and%20comments%20calls%20all%20pass%20%60%22--paginate%22%60%2C%20but%20the%20check-runs%20call%20uses%20only%20%60per_page%3D100%60%20with%20no%20pagination%20flag.%20If%20a%20commit%20accumulates%20more%20than%20100%20check%20runs%20%28possible%20on%20active%20PRs%20with%20many%20matrix%20jobs%20or%20retries%29%2C%20the%20required-checks%20like%20%60ci-gate%60%20or%20%60e2e-gate%60%20may%20fall%20outside%20the%20first%20page%20and%20be%20treated%20as%20%60pending%60%20indefinitely.%20The%20coordinator%20would%20then%20never%20apply%20%60automation%3Apr-intake-ready%60%20for%20those%20PRs%20without%20timing%20out.%20Adding%20%60%22--paginate%22%60%20keeps%20parity%20with%20the%20other%20API%20calls.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=306&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Add PR signal coordinator"](https://github.com/asymmetric-al/core/commit/2b7919b4e193d42864df606f16669b3a440c45b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37085207)</sub>

<!-- /greptile_comment -->