### PR TITLE
fix(cms): keep transitional staging alias in Payload protected-env gate

### DIFF
--- a/apps/admin/src/cms/payload-database-config.ts
+++ b/apps/admin/src/cms/payload-database-config.ts
@@ -10,7 +10,16 @@ const DEFAULT_HOSTED_PAYLOAD_DATABASE_POOL_MAX = 2;
 const DEFAULT_HOSTED_PAYLOAD_DATABASE_POOL_IDLE_TIMEOUT_MS = 5_000;
 const DEFAULT_HOSTED_PAYLOAD_DATABASE_POOL_CONNECTION_TIMEOUT_MS = 5_000;
 const MIN_PAYLOAD_DATABASE_POOL_MAX = 2;
-const PROTECTED_TARGET_ENVIRONMENTS = new Set(["production", "development"]);
+// "staging" is a transitional alias: the renamed "development" environment may still report
+// VERCEL_TARGET_ENV="staging" until the Vercel custom-environment rename lands. Keep the
+// Payload protected-database guards active during the cutover, matching
+// packages/env/src/schema.ts and packages/api/src/admin/crm/twenty-health.ts. Safe to remove
+// once infra reports "development".
+const PROTECTED_TARGET_ENVIRONMENTS = new Set([
+  "production",
+  "development",
+  "staging",
+]);
 const DIRECT_SUPABASE_HOST_RE = /^db\.[a-z0-9]+\.supabase\.co$/i;
 const SUPAVISOR_POOLER_HOST_RE = /(?:^|\.)pooler\.supabase\.com$/i;
 

--- a/tests/unit/cms/payload-database-config.test.ts
+++ b/tests/unit/cms/payload-database-config.test.ts
@@ -170,6 +170,17 @@ describe("resolvePayloadDatabaseConfig", () => {
     expect(config.issue?.code).toBe("direct-supabase-host");
   });
 
+  it("treats the transitional staging target as a protected deployment", () => {
+    const config = resolvePayloadDatabaseConfig({
+      PAYLOAD_DATABASE_URI: DIRECT_SUPABASE_URL,
+      VERCEL_ENV: "preview",
+      VERCEL_TARGET_ENV: "staging",
+    });
+
+    expect(config.isProtectedDeployment).toBe(true);
+    expect(config.issue?.code).toBe("direct-supabase-host");
+  });
+
   it("rejects invalid database URLs in protected deployments without echoing raw values", () => {
     const config = resolvePayloadDatabaseConfig({
       PAYLOAD_DATABASE_URI: "postgresql://postgres:super-secret@",


### PR DESCRIPTION
Caught by the PR review bots on #377 (Greptile P1 + four cursor[bot] High, converged).

`PROTECTED_TARGET_ENVIRONMENTS` in `apps/admin/src/cms/payload-database-config.ts` listed only `production` + `development`, dropping the transitional `"staging"` alias that the rest of the staging→development rename carries (`packages/env/src/schema.ts`, `packages/api/src/admin/crm/twenty-health.ts`). Because the Vercel env still reports `VERCEL_TARGET_ENV="staging"` during the cutover, this silently disabled the Payload database safety guards (missing / invalid / direct-Supabase-host URL) on the staging deployment. Production was unaffected (covered by the `VERCEL_ENV === "production"` branch).

Re-adds `"staging"` to the set with the same transitional comment as the other two sites, plus a unit test. Blocks the develop→production activation release (#377) until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-adds `"staging"` to the `PROTECTED_TARGET_ENVIRONMENTS` set in `payload-database-config.ts`, restoring the Payload database safety guards (missing/invalid/direct-Supabase-host URL checks) for staging deployments during the transitional period when Vercel still reports `VERCEL_TARGET_ENV="staging"` before the custom-environment rename completes.

- **`apps/admin/src/cms/payload-database-config.ts`**: `"staging"` is added back to the protected set alongside `"production"` and `"development"`, with a comment explaining it is a transitional alias and when it can be removed.
- **`tests/unit/cms/payload-database-config.test.ts`**: A new test verifies that `VERCEL_ENV="preview"` + `VERCEL_TARGET_ENV="staging"` correctly sets `isProtectedDeployment: true` and triggers the `direct-supabase-host` issue code — matching the existing pattern for the `"development"` custom-environment test.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line set membership addition with a clear removal condition and direct test coverage.

The fix is minimal and surgical: one value added to a constant set, guarded by a well-documented transitional comment, and backed by a new unit test that exercises exactly the scenario described in the PR. The logic in isProtectedPayloadDeployment is unchanged; adding staging simply closes the gap that left the staging deployment without database safety guards during the cutover window. No regressions are introduced.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/admin/src/cms/payload-database-config.ts | Adds "staging" to PROTECTED_TARGET_ENVIRONMENTS with a clear transitional comment; change is minimal, correct, and matches the same pattern used for "development". |
| tests/unit/cms/payload-database-config.test.ts | New test mirrors the existing "development" custom-environment test, correctly asserting isProtectedDeployment and direct-supabase-host detection for VERCEL_TARGET_ENV="staging". |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["isProtectedPayloadDeployment(env)"] --> B{"PROTECTED_TARGET_ENVIRONMENTS\n.has(VERCEL_TARGET_ENV)"}
    B -- yes --> E["isProtectedDeployment = true"]
    B -- no --> C{"VERCEL_ENV === 'production'"}
    C -- yes --> E
    C -- no --> F["isProtectedDeployment = false"]

    subgraph Set["PROTECTED_TARGET_ENVIRONMENTS (after fix)"]
        G["production"]
        H["development"]
        I["staging  ← re-added (transitional)"]
    end

    B -.->|membership check| Set
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["isProtectedPayloadDeployment(env)"] --> B{"PROTECTED_TARGET_ENVIRONMENTS\n.has(VERCEL_TARGET_ENV)"}
    B -- yes --> E["isProtectedDeployment = true"]
    B -- no --> C{"VERCEL_ENV === 'production'"}
    C -- yes --> E
    C -- no --> F["isProtectedDeployment = false"]

    subgraph Set["PROTECTED_TARGET_ENVIRONMENTS (after fix)"]
        G["production"]
        H["development"]
        I["staging  ← re-added (transitional)"]
    end

    B -.->|membership check| Set
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cms): keep transitional staging alia..."](https://github.com/asymmetric-al/core/commit/d2ef26a53400d67a3706674223253ef376970dc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38709487)</sub>

<!-- /greptile_comment -->