### PR TITLE
fix(ui): improve data table action accessibility

### DIFF
--- a/packages/ui/components/shadcn/data-table/data-table-body.tsx
+++ b/packages/ui/components/shadcn/data-table/data-table-body.tsx
@@ -74,6 +74,7 @@ export interface DataTableBodyWithTableStateProps<TData, TValue> {
     variant?: "default" | "destructive";
   }[];
   rowActions?: DataTableInteractiveRowAction<TData>[];
+  getRowActionAriaLabel?: (row: Row<TData>) => string;
   onRowClick?: (row: Row<TData>) => void;
   getRowId?: TableOptions<TData>["getRowId"];
   className?: string;
@@ -108,6 +109,7 @@ export type DataTableBodyShellProps<TData, TValue> = {
     variant?: "default" | "destructive";
   }[];
   rowActions?: DataTableInteractiveRowAction<TData>[];
+  getRowActionAriaLabel?: (row: Row<TData>) => string;
   onRowClick?: (row: Row<TData>) => void;
   state?: DataTableControlledState;
   getRowId?: TableOptions<TData>["getRowId"];
@@ -142,6 +144,7 @@ export function DataTableBody<TData, TValue>({
   onColumnVisibilityChange,
   actionBarActions,
   rowActions,
+  getRowActionAriaLabel,
   onRowClick,
   state,
   getRowId,
@@ -178,6 +181,7 @@ export function DataTableBody<TData, TValue>({
       rowCount={rowCount}
       actionBarActions={actionBarActions}
       rowActions={rowActions}
+      getRowActionAriaLabel={getRowActionAriaLabel}
       onRowClick={onRowClick}
       getRowId={getRowId}
       className={className}
@@ -207,6 +211,7 @@ export function DataTableBodyWithUrl<TData, TValue>({
   onColumnVisibilityChange,
   actionBarActions,
   rowActions,
+  getRowActionAriaLabel,
   onRowClick,
   state,
   getRowId,
@@ -249,6 +254,7 @@ export function DataTableBodyWithUrl<TData, TValue>({
       rowCount={rowCount}
       actionBarActions={actionBarActions}
       rowActions={rowActions}
+      getRowActionAriaLabel={getRowActionAriaLabel}
       onRowClick={onRowClick}
       getRowId={getRowId}
       className={className}
@@ -272,6 +278,7 @@ export function DataTableBodyWithTableState<TData, TValue>({
   rowCount,
   actionBarActions,
   rowActions,
+  getRowActionAriaLabel,
   onRowClick,
   getRowId,
   className,
@@ -422,7 +429,11 @@ export function DataTableBodyWithTableState<TData, TValue>({
 
     return (
       <TableCell className="w-0 p-4 text-right">
-        <DataTableRowActions row={row} actions={rowActions} />
+        <DataTableRowActions
+          row={row}
+          actions={rowActions}
+          getAriaLabel={getRowActionAriaLabel}
+        />
       </TableCell>
     );
   };

--- a/packages/ui/components/shadcn/data-table/data-table-card-view.tsx
+++ b/packages/ui/components/shadcn/data-table/data-table-card-view.tsx
@@ -32,6 +32,7 @@ interface DataTableCardViewProps<TData> {
   enableRowSelection?: boolean;
   onRowClick?: (row: Row<TData>) => void;
   rowActions?: DataTableInteractiveRowAction<TData>[];
+  getRowActionAriaLabel?: (row: Row<TData>) => string;
   renderCard?: (row: Row<TData>) => React.ReactNode;
   className?: string;
 }
@@ -46,6 +47,7 @@ export function DataTableCardView<TData>({
   enableRowSelection = true,
   onRowClick,
   rowActions,
+  getRowActionAriaLabel,
   renderCard,
   className,
 }: DataTableCardViewProps<TData>) {
@@ -78,6 +80,7 @@ export function DataTableCardView<TData>({
             enableRowSelection={enableRowSelection}
             onRowClick={onRowClick}
             rowActions={rowActions}
+            getRowActionAriaLabel={getRowActionAriaLabel}
           />
         );
       })}
@@ -105,6 +108,7 @@ interface DataTableCardItemProps<TData> {
   enableRowSelection?: boolean;
   onRowClick?: (row: Row<TData>) => void;
   rowActions?: DataTableInteractiveRowAction<TData>[];
+  getRowActionAriaLabel?: (row: Row<TData>) => string;
 }
 
 function DataTableCardItem<TData>({
@@ -117,6 +121,7 @@ function DataTableCardItem<TData>({
   enableRowSelection = true,
   onRowClick,
   rowActions,
+  getRowActionAriaLabel,
 }: DataTableCardItemProps<TData>) {
   const original = row.original as Record<string, unknown>;
   const isSelected = row.getIsSelected();
@@ -219,9 +224,12 @@ function DataTableCardItem<TData>({
                         variant="ghost"
                         size="icon"
                         className="size-8 rounded-lg"
+                        aria-label={
+                          getRowActionAriaLabel?.(row) ?? "Open row actions"
+                        }
                         onClick={(e) => e.stopPropagation()}
                       >
-                        <MoreHorizontal className="size-4" />
+                        <MoreHorizontal className="size-4" aria-hidden="true" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="rounded-xl">

--- a/packages/ui/components/shadcn/data-table/data-table-responsive-inner.tsx
+++ b/packages/ui/components/shadcn/data-table/data-table-responsive-inner.tsx
@@ -76,6 +76,7 @@ export function DataTableResponsiveInner<TData, TValue>({
   enableVirtualization,
   floatingBarActions,
   rowActions,
+  getRowActionAriaLabel,
   mobileCardConfig,
   className,
   tableClassName,
@@ -333,6 +334,7 @@ export function DataTableResponsiveInner<TData, TValue>({
             enableRowSelection={enableRowSelection}
             onRowClick={onRowClick}
             rowActions={rowActions}
+            getRowActionAriaLabel={getRowActionAriaLabel}
             renderCard={mobileCardConfig?.renderCard}
           />
         )}

--- a/packages/ui/components/shadcn/data-table/data-table-responsive-types.ts
+++ b/packages/ui/components/shadcn/data-table/data-table-responsive-types.ts
@@ -71,6 +71,7 @@ export interface DataTableResponsiveProps<TData, TValue> {
     variant?: "default" | "destructive";
   }[];
   rowActions?: DataTableInteractiveRowAction<TData>[];
+  getRowActionAriaLabel?: (row: Row<TData>) => string;
   mobileCardConfig?: {
     primaryField?: string;
     secondaryField?: string;

--- a/packages/ui/components/shadcn/data-table/data-table-row-actions.tsx
+++ b/packages/ui/components/shadcn/data-table/data-table-row-actions.tsx
@@ -22,16 +22,20 @@ interface DataTableRowActionsProps<TData> {
   row: Row<TData>;
   actions: DataTableInteractiveRowAction<TData>[];
   className?: string;
+  getAriaLabel?: (row: Row<TData>) => string;
 }
 
 export function DataTableRowActions<TData>({
   row,
   actions,
   className,
+  getAriaLabel,
 }: DataTableRowActionsProps<TData>) {
   if (actions.length === 0) {
     return null;
   }
+
+  const triggerLabel = getAriaLabel?.(row) ?? "Open row actions";
 
   return (
     <DropdownMenu>
@@ -41,10 +45,10 @@ export function DataTableRowActions<TData>({
           variant="ghost"
           size="icon"
           className={cn("size-8 rounded-lg", className)}
+          aria-label={triggerLabel}
           onClick={(event) => event.stopPropagation()}
         >
-          <MoreHorizontal className="size-4" />
-          <span className="sr-only">Open row actions</span>
+          <MoreHorizontal className="size-4" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="rounded-xl">

--- a/packages/ui/components/shadcn/data-table/data-table-wrapper.tsx
+++ b/packages/ui/components/shadcn/data-table/data-table-wrapper.tsx
@@ -23,7 +23,7 @@ import type {
   DataTableInteractiveRowAction,
   DataTableUrlStateConfig,
 } from "./types";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, Row } from "@tanstack/react-table";
 
 interface DataTableWrapperProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -46,6 +46,7 @@ interface DataTableWrapperProps<TData, TValue> {
   onRetry?: () => void;
   onRowClick?: (row: TData) => void;
   rowActions?: DataTableInteractiveRowAction<TData>[];
+  getRowActionAriaLabel?: (row: Row<TData>) => string;
   emptyState?: {
     title?: string;
     description?: string;
@@ -74,6 +75,7 @@ export function DataTableWrapper<TData, TValue>({
   onRetry,
   onRowClick,
   rowActions,
+  getRowActionAriaLabel,
   emptyState,
   className,
   tableClassName,
@@ -159,6 +161,7 @@ export function DataTableWrapper<TData, TValue>({
         urlState={urlState}
         onRowClick={onRowClick ? (row) => onRowClick(row.original) : undefined}
         rowActions={rowActions}
+        getRowActionAriaLabel={getRowActionAriaLabel}
         emptyState={customEmptyState}
         tableClassName={tableClassName}
         toolbar={toolbar}

--- a/packages/ui/components/shadcn/data-table/data-table.tsx
+++ b/packages/ui/components/shadcn/data-table/data-table.tsx
@@ -50,6 +50,7 @@ interface DataTableProps<TData, TValue> {
     variant?: "default" | "destructive";
   }[];
   rowActions?: DataTableInteractiveRowAction<TData>[];
+  getRowActionAriaLabel?: (row: Row<TData>) => string;
   onRowClick?: (row: Row<TData>) => void;
   state?: DataTableControlledState;
   getRowId?: TableOptions<TData>["getRowId"];

--- a/packages/ui/components/shadcn/sidebar.tsx
+++ b/packages/ui/components/shadcn/sidebar.tsx
@@ -267,7 +267,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <PanelLeftIcon />
+      <PanelLeftIcon aria-hidden="true" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );
@@ -474,7 +474,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",

--- a/tests/unit/packages/ui/components/shadcn/data-table-card-view.test.tsx
+++ b/tests/unit/packages/ui/components/shadcn/data-table-card-view.test.tsx
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DataTableCardView } from "../../../../../../packages/ui/components/shadcn/data-table/data-table-card-view";
+
+type Person = { id: string; name: string };
+
+const rows = [
+  {
+    id: "row-1",
+    original: { id: "person-1", name: "Ada Lovelace" },
+    getIsSelected: () => false,
+    toggleSelected: vi.fn(),
+  },
+] as never;
+
+const rowActions = [{ label: "Edit", onClick: vi.fn() }];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DataTableCardView row action trigger", () => {
+  it("names the card row action trigger with a default label", () => {
+    render(
+      <DataTableCardView
+        rows={rows}
+        primaryField="name"
+        enableRowSelection={false}
+        rowActions={rowActions}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open row actions" }),
+    ).toBeTruthy();
+  });
+
+  it("uses getRowActionAriaLabel when provided", () => {
+    render(
+      <DataTableCardView<Person>
+        rows={rows}
+        primaryField="name"
+        enableRowSelection={false}
+        rowActions={rowActions}
+        getRowActionAriaLabel={(row) =>
+          `Row actions for ${(row.original as Person).name}`
+        }
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Row actions for Ada Lovelace" }),
+    ).toBeTruthy();
+  });
+});

--- a/tests/unit/packages/ui/components/shadcn/data-table-row-actions.test.tsx
+++ b/tests/unit/packages/ui/components/shadcn/data-table-row-actions.test.tsx
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DataTableRowActions } from "../../../../../../packages/ui/components/shadcn/data-table/data-table-row-actions";
+
+type SampleRow = { id: string; name: string };
+
+const mockRow = {
+  original: { id: "row-1", name: "Ada Lovelace" },
+} as never;
+
+const actions = [{ label: "Edit", onClick: vi.fn() }];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DataTableRowActions", () => {
+  it("uses default aria-label when getAriaLabel is omitted", () => {
+    render(<DataTableRowActions row={mockRow} actions={actions} />);
+
+    expect(
+      screen.getByRole("button", { name: "Open row actions" }),
+    ).toBeTruthy();
+  });
+
+  it("uses contextual aria-label from getAriaLabel", () => {
+    render(
+      <DataTableRowActions<SampleRow>
+        row={mockRow}
+        actions={actions}
+        getAriaLabel={(row) =>
+          `Row actions for ${(row.original as SampleRow).name}`
+        }
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Row actions for Ada Lovelace" }),
+    ).toBeTruthy();
+  });
+
+  it("marks the decorative menu icon as aria-hidden", () => {
+    const { container } = render(
+      <DataTableRowActions row={mockRow} actions={actions} />,
+    );
+
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Split the shared UI primitives slice out of PR #251.
- Thread contextual row action aria labels through the shared data table menu triggers and mobile card view.
- Mark decorative row/sidebar icons as hidden from assistive tech and switch sidebar outline shadows to CSS variable tokens.
- Add unit coverage for default/contextual row action trigger labels and decorative icon hiding.

Refs #251.

## Validation

- `bun run test:unit -- data-table-row-actions data-table-card-view`
- `bunx turbo run typecheck --filter=@asym/ui`
- `bunx turbo run lint --filter=@asym/ui`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`
- `bun run format:check`
- pre-push `bun run ci:preflight` (passed: attribution, format, skills verify, lint, data-boundary, workspace contract, eslint config, shadcn guards, typecheck, build, test-unit)

## Notes

- `bun install` was run after fast-forwarding `develop` to refresh the missing local `@asym/mock-data` workspace symlink; it did not change tracked files.
- Nia tools were unavailable in this session, so discovery used repo-scoped `rg`, direct file reads, official shadcn docs, and official TanStack CLI docs output.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves accessibility on the shared data table components by threading a contextual `getRowActionAriaLabel` callback through the full component tree (wrapper → body → row-actions and card-view) and fixing a missing label on the mobile card view trigger. It also marks decorative icons `aria-hidden="true"` and corrects sidebar shadow tokens that were incorrectly wrapping `oklch()` values inside `hsl()`.

- `getRowActionAriaLabel` is wired through every variant (`DataTableBody`, `DataTableBodyWithUrl`, `DataTableBodyWithTableState`, `DataTableResponsiveInner`, `DataTableCardView`, `DataTableWrapper`) and falls back to `"Open row actions"` when omitted, keeping the default accessible label intact.
- The sidebar `outline` variant shadow was changed from `shadow-[0_0_0_1px_hsl(var(--sidebar-border))]` to `shadow-[0_0_0_1px_var(--sidebar-border)]`; since the tokens are already full `oklch(…)` values, the old `hsl()` wrapper was wrong and the new form is correct.
- Unit tests cover default label, contextual label, and decorative-icon hiding for both `DataTableRowActions` and `DataTableCardView`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Straightforward accessibility hardening — no logic changes, no data paths altered, fully backward-compatible optional prop.

Every changed file is a UI-only accessibility improvement. The prop is optional with a safe default string, so existing callers are unaffected. The sidebar shadow fix corrects a pre-existing mismatch between the token format and its wrapper function. Tests cover all three new behaviours. No auth, data, or build paths are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/components/shadcn/data-table/data-table-row-actions.tsx | Replaces sr-only span with aria-label on the button and adds aria-hidden to the decorative icon; adds optional getAriaLabel callback with a safe default. |
| packages/ui/components/shadcn/data-table/data-table-card-view.tsx | Adds previously missing aria-label to the mobile card view action trigger; threads getRowActionAriaLabel through DataTableCardView and DataTableCardItem. |
| packages/ui/components/shadcn/data-table/data-table-body.tsx | Adds getRowActionAriaLabel to all three body-variant interfaces and destructure sites; passes it through to DataTableRowActions as getAriaLabel. |
| packages/ui/components/shadcn/data-table/data-table-responsive-types.ts | Extends DataTableResponsiveProps with the new optional getRowActionAriaLabel callback. |
| packages/ui/components/shadcn/data-table/data-table-responsive-inner.tsx | Destructures and passes getRowActionAriaLabel to DataTableCardView in the mobile card path. |
| packages/ui/components/shadcn/data-table/data-table-wrapper.tsx | Adds Row import and threads getRowActionAriaLabel through DataTableWrapper to the responsive inner component. |
| packages/ui/components/shadcn/data-table/data-table.tsx | Adds getRowActionAriaLabel to DataTableProps; spreads it through to both DataTableBody and DataTableBodyWithUrl. |
| packages/ui/components/shadcn/sidebar.tsx | Adds aria-hidden to PanelLeftIcon and fixes outline shadow tokens from hsl(var(--sidebar-border)) to var(--sidebar-border), which is correct since the tokens are already oklch() values. |
| tests/unit/packages/ui/components/shadcn/data-table-row-actions.test.tsx | New tests covering default label, contextual label, and decorative icon aria-hidden for DataTableRowActions. |
| tests/unit/packages/ui/components/shadcn/data-table-card-view.test.tsx | New tests covering default label and contextual label for the DataTableCardView row action trigger. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DataTableWrapper\n(getRowActionAriaLabel)"] --> B["DataTableResponsiveInner\n(getRowActionAriaLabel)"]
    A --> C["DataTable\n(getRowActionAriaLabel)"]
    C --> D["DataTableBody / DataTableBodyWithUrl"]
    D --> E["DataTableBodyWithTableState\n(getRowActionAriaLabel)"]
    E -->|"desktop table row"| F["DataTableRowActions\ngetAriaLabel={getRowActionAriaLabel}"]
    F --> G["Button aria-label={triggerLabel}\n+ MoreHorizontal aria-hidden"]
    B -->|"mobile / showCards"| H["DataTableCardView\n(getRowActionAriaLabel)"]
    H --> I["DataTableCardItem"]
    I --> J["Button aria-label={getRowActionAriaLabel?.(row) ?? 'Open row actions'}\n+ MoreHorizontal aria-hidden"]
    K["getRowActionAriaLabel omitted"] -->|"fallback"| L["'Open row actions'"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["DataTableWrapper\n(getRowActionAriaLabel)"] --> B["DataTableResponsiveInner\n(getRowActionAriaLabel)"]
    A --> C["DataTable\n(getRowActionAriaLabel)"]
    C --> D["DataTableBody / DataTableBodyWithUrl"]
    D --> E["DataTableBodyWithTableState\n(getRowActionAriaLabel)"]
    E -->|"desktop table row"| F["DataTableRowActions\ngetAriaLabel={getRowActionAriaLabel}"]
    F --> G["Button aria-label={triggerLabel}\n+ MoreHorizontal aria-hidden"]
    B -->|"mobile / showCards"| H["DataTableCardView\n(getRowActionAriaLabel)"]
    H --> I["DataTableCardItem"]
    I --> J["Button aria-label={getRowActionAriaLabel?.(row) ?? 'Open row actions'}\n+ MoreHorizontal aria-hidden"]
    K["getRowActionAriaLabel omitted"] -->|"fallback"| L["'Open row actions'"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): improve data table action acces..."](https://github.com/asymmetric-al/core/commit/7bf5cb67cc9781530b2ef9ff7488eab5e9a436fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38869426)</sub>

<!-- /greptile_comment -->