### PR TITLE
feat(api): add contribution operations read model

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,6 +31,7 @@
     "./admin/missionary-directory": "./src/admin/missionary-directory.ts",
     "./admin/users": "./src/admin/users.ts",
     "./admin/contribution-shared": "./src/admin/contribution-shared/index.ts",
+    "./admin/contribution-operations": "./src/admin/contribution-operations/index.ts",
     "./admin/contributions": "./src/admin/contributions/index.ts",
     "./admin/contributions/reconcile": "./src/admin/contributions/reconcile.ts",
     "./admin/contributions/replay": "./src/admin/contributions/replay.ts",

--- a/packages/api/src/admin/contribution-operations/action-availability.ts
+++ b/packages/api/src/admin/contribution-operations/action-availability.ts
@@ -1,0 +1,195 @@
+import { getContributionActionRiskLevel } from "./policy";
+
+import type { ContributionActionType, ContributionRiskLevel } from "./types";
+
+/**
+ * Server-computed action availability (ADR-CD-017 / ADR-CD-018).
+ *
+ * The backend is the authority for which gift actions are valid. The UI never
+ * infers availability from local state; it renders `available` actions and
+ * explains blocked ones using `blockedReason` and `nextStep` product language.
+ */
+export interface ContributionActionAvailability {
+  actionType: ContributionActionType;
+  available: boolean;
+  blockedReason: string | null;
+  nextStep: string | null;
+  riskLevel: ContributionRiskLevel;
+}
+
+export interface ActionAvailabilityStagedGiftInput {
+  id: string;
+  status: string | null;
+  receiptStatus: string | null;
+  crmPostStatus: string | null;
+}
+
+export interface BuildContributionActionAvailabilityInput {
+  stagedGift: ActionAvailabilityStagedGiftInput | null;
+  paymentStatus: string | null;
+  /** Refund context: original amount, refunded so far, provider charge. */
+  refund?: {
+    amountCents: number;
+    refundedAmountCents: number;
+    hasProviderCharge: boolean;
+  };
+}
+
+/**
+ * A gift without a staged gift is valid read-only financial truth — never
+ * describe the donation itself as missing or invalid (issue #258).
+ */
+const NO_STAGED_GIFT_REASON =
+  "This gift has no staged gift workflow record, so finance workflow actions are unavailable.";
+const NO_STAGED_GIFT_NEXT_STEP =
+  "The donation is valid and shown read-only. Import or create a staged gift to run finance workflow actions for it.";
+
+function entry(
+  actionType: ContributionActionType,
+  result:
+    | { available: true }
+    | { available: false; blockedReason: string; nextStep: string },
+): ContributionActionAvailability {
+  return {
+    actionType,
+    available: result.available,
+    blockedReason: result.available ? null : result.blockedReason,
+    nextStep: result.available ? null : result.nextStep,
+    riskLevel: getContributionActionRiskLevel(actionType),
+  };
+}
+
+function blockedWithoutStagedGift(
+  actionType: ContributionActionType,
+): ContributionActionAvailability {
+  return entry(actionType, {
+    available: false,
+    blockedReason: NO_STAGED_GIFT_REASON,
+    nextStep: NO_STAGED_GIFT_NEXT_STEP,
+  });
+}
+
+function approveAvailability(
+  stagedGift: ActionAvailabilityStagedGiftInput,
+): ContributionActionAvailability {
+  if (
+    stagedGift.status === "received" ||
+    stagedGift.status === "needs_review"
+  ) {
+    return entry("approve_staged_gift", { available: true });
+  }
+
+  return entry("approve_staged_gift", {
+    available: false,
+    blockedReason: `This gift is not awaiting finance review (current workflow state: ${
+      stagedGift.status?.replace(/_/g, " ") ?? "unknown"
+    }).`,
+    nextStep:
+      "Approval is only needed while a gift is received or needs review.",
+  });
+}
+
+function retryAvailability(
+  stagedGift: ActionAvailabilityStagedGiftInput,
+): ContributionActionAvailability {
+  const retryable =
+    stagedGift.status === "failed" ||
+    stagedGift.crmPostStatus === "failed" ||
+    stagedGift.crmPostStatus === "blocked";
+
+  if (retryable) {
+    return entry("retry_staged_gift", { available: true });
+  }
+
+  return entry("retry_staged_gift", {
+    available: false,
+    blockedReason: "There is no failed or blocked posting to retry.",
+    nextStep:
+      "Retry becomes available when staged gift processing or CRM posting fails.",
+  });
+}
+
+function receiptAvailability(
+  stagedGift: ActionAvailabilityStagedGiftInput,
+  paymentStatus: string | null,
+): ContributionActionAvailability {
+  if (stagedGift.receiptStatus === "suppressed") {
+    return entry("resend_receipt", {
+      available: false,
+      blockedReason: "Receipts are suppressed for this gift.",
+      nextStep:
+        "Review the donor's receipt preference before sending donor communication.",
+    });
+  }
+
+  if (paymentStatus !== "completed") {
+    return entry("resend_receipt", {
+      available: false,
+      blockedReason: "The payment is not completed yet.",
+      nextStep: "Receipts can be sent once the gift payment completes.",
+    });
+  }
+
+  return entry("resend_receipt", { available: true });
+}
+
+function refundAvailability(
+  paymentStatus: string | null,
+  refund: NonNullable<BuildContributionActionAvailabilityInput["refund"]>,
+): ContributionActionAvailability {
+  if (paymentStatus !== "completed" && paymentStatus !== "refunded") {
+    return entry("refund", {
+      available: false,
+      blockedReason: "Only completed payments can be refunded.",
+      nextStep: "Refunds become available once the gift payment completes.",
+    });
+  }
+
+  if (!refund.hasProviderCharge) {
+    return entry("refund", {
+      available: false,
+      blockedReason:
+        "This gift has no payment provider charge to refund against.",
+      nextStep:
+        "Offline gifts are corrected through adjustments rather than provider refunds.",
+    });
+  }
+
+  const remaining = refund.amountCents - refund.refundedAmountCents;
+  if (remaining <= 0) {
+    return entry("refund", {
+      available: false,
+      blockedReason: "This gift is already fully refunded.",
+      nextStep: "No refundable amount remains on this gift.",
+    });
+  }
+
+  return entry("refund", { available: true });
+}
+
+export function buildContributionActionAvailability(
+  input: BuildContributionActionAvailabilityInput,
+): ContributionActionAvailability[] {
+  const { stagedGift, paymentStatus } = input;
+  const refund = input.refund ?? {
+    amountCents: 0,
+    refundedAmountCents: 0,
+    hasProviderCharge: false,
+  };
+
+  if (!stagedGift) {
+    return [
+      blockedWithoutStagedGift("approve_staged_gift"),
+      blockedWithoutStagedGift("retry_staged_gift"),
+      blockedWithoutStagedGift("resend_receipt"),
+      refundAvailability(paymentStatus, refund),
+    ];
+  }
+
+  return [
+    approveAvailability(stagedGift),
+    retryAvailability(stagedGift),
+    receiptAvailability(stagedGift, paymentStatus),
+    refundAvailability(paymentStatus, refund),
+  ];
+}

--- a/packages/api/src/admin/contribution-operations/action-availability.ts
+++ b/packages/api/src/admin/contribution-operations/action-availability.ts
@@ -113,6 +113,16 @@ function retryAvailability(
   });
 }
 
+function isCompletedPaymentStatus(paymentStatus: string | null): boolean {
+  const normalizedStatus = paymentStatus?.toLowerCase() ?? null;
+
+  return (
+    normalizedStatus === "completed" ||
+    normalizedStatus === "succeeded" ||
+    normalizedStatus === "success"
+  );
+}
+
 function receiptAvailability(
   stagedGift: ActionAvailabilityStagedGiftInput,
   paymentStatus: string | null,
@@ -126,7 +136,7 @@ function receiptAvailability(
     });
   }
 
-  if (paymentStatus !== "completed") {
+  if (!isCompletedPaymentStatus(paymentStatus)) {
     return entry("resend_receipt", {
       available: false,
       blockedReason: "The payment is not completed yet.",
@@ -141,7 +151,10 @@ function refundAvailability(
   paymentStatus: string | null,
   refund: NonNullable<BuildContributionActionAvailabilityInput["refund"]>,
 ): ContributionActionAvailability {
-  if (paymentStatus !== "completed" && paymentStatus !== "refunded") {
+  if (
+    !isCompletedPaymentStatus(paymentStatus) &&
+    paymentStatus !== "refunded"
+  ) {
     return entry("refund", {
       available: false,
       blockedReason: "Only completed payments can be refunded.",

--- a/packages/api/src/admin/contribution-operations/action-availability.ts
+++ b/packages/api/src/admin/contribution-operations/action-availability.ts
@@ -27,6 +27,8 @@ export interface ActionAvailabilityStagedGiftInput {
 export interface BuildContributionActionAvailabilityInput {
   stagedGift: ActionAvailabilityStagedGiftInput | null;
   paymentStatus: string | null;
+  /** Unified CRM post state from parent/child links, not just staged columns. */
+  hasCrmPostFailure?: boolean;
   /** Refund context: original amount, refunded so far, provider charge. */
   refund?: {
     amountCents: number;
@@ -91,11 +93,13 @@ function approveAvailability(
 
 function retryAvailability(
   stagedGift: ActionAvailabilityStagedGiftInput,
+  hasCrmPostFailure: boolean,
 ): ContributionActionAvailability {
   const retryable =
     stagedGift.status === "failed" ||
     stagedGift.crmPostStatus === "failed" ||
-    stagedGift.crmPostStatus === "blocked";
+    stagedGift.crmPostStatus === "blocked" ||
+    hasCrmPostFailure;
 
   if (retryable) {
     return entry("retry_staged_gift", { available: true });
@@ -171,6 +175,7 @@ export function buildContributionActionAvailability(
   input: BuildContributionActionAvailabilityInput,
 ): ContributionActionAvailability[] {
   const { stagedGift, paymentStatus } = input;
+  const hasCrmPostFailure = input.hasCrmPostFailure ?? false;
   const refund = input.refund ?? {
     amountCents: 0,
     refundedAmountCents: 0,
@@ -188,7 +193,7 @@ export function buildContributionActionAvailability(
 
   return [
     approveAvailability(stagedGift),
-    retryAvailability(stagedGift),
+    retryAvailability(stagedGift, hasCrmPostFailure),
     receiptAvailability(stagedGift, paymentStatus),
     refundAvailability(paymentStatus, refund),
   ];

--- a/packages/api/src/admin/contribution-operations/approval-policy.ts
+++ b/packages/api/src/admin/contribution-operations/approval-policy.ts
@@ -1,7 +1,9 @@
 import { isHighRiskContributionAction } from "./policy";
+import {
+  CONTRIBUTION_ACTION_TYPES,
+  type ContributionActionType,
+} from "./types";
 import { ApiHttpError } from "../../shared/http-errors";
-
-import type { ContributionActionType } from "./types";
 
 /**
  * Tenant-configurable correction approval policy (ADR-CD-005 / ADR-CD-025).
@@ -42,11 +44,14 @@ const OWNERSHIP_MODES: CorrectionApprovalOwnershipMode[] = [
   "one_approver",
   "separation_of_duties",
 ];
+const CONTRIBUTION_ACTION_TYPE_SET = new Set<string>(CONTRIBUTION_ACTION_TYPES);
 
 function normalizeActionTypes(
   values: string[] | null | undefined,
 ): ContributionActionType[] {
-  return (values ?? []).filter(Boolean) as ContributionActionType[];
+  return (values ?? []).filter((value): value is ContributionActionType =>
+    CONTRIBUTION_ACTION_TYPE_SET.has(value),
+  );
 }
 
 export function resolveCorrectionApprovalPolicy(

--- a/packages/api/src/admin/contribution-operations/approval-policy.ts
+++ b/packages/api/src/admin/contribution-operations/approval-policy.ts
@@ -1,0 +1,127 @@
+import { isHighRiskContributionAction } from "./policy";
+import { ApiHttpError } from "../../shared/http-errors";
+
+import type { ContributionActionType } from "./types";
+
+/**
+ * Tenant-configurable correction approval policy (ADR-CD-005 / ADR-CD-025).
+ *
+ * Externally visible (high-risk) corrections require approval by default.
+ * Super admins may suppress individual gates, but stronger approval
+ * categories stay gated regardless of suppression or relaxed ownership, and
+ * suppression never bypasses audit, reasons, concurrency, or idempotency.
+ */
+
+export type CorrectionApprovalOwnershipMode =
+  | "no_approval_required"
+  | "one_approver"
+  | "separation_of_duties";
+
+export interface CorrectionApprovalPolicy {
+  ownershipMode: CorrectionApprovalOwnershipMode;
+  /** Action types whose approval gate the tenant explicitly suppressed. */
+  suppressedGates: ContributionActionType[];
+  /** Action types that always require approval, even when suppressed. */
+  strongerApprovalCategories: ContributionActionType[];
+  /** Hours before a pending request reminds eligible approvers (#262). */
+  reminderHours: number;
+  /** Hours before a pending request escalates; null disables escalation. */
+  escalationHours: number | null;
+}
+
+export interface CorrectionApprovalPolicyRow {
+  ownership_mode?: string | null;
+  suppressed_gates?: string[] | null;
+  stronger_approval_categories?: string[] | null;
+  reminder_hours?: number | null;
+  escalation_hours?: number | null;
+}
+
+const OWNERSHIP_MODES: CorrectionApprovalOwnershipMode[] = [
+  "no_approval_required",
+  "one_approver",
+  "separation_of_duties",
+];
+
+function normalizeActionTypes(
+  values: string[] | null | undefined,
+): ContributionActionType[] {
+  return (values ?? []).filter(Boolean) as ContributionActionType[];
+}
+
+export function resolveCorrectionApprovalPolicy(
+  row: CorrectionApprovalPolicyRow | null | undefined,
+): CorrectionApprovalPolicy {
+  const ownershipMode = OWNERSHIP_MODES.includes(
+    row?.ownership_mode as CorrectionApprovalOwnershipMode,
+  )
+    ? (row?.ownership_mode as CorrectionApprovalOwnershipMode)
+    : "separation_of_duties";
+
+  return {
+    ownershipMode,
+    suppressedGates: normalizeActionTypes(row?.suppressed_gates),
+    strongerApprovalCategories: normalizeActionTypes(
+      row?.stronger_approval_categories,
+    ),
+    reminderHours: row?.reminder_hours ?? 24,
+    escalationHours: row?.escalation_hours ?? null,
+  };
+}
+
+/**
+ * Whether a correction must go through a correction request instead of
+ * applying immediately. Server-side enforcement; UI state is advisory only.
+ */
+export function correctionRequiresApproval(input: {
+  actionType: ContributionActionType;
+  policy: CorrectionApprovalPolicy;
+}): boolean {
+  const { actionType, policy } = input;
+
+  if (policy.strongerApprovalCategories.includes(actionType)) {
+    return true;
+  }
+
+  if (!isHighRiskContributionAction(actionType)) {
+    return false;
+  }
+
+  if (policy.ownershipMode === "no_approval_required") {
+    return false;
+  }
+
+  return !policy.suppressedGates.includes(actionType);
+}
+
+/**
+ * Server-side approver check (ADR-CD-025). Separation of duties means the
+ * requester can never approve or reject their own high-risk correction.
+ */
+export function assertCanDecideCorrectionRequest(input: {
+  policy: CorrectionApprovalPolicy;
+  request: { requestedByProfileId: string | null };
+  deciderProfileId: string | null;
+  deciderCapabilities: string[];
+}): void {
+  if (
+    !input.deciderCapabilities.includes("contributions.approve_corrections")
+  ) {
+    throw new ApiHttpError(
+      403,
+      "Forbidden: requires contributions.approve_corrections",
+    );
+  }
+
+  if (
+    input.policy.ownershipMode === "separation_of_duties" &&
+    input.request.requestedByProfileId !== null &&
+    input.deciderProfileId !== null &&
+    input.request.requestedByProfileId === input.deciderProfileId
+  ) {
+    throw new ApiHttpError(
+      403,
+      "You cannot approve or reject your own correction request. Another approver must decide it.",
+    );
+  }
+}

--- a/packages/api/src/admin/contribution-operations/crm-post-state.ts
+++ b/packages/api/src/admin/contribution-operations/crm-post-state.ts
@@ -1,0 +1,116 @@
+import { normalizeSharedCrmPostStatus } from "../contribution-shared/row-contract";
+
+import type { SharedContributionCrmPostStatus } from "@asym/database/types";
+
+/**
+ * CRM/Twenty parent + child post state (ADR-CD-012).
+ *
+ * One CRM parent gift record represents the donation; each designation line
+ * may post as a child record under it. Failures are parent- or line-scoped so
+ * retries can target the failed scope, and adapter limitations are surfaced
+ * instead of silently collapsing designation detail. CRM/Twenty post state is
+ * workflow metadata — never payment truth.
+ */
+
+export interface CrmPostLinkInput {
+  id: string;
+  scope: "parent" | "designation";
+  allocationId: string | null;
+  linkStatus: string | null;
+  twentyRecordId: string | null;
+  lastError: string | null;
+}
+
+export interface CrmDesignationRecordState {
+  allocationId: string | null;
+  status: SharedContributionCrmPostStatus | null;
+  twentyRecordId: string | null;
+  lastError: string | null;
+}
+
+export type CrmPostFailedScope =
+  | { scope: "parent" }
+  | { scope: "designation"; allocationId: string | null };
+
+export interface ContributionCrmPostState {
+  parent: {
+    status: SharedContributionCrmPostStatus | null;
+    twentyRecordId: string | null;
+    lastError: string | null;
+  };
+  designationRecords: CrmDesignationRecordState[];
+  /** Scopes a retry action may target without reposting unrelated lines. */
+  failedScopes: CrmPostFailedScope[];
+  /** Staff-readable adapter limitation, when designation detail is flattened. */
+  adapterLimitation: string | null;
+}
+
+export const CRM_CHILD_RECORDS_UNSUPPORTED_MESSAGE =
+  "The connected CRM adapter posts this gift as a single parent record and does not yet represent each designation line as a child record.";
+
+function normalizeLinkStatus(
+  linkStatus: string | null,
+): SharedContributionCrmPostStatus | null {
+  switch (linkStatus) {
+    case "active":
+      return "posted";
+    case "queued":
+      return "queued";
+    case "failed":
+      return "failed";
+    case "archived":
+      return "not_required";
+    default:
+      return normalizeSharedCrmPostStatus(linkStatus);
+  }
+}
+
+export function buildContributionCrmPostState(input: {
+  stagedGiftCrmPostStatus: string | null;
+  stagedGiftTwentyRecordId: string | null;
+  links: CrmPostLinkInput[];
+  designationLineCount: number;
+}): ContributionCrmPostState {
+  const parentLink =
+    input.links.find((link) => link.scope === "parent") ?? null;
+  const childLinks = input.links.filter((link) => link.scope === "designation");
+
+  const parentStatus = normalizeSharedCrmPostStatus(
+    input.stagedGiftCrmPostStatus,
+  );
+  const parent = {
+    status: parentStatus,
+    twentyRecordId:
+      input.stagedGiftTwentyRecordId ?? parentLink?.twentyRecordId ?? null,
+    lastError: parentLink?.lastError ?? null,
+  };
+
+  const designationRecords: CrmDesignationRecordState[] = childLinks.map(
+    (link) => ({
+      allocationId: link.allocationId,
+      status: normalizeLinkStatus(link.linkStatus),
+      twentyRecordId: link.twentyRecordId,
+      lastError: link.lastError,
+    }),
+  );
+
+  const failedScopes: CrmPostFailedScope[] = [];
+  if (parent.status === "failed" || parent.status === "blocked") {
+    failedScopes.push({ scope: "parent" });
+  }
+  for (const record of designationRecords) {
+    if (record.status === "failed" || record.status === "blocked") {
+      failedScopes.push({
+        scope: "designation",
+        allocationId: record.allocationId,
+      });
+    }
+  }
+
+  const adapterLimitation =
+    input.designationLineCount > 1 && childLinks.length === 0
+      ? CRM_CHILD_RECORDS_UNSUPPORTED_MESSAGE
+      : null;
+
+  return { parent, designationRecords, failedScopes, adapterLimitation };
+}

--- a/packages/api/src/admin/contribution-operations/crm-post-state.ts
+++ b/packages/api/src/admin/contribution-operations/crm-post-state.ts
@@ -86,7 +86,7 @@ export function buildContributionCrmPostState(input: {
   const parent = {
     status: parentStatus,
     twentyRecordId:
-      input.stagedGiftTwentyRecordId ?? parentLink?.twentyRecordId ?? null,
+      parentLink?.twentyRecordId ?? input.stagedGiftTwentyRecordId ?? null,
     lastError: parentLink?.lastError ?? null,
   };
 

--- a/packages/api/src/admin/contribution-operations/crm-post-state.ts
+++ b/packages/api/src/admin/contribution-operations/crm-post-state.ts
@@ -75,9 +75,14 @@ export function buildContributionCrmPostState(input: {
     input.links.find((link) => link.scope === "parent") ?? null;
   const childLinks = input.links.filter((link) => link.scope === "designation");
 
-  const parentStatus = normalizeSharedCrmPostStatus(
+  const aggregateParentStatus = normalizeSharedCrmPostStatus(
     input.stagedGiftCrmPostStatus,
   );
+  const parentLinkStatus = normalizeLinkStatus(parentLink?.linkStatus ?? null);
+  const parentStatus =
+    parentLinkStatus === "failed" || parentLinkStatus === "blocked"
+      ? parentLinkStatus
+      : (aggregateParentStatus ?? parentLinkStatus);
   const parent = {
     status: parentStatus,
     twentyRecordId:

--- a/packages/api/src/admin/contribution-operations/detail-read-model.ts
+++ b/packages/api/src/admin/contribution-operations/detail-read-model.ts
@@ -723,7 +723,9 @@ export function buildContributionDetail(
       refund: {
         amountCents: effective.amountCents,
         refundedAmountCents: donation.refundAmount,
-        hasProviderCharge: Boolean(donation.stripeChargeId),
+        hasProviderCharge: Boolean(
+          donation.stripeChargeId || donation.stripePaymentIntentId,
+        ),
       },
     }),
     tasks: [],

--- a/packages/api/src/admin/contribution-operations/detail-read-model.ts
+++ b/packages/api/src/admin/contribution-operations/detail-read-model.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   buildContributionActionAvailability,
   type ContributionActionAvailability,
@@ -311,15 +313,81 @@ function donorVisibleStatus(
   return "Processing" as const;
 }
 
-function refundStatus(
-  donation: Pick<ContributionDetailDonationInput, "amount" | "refundAmount">,
-) {
-  if (donation.refundAmount <= 0) {
+function refundStatus(input: {
+  amountCents: number;
+  refundedAmountCents: number;
+}) {
+  if (input.refundedAmountCents <= 0) {
     return "none" as const;
   }
-  return donation.refundAmount >= donation.amount
+  return input.refundedAmountCents >= input.amountCents
     ? ("refunded" as const)
     : ("partial_refund" as const);
+}
+
+function effectiveValuesRevisionPayload(
+  values: ContributionAdjustmentRecord["effectiveValues"],
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  if (values.amountCents !== undefined) {
+    payload.amountCents = values.amountCents;
+  }
+  if (values.fundId !== undefined) {
+    payload.fundId = values.fundId;
+  }
+  if (values.missionaryId !== undefined) {
+    payload.missionaryId = values.missionaryId;
+  }
+  if (values.paymentStatus !== undefined) {
+    payload.paymentStatus = values.paymentStatus;
+  }
+  if (values.designationLines !== undefined) {
+    payload.designationLines = values.designationLines.map((line) => ({
+      id: line.id,
+      amountCents: line.amountCents,
+      fundId: line.fundId,
+      missionaryId: line.missionaryId,
+      memo: line.memo,
+    }));
+  }
+
+  return payload;
+}
+
+function buildContributionRevision(input: {
+  donationUpdatedAt: string;
+  adjustments: ContributionAdjustmentRecord[];
+}): string {
+  const adjustmentFingerprint = [...input.adjustments]
+    .sort((left, right) => {
+      const createdAtDiff =
+        new Date(left.createdAt).getTime() -
+        new Date(right.createdAt).getTime();
+      if (createdAtDiff !== 0) {
+        return createdAtDiff;
+      }
+      return left.id.localeCompare(right.id);
+    })
+    .map((adjustment) => ({
+      id: adjustment.id,
+      adjustmentType: adjustment.adjustmentType,
+      status: adjustment.status,
+      effectiveValues: effectiveValuesRevisionPayload(
+        adjustment.effectiveValues,
+      ),
+      reason: adjustment.reason,
+      actorProfileId: adjustment.actorProfileId,
+      sourceSurface: adjustment.sourceSurface,
+      createdAt: adjustment.createdAt,
+    }));
+
+  const adjustmentHash = createHash("sha256")
+    .update(JSON.stringify(adjustmentFingerprint))
+    .digest("hex")
+    .slice(0, 16);
+
+  return `${input.donationUpdatedAt}#${input.adjustments.length}#${adjustmentHash}`;
 }
 
 export function buildContributionDetail(
@@ -445,6 +513,13 @@ export function buildContributionDetail(
     ],
   });
 
+  const crmPostState = buildContributionCrmPostState({
+    stagedGiftCrmPostStatus: stagedGift?.crmPostStatus ?? null,
+    stagedGiftTwentyRecordId: stagedGift?.twentyRecordId ?? null,
+    links: input.crmLinks ?? [],
+    designationLineCount: designations.lines.length,
+  });
+
   return {
     shared,
     id: donation.id,
@@ -494,7 +569,10 @@ export function buildContributionDetail(
       statementStatus: null,
     },
     refund: {
-      status: refundStatus(donation),
+      status: refundStatus({
+        amountCents: effective.amountCents,
+        refundedAmountCents: donation.refundAmount,
+      }),
       amount: donation.refundAmount,
       refundedAt: donation.refundedAt,
     },
@@ -512,12 +590,7 @@ export function buildContributionDetail(
     crm: {
       postStatus: stagedGift?.crmPostStatus ?? null,
       twentyRecordId: stagedGift?.twentyRecordId ?? null,
-      ...buildContributionCrmPostState({
-        stagedGiftCrmPostStatus: stagedGift?.crmPostStatus ?? null,
-        stagedGiftTwentyRecordId: stagedGift?.twentyRecordId ?? null,
-        links: input.crmLinks ?? [],
-        designationLineCount: designations.lines.length,
-      }),
+      ...crmPostState,
     },
     auditEvents: input.auditEvents ?? [],
     corrections: input.corrections ?? [],
@@ -529,7 +602,10 @@ export function buildContributionDetail(
       materiallyDiffers: effectiveResult.materiallyDiffers,
     },
     adjustments,
-    revision: `${donation.updatedAt}#${adjustments.length}`,
+    revision: buildContributionRevision({
+      donationUpdatedAt: donation.updatedAt,
+      adjustments,
+    }),
     actionAvailability: buildContributionActionAvailability({
       stagedGift: stagedGift
         ? {
@@ -539,7 +615,8 @@ export function buildContributionDetail(
             crmPostStatus: stagedGift.crmPostStatus,
           }
         : null,
-      paymentStatus: donation.status,
+      paymentStatus: effective.paymentStatus,
+      hasCrmPostFailure: crmPostState.failedScopes.length > 0,
       refund: {
         amountCents: effective.amountCents,
         refundedAmountCents: donation.refundAmount,
@@ -550,12 +627,12 @@ export function buildContributionDetail(
     batches: [],
     donorVisible: {
       status: donorVisibleStatus(
-        donation.status,
+        effective.paymentStatus,
         donation.refundAmount,
-        donation.amount,
+        effective.amountCents,
       ),
       historyUpdatedImmediately: true,
-      amount: donation.amount,
+      amount: effective.amountCents,
       currency,
     },
   };

--- a/packages/api/src/admin/contribution-operations/detail-read-model.ts
+++ b/packages/api/src/admin/contribution-operations/detail-read-model.ts
@@ -1,0 +1,562 @@
+import {
+  buildContributionActionAvailability,
+  type ContributionActionAvailability,
+} from "./action-availability";
+import {
+  buildContributionCrmPostState,
+  type ContributionCrmPostState,
+  type CrmPostLinkInput,
+} from "./crm-post-state";
+import {
+  buildContributionDesignationSet,
+  type DesignationAllocationInput,
+  type DesignationFundInput,
+} from "../contribution-shared/designation-set";
+import {
+  deriveEffectiveContribution,
+  type ContributionAdjustmentRecord,
+} from "../contribution-shared/effective-values";
+import {
+  buildSharedContributionRowFields,
+  type SharedContributionRowFields,
+} from "../contribution-shared/row-contract";
+
+import type { ContributionDesignationSet } from "@asym/database/types";
+
+export type ContributionDetailDonationInput = {
+  id: string;
+  tenantId: string;
+  donorId: string | null;
+  missionaryId: string | null;
+  fundId: string | null;
+  amount: number;
+  currency: string;
+  status: string | null;
+  donationType: string | null;
+  paymentMethod: string | null;
+  isRecurring: boolean | null;
+  recurringInterval: string | null;
+  notes: string | null;
+  stripePaymentIntentId: string | null;
+  stripeChargeId: string | null;
+  giftDate: string;
+  campaignId: string | null;
+  pledgeId: string | null;
+  processedAt: string | null;
+  completedAt: string | null;
+  failedAt: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  refundedAt: string | null;
+  refundAmount: number;
+  source: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ContributionDetailDonorInput = {
+  id: string;
+  profileId: string | null;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  mobile?: string | null;
+  location: string | null;
+  organization: string | null;
+} | null;
+
+export interface ContributionDetailInput {
+  donation: ContributionDetailDonationInput;
+  donor?: ContributionDetailDonorInput;
+  fund?: { id: string; name: string | null } | null;
+  missionary?: { id: string; name: string | null } | null;
+  stagedGift?: {
+    id: string;
+    status: string | null;
+    receiptStatus: string | null;
+    crmPostStatus: string | null;
+    reviewReason: string | null;
+    twentyRecordId: string | null;
+  } | null;
+  auditEvents?: Array<{
+    id: string;
+    actionType: string;
+    sourceSurface: string;
+    reason: string | null;
+    createdAt: string;
+  }>;
+  corrections?: Array<{
+    id: string;
+    correctionType: string;
+    status: string;
+  }>;
+  /** Correction requests linked to this donation (ADR-CD-005). */
+  correctionRequests?: Array<{
+    id: string;
+    actionType: string;
+    status: string;
+    reason: string;
+    requestedByProfileId: string | null;
+    createdAt: string;
+  }>;
+  /** Applied/reversed adjustment records linked to this donation (ADR-CD-004). */
+  adjustments?: ContributionAdjustmentRecord[];
+  /** Allocation rows backing the designation set (staged_gift_allocations). */
+  allocations?: DesignationAllocationInput[];
+  /** Fund metadata for designation lines (subtype derivation). */
+  allocationFunds?: DesignationFundInput[];
+  /** Missionary display names for designation lines. */
+  allocationMissionaries?: Array<{
+    id: string;
+    display_name: string | null;
+  }>;
+  /** Parent and child CRM record links for this donation (ADR-CD-012). */
+  crmLinks?: CrmPostLinkInput[];
+  /**
+   * The internal recurring agreement linked via `donations.pledge_id`
+   * (ADR-CD-007). Stripe references on it are secondary technical proof.
+   */
+  recurringAgreement?: {
+    id: string;
+    status: string | null;
+    frequency: string | null;
+    amountCents: number;
+    currencyCode: string;
+    fundId: string | null;
+    fundName: string | null;
+    missionaryId: string | null;
+    nextExpectedGiftAt: string | null;
+    stripeSubscriptionId: string | null;
+  } | null;
+}
+
+export interface ContributionDetail {
+  /**
+   * Shared contribution row contract fields (ADR-CD-032). Hub rows, CRM
+   * gift-history rows, and this detail payload derive overlapping fields from
+   * the same builder so surfaces cannot drift.
+   */
+  shared: SharedContributionRowFields;
+  id: string;
+  tenantId: string;
+  donor: {
+    id: string;
+    profileId: string | null;
+    name: string;
+    email: string | null;
+    phoneNumbers: string[];
+    location: string | null;
+    organization: string | null;
+  } | null;
+  gift: {
+    date: string;
+    createdAt: string;
+    updatedAt: string;
+    source: string;
+    campaignId: string | null;
+    pledgeId: string | null;
+  };
+  amount: {
+    value: number;
+    gross: number;
+    net: number | null;
+    fee: number | null;
+    taxDeductible: number | null;
+    currency: string;
+  };
+  payment: {
+    type: string;
+    method: string;
+    status: string;
+    lastFour: string | null;
+    stripe: {
+      paymentIntentId: string | null;
+      chargeId: string | null;
+      refundIds: string[];
+      replayContext: Record<string, unknown> | null;
+    };
+  };
+  /**
+   * The gift's complete designation set — financial truth per ADR-CD-008.
+   * Lines are equal; there is intentionally no single primary designation.
+   */
+  designations: ContributionDesignationSet;
+  receipt: {
+    status: string;
+    statementStatus: string | null;
+  };
+  refund: {
+    status: "none" | "partial_refund" | "refunded";
+    amount: number;
+    refundedAt: string | null;
+  };
+  /**
+   * Recurring context (ADR-CD-007). The internal recurring agreement is the
+   * primary link; provider recurrence without one is a reconciliation gap.
+   */
+  recurring: {
+    isRecurring: boolean;
+    interval: string | null;
+    pledgeId: string | null;
+    agreement: NonNullable<
+      ContributionDetailInput["recurringAgreement"]
+    > | null;
+    providerRecurrenceWithoutAgreement: boolean;
+  };
+  stagedGift: ContributionDetailInput["stagedGift"];
+  /**
+   * CRM/Twenty post state — workflow metadata, never payment truth
+   * (ADR-CD-012). Parent gift status and child designation record status are
+   * distinguished so retries can target the failed scope.
+   */
+  crm: ContributionCrmPostState & {
+    postStatus: string | null;
+    twentyRecordId: string | null;
+  };
+  auditEvents: NonNullable<ContributionDetailInput["auditEvents"]>;
+  corrections: NonNullable<ContributionDetailInput["corrections"]>;
+  /** Pending and decided correction requests for this gift (ADR-CD-005). */
+  correctionRequests: NonNullable<
+    ContributionDetailInput["correctionRequests"]
+  >;
+  /** Server-computed action availability (ADR-CD-017 / ADR-CD-018). */
+  actionAvailability: ContributionActionAvailability[];
+  /** Original donation truth — never mutated by corrections (ADR-CD-004). */
+  original: {
+    amountCents: number;
+    fundId: string | null;
+    missionaryId: string | null;
+    paymentStatus: string;
+  };
+  /** Current effective view derived from original + applied adjustments. */
+  effective: {
+    amountCents: number;
+    fundId: string | null;
+    missionaryId: string | null;
+    paymentStatus: string;
+    changedFields: string[];
+    materiallyDiffers: boolean;
+  };
+  /** Adjustment history linked to this donation, oldest first. */
+  adjustments: ContributionAdjustmentRecord[];
+  /**
+   * Optimistic-concurrency token (ADR-CD-022). Save APIs verify the submitted
+   * revision before applying so stale saves are rejected with recovery.
+   */
+  revision: string;
+  tasks: unknown[];
+  batches: unknown[];
+  donorVisible: {
+    status:
+      | "Succeeded"
+      | "Processing"
+      | "Failed"
+      | "Partially Refunded"
+      | "Refunded";
+    historyUpdatedImmediately: true;
+    amount: number;
+    currency: string;
+  };
+}
+
+function normalizeCurrency(currency: string | null | undefined): string {
+  return (currency ?? "usd").toUpperCase();
+}
+
+function displayNameFromDonor(
+  donor: NonNullable<ContributionDetailDonorInput>,
+) {
+  return (
+    donor.name?.trim() ||
+    donor.email?.trim() ||
+    donor.organization?.trim() ||
+    "Unknown donor"
+  );
+}
+
+function phoneNumbersFromDonor(
+  donor: NonNullable<ContributionDetailDonorInput>,
+): string[] {
+  return Array.from(
+    new Set(
+      [donor.phone, donor.mobile].filter((value): value is string =>
+        Boolean(value?.trim()),
+      ),
+    ),
+  );
+}
+
+function donorVisibleStatus(
+  status: string | null,
+  refundAmount: number,
+  amount: number,
+) {
+  const normalized = status?.toLowerCase() ?? "";
+  if (refundAmount > 0 && refundAmount < amount) {
+    return "Partially Refunded" as const;
+  }
+  if (normalized === "refunded" || (amount > 0 && refundAmount >= amount)) {
+    return "Refunded" as const;
+  }
+  if (
+    normalized === "completed" ||
+    normalized === "succeeded" ||
+    normalized === "success"
+  ) {
+    return "Succeeded" as const;
+  }
+  if (normalized === "failed") {
+    return "Failed" as const;
+  }
+  return "Processing" as const;
+}
+
+function refundStatus(
+  donation: Pick<ContributionDetailDonationInput, "amount" | "refundAmount">,
+) {
+  if (donation.refundAmount <= 0) {
+    return "none" as const;
+  }
+  return donation.refundAmount >= donation.amount
+    ? ("refunded" as const)
+    : ("partial_refund" as const);
+}
+
+export function buildContributionDetail(
+  input: ContributionDetailInput,
+): ContributionDetail {
+  const { donation, donor, fund, missionary, stagedGift } = input;
+  const currency = normalizeCurrency(donation.currency);
+
+  const designationFunds = new Map<string, DesignationFundInput>();
+  if (fund) {
+    designationFunds.set(fund.id, {
+      id: fund.id,
+      name: fund.name,
+      missionary_id: null,
+      goal_amount: null,
+      start_date: null,
+      end_date: null,
+    });
+  }
+  for (const allocationFund of input.allocationFunds ?? []) {
+    designationFunds.set(allocationFund.id, allocationFund);
+  }
+
+  const designationMissionaries = new Map<string, string | null>();
+  if (missionary) {
+    designationMissionaries.set(missionary.id, missionary.name);
+  }
+  for (const allocationMissionary of input.allocationMissionaries ?? []) {
+    designationMissionaries.set(
+      allocationMissionary.id,
+      allocationMissionary.display_name,
+    );
+  }
+
+  const adjustments = input.adjustments ?? [];
+  const original = {
+    amountCents: donation.amount,
+    fundId: donation.fundId,
+    missionaryId: donation.missionaryId,
+    paymentStatus: donation.status ?? "pending",
+  };
+  const effectiveResult = deriveEffectiveContribution({
+    original,
+    adjustments,
+  });
+  const effective = effectiveResult.effective;
+
+  const effectiveFund = effective.fundId
+    ? (designationFunds.get(effective.fundId) ?? null)
+    : null;
+  const effectiveMissionary = effective.missionaryId
+    ? {
+        id: effective.missionaryId,
+        display_name:
+          designationMissionaries.get(effective.missionaryId) ?? null,
+      }
+    : null;
+
+  const designations = buildContributionDesignationSet({
+    donation: {
+      id: donation.id,
+      amount: effective.amountCents,
+      currency: donation.currency,
+      fund_id: effective.fundId,
+      missionary_id: effective.missionaryId,
+    },
+    effectiveAmountCents: effective.amountCents,
+    allocations: effectiveResult.effectiveDesignationLines
+      ? effectiveResult.effectiveDesignationLines.map((line) => ({
+          id: line.id,
+          amount: line.amountCents,
+          fund_id: line.fundId,
+          missionary_id: line.missionaryId,
+          memo: line.memo,
+        }))
+      : (input.allocations ?? []),
+    funds: designationFunds,
+    missionaries: designationMissionaries,
+  });
+
+  const shared = buildSharedContributionRowFields({
+    designationSet: designations,
+    donation: {
+      id: donation.id,
+      donor_id: donation.donorId,
+      missionary_id: effective.missionaryId,
+      fund_id: effective.fundId,
+      amount: effective.amountCents,
+      currency: donation.currency,
+      status: effective.paymentStatus,
+      gift_date: donation.giftDate,
+      refund_amount: donation.refundAmount,
+      refunded_at: donation.refundedAt,
+      created_at: donation.createdAt,
+      updated_at: donation.updatedAt,
+      is_recurring: donation.isRecurring,
+      recurring_interval: donation.recurringInterval,
+      pledge_id: donation.pledgeId,
+    },
+    donor: donor
+      ? { id: donor.id, name: donor.name, email: donor.email }
+      : null,
+    profile: null,
+    fund: effectiveFund
+      ? { id: effectiveFund.id, name: effectiveFund.name }
+      : null,
+    missionary: effectiveMissionary,
+    stagedGift: stagedGift
+      ? {
+          id: stagedGift.id,
+          status: stagedGift.status,
+          receipt_status: stagedGift.receiptStatus,
+          crm_post_status: stagedGift.crmPostStatus,
+        }
+      : null,
+    corrections: [
+      ...(input.corrections ?? []).map((correction) => ({
+        status: correction.status,
+      })),
+      ...(input.correctionRequests ?? [])
+        .filter((request) => request.status === "pending")
+        .map(() => ({ status: "pending" })),
+    ],
+  });
+
+  return {
+    shared,
+    id: donation.id,
+    tenantId: donation.tenantId,
+    donor: donor
+      ? {
+          id: donor.id,
+          profileId: donor.profileId,
+          name: displayNameFromDonor(donor),
+          email: donor.email,
+          phoneNumbers: phoneNumbersFromDonor(donor),
+          location: donor.location,
+          organization: donor.organization,
+        }
+      : null,
+    gift: {
+      date: donation.giftDate,
+      createdAt: donation.createdAt,
+      updatedAt: donation.updatedAt,
+      source: donation.source ?? "online",
+      campaignId: donation.campaignId,
+      pledgeId: donation.pledgeId,
+    },
+    amount: {
+      value: effective.amountCents,
+      gross: effective.amountCents,
+      net: null,
+      fee: null,
+      taxDeductible: null,
+      currency,
+    },
+    payment: {
+      type: donation.donationType ?? "one_time",
+      method: donation.paymentMethod ?? "unknown",
+      status: effective.paymentStatus,
+      lastFour: null,
+      stripe: {
+        paymentIntentId: donation.stripePaymentIntentId,
+        chargeId: donation.stripeChargeId,
+        refundIds: [],
+        replayContext: null,
+      },
+    },
+    designations,
+    receipt: {
+      status: stagedGift?.receiptStatus ?? "pending",
+      statementStatus: null,
+    },
+    refund: {
+      status: refundStatus(donation),
+      amount: donation.refundAmount,
+      refundedAt: donation.refundedAt,
+    },
+    recurring: {
+      isRecurring: Boolean(donation.isRecurring || donation.recurringInterval),
+      interval: donation.recurringInterval,
+      pledgeId: donation.pledgeId,
+      agreement: input.recurringAgreement ?? null,
+      providerRecurrenceWithoutAgreement: Boolean(
+        (donation.isRecurring || donation.recurringInterval) &&
+        !input.recurringAgreement,
+      ),
+    },
+    stagedGift: stagedGift ?? null,
+    crm: {
+      postStatus: stagedGift?.crmPostStatus ?? null,
+      twentyRecordId: stagedGift?.twentyRecordId ?? null,
+      ...buildContributionCrmPostState({
+        stagedGiftCrmPostStatus: stagedGift?.crmPostStatus ?? null,
+        stagedGiftTwentyRecordId: stagedGift?.twentyRecordId ?? null,
+        links: input.crmLinks ?? [],
+        designationLineCount: designations.lines.length,
+      }),
+    },
+    auditEvents: input.auditEvents ?? [],
+    corrections: input.corrections ?? [],
+    correctionRequests: input.correctionRequests ?? [],
+    original,
+    effective: {
+      ...effective,
+      changedFields: effectiveResult.changedFields,
+      materiallyDiffers: effectiveResult.materiallyDiffers,
+    },
+    adjustments,
+    revision: `${donation.updatedAt}#${adjustments.length}`,
+    actionAvailability: buildContributionActionAvailability({
+      stagedGift: stagedGift
+        ? {
+            id: stagedGift.id,
+            status: stagedGift.status,
+            receiptStatus: stagedGift.receiptStatus,
+            crmPostStatus: stagedGift.crmPostStatus,
+          }
+        : null,
+      paymentStatus: donation.status,
+      refund: {
+        amountCents: effective.amountCents,
+        refundedAmountCents: donation.refundAmount,
+        hasProviderCharge: Boolean(donation.stripeChargeId),
+      },
+    }),
+    tasks: [],
+    batches: [],
+    donorVisible: {
+      status: donorVisibleStatus(
+        donation.status,
+        donation.refundAmount,
+        donation.amount,
+      ),
+      historyUpdatedImmediately: true,
+      amount: donation.amount,
+      currency,
+    },
+  };
+}

--- a/packages/api/src/admin/contribution-operations/detail-read-model.ts
+++ b/packages/api/src/admin/contribution-operations/detail-read-model.ts
@@ -519,6 +519,19 @@ export function buildContributionDetail(
     links: input.crmLinks ?? [],
     designationLineCount: designations.lines.length,
   });
+  const hasLoadedRecurringAgreement = input.recurringAgreement != null;
+  const hasInternalRecurringLink = Boolean(
+    donation.pledgeId || hasLoadedRecurringAgreement,
+  );
+  const isRecurringGift = Boolean(
+    donation.isRecurring ||
+    donation.recurringInterval ||
+    hasInternalRecurringLink,
+  );
+  const providerRecurrenceWithoutAgreement = Boolean(
+    (donation.isRecurring || donation.recurringInterval) &&
+    !hasInternalRecurringLink,
+  );
 
   return {
     shared,
@@ -577,14 +590,11 @@ export function buildContributionDetail(
       refundedAt: donation.refundedAt,
     },
     recurring: {
-      isRecurring: Boolean(donation.isRecurring || donation.recurringInterval),
+      isRecurring: isRecurringGift,
       interval: donation.recurringInterval,
       pledgeId: donation.pledgeId,
       agreement: input.recurringAgreement ?? null,
-      providerRecurrenceWithoutAgreement: Boolean(
-        (donation.isRecurring || donation.recurringInterval) &&
-        !input.recurringAgreement,
-      ),
+      providerRecurrenceWithoutAgreement,
     },
     stagedGift: stagedGift ?? null,
     crm: {

--- a/packages/api/src/admin/contribution-operations/detail-read-model.ts
+++ b/packages/api/src/admin/contribution-operations/detail-read-model.ts
@@ -358,6 +358,13 @@ function effectiveValuesRevisionPayload(
 function buildContributionRevision(input: {
   donationUpdatedAt: string;
   adjustments: ContributionAdjustmentRecord[];
+  stagedGift: ContributionDetailInput["stagedGift"];
+  crmLinks: CrmPostLinkInput[];
+  corrections: NonNullable<ContributionDetailInput["corrections"]>;
+  correctionRequests: NonNullable<
+    ContributionDetailInput["correctionRequests"]
+  >;
+  auditEvents: NonNullable<ContributionDetailInput["auditEvents"]>;
 }): string {
   const adjustmentFingerprint = [...input.adjustments]
     .sort((left, right) => {
@@ -381,9 +388,90 @@ function buildContributionRevision(input: {
       sourceSurface: adjustment.sourceSurface,
       createdAt: adjustment.createdAt,
     }));
+  const workflowFingerprint = {
+    stagedGift: input.stagedGift
+      ? {
+          id: input.stagedGift.id,
+          status: input.stagedGift.status,
+          receiptStatus: input.stagedGift.receiptStatus,
+          crmPostStatus: input.stagedGift.crmPostStatus,
+          reviewReason: input.stagedGift.reviewReason,
+          twentyRecordId: input.stagedGift.twentyRecordId,
+        }
+      : null,
+    crmLinks: [...input.crmLinks]
+      .sort((left, right) => {
+        const scopeDiff = left.scope.localeCompare(right.scope);
+        if (scopeDiff !== 0) {
+          return scopeDiff;
+        }
+        const allocationDiff = (left.allocationId ?? "").localeCompare(
+          right.allocationId ?? "",
+        );
+        if (allocationDiff !== 0) {
+          return allocationDiff;
+        }
+        return left.id.localeCompare(right.id);
+      })
+      .map((link) => ({
+        id: link.id,
+        scope: link.scope,
+        allocationId: link.allocationId,
+        linkStatus: link.linkStatus,
+        twentyRecordId: link.twentyRecordId,
+        lastError: link.lastError,
+      })),
+    corrections: [...input.corrections]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((correction) => ({
+        id: correction.id,
+        correctionType: correction.correctionType,
+        status: correction.status,
+      })),
+    correctionRequests: [...input.correctionRequests]
+      .sort((left, right) => {
+        const createdAtDiff =
+          new Date(left.createdAt).getTime() -
+          new Date(right.createdAt).getTime();
+        if (createdAtDiff !== 0) {
+          return createdAtDiff;
+        }
+        return left.id.localeCompare(right.id);
+      })
+      .map((request) => ({
+        id: request.id,
+        actionType: request.actionType,
+        status: request.status,
+        reason: request.reason,
+        requestedByProfileId: request.requestedByProfileId,
+        createdAt: request.createdAt,
+      })),
+    auditEvents: [...input.auditEvents]
+      .sort((left, right) => {
+        const createdAtDiff =
+          new Date(left.createdAt).getTime() -
+          new Date(right.createdAt).getTime();
+        if (createdAtDiff !== 0) {
+          return createdAtDiff;
+        }
+        return left.id.localeCompare(right.id);
+      })
+      .map((event) => ({
+        id: event.id,
+        actionType: event.actionType,
+        sourceSurface: event.sourceSurface,
+        reason: event.reason,
+        createdAt: event.createdAt,
+      })),
+  };
 
   const adjustmentHash = createHash("sha256")
-    .update(JSON.stringify(adjustmentFingerprint))
+    .update(
+      JSON.stringify({
+        adjustments: adjustmentFingerprint,
+        workflow: workflowFingerprint,
+      }),
+    )
     .digest("hex")
     .slice(0, 16);
 
@@ -615,6 +703,11 @@ export function buildContributionDetail(
     revision: buildContributionRevision({
       donationUpdatedAt: donation.updatedAt,
       adjustments,
+      stagedGift,
+      crmLinks: input.crmLinks ?? [],
+      corrections: input.corrections ?? [],
+      correctionRequests: input.correctionRequests ?? [],
+      auditEvents: input.auditEvents ?? [],
     }),
     actionAvailability: buildContributionActionAvailability({
       stagedGift: stagedGift

--- a/packages/api/src/admin/contribution-operations/index.ts
+++ b/packages/api/src/admin/contribution-operations/index.ts
@@ -1,0 +1,71 @@
+export {
+  buildContributionActionAvailability,
+  type ContributionActionAvailability,
+} from "./action-availability";
+export {
+  assertCanDecideCorrectionRequest,
+  correctionRequiresApproval,
+  resolveCorrectionApprovalPolicy,
+  type CorrectionApprovalOwnershipMode,
+  type CorrectionApprovalPolicy,
+} from "./approval-policy";
+export {
+  buildContributionCrmPostState,
+  CRM_CHILD_RECORDS_UNSUPPORTED_MESSAGE,
+  type ContributionCrmPostState,
+  type CrmDesignationRecordState,
+  type CrmPostFailedScope,
+  type CrmPostLinkInput,
+} from "./crm-post-state";
+export { buildContributionDetail } from "./detail-read-model";
+export {
+  getContributionActionPolicy,
+  getContributionActionRiskLevel,
+  isContributionConfirmationRequired,
+  isContributionReasonRequired,
+  isHighRiskContributionAction,
+} from "./policy";
+export {
+  computeReceiptAffectedFields,
+  evaluateReceiptDeliveryOptions,
+  parseReceiptDeliverySelection,
+  resolveConfirmedReceiptDelivery,
+  resolveTenantReceiptDeliveryPolicy,
+  validateReceiptDeliverySelection,
+  type ReceiptDeliveryChoice,
+  type ReceiptDeliveryDonorContext,
+  type ReceiptDeliveryOption,
+  type ReceiptDeliveryOutcome,
+  type ReceiptDeliverySelection,
+  type TenantReceiptDeliveryPolicy,
+  type TenantReceiptDeliveryPolicyRow,
+} from "./receipt-delivery";
+export {
+  projectContributionDetailForViewer,
+  stripeReplayAvailability,
+  type ContributionProviderProof,
+  type ViewerProjectedContributionDetail,
+} from "./viewer-projection";
+
+export type {
+  ContributionActionDependencies,
+  ContributionActionPolicy,
+  ContributionActionResult,
+  ContributionActionType,
+  ContributionCorrectionRecordInput,
+  ContributionOperationAuditEventInput,
+  ContributionOperationOrganizationSettings,
+  ContributionOperationUserPreferences,
+  ContributionPermission,
+  ContributionProviderOutcome,
+  ContributionReasonMode,
+  ContributionRiskLevel,
+  ContributionSourceSurface,
+  ExecuteContributionActionInput,
+} from "./types";
+export type {
+  ContributionDetail,
+  ContributionDetailDonationInput,
+  ContributionDetailDonorInput,
+  ContributionDetailInput,
+} from "./detail-read-model";

--- a/packages/api/src/admin/contribution-operations/policy.ts
+++ b/packages/api/src/admin/contribution-operations/policy.ts
@@ -1,0 +1,102 @@
+import type {
+  ContributionActionPolicy,
+  ContributionActionType,
+  ContributionOperationOrganizationSettings,
+  ContributionOperationUserPreferences,
+  ContributionRiskLevel,
+} from "./types";
+
+const HIGH_RISK_ACTIONS = new Set<ContributionActionType>([
+  "refund",
+  "donor_relink",
+  "amount_correction",
+  "designation_correction",
+  "fund_correction",
+  "payment_state_correction",
+  "stripe_replay",
+]);
+
+const MEDIUM_RISK_ACTIONS = new Set<ContributionActionType>([
+  "allocation_correction",
+  "receipt_correction",
+  "statement_correction",
+  "crm_repost",
+]);
+
+export function getContributionActionRiskLevel(
+  actionType: ContributionActionType,
+): ContributionRiskLevel {
+  if (HIGH_RISK_ACTIONS.has(actionType)) {
+    return "high";
+  }
+
+  if (MEDIUM_RISK_ACTIONS.has(actionType)) {
+    return "medium";
+  }
+
+  return "low";
+}
+
+export function isHighRiskContributionAction(
+  actionType: ContributionActionType,
+): boolean {
+  return getContributionActionRiskLevel(actionType) === "high";
+}
+
+function shouldRequireReasonFromSettings(input: {
+  riskLevel: ContributionRiskLevel;
+  organizationSettings?: ContributionOperationOrganizationSettings;
+  userPreferences?: ContributionOperationUserPreferences;
+}) {
+  const { riskLevel, organizationSettings, userPreferences } = input;
+  if (riskLevel === "high") {
+    return true;
+  }
+
+  if (organizationSettings?.defaultReasonMode !== "required") {
+    return false;
+  }
+
+  if (!organizationSettings.allowUserReasonPromptReduction) {
+    return true;
+  }
+
+  return userPreferences?.reduceReasonPrompts !== true;
+}
+
+export function getContributionActionPolicy(input: {
+  actionType: ContributionActionType;
+  organizationSettings?: ContributionOperationOrganizationSettings;
+  userPreferences?: ContributionOperationUserPreferences;
+}): ContributionActionPolicy {
+  const riskLevel = getContributionActionRiskLevel(input.actionType);
+  const nonSuppressibleReason = riskLevel === "high";
+  const requiresReason = shouldRequireReasonFromSettings({
+    riskLevel,
+    organizationSettings: input.organizationSettings,
+    userPreferences: input.userPreferences,
+  });
+
+  return {
+    actionType: input.actionType,
+    riskLevel,
+    requiresReason,
+    requiresConfirmation: riskLevel === "high",
+    canSuppressReason: !nonSuppressibleReason,
+    requiredPermission:
+      riskLevel === "high" ? "finance:manage_contributions" : null,
+    nonSuppressibleReason,
+  };
+}
+
+export function isContributionReasonRequired(
+  policy: Pick<ContributionActionPolicy, "requiresReason">,
+) {
+  return policy.requiresReason;
+}
+
+export function isContributionConfirmationRequired(
+  policy: Pick<ContributionActionPolicy, "requiresConfirmation">,
+) {
+  return policy.requiresConfirmation;
+}

--- a/packages/api/src/admin/contribution-operations/receipt-delivery.ts
+++ b/packages/api/src/admin/contribution-operations/receipt-delivery.ts
@@ -100,7 +100,10 @@ export function evaluateReceiptDeliveryOptions(input: {
   policy: TenantReceiptDeliveryPolicy;
   donor: ReceiptDeliveryDonorContext;
   actorCapabilities: string[];
-}): { options: ReceiptDeliveryOption[]; defaultChoice: ReceiptDeliveryChoice } {
+}): {
+  options: ReceiptDeliveryOption[];
+  defaultChoice: ReceiptDeliveryChoice | null;
+} {
   const { policy, donor, actorCapabilities } = input;
 
   let emailBlockedReason: string | null = null;
@@ -154,8 +157,7 @@ export function evaluateReceiptDeliveryOptions(input: {
     "email",
   ];
   const defaultChoice =
-    fallbackOrder.find((choice) => availability.get(choice)) ??
-    policy.defaultChoice;
+    fallbackOrder.find((choice) => availability.get(choice)) ?? null;
 
   return { options, defaultChoice };
 }

--- a/packages/api/src/admin/contribution-operations/receipt-delivery.ts
+++ b/packages/api/src/admin/contribution-operations/receipt-delivery.ts
@@ -117,9 +117,14 @@ export function evaluateReceiptDeliveryOptions(input: {
     ? null
     : `Generating updated receipt PDFs requires ${policy.pdfCapability}.`;
 
-  const deferBlockedReason = policy.allowDefer
-    ? null
-    : "Deferring the updated receipt is not allowed; this organization requires a receipt action for receipt-affecting corrections.";
+  let deferBlockedReason: string | null = null;
+  if (policy.requireDeliveryAction) {
+    deferBlockedReason =
+      "Deferring the updated receipt is not allowed; this organization requires email delivery or PDF generation for receipt-affecting corrections.";
+  } else if (!policy.allowDefer) {
+    deferBlockedReason =
+      "Deferring the updated receipt is not allowed; this organization requires a receipt action for receipt-affecting corrections.";
+  }
 
   const options: ReceiptDeliveryOption[] = [
     {

--- a/packages/api/src/admin/contribution-operations/receipt-delivery.ts
+++ b/packages/api/src/admin/contribution-operations/receipt-delivery.ts
@@ -1,0 +1,247 @@
+import { ApiHttpError } from "../../shared/http-errors";
+
+import type { ContributionAdjustmentEffectiveValues } from "../contribution-shared/effective-values";
+
+/**
+ * Updated receipt delivery policy (ADR-CD-029 / ADR-CD-030 / ADR-CD-031).
+ *
+ * When a correction changes values already represented on a sent receipt,
+ * staff choose at correction time: email (only when the donor has an address
+ * and has not opted out), PDF, or defer with a reason where policy permits.
+ * A receipt is never auto-sent just because a correction was saved, donor
+ * email opt-out is an absolute block, and the policy is enforced server-side.
+ */
+
+export type ReceiptDeliveryChoice = "email" | "pdf" | "defer";
+
+export interface ReceiptDeliverySelection {
+  choice: ReceiptDeliveryChoice;
+  deferReason?: string | null;
+}
+
+export interface TenantReceiptDeliveryPolicy {
+  defaultChoice: ReceiptDeliveryChoice;
+  allowDefer: boolean;
+  deferReasonRequired: boolean;
+  /** When true, receipt-affecting corrections must select email or PDF. */
+  requireDeliveryAction: boolean;
+  /** Capability required to send updated receipt emails. */
+  emailCapability: string;
+  /** Capability required to generate updated receipt PDFs. */
+  pdfCapability: string;
+}
+
+export interface TenantReceiptDeliveryPolicyRow {
+  default_choice?: string | null;
+  allow_defer?: boolean | null;
+  defer_reason_required?: boolean | null;
+  require_delivery_action?: boolean | null;
+  email_capability?: string | null;
+  pdf_capability?: string | null;
+}
+
+const DELIVERY_CHOICES: ReceiptDeliveryChoice[] = ["email", "pdf", "defer"];
+
+export function resolveTenantReceiptDeliveryPolicy(
+  row: TenantReceiptDeliveryPolicyRow | null | undefined,
+): TenantReceiptDeliveryPolicy {
+  const defaultChoice = DELIVERY_CHOICES.includes(
+    row?.default_choice as ReceiptDeliveryChoice,
+  )
+    ? (row?.default_choice as ReceiptDeliveryChoice)
+    : "email";
+
+  return {
+    defaultChoice,
+    allowDefer: row?.allow_defer ?? true,
+    deferReasonRequired: row?.defer_reason_required ?? true,
+    requireDeliveryAction: row?.require_delivery_action ?? false,
+    emailCapability: row?.email_capability ?? "contributions.manage_receipts",
+    pdfCapability: row?.pdf_capability ?? "contributions.manage_receipts",
+  };
+}
+
+/**
+ * Which receipt-visible fields a correction changes (ADR-CD-013). Used so
+ * staff see what changed before choosing a delivery action.
+ */
+export function computeReceiptAffectedFields(
+  effectiveValues: ContributionAdjustmentEffectiveValues,
+): string[] {
+  const fields: string[] = [];
+  if (effectiveValues.amountCents !== undefined) {
+    fields.push("amount");
+  }
+  if (
+    effectiveValues.fundId !== undefined ||
+    effectiveValues.missionaryId !== undefined ||
+    effectiveValues.designationLines !== undefined
+  ) {
+    fields.push("designation");
+  }
+  if (effectiveValues.paymentStatus !== undefined) {
+    fields.push("payment status");
+  }
+  return fields;
+}
+
+export interface ReceiptDeliveryDonorContext {
+  email: string | null;
+  doNotEmail: boolean;
+}
+
+export interface ReceiptDeliveryOption {
+  choice: ReceiptDeliveryChoice;
+  available: boolean;
+  blockedReason: string | null;
+}
+
+export function evaluateReceiptDeliveryOptions(input: {
+  policy: TenantReceiptDeliveryPolicy;
+  donor: ReceiptDeliveryDonorContext;
+  actorCapabilities: string[];
+}): { options: ReceiptDeliveryOption[]; defaultChoice: ReceiptDeliveryChoice } {
+  const { policy, donor, actorCapabilities } = input;
+
+  let emailBlockedReason: string | null = null;
+  if (!donor.email?.trim()) {
+    emailBlockedReason = "The donor has no email address on file.";
+  } else if (donor.doNotEmail) {
+    emailBlockedReason =
+      "The donor opted out of email; email receipts are blocked.";
+  } else if (!actorCapabilities.includes(policy.emailCapability)) {
+    emailBlockedReason = `Sending updated receipt emails requires ${policy.emailCapability}.`;
+  }
+
+  const pdfBlockedReason = actorCapabilities.includes(policy.pdfCapability)
+    ? null
+    : `Generating updated receipt PDFs requires ${policy.pdfCapability}.`;
+
+  const deferBlockedReason = policy.allowDefer
+    ? null
+    : "Deferring the updated receipt is not allowed; this organization requires a receipt action for receipt-affecting corrections.";
+
+  const options: ReceiptDeliveryOption[] = [
+    {
+      choice: "email",
+      available: emailBlockedReason === null,
+      blockedReason: emailBlockedReason,
+    },
+    {
+      choice: "pdf",
+      available: pdfBlockedReason === null,
+      blockedReason: pdfBlockedReason,
+    },
+    {
+      choice: "defer",
+      available: deferBlockedReason === null,
+      blockedReason: deferBlockedReason,
+    },
+  ];
+
+  const availability = new Map(
+    options.map((option) => [option.choice, option.available]),
+  );
+  const fallbackOrder: ReceiptDeliveryChoice[] = [
+    policy.defaultChoice,
+    "pdf",
+    "defer",
+    "email",
+  ];
+  const defaultChoice =
+    fallbackOrder.find((choice) => availability.get(choice)) ??
+    policy.defaultChoice;
+
+  return { options, defaultChoice };
+}
+
+/**
+ * Server-side validation of a staff delivery selection. The UI only shows
+ * allowed choices, but policy enforcement never trusts client state.
+ */
+export function validateReceiptDeliverySelection(input: {
+  policy: TenantReceiptDeliveryPolicy;
+  donor: ReceiptDeliveryDonorContext;
+  actorCapabilities: string[];
+  selection: ReceiptDeliverySelection;
+}): void {
+  const { options } = evaluateReceiptDeliveryOptions(input);
+  const option = options.find(
+    (candidate) => candidate.choice === input.selection.choice,
+  );
+  if (!option) {
+    throw new ApiHttpError(400, "Unknown receipt delivery choice.");
+  }
+  if (!option.available) {
+    throw new ApiHttpError(
+      option.blockedReason?.includes("requires") ? 403 : 400,
+      option.blockedReason ?? "Receipt delivery choice unavailable.",
+    );
+  }
+
+  if (
+    input.selection.choice === "defer" &&
+    input.policy.deferReasonRequired &&
+    !input.selection.deferReason?.trim()
+  ) {
+    throw new ApiHttpError(
+      400,
+      "A reason is required when deferring the updated receipt.",
+    );
+  }
+}
+
+/**
+ * The requester proposes a delivery action; the approver confirms or changes
+ * it at approval time (ADR-CD-030). Both values stay visible in the result.
+ */
+export function resolveConfirmedReceiptDelivery(input: {
+  proposal: ReceiptDeliverySelection | null;
+  approverSelection: ReceiptDeliverySelection | null;
+}): {
+  requested: ReceiptDeliverySelection | null;
+  confirmed: ReceiptDeliverySelection | null;
+  changedByApprover: boolean;
+} {
+  const confirmed = input.approverSelection ?? input.proposal;
+  const changedByApprover =
+    input.approverSelection !== null &&
+    input.proposal !== null &&
+    (input.approverSelection.choice !== input.proposal.choice ||
+      (input.approverSelection.deferReason ?? null) !==
+        (input.proposal.deferReason ?? null));
+
+  return {
+    requested: input.proposal,
+    confirmed: confirmed ?? null,
+    changedByApprover,
+  };
+}
+
+/** Parses an untyped payload field into a delivery selection, if present. */
+export function parseReceiptDeliverySelection(
+  value: unknown,
+): ReceiptDeliverySelection | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const choice = record.choice;
+  if (choice !== "email" && choice !== "pdf" && choice !== "defer") {
+    return null;
+  }
+  return {
+    choice,
+    deferReason:
+      typeof record.deferReason === "string" ? record.deferReason : null,
+  };
+}
+
+export interface ReceiptDeliveryOutcome {
+  status: "emailed" | "pdf_generated" | "deferred" | "blocked" | "not_required";
+  reason: string | null;
+  snapshotId: string | null;
+  affectedFields: string[];
+  requested: ReceiptDeliverySelection | null;
+  confirmed: ReceiptDeliverySelection | null;
+}

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -1,22 +1,25 @@
 import type { CorrectionApprovalPolicy } from "./approval-policy";
 import type { ReceiptDeliveryOutcome } from "./receipt-delivery";
 
-export type ContributionActionType =
-  | "resend_receipt"
-  | "approve_staged_gift"
-  | "retry_staged_gift"
-  | "crm_repost"
-  | "metadata_update"
-  | "refund"
-  | "donor_relink"
-  | "amount_correction"
-  | "designation_correction"
-  | "fund_correction"
-  | "allocation_correction"
-  | "receipt_correction"
-  | "statement_correction"
-  | "payment_state_correction"
-  | "stripe_replay";
+export const CONTRIBUTION_ACTION_TYPES = [
+  "resend_receipt",
+  "approve_staged_gift",
+  "retry_staged_gift",
+  "crm_repost",
+  "metadata_update",
+  "refund",
+  "donor_relink",
+  "amount_correction",
+  "designation_correction",
+  "fund_correction",
+  "allocation_correction",
+  "receipt_correction",
+  "statement_correction",
+  "payment_state_correction",
+  "stripe_replay",
+] as const;
+
+export type ContributionActionType = (typeof CONTRIBUTION_ACTION_TYPES)[number];
 
 export type ContributionSourceSurface =
   | "contribution_hub"

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -1,0 +1,256 @@
+import type { CorrectionApprovalPolicy } from "./approval-policy";
+import type { ReceiptDeliveryOutcome } from "./receipt-delivery";
+
+export type ContributionActionType =
+  | "resend_receipt"
+  | "approve_staged_gift"
+  | "retry_staged_gift"
+  | "crm_repost"
+  | "metadata_update"
+  | "refund"
+  | "donor_relink"
+  | "amount_correction"
+  | "designation_correction"
+  | "fund_correction"
+  | "allocation_correction"
+  | "receipt_correction"
+  | "statement_correction"
+  | "payment_state_correction"
+  | "stripe_replay";
+
+export type ContributionSourceSurface =
+  | "contribution_hub"
+  | "donor_crm_record"
+  | "automation"
+  | "bulk_action"
+  | "api";
+
+export type ContributionRiskLevel = "low" | "medium" | "high";
+
+export type ContributionPermission = "finance:manage_contributions";
+
+export type ContributionReasonMode = "optional" | "required";
+
+export interface ContributionOperationOrganizationSettings {
+  defaultReasonMode?: ContributionReasonMode;
+  allowUserReasonPromptReduction?: boolean;
+}
+
+export interface ContributionOperationUserPreferences {
+  reduceReasonPrompts?: boolean;
+}
+
+export interface ContributionActionPolicy {
+  actionType: ContributionActionType;
+  riskLevel: ContributionRiskLevel;
+  requiresReason: boolean;
+  requiresConfirmation: boolean;
+  canSuppressReason: boolean;
+  requiredPermission: ContributionPermission | null;
+  nonSuppressibleReason: boolean;
+}
+
+export interface ContributionOperationAuditEventInput {
+  tenantId: string;
+  actorProfileId: string | null;
+  contributionId: string;
+  stagedGiftId?: string | null;
+  donorId?: string | null;
+  actionType: ContributionActionType;
+  sourceSurface: ContributionSourceSurface;
+  reason?: string | null;
+  correctionId?: string | null;
+  providerOutcome?: ContributionProviderOutcome | null;
+  beforeSummary?: Record<string, unknown> | null;
+  afterSummary?: Record<string, unknown> | null;
+  downstreamEffects?: Record<string, unknown>;
+}
+
+export interface ContributionProviderOutcome {
+  provider: "stripe" | "resend" | "twenty" | "platform";
+  status: string;
+  referenceId?: string | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  raw?: Record<string, unknown>;
+}
+
+export interface ContributionCorrectionRecordInput {
+  tenantId: string;
+  contributionId: string;
+  stagedGiftId?: string | null;
+  actorProfileId: string | null;
+  sourceSurface: ContributionSourceSurface;
+  correctionType: ContributionActionType;
+  status?: "pending" | "applied" | "failed" | "voided";
+  reason: string;
+  beforeSummary?: Record<string, unknown> | null;
+  afterSummary?: Record<string, unknown> | null;
+  providerOutcome?: ContributionProviderOutcome | null;
+}
+
+export interface ContributionActionResult<TContribution = unknown> {
+  canonicalContribution: TContribution;
+  auditEventId: string;
+  correctionId?: string | null;
+  /** Pending correction request id when approval policy gated the action. */
+  correctionRequestId?: string | null;
+  /** Whether the correction applied immediately or awaits approval. */
+  approvalStatus?: "applied" | "pending_approval";
+  /** Adjustment record id when the action applied an adjustment (ADR-CD-004). */
+  adjustmentId?: string | null;
+  /** Updated receipt delivery outcome for receipt-affecting corrections. */
+  receiptOutcome?: ReceiptDeliveryOutcome | null;
+  /** True when an idempotent retry returned the previously applied adjustment. */
+  idempotentReplay?: boolean;
+  notification?: {
+    decision: "sent" | "suppressed" | "blocked" | "failed" | "not_required";
+    taskIds?: string[];
+  };
+  taskIds: string[];
+  providerOutcome?: ContributionProviderOutcome | null;
+}
+
+export interface ContributionActionDependencies<TContribution = unknown> {
+  sendReceipt?: (input: {
+    tenantId: string;
+    stagedGiftId: string;
+  }) => Promise<{ status: string; sendLogId?: string | null }>;
+  approveStagedGift?: (input: {
+    tenantId: string;
+    stagedGiftId: string;
+    actorProfileId: string | null;
+    note?: string | null;
+  }) => Promise<unknown>;
+  retryStagedGift?: (input: {
+    tenantId: string;
+    stagedGiftId: string;
+    actorProfileId: string | null;
+    note?: string | null;
+  }) => Promise<unknown>;
+  /**
+   * Retries posting one designation child record (ADR-CD-012). Optional —
+   * when the CRM adapter cannot post child records this stays undefined and
+   * the limitation is surfaced to staff instead of silently reposting.
+   */
+  retryDesignationPost?: (input: {
+    tenantId: string;
+    stagedGiftId: string;
+    allocationId: string;
+    actorProfileId: string | null;
+    note?: string | null;
+  }) => Promise<unknown>;
+  relinkDonor?: (input: {
+    tenantId: string;
+    contributionId: string;
+    donorId: string;
+  }) => Promise<{
+    before?: Record<string, unknown> | null;
+    after?: Record<string, unknown> | null;
+  }>;
+  applyCorrection?: (input: {
+    tenantId: string;
+    contributionId: string;
+    actionType: ContributionActionType;
+    payload: Record<string, unknown>;
+    reason: string;
+    actorProfileId: string | null;
+    sourceSurface: ContributionSourceSurface;
+    actorCapabilities?: string[];
+    expectedRevision?: string | null;
+    idempotencyKey?: string | null;
+  }) => Promise<{
+    before?: Record<string, unknown> | null;
+    after?: Record<string, unknown> | null;
+    status?: "pending" | "applied" | "failed" | "voided";
+    adjustmentId?: string | null;
+    idempotentReplay?: boolean;
+    receiptOutcome?: ReceiptDeliveryOutcome | null;
+  }>;
+  replayStripeEvent?: (input: {
+    tenantId: string;
+    contributionId: string;
+    payload: Record<string, unknown>;
+  }) => Promise<ContributionProviderOutcome>;
+  sendCorrectionNotification?: (input: {
+    tenantId: string;
+    actionType: ContributionActionType;
+    contributionId: string;
+    correctionId: string | null;
+    auditEventId: string;
+    actorProfileId: string | null;
+    providerOutcome?: ContributionProviderOutcome | null;
+    beforeSummary?: Record<string, unknown> | null;
+    afterSummary?: Record<string, unknown> | null;
+  }) => Promise<{
+    decision: "sent" | "suppressed" | "blocked" | "failed" | "not_required";
+    taskIds?: string[];
+  }>;
+  refundContribution?: (input: {
+    tenantId: string;
+    contributionId: string;
+    amount: number;
+    reason: string;
+    confirmationToken: string;
+  }) => Promise<ContributionProviderOutcome>;
+  appendAuditEvent?: (
+    input: ContributionOperationAuditEventInput,
+  ) => Promise<string>;
+  createCorrectionRecord?: (
+    input: ContributionCorrectionRecordInput,
+  ) => Promise<string>;
+  loadContributionDetail?: (input: {
+    tenantId: string;
+    contributionId: string;
+  }) => Promise<TContribution>;
+  /** Persists a pending correction request (ADR-CD-005); returns its id. */
+  createCorrectionRequest?: (input: {
+    tenantId: string;
+    contributionId: string;
+    actionType: ContributionActionType;
+    payload: Record<string, unknown>;
+    reason: string;
+    requestedByProfileId: string | null;
+    sourceSurface: ContributionSourceSurface;
+    expectedRevision?: string | null;
+    idempotencyKey?: string | null;
+    /** Requester's proposed updated receipt delivery action (ADR-CD-030). */
+    receiptDeliveryProposal?: Record<string, unknown> | null;
+  }) => Promise<string>;
+}
+
+export interface ExecuteContributionActionInput<TContribution = unknown> {
+  tenantId: string;
+  actorProfileId: string | null;
+  actorPermissions: ContributionPermission[];
+  /** Granular backend capabilities for the actor (ADR-CD-024). */
+  actorCapabilities?: string[];
+  /**
+   * Tenant correction approval policy (ADR-CD-005 / ADR-CD-025). When
+   * omitted, the conservative default (separation of duties, no
+   * suppression) applies and high-risk corrections create requests.
+   */
+  approvalPolicy?: CorrectionApprovalPolicy;
+  /**
+   * Set when an approver applies a previously approved correction request;
+   * bypasses request creation but never audit, reasons, or idempotency.
+   */
+  approvedRequestId?: string | null;
+  sourceSurface: ContributionSourceSurface;
+  contributionId: string;
+  stagedGiftId?: string | null;
+  actionType: ContributionActionType;
+  reason?: string | null;
+  confirmationToken?: string | null;
+  /**
+   * Optimistic-concurrency token from the detail payload (`detail.revision`).
+   * Stale saves are rejected server-side with a recovery path (ADR-CD-022).
+   */
+  expectedRevision?: string | null;
+  /** Caller idempotency key so retried saves cannot double-apply. */
+  idempotencyKey?: string | null;
+  payload?: Record<string, unknown>;
+  organizationSettings?: ContributionOperationOrganizationSettings;
+  userPreferences?: ContributionOperationUserPreferences;
+  dependencies?: ContributionActionDependencies<TContribution>;
+}

--- a/packages/api/src/admin/contribution-operations/viewer-projection.ts
+++ b/packages/api/src/admin/contribution-operations/viewer-projection.ts
@@ -1,0 +1,113 @@
+import type { ContributionActionAvailability } from "./action-availability";
+import type { ContributionDetail } from "./detail-read-model";
+
+/**
+ * Role-gated provider proof (ADR-CD-014 / ADR-CD-015).
+ *
+ * Normal staff see payment summaries without raw provider identifiers.
+ * Authorized finance/admin operators (contributions.use_provider_actions)
+ * get an expandable proof block with provider ids and dashboard links, plus
+ * the safe provider actions. Raw provider payloads and secrets are never
+ * part of the detail payload for unauthorized viewers.
+ */
+
+export interface ContributionProviderProof {
+  paymentIntentId: string | null;
+  chargeId: string | null;
+  refundIds: string[];
+  replayContext: Record<string, unknown> | null;
+  dashboardUrls: {
+    paymentIntent: string | null;
+    charge: string | null;
+  };
+}
+
+export type ViewerProjectedContributionDetail = ContributionDetail & {
+  /** Present only for viewers with contributions.use_provider_actions. */
+  providerProof: ContributionProviderProof | null;
+};
+
+export function stripeReplayAvailability(
+  paymentIntentId: string | null,
+): ContributionActionAvailability {
+  if (!paymentIntentId) {
+    return {
+      actionType: "stripe_replay",
+      available: false,
+      blockedReason: "This gift has no provider payment events to replay.",
+      nextStep:
+        "Webhook replay applies to gifts processed through the payment provider.",
+      riskLevel: "high",
+    };
+  }
+
+  return {
+    actionType: "stripe_replay",
+    available: true,
+    blockedReason: null,
+    nextStep: null,
+    riskLevel: "high",
+  };
+}
+
+export function projectContributionDetailForViewer(
+  detail: ContributionDetail,
+  viewerCapabilities: string[],
+): ViewerProjectedContributionDetail {
+  const hasProviderAccess = viewerCapabilities.includes(
+    "contributions.use_provider_actions",
+  );
+
+  if (!hasProviderAccess) {
+    return {
+      ...detail,
+      payment: {
+        ...detail.payment,
+        stripe: {
+          paymentIntentId: null,
+          chargeId: null,
+          refundIds: [],
+          replayContext: null,
+        },
+      },
+      recurring: {
+        ...detail.recurring,
+        agreement: detail.recurring.agreement
+          ? { ...detail.recurring.agreement, stripeSubscriptionId: null }
+          : null,
+      },
+      // Hide provider/admin actions entirely for unauthorized viewers
+      // (ADR-CD-018 mixed visibility: irrelevant or unauthorized → hidden).
+      actionAvailability: detail.actionAvailability.filter(
+        (entry) => entry.actionType !== "stripe_replay",
+      ),
+      providerProof: null,
+    };
+  }
+
+  const { paymentIntentId, chargeId } = detail.payment.stripe;
+
+  return {
+    ...detail,
+    actionAvailability: [
+      ...detail.actionAvailability.filter(
+        (entry) => entry.actionType !== "stripe_replay",
+      ),
+      stripeReplayAvailability(paymentIntentId),
+    ],
+    providerProof: {
+      paymentIntentId,
+      chargeId,
+      refundIds: detail.payment.stripe.refundIds,
+      replayContext: detail.payment.stripe.replayContext,
+      dashboardUrls: {
+        paymentIntent: paymentIntentId
+          ? `https://dashboard.stripe.com/payments/${paymentIntentId}`
+          : null,
+        charge: chargeId
+          ? `https://dashboard.stripe.com/charges/${chargeId}`
+          : null,
+      },
+    },
+  };
+}

--- a/packages/api/src/admin/contribution-operations/viewer-projection.ts
+++ b/packages/api/src/admin/contribution-operations/viewer-projection.ts
@@ -29,8 +29,9 @@ export type ViewerProjectedContributionDetail = ContributionDetail & {
 
 export function stripeReplayAvailability(
   paymentIntentId: string | null,
+  chargeId: string | null,
 ): ContributionActionAvailability {
-  if (!paymentIntentId) {
+  if (!paymentIntentId && !chargeId) {
     return {
       actionType: "stripe_replay",
       available: false,
@@ -93,7 +94,7 @@ export function projectContributionDetailForViewer(
       ...detail.actionAvailability.filter(
         (entry) => entry.actionType !== "stripe_replay",
       ),
-      stripeReplayAvailability(paymentIntentId),
+      stripeReplayAvailability(paymentIntentId, chargeId),
     ],
     providerProof: {
       paymentIntentId,

--- a/packages/api/src/admin/contribution-shared/designation-set.ts
+++ b/packages/api/src/admin/contribution-shared/designation-set.ts
@@ -100,7 +100,7 @@ function buildLine(input: {
     id: input.id,
     amountCents: input.amountCents,
     currencyCode: input.currencyCode,
-    fundId: fund?.id ?? null,
+    fundId: fund?.id ?? input.fundId,
     fundName: fund?.name?.trim() || SHARED_GENERAL_FUND_NAME,
     fundType: deriveFundType(fund),
     missionaryId: input.missionaryId,

--- a/packages/database/types/database.ts
+++ b/packages/database/types/database.ts
@@ -301,6 +301,23 @@ export type ContributionOperationSourceSurface =
   | "bulk_action"
   | "api";
 
+export type ContributionCorrectionType =
+  | "resend_receipt"
+  | "approve_staged_gift"
+  | "retry_staged_gift"
+  | "crm_repost"
+  | "metadata_update"
+  | "refund"
+  | "donor_relink"
+  | "amount_correction"
+  | "designation_correction"
+  | "fund_correction"
+  | "allocation_correction"
+  | "receipt_correction"
+  | "statement_correction"
+  | "payment_state_correction"
+  | "stripe_replay";
+
 export type ContributionCorrectionStatus =
   | "pending"
   | "applied"
@@ -330,7 +347,7 @@ export interface ContributionCorrection {
   tenant_id: string;
   donation_id: string;
   staged_gift_id: string | null;
-  correction_type: string;
+  correction_type: ContributionCorrectionType;
   status: ContributionCorrectionStatus;
   reason: string;
   source_surface: ContributionOperationSourceSurface;

--- a/packages/database/types/index.ts
+++ b/packages/database/types/index.ts
@@ -80,6 +80,7 @@ export type {
 } from "./crm-reports";
 export type {
   ContributionCorrection,
+  ContributionCorrectionType,
   ContributionCorrectionStatus,
   ContributionNotificationDecision,
   ContributionNotificationEvent,

--- a/supabase/migrations/20260526132000_contribution_operations_core.sql
+++ b/supabase/migrations/20260526132000_contribution_operations_core.sql
@@ -94,6 +94,109 @@ ALTER TABLE public.contribution_corrections
     REFERENCES public.contribution_operation_audit_events(id)
     ON DELETE SET NULL;
 
+CREATE OR REPLACE FUNCTION public.enforce_contribution_operation_tenant_refs()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO public
+AS $function$
+DECLARE
+    row_data JSONB;
+    row_tenant_id UUID;
+    ref_id UUID;
+    ref_tenant_id UUID;
+BEGIN
+    row_data := to_jsonb(NEW);
+    row_tenant_id := (row_data ->> 'tenant_id')::uuid;
+
+    IF row_data ? 'donation_id' AND (row_data ->> 'donation_id') IS NOT NULL THEN
+        ref_id := (row_data ->> 'donation_id')::uuid;
+        SELECT d.tenant_id
+        INTO ref_tenant_id
+        FROM public.donations AS d
+        WHERE d.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution operation donation tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF
+        row_data ? 'staged_gift_id'
+        AND (row_data ->> 'staged_gift_id') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'staged_gift_id')::uuid;
+        SELECT sg.tenant_id
+        INTO ref_tenant_id
+        FROM public.staged_gifts AS sg
+        WHERE sg.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution operation staged gift tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF row_data ? 'correction_id' AND (row_data ->> 'correction_id') IS NOT NULL THEN
+        ref_id := (row_data ->> 'correction_id')::uuid;
+        SELECT cc.tenant_id
+        INTO ref_tenant_id
+        FROM public.contribution_corrections AS cc
+        WHERE cc.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution operation correction tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF
+        row_data ? 'audit_event_id'
+        AND (row_data ->> 'audit_event_id') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'audit_event_id')::uuid;
+        SELECT ae.tenant_id
+        INTO ref_tenant_id
+        FROM public.contribution_operation_audit_events AS ae
+        WHERE ae.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution operation audit event tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS enforce_contribution_corrections_tenant_refs
+    ON public.contribution_corrections;
+
+CREATE TRIGGER enforce_contribution_corrections_tenant_refs
+    BEFORE INSERT OR UPDATE OF
+        tenant_id,
+        donation_id,
+        staged_gift_id,
+        audit_event_id
+    ON public.contribution_corrections
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_contribution_operation_tenant_refs();
+
+DROP TRIGGER IF EXISTS enforce_contribution_operation_audit_events_tenant_refs
+    ON public.contribution_operation_audit_events;
+
+CREATE TRIGGER enforce_contribution_operation_audit_events_tenant_refs
+    BEFORE INSERT OR UPDATE OF
+        tenant_id,
+        donation_id,
+        staged_gift_id,
+        correction_id
+    ON public.contribution_operation_audit_events
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_contribution_operation_tenant_refs();
+
 CREATE INDEX IF NOT EXISTS idx_contribution_corrections_tenant_donation
     ON public.contribution_corrections (tenant_id, donation_id, created_at DESC);
 

--- a/supabase/migrations/20260526132000_contribution_operations_core.sql
+++ b/supabase/migrations/20260526132000_contribution_operations_core.sql
@@ -27,7 +27,26 @@ CREATE TABLE IF NOT EXISTS public.contribution_corrections (
     tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
     donation_id UUID NOT NULL REFERENCES public.donations(id) ON DELETE CASCADE,
     staged_gift_id UUID REFERENCES public.staged_gifts(id) ON DELETE SET NULL,
-    correction_type TEXT NOT NULL,
+    correction_type TEXT NOT NULL
+        CHECK (
+            correction_type IN (
+                'resend_receipt',
+                'approve_staged_gift',
+                'retry_staged_gift',
+                'crm_repost',
+                'metadata_update',
+                'refund',
+                'donor_relink',
+                'amount_correction',
+                'designation_correction',
+                'fund_correction',
+                'allocation_correction',
+                'receipt_correction',
+                'statement_correction',
+                'payment_state_correction',
+                'stripe_replay'
+            )
+        ),
     status TEXT NOT NULL DEFAULT 'applied'
         CHECK (status IN ('pending', 'applied', 'failed', 'voided')),
     reason TEXT NOT NULL,

--- a/supabase/migrations/20260526132000_contribution_operations_core.sql
+++ b/supabase/migrations/20260526132000_contribution_operations_core.sql
@@ -104,9 +104,11 @@ DECLARE
     row_data JSONB;
     row_tenant_id UUID;
     row_donation_id UUID;
+    row_staged_gift_id UUID;
     ref_id UUID;
     ref_tenant_id UUID;
     ref_donation_id UUID;
+    ref_staged_gift_id UUID;
 BEGIN
     row_data := to_jsonb(NEW);
     row_tenant_id := (row_data ->> 'tenant_id')::uuid;
@@ -128,7 +130,8 @@ BEGIN
         row_data ? 'staged_gift_id'
         AND (row_data ->> 'staged_gift_id') IS NOT NULL
     THEN
-        ref_id := (row_data ->> 'staged_gift_id')::uuid;
+        row_staged_gift_id := (row_data ->> 'staged_gift_id')::uuid;
+        ref_id := row_staged_gift_id;
         SELECT sg.tenant_id, sg.donation_id
         INTO ref_tenant_id, ref_donation_id
         FROM public.staged_gifts AS sg
@@ -151,13 +154,33 @@ BEGIN
 
     IF row_data ? 'correction_id' AND (row_data ->> 'correction_id') IS NOT NULL THEN
         ref_id := (row_data ->> 'correction_id')::uuid;
-        SELECT cc.tenant_id
-        INTO ref_tenant_id
+        SELECT cc.tenant_id, cc.donation_id, cc.staged_gift_id
+        INTO ref_tenant_id, ref_donation_id, ref_staged_gift_id
         FROM public.contribution_corrections AS cc
         WHERE cc.id = ref_id;
 
         IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
             RAISE EXCEPTION 'contribution operation correction tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+
+        IF
+            FOUND
+            AND row_donation_id IS NOT NULL
+            AND ref_donation_id IS NOT NULL
+            AND ref_donation_id IS DISTINCT FROM row_donation_id
+        THEN
+            RAISE EXCEPTION 'contribution operation correction donation mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+
+        IF
+            FOUND
+            AND row_staged_gift_id IS NOT NULL
+            AND ref_staged_gift_id IS NOT NULL
+            AND ref_staged_gift_id IS DISTINCT FROM row_staged_gift_id
+        THEN
+            RAISE EXCEPTION 'contribution operation correction staged gift mismatch'
                 USING ERRCODE = '23514';
         END IF;
     END IF;
@@ -167,13 +190,33 @@ BEGIN
         AND (row_data ->> 'audit_event_id') IS NOT NULL
     THEN
         ref_id := (row_data ->> 'audit_event_id')::uuid;
-        SELECT ae.tenant_id
-        INTO ref_tenant_id
+        SELECT ae.tenant_id, ae.donation_id, ae.staged_gift_id
+        INTO ref_tenant_id, ref_donation_id, ref_staged_gift_id
         FROM public.contribution_operation_audit_events AS ae
         WHERE ae.id = ref_id;
 
         IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
             RAISE EXCEPTION 'contribution operation audit event tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+
+        IF
+            FOUND
+            AND row_donation_id IS NOT NULL
+            AND ref_donation_id IS NOT NULL
+            AND ref_donation_id IS DISTINCT FROM row_donation_id
+        THEN
+            RAISE EXCEPTION 'contribution operation audit event donation mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+
+        IF
+            FOUND
+            AND row_staged_gift_id IS NOT NULL
+            AND ref_staged_gift_id IS NOT NULL
+            AND ref_staged_gift_id IS DISTINCT FROM row_staged_gift_id
+        THEN
+            RAISE EXCEPTION 'contribution operation audit event staged gift mismatch'
                 USING ERRCODE = '23514';
         END IF;
     END IF;

--- a/supabase/migrations/20260526132000_contribution_operations_core.sql
+++ b/supabase/migrations/20260526132000_contribution_operations_core.sql
@@ -1,0 +1,125 @@
+-- Mission Control Contribution Operations Core.
+-- Created after `supabase migration new contribution_operations_core` hung in
+-- this environment; timestamped manually to keep the migration deterministic.
+
+CREATE TABLE IF NOT EXISTS public.contribution_operation_prompt_settings (
+    tenant_id UUID PRIMARY KEY REFERENCES public.tenants(id) ON DELETE CASCADE,
+    default_reason_mode TEXT NOT NULL DEFAULT 'optional'
+        CHECK (default_reason_mode IN ('optional', 'required')),
+    allow_user_reason_prompt_reduction BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.contribution_operation_user_preferences (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    reduce_reason_prompts BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, profile_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.contribution_corrections (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    donation_id UUID NOT NULL REFERENCES public.donations(id) ON DELETE CASCADE,
+    staged_gift_id UUID REFERENCES public.staged_gifts(id) ON DELETE SET NULL,
+    correction_type TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'applied'
+        CHECK (status IN ('pending', 'applied', 'failed', 'voided')),
+    reason TEXT NOT NULL,
+    source_surface TEXT NOT NULL
+        CHECK (
+            source_surface IN (
+                'contribution_hub',
+                'donor_crm_record',
+                'automation',
+                'bulk_action',
+                'api'
+            )
+        ),
+    actor_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    before_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+    after_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+    provider_outcome JSONB NOT NULL DEFAULT '{}'::jsonb,
+    donor_visible_effect JSONB NOT NULL DEFAULT '{}'::jsonb,
+    receipt_effect JSONB NOT NULL DEFAULT '{}'::jsonb,
+    statement_effect JSONB NOT NULL DEFAULT '{}'::jsonb,
+    audit_event_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    applied_at TIMESTAMPTZ,
+    failed_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS public.contribution_operation_audit_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    actor_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    donation_id UUID REFERENCES public.donations(id) ON DELETE CASCADE,
+    staged_gift_id UUID REFERENCES public.staged_gifts(id) ON DELETE SET NULL,
+    donor_id UUID REFERENCES public.donors(id) ON DELETE SET NULL,
+    correction_id UUID REFERENCES public.contribution_corrections(id) ON DELETE SET NULL,
+    operation TEXT NOT NULL,
+    resource_type TEXT NOT NULL DEFAULT 'donation',
+    resource_id UUID,
+    source_surface TEXT NOT NULL
+        CHECK (
+            source_surface IN (
+                'contribution_hub',
+                'donor_crm_record',
+                'automation',
+                'bulk_action',
+                'api'
+            )
+        ),
+    reason TEXT,
+    confirmation_label TEXT,
+    policy_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    before_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    after_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    provider_outcome JSONB NOT NULL DEFAULT '{}'::jsonb,
+    downstream_effects JSONB NOT NULL DEFAULT '{}'::jsonb,
+    related_task_ids UUID[] NOT NULL DEFAULT '{}'::uuid[],
+    related_batch_id UUID,
+    correlation_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.contribution_corrections
+    ADD CONSTRAINT contribution_corrections_audit_event_id_fkey
+    FOREIGN KEY (audit_event_id)
+    REFERENCES public.contribution_operation_audit_events(id)
+    ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_contribution_corrections_tenant_donation
+    ON public.contribution_corrections (tenant_id, donation_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_corrections_staged_gift
+    ON public.contribution_corrections (staged_gift_id)
+    WHERE staged_gift_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_contribution_operation_audit_tenant_donation
+    ON public.contribution_operation_audit_events (tenant_id, donation_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_operation_audit_staged_gift
+    ON public.contribution_operation_audit_events (staged_gift_id)
+    WHERE staged_gift_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_contribution_operation_audit_actor
+    ON public.contribution_operation_audit_events (tenant_id, actor_profile_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_operation_user_preferences_profile
+    ON public.contribution_operation_user_preferences (profile_id);
+
+ALTER TABLE public.contribution_operation_prompt_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_operation_user_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_corrections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_operation_audit_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.contribution_operation_prompt_settings FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_operation_user_preferences FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_corrections FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_operation_audit_events FROM anon, authenticated;

--- a/supabase/migrations/20260526132000_contribution_operations_core.sql
+++ b/supabase/migrations/20260526132000_contribution_operations_core.sql
@@ -103,18 +103,20 @@ AS $function$
 DECLARE
     row_data JSONB;
     row_tenant_id UUID;
+    row_donation_id UUID;
     ref_id UUID;
     ref_tenant_id UUID;
+    ref_donation_id UUID;
 BEGIN
     row_data := to_jsonb(NEW);
     row_tenant_id := (row_data ->> 'tenant_id')::uuid;
 
     IF row_data ? 'donation_id' AND (row_data ->> 'donation_id') IS NOT NULL THEN
-        ref_id := (row_data ->> 'donation_id')::uuid;
+        row_donation_id := (row_data ->> 'donation_id')::uuid;
         SELECT d.tenant_id
         INTO ref_tenant_id
         FROM public.donations AS d
-        WHERE d.id = ref_id;
+        WHERE d.id = row_donation_id;
 
         IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
             RAISE EXCEPTION 'contribution operation donation tenant mismatch'
@@ -127,13 +129,22 @@ BEGIN
         AND (row_data ->> 'staged_gift_id') IS NOT NULL
     THEN
         ref_id := (row_data ->> 'staged_gift_id')::uuid;
-        SELECT sg.tenant_id
-        INTO ref_tenant_id
+        SELECT sg.tenant_id, sg.donation_id
+        INTO ref_tenant_id, ref_donation_id
         FROM public.staged_gifts AS sg
         WHERE sg.id = ref_id;
 
         IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
             RAISE EXCEPTION 'contribution operation staged gift tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+
+        IF
+            FOUND
+            AND row_donation_id IS NOT NULL
+            AND ref_donation_id IS DISTINCT FROM row_donation_id
+        THEN
+            RAISE EXCEPTION 'contribution operation staged gift donation mismatch'
                 USING ERRCODE = '23514';
         END IF;
     END IF;

--- a/supabase/migrations/20260526203000_contribution_operations_service_role_grants.sql
+++ b/supabase/migrations/20260526203000_contribution_operations_service_role_grants.sql
@@ -1,0 +1,7 @@
+-- Grant service_role access to contribution operations core tables.
+-- The foundation migration revoked anon/authenticated but omitted service_role grants.
+
+GRANT ALL ON TABLE public.contribution_operation_prompt_settings TO service_role;
+GRANT ALL ON TABLE public.contribution_operation_user_preferences TO service_role;
+GRANT ALL ON TABLE public.contribution_corrections TO service_role;
+GRANT ALL ON TABLE public.contribution_operation_audit_events TO service_role;

--- a/tests/unit/packages/api/admin/contribution-action-availability.test.ts
+++ b/tests/unit/packages/api/admin/contribution-action-availability.test.ts
@@ -116,6 +116,28 @@ describe("admin/contribution-operations/action-availability", () => {
     expect(pendingEntry.blockedReason).toMatch(/not completed/i);
   });
 
+  it("normalizes provider success aliases for receipt and refund availability", () => {
+    for (const paymentStatus of ["succeeded", "success"]) {
+      const entries = buildContributionActionAvailability({
+        stagedGift: {
+          id: "staged-1",
+          status: "posted",
+          receiptStatus: "sent",
+          crmPostStatus: "posted",
+        },
+        paymentStatus,
+        refund: {
+          amountCents: 12_00,
+          refundedAmountCents: 0,
+          hasProviderCharge: true,
+        },
+      });
+
+      expect(availabilityFor(entries, "resend_receipt").available).toBe(true);
+      expect(availabilityFor(entries, "refund").available).toBe(true);
+    }
+  });
+
   it("labels every entry with the policy risk level", () => {
     const entries = buildContributionActionAvailability({
       stagedGift: null,

--- a/tests/unit/packages/api/admin/contribution-action-availability.test.ts
+++ b/tests/unit/packages/api/admin/contribution-action-availability.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributionActionAvailability } from "../../../../../packages/api/src/admin/contribution-operations/action-availability";
+
+function availabilityFor(
+  entries: ReturnType<typeof buildContributionActionAvailability>,
+  actionType: string,
+) {
+  const entry = entries.find((item) => item.actionType === actionType);
+  if (!entry) {
+    throw new Error(`No availability entry for ${actionType}`);
+  }
+  return entry;
+}
+
+describe("admin/contribution-operations/action-availability", () => {
+  it("blocks staged-gift workflow actions with clear reasons when no staged gift exists", () => {
+    const entries = buildContributionActionAvailability({
+      stagedGift: null,
+      paymentStatus: "completed",
+    });
+
+    for (const actionType of [
+      "approve_staged_gift",
+      "retry_staged_gift",
+      "resend_receipt",
+    ]) {
+      const entry = availabilityFor(entries, actionType);
+      expect(entry.available).toBe(false);
+      expect(entry.blockedReason).toMatch(/no staged gift/i);
+      expect(entry.nextStep).toBeTruthy();
+      // The donation itself must never be described as missing or invalid.
+      expect(entry.blockedReason).not.toMatch(/invalid|missing donation/i);
+      expect(entry.nextStep).toMatch(/valid/i);
+    }
+  });
+
+  it("computes staged-gift action availability from workflow state", () => {
+    const reviewable = buildContributionActionAvailability({
+      stagedGift: {
+        id: "staged-1",
+        status: "needs_review",
+        receiptStatus: "pending",
+        crmPostStatus: "queued",
+      },
+      paymentStatus: "completed",
+    });
+
+    expect(availabilityFor(reviewable, "approve_staged_gift").available).toBe(
+      true,
+    );
+    expect(availabilityFor(reviewable, "retry_staged_gift").available).toBe(
+      false,
+    );
+    expect(
+      availabilityFor(reviewable, "retry_staged_gift").blockedReason,
+    ).toBeTruthy();
+    expect(availabilityFor(reviewable, "resend_receipt").available).toBe(true);
+
+    const failed = buildContributionActionAvailability({
+      stagedGift: {
+        id: "staged-1",
+        status: "failed",
+        receiptStatus: "pending",
+        crmPostStatus: "failed",
+      },
+      paymentStatus: "completed",
+    });
+
+    expect(availabilityFor(failed, "retry_staged_gift").available).toBe(true);
+    expect(availabilityFor(failed, "approve_staged_gift").available).toBe(
+      false,
+    );
+  });
+
+  it("blocks receipt sends for suppressed receipts and uncompleted payments", () => {
+    const suppressed = buildContributionActionAvailability({
+      stagedGift: {
+        id: "staged-1",
+        status: "posted",
+        receiptStatus: "suppressed",
+        crmPostStatus: "posted",
+      },
+      paymentStatus: "completed",
+    });
+    const suppressedEntry = availabilityFor(suppressed, "resend_receipt");
+    expect(suppressedEntry.available).toBe(false);
+    expect(suppressedEntry.blockedReason).toMatch(/suppressed/i);
+
+    const pendingPayment = buildContributionActionAvailability({
+      stagedGift: {
+        id: "staged-1",
+        status: "received",
+        receiptStatus: "pending",
+        crmPostStatus: "queued",
+      },
+      paymentStatus: "pending",
+    });
+    const pendingEntry = availabilityFor(pendingPayment, "resend_receipt");
+    expect(pendingEntry.available).toBe(false);
+    expect(pendingEntry.blockedReason).toMatch(/not completed/i);
+  });
+
+  it("labels every entry with the policy risk level", () => {
+    const entries = buildContributionActionAvailability({
+      stagedGift: null,
+      paymentStatus: "completed",
+    });
+
+    for (const entry of entries) {
+      expect(["low", "medium", "high"]).toContain(entry.riskLevel);
+    }
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-action-availability.test.ts
+++ b/tests/unit/packages/api/admin/contribution-action-availability.test.ts
@@ -73,6 +73,21 @@ describe("admin/contribution-operations/action-availability", () => {
     );
   });
 
+  it("allows retry when unified CRM post state reports link-derived failures", () => {
+    const entries = buildContributionActionAvailability({
+      stagedGift: {
+        id: "staged-1",
+        status: "posted",
+        receiptStatus: "sent",
+        crmPostStatus: "posted",
+      },
+      paymentStatus: "completed",
+      hasCrmPostFailure: true,
+    });
+
+    expect(availabilityFor(entries, "retry_staged_gift").available).toBe(true);
+  });
+
   it("blocks receipt sends for suppressed receipts and uncompleted payments", () => {
     const suppressed = buildContributionActionAvailability({
       stagedGift: {

--- a/tests/unit/packages/api/admin/contribution-approval-policy.test.ts
+++ b/tests/unit/packages/api/admin/contribution-approval-policy.test.ts
@@ -56,6 +56,20 @@ describe("admin/contribution-operations/approval-policy", () => {
     ).toBe(false);
   });
 
+  it("ignores unknown configured action types", () => {
+    const policy = resolveCorrectionApprovalPolicy({
+      ownership_mode: "separation_of_duties",
+      suppressed_gates: ["not_a_real_action", "amount_correction"],
+      stronger_approval_categories: [
+        "unknown_stronger_action",
+        "fund_correction",
+      ],
+    });
+
+    expect(policy.suppressedGates).toEqual(["amount_correction"]);
+    expect(policy.strongerApprovalCategories).toEqual(["fund_correction"]);
+  });
+
   it("blocks requesters from approving their own request under separation of duties", () => {
     const policy = resolveCorrectionApprovalPolicy(null);
 

--- a/tests/unit/packages/api/admin/contribution-approval-policy.test.ts
+++ b/tests/unit/packages/api/admin/contribution-approval-policy.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertCanDecideCorrectionRequest,
+  correctionRequiresApproval,
+  resolveCorrectionApprovalPolicy,
+} from "../../../../../packages/api/src/admin/contribution-operations/approval-policy";
+
+describe("admin/contribution-operations/approval-policy", () => {
+  it("defaults to separation of duties with no suppression", () => {
+    const policy = resolveCorrectionApprovalPolicy(null);
+
+    expect(policy.ownershipMode).toBe("separation_of_duties");
+    expect(policy.suppressedGates).toEqual([]);
+    expect(policy.strongerApprovalCategories).toEqual([]);
+  });
+
+  it("requires approval for high-risk corrections unless the gate is suppressed", () => {
+    const policy = resolveCorrectionApprovalPolicy(null);
+
+    expect(
+      correctionRequiresApproval({ actionType: "amount_correction", policy }),
+    ).toBe(true);
+    expect(
+      correctionRequiresApproval({
+        actionType: "allocation_correction",
+        policy,
+      }),
+    ).toBe(false);
+
+    const suppressed = resolveCorrectionApprovalPolicy({
+      ownership_mode: "separation_of_duties",
+      suppressed_gates: ["amount_correction"],
+      stronger_approval_categories: [],
+    });
+    expect(
+      correctionRequiresApproval({
+        actionType: "amount_correction",
+        policy: suppressed,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps stronger approval categories gated even when suppressed or relaxed", () => {
+    const policy = resolveCorrectionApprovalPolicy({
+      ownership_mode: "no_approval_required",
+      suppressed_gates: ["amount_correction", "fund_correction"],
+      stronger_approval_categories: ["amount_correction"],
+    });
+
+    expect(
+      correctionRequiresApproval({ actionType: "amount_correction", policy }),
+    ).toBe(true);
+    expect(
+      correctionRequiresApproval({ actionType: "fund_correction", policy }),
+    ).toBe(false);
+  });
+
+  it("blocks requesters from approving their own request under separation of duties", () => {
+    const policy = resolveCorrectionApprovalPolicy(null);
+
+    expect(() =>
+      assertCanDecideCorrectionRequest({
+        policy,
+        request: { requestedByProfileId: "profile-1" },
+        deciderProfileId: "profile-1",
+        deciderCapabilities: ["contributions.approve_corrections"],
+      }),
+    ).toThrowError(/cannot approve|own/i);
+
+    expect(() =>
+      assertCanDecideCorrectionRequest({
+        policy,
+        request: { requestedByProfileId: "profile-1" },
+        deciderProfileId: "profile-2",
+        deciderCapabilities: ["contributions.approve_corrections"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows self-approval under one_approver mode but still requires the capability", () => {
+    const policy = resolveCorrectionApprovalPolicy({
+      ownership_mode: "one_approver",
+      suppressed_gates: [],
+      stronger_approval_categories: [],
+    });
+
+    expect(() =>
+      assertCanDecideCorrectionRequest({
+        policy,
+        request: { requestedByProfileId: "profile-1" },
+        deciderProfileId: "profile-1",
+        deciderCapabilities: ["contributions.approve_corrections"],
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      assertCanDecideCorrectionRequest({
+        policy,
+        request: { requestedByProfileId: "profile-1" },
+        deciderProfileId: "profile-2",
+        deciderCapabilities: ["contributions.view_detail"],
+      }),
+    ).toThrowError(/approve_corrections/);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-crm-post-state.test.ts
+++ b/tests/unit/packages/api/admin/contribution-crm-post-state.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributionCrmPostState } from "../../../../../packages/api/src/admin/contribution-operations/crm-post-state";
+
+describe("admin/contribution-operations/crm-post-state", () => {
+  it("reports a successful parent and child posting state", () => {
+    const state = buildContributionCrmPostState({
+      stagedGiftCrmPostStatus: "posted",
+      stagedGiftTwentyRecordId: "twenty-parent",
+      links: [
+        {
+          id: "link-parent",
+          scope: "parent",
+          allocationId: null,
+          linkStatus: "active",
+          twentyRecordId: "twenty-parent",
+          lastError: null,
+        },
+        {
+          id: "link-child-1",
+          scope: "designation",
+          allocationId: "alloc-1",
+          linkStatus: "active",
+          twentyRecordId: "twenty-child-1",
+          lastError: null,
+        },
+        {
+          id: "link-child-2",
+          scope: "designation",
+          allocationId: "alloc-2",
+          linkStatus: "active",
+          twentyRecordId: "twenty-child-2",
+          lastError: null,
+        },
+      ],
+      designationLineCount: 2,
+    });
+
+    expect(state.parent.status).toBe("posted");
+    expect(state.parent.twentyRecordId).toBe("twenty-parent");
+    expect(state.designationRecords).toHaveLength(2);
+    expect(state.designationRecords[0]).toMatchObject({
+      allocationId: "alloc-1",
+      status: "posted",
+    });
+    expect(state.failedScopes).toEqual([]);
+    expect(state.adapterLimitation).toBeNull();
+  });
+
+  it("surfaces a parent-level failure as a parent retry scope", () => {
+    const state = buildContributionCrmPostState({
+      stagedGiftCrmPostStatus: "failed",
+      stagedGiftTwentyRecordId: null,
+      links: [],
+      designationLineCount: 1,
+    });
+
+    expect(state.parent.status).toBe("failed");
+    expect(state.failedScopes).toEqual([{ scope: "parent" }]);
+  });
+
+  it("surfaces line-specific child failures so retries target only that line", () => {
+    const state = buildContributionCrmPostState({
+      stagedGiftCrmPostStatus: "posted",
+      stagedGiftTwentyRecordId: "twenty-parent",
+      links: [
+        {
+          id: "link-child-1",
+          scope: "designation",
+          allocationId: "alloc-1",
+          linkStatus: "active",
+          twentyRecordId: "twenty-child-1",
+          lastError: null,
+        },
+        {
+          id: "link-child-2",
+          scope: "designation",
+          allocationId: "alloc-2",
+          linkStatus: "failed",
+          twentyRecordId: null,
+          lastError: "Twenty rejected the designation record.",
+        },
+      ],
+      designationLineCount: 2,
+    });
+
+    expect(state.parent.status).toBe("posted");
+    expect(state.failedScopes).toEqual([
+      { scope: "designation", allocationId: "alloc-2" },
+    ]);
+    expect(
+      state.designationRecords.find((r) => r.allocationId === "alloc-2")
+        ?.lastError,
+    ).toMatch(/rejected/);
+  });
+
+  it("surfaces the adapter limitation for split gifts without child records", () => {
+    const state = buildContributionCrmPostState({
+      stagedGiftCrmPostStatus: "posted",
+      stagedGiftTwentyRecordId: "twenty-parent",
+      links: [],
+      designationLineCount: 3,
+    });
+
+    expect(state.adapterLimitation).toMatch(/single parent record/i);
+    expect(state.designationRecords).toEqual([]);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-crm-post-state.test.ts
+++ b/tests/unit/packages/api/admin/contribution-crm-post-state.test.ts
@@ -59,6 +59,49 @@ describe("admin/contribution-operations/crm-post-state", () => {
     expect(state.failedScopes).toEqual([{ scope: "parent" }]);
   });
 
+  it("uses parent link failures when the staged gift aggregate is unset or stale", () => {
+    const state = buildContributionCrmPostState({
+      stagedGiftCrmPostStatus: null,
+      stagedGiftTwentyRecordId: null,
+      links: [
+        {
+          id: "link-parent",
+          scope: "parent",
+          allocationId: null,
+          linkStatus: "failed",
+          twentyRecordId: null,
+          lastError: "Twenty rejected the parent record.",
+        },
+      ],
+      designationLineCount: 1,
+    });
+
+    expect(state.parent).toMatchObject({
+      status: "failed",
+      lastError: "Twenty rejected the parent record.",
+    });
+    expect(state.failedScopes).toEqual([{ scope: "parent" }]);
+
+    const staleAggregate = buildContributionCrmPostState({
+      stagedGiftCrmPostStatus: "posted",
+      stagedGiftTwentyRecordId: "twenty-parent",
+      links: [
+        {
+          id: "link-parent",
+          scope: "parent",
+          allocationId: null,
+          linkStatus: "failed",
+          twentyRecordId: "twenty-parent",
+          lastError: "Twenty rejected the parent record.",
+        },
+      ],
+      designationLineCount: 1,
+    });
+
+    expect(staleAggregate.parent.status).toBe("failed");
+    expect(staleAggregate.failedScopes).toEqual([{ scope: "parent" }]);
+  });
+
   it("surfaces line-specific child failures so retries target only that line", () => {
     const state = buildContributionCrmPostState({
       stagedGiftCrmPostStatus: "posted",

--- a/tests/unit/packages/api/admin/contribution-crm-post-state.test.ts
+++ b/tests/unit/packages/api/admin/contribution-crm-post-state.test.ts
@@ -84,14 +84,14 @@ describe("admin/contribution-operations/crm-post-state", () => {
 
     const staleAggregate = buildContributionCrmPostState({
       stagedGiftCrmPostStatus: "posted",
-      stagedGiftTwentyRecordId: "twenty-parent",
+      stagedGiftTwentyRecordId: "twenty-stale-parent",
       links: [
         {
           id: "link-parent",
           scope: "parent",
           allocationId: null,
           linkStatus: "failed",
-          twentyRecordId: "twenty-parent",
+          twentyRecordId: "twenty-current-parent",
           lastError: "Twenty rejected the parent record.",
         },
       ],
@@ -99,6 +99,7 @@ describe("admin/contribution-operations/crm-post-state", () => {
     });
 
     expect(staleAggregate.parent.status).toBe("failed");
+    expect(staleAggregate.parent.twentyRecordId).toBe("twenty-current-parent");
     expect(staleAggregate.failedScopes).toEqual([{ scope: "parent" }]);
   });
 

--- a/tests/unit/packages/api/admin/contribution-operations-policy.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-policy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getContributionActionPolicy,
+  isContributionReasonRequired,
+  isContributionConfirmationRequired,
+} from "../../../../../packages/api/src/admin/contribution-operations/policy";
+
+describe("contribution operations policy", () => {
+  it.each([
+    "refund",
+    "donor_relink",
+    "amount_correction",
+    "designation_correction",
+    "fund_correction",
+    "payment_state_correction",
+    "stripe_replay",
+  ] as const)(
+    "keeps %s reason and confirmation non-suppressible",
+    (actionType) => {
+      const policy = getContributionActionPolicy({
+        actionType,
+        organizationSettings: {
+          defaultReasonMode: "optional",
+          allowUserReasonPromptReduction: true,
+        },
+        userPreferences: {
+          reduceReasonPrompts: true,
+        },
+      });
+
+      expect(policy.riskLevel).toBe("high");
+      expect(policy.requiresReason).toBe(true);
+      expect(policy.requiresConfirmation).toBe(true);
+      expect(policy.canSuppressReason).toBe(false);
+      expect(isContributionReasonRequired(policy)).toBe(true);
+      expect(isContributionConfirmationRequired(policy)).toBe(true);
+    },
+  );
+
+  it("allows low-risk receipt resend reason prompts to be reduced by settings", () => {
+    const policy = getContributionActionPolicy({
+      actionType: "resend_receipt",
+      organizationSettings: {
+        defaultReasonMode: "optional",
+        allowUserReasonPromptReduction: true,
+      },
+      userPreferences: {
+        reduceReasonPrompts: true,
+      },
+    });
+
+    expect(policy.riskLevel).toBe("low");
+    expect(policy.requiresReason).toBe(false);
+    expect(policy.requiresConfirmation).toBe(false);
+    expect(policy.canSuppressReason).toBe(true);
+  });
+
+  it("requires reasons for metadata edits when the organization baseline is required", () => {
+    const policy = getContributionActionPolicy({
+      actionType: "metadata_update",
+      organizationSettings: {
+        defaultReasonMode: "required",
+        allowUserReasonPromptReduction: false,
+      },
+      userPreferences: {
+        reduceReasonPrompts: true,
+      },
+    });
+
+    expect(policy.riskLevel).toBe("low");
+    expect(policy.requiresReason).toBe(true);
+    expect(policy.canSuppressReason).toBe(true);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
@@ -270,7 +270,7 @@ describe("contribution operations detail read model", () => {
       }),
       expect.objectContaining({
         actionType: "refund",
-        available: false,
+        available: true,
       }),
     ]);
 
@@ -765,6 +765,30 @@ describe("contribution operations detail read model", () => {
     expect(availabilityFor(detail, "refund")).toMatchObject({
       available: false,
       blockedReason: expect.stringMatching(/completed payments/i),
+    });
+  });
+
+  it("allows refunds when Stripe proof has only a payment intent id", () => {
+    const detail = buildContributionDetail({
+      donation: donationInput({
+        stripePaymentIntentId: "pi_only",
+        stripeChargeId: null,
+      }),
+      stagedGift: {
+        id: "staged_1",
+        status: "posted",
+        receiptStatus: "sent",
+        crmPostStatus: "posted",
+        reviewReason: null,
+        twentyRecordId: null,
+      },
+    });
+
+    expect(detail.payment.stripe.paymentIntentId).toBe("pi_only");
+    expect(detail.payment.stripe.chargeId).toBeNull();
+    expect(availabilityFor(detail, "refund")).toMatchObject({
+      available: true,
+      blockedReason: null,
     });
   });
 

--- a/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
@@ -2,6 +2,79 @@ import { describe, expect, it } from "vitest";
 
 import { buildContributionDetail } from "../../../../../packages/api/src/admin/contribution-operations/detail-read-model";
 
+type ContributionDetailInputForTest = Parameters<
+  typeof buildContributionDetail
+>[0];
+type ContributionAdjustmentForTest = NonNullable<
+  ContributionDetailInputForTest["adjustments"]
+>[number];
+type ContributionDetailForTest = ReturnType<typeof buildContributionDetail>;
+
+function donationInput(
+  overrides: Partial<ContributionDetailInputForTest["donation"]> = {},
+): ContributionDetailInputForTest["donation"] {
+  return {
+    id: "donation_test",
+    tenantId: "tenant_1",
+    donorId: "donor_1",
+    missionaryId: null,
+    fundId: "fund_1",
+    amount: 10_000,
+    currency: "usd",
+    status: "completed",
+    donationType: "one_time",
+    paymentMethod: "card",
+    isRecurring: false,
+    recurringInterval: null,
+    notes: null,
+    stripePaymentIntentId: "pi_test",
+    stripeChargeId: "ch_test",
+    giftDate: "2026-05-20",
+    campaignId: null,
+    pledgeId: null,
+    processedAt: null,
+    completedAt: "2026-05-20T00:00:00.000Z",
+    failedAt: null,
+    errorCode: null,
+    errorMessage: null,
+    refundedAt: null,
+    refundAmount: 0,
+    source: "online",
+    createdAt: "2026-05-20T00:00:00.000Z",
+    updatedAt: "2026-05-21T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function adjustmentInput(
+  overrides: Partial<ContributionAdjustmentForTest> = {},
+): ContributionAdjustmentForTest {
+  return {
+    id: "adj_test",
+    adjustmentType: "amount_correction",
+    status: "applied",
+    effectiveValues: { amountCents: 9_000 },
+    reason: "test correction",
+    actorProfileId: "profile_1",
+    sourceSurface: "contribution_hub",
+    createdAt: "2026-05-21T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function availabilityFor(
+  detail: ContributionDetailForTest,
+  actionType: string,
+) {
+  const entry = detail.actionAvailability.find(
+    (candidate) => candidate.actionType === actionType,
+  );
+  if (!entry) {
+    throw new Error(`No availability entry for ${actionType}`);
+  }
+  return entry;
+}
+
 describe("contribution operations detail read model", () => {
   it("builds canonical staff and donor-visible contribution truth", () => {
     const detail = buildContributionDetail({
@@ -581,6 +654,121 @@ describe("contribution operations detail read model", () => {
 
     // Adjustment history and version metadata are part of the contract.
     expect(detail.adjustments).toHaveLength(2);
-    expect(detail.revision).toBe("2026-05-21T00:00:00.000Z#2");
+    expect(detail.revision).toMatch(
+      /^2026-05-21T00:00:00\.000Z#2#[a-f0-9]{16}$/,
+    );
+  });
+
+  it("labels refunds against the effective corrected amount", () => {
+    const detail = buildContributionDetail({
+      donation: donationInput({
+        amount: 10_000,
+        refundAmount: 7_500,
+        refundedAt: "2026-05-22T00:00:00.000Z",
+      }),
+      adjustments: [
+        adjustmentInput({
+          id: "adj_amount",
+          effectiveValues: { amountCents: 7_500 },
+        }),
+      ],
+    });
+
+    expect(detail.effective.amountCents).toBe(7_500);
+    expect(detail.refund.status).toBe("refunded");
+    expect(detail.donorVisible.status).toBe("Refunded");
+    expect(detail.donorVisible.amount).toBe(7_500);
+  });
+
+  it("gates actions and donor-visible status from effective payment status", () => {
+    const detail = buildContributionDetail({
+      donation: donationInput({
+        status: "completed",
+        stripeChargeId: "ch_test",
+      }),
+      stagedGift: {
+        id: "staged_1",
+        status: "posted",
+        receiptStatus: "sent",
+        crmPostStatus: "posted",
+        reviewReason: null,
+        twentyRecordId: null,
+      },
+      adjustments: [
+        adjustmentInput({
+          id: "adj_payment_status",
+          adjustmentType: "payment_status_correction",
+          effectiveValues: { paymentStatus: "failed" },
+        }),
+      ],
+    });
+
+    expect(detail.payment.status).toBe("failed");
+    expect(detail.shared.paymentStatus).toBe("failed");
+    expect(detail.donorVisible.status).toBe("Failed");
+    expect(availabilityFor(detail, "resend_receipt")).toMatchObject({
+      available: false,
+      blockedReason: expect.stringMatching(/not completed/i),
+    });
+    expect(availabilityFor(detail, "refund")).toMatchObject({
+      available: false,
+      blockedReason: expect.stringMatching(/completed payments/i),
+    });
+  });
+
+  it("makes retry available when CRM link state exposes failed scopes", () => {
+    const detail = buildContributionDetail({
+      donation: donationInput(),
+      stagedGift: {
+        id: "staged_1",
+        status: "posted",
+        receiptStatus: "sent",
+        crmPostStatus: "posted",
+        reviewReason: null,
+        twentyRecordId: "twenty_parent",
+      },
+      crmLinks: [
+        {
+          id: "link_child",
+          scope: "designation",
+          allocationId: "alloc_1",
+          linkStatus: "failed",
+          twentyRecordId: null,
+          lastError: "Twenty rejected the designation record.",
+        },
+      ],
+    });
+
+    expect(detail.crm.failedScopes).toEqual([
+      { scope: "designation", allocationId: "alloc_1" },
+    ]);
+    expect(availabilityFor(detail, "retry_staged_gift").available).toBe(true);
+  });
+
+  it("changes revision when adjustment state changes with the same donation timestamp and count", () => {
+    const donation = donationInput({
+      updatedAt: "2026-05-21T00:00:00.000Z",
+    });
+    const adjustment = adjustmentInput({
+      id: "adj_same_count",
+      effectiveValues: { amountCents: 8_000 },
+    });
+
+    const applied = buildContributionDetail({
+      donation,
+      adjustments: [adjustment],
+    });
+    const reversed = buildContributionDetail({
+      donation,
+      adjustments: [{ ...adjustment, status: "reversed" }],
+    });
+
+    expect(applied.revision).toMatch(
+      /^2026-05-21T00:00:00\.000Z#1#[a-f0-9]{16}$/,
+    );
+    expect(reversed.revision).toMatch(
+      /^2026-05-21T00:00:00\.000Z#1#[a-f0-9]{16}$/,
+    );
+    expect(reversed.revision).not.toBe(applied.revision);
   });
 });

--- a/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
@@ -676,6 +676,41 @@ describe("contribution operations detail read model", () => {
     );
   });
 
+  it("preserves corrected fund ids when fund metadata is not loaded", () => {
+    const detail = buildContributionDetail({
+      donation: donationInput({ fundId: "fund_1" }),
+      funds: [
+        {
+          id: "fund_1",
+          name: "Original Fund",
+          missionary_id: null,
+          goal_amount: 0,
+          start_date: null,
+          end_date: null,
+        },
+      ],
+      adjustments: [
+        adjustmentInput({
+          adjustmentType: "fund_correction",
+          effectiveValues: { fundId: "fund_2" },
+        }),
+      ],
+    });
+
+    expect(detail.effective.fundId).toBe("fund_2");
+    expect(detail.designations.lines[0]).toMatchObject({
+      fundId: "fund_2",
+      fundName: "General Fund",
+    });
+    expect(detail.shared.designationSummary).toMatchObject({
+      fundId: "fund_2",
+      fundName: "General Fund",
+    });
+    expect(detail.designations.issues).toEqual([
+      expect.stringMatching(/unknown fund/i),
+    ]);
+  });
+
   it("labels refunds against the effective corrected amount", () => {
     const detail = buildContributionDetail({
       donation: donationInput({

--- a/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
@@ -823,4 +823,68 @@ describe("contribution operations detail read model", () => {
     );
     expect(reversed.revision).not.toBe(applied.revision);
   });
+
+  it("changes revision when staged gift workflow state changes", () => {
+    const donation = donationInput({
+      updatedAt: "2026-05-21T00:00:00.000Z",
+    });
+    const pending = buildContributionDetail({
+      donation,
+      stagedGift: {
+        id: "staged_1",
+        status: "pending_review",
+        receiptStatus: "pending",
+        crmPostStatus: "queued",
+        reviewReason: null,
+        twentyRecordId: null,
+      },
+    });
+    const posted = buildContributionDetail({
+      donation,
+      stagedGift: {
+        id: "staged_1",
+        status: "posted",
+        receiptStatus: "sent",
+        crmPostStatus: "posted",
+        reviewReason: null,
+        twentyRecordId: "twenty_1",
+      },
+    });
+
+    expect(posted.revision).not.toBe(pending.revision);
+  });
+
+  it("changes revision when CRM links change", () => {
+    const donation = donationInput({
+      updatedAt: "2026-05-21T00:00:00.000Z",
+    });
+    const queued = buildContributionDetail({
+      donation,
+      crmLinks: [
+        {
+          id: "link_parent",
+          scope: "parent",
+          allocationId: null,
+          linkStatus: "queued",
+          twentyRecordId: null,
+          lastError: null,
+        },
+      ],
+    });
+    const failed = buildContributionDetail({
+      donation,
+      crmLinks: [
+        {
+          id: "link_parent",
+          scope: "parent",
+          allocationId: null,
+          linkStatus: "failed",
+          twentyRecordId: null,
+          lastError: "Twenty rejected the parent record.",
+        },
+      ],
+    });
+
+    expect(failed.revision).not.toBe(queued.revision);
+  });
 });

--- a/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
@@ -525,6 +525,23 @@ describe("contribution operations detail read model", () => {
     expect(linked.recurring.providerRecurrenceWithoutAgreement).toBe(false);
     expect(linked.shared.recurringLinkState).toBe("agreement_linked");
 
+    const linkedWithoutLoadedAgreement = buildContributionDetail({
+      donation: {
+        ...base,
+        isRecurring: true,
+        recurringInterval: "month",
+        pledgeId: "pledge_1",
+      },
+    });
+    expect(linkedWithoutLoadedAgreement.recurring.agreement).toBeNull();
+    expect(linkedWithoutLoadedAgreement.recurring.isRecurring).toBe(true);
+    expect(
+      linkedWithoutLoadedAgreement.recurring.providerRecurrenceWithoutAgreement,
+    ).toBe(false);
+    expect(linkedWithoutLoadedAgreement.shared.recurringLinkState).toBe(
+      "agreement_linked",
+    );
+
     const providerOnly = buildContributionDetail({
       donation: {
         ...base,

--- a/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-read-model.test.ts
@@ -1,0 +1,586 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributionDetail } from "../../../../../packages/api/src/admin/contribution-operations/detail-read-model";
+
+describe("contribution operations detail read model", () => {
+  it("builds canonical staff and donor-visible contribution truth", () => {
+    const detail = buildContributionDetail({
+      donation: {
+        id: "donation_1",
+        tenantId: "tenant_1",
+        donorId: "donor_1",
+        missionaryId: "missionary_1",
+        fundId: "fund_1",
+        amount: 12000,
+        currency: "usd",
+        status: "refunded",
+        donationType: "recurring",
+        paymentMethod: "card",
+        isRecurring: true,
+        recurringInterval: "month",
+        notes: "internal note",
+        stripePaymentIntentId: "pi_123",
+        stripeChargeId: "ch_123",
+        giftDate: "2026-05-01T00:00:00.000Z",
+        campaignId: "campaign_1",
+        pledgeId: "pledge_1",
+        processedAt: "2026-05-01T00:01:00.000Z",
+        completedAt: "2026-05-01T00:02:00.000Z",
+        failedAt: null,
+        errorCode: null,
+        errorMessage: null,
+        refundedAt: "2026-05-02T00:00:00.000Z",
+        refundAmount: 12000,
+        source: "online",
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      },
+      donor: {
+        id: "donor_1",
+        profileId: "profile_1",
+        name: "Jordan Donor",
+        email: "jordan@example.com",
+        phone: "555-0100",
+        mobile: "555-0101",
+        location: "Austin, TX",
+        organization: "Jordan Family",
+      },
+      fund: { id: "fund_1", name: "General Fund" },
+      missionary: { id: "missionary_1", name: "Riley Worker" },
+      stagedGift: {
+        id: "staged_1",
+        status: "posted",
+        receiptStatus: "sent",
+        crmPostStatus: "posted",
+        reviewReason: null,
+        twentyRecordId: "twenty_1",
+      },
+      auditEvents: [
+        {
+          id: "audit_1",
+          actionType: "refund",
+          sourceSurface: "contribution_hub",
+          reason: "duplicate gift",
+          createdAt: "2026-05-02T00:00:00.000Z",
+        },
+      ],
+      corrections: [
+        {
+          id: "correction_1",
+          correctionType: "refund_correction",
+          status: "applied",
+        },
+      ],
+    });
+
+    expect(detail.id).toBe("donation_1");
+    expect(detail.donor?.phoneNumbers).toEqual(["555-0100", "555-0101"]);
+    expect(detail.payment.stripe.paymentIntentId).toBe("pi_123");
+    expect(detail.payment.stripe.chargeId).toBe("ch_123");
+    expect(detail.refund.status).toBe("refunded");
+    expect(detail.refund.amount).toBe(12000);
+    expect(detail.receipt.status).toBe("sent");
+    expect(detail.recurring.isRecurring).toBe(true);
+    expect(detail.crm.postStatus).toBe("posted");
+    expect(detail.auditEvents).toHaveLength(1);
+    expect(detail.corrections).toHaveLength(1);
+    expect(detail.donorVisible.status).toBe("Refunded");
+    expect(detail.donorVisible.historyUpdatedImmediately).toBe(true);
+  });
+
+  it("keeps partial refunds distinct from full refunds in donor-visible staff detail", () => {
+    const detail = buildContributionDetail({
+      donation: {
+        id: "donation_1",
+        tenantId: "tenant_1",
+        donorId: "donor_1",
+        missionaryId: null,
+        fundId: null,
+        amount: 12000,
+        currency: "usd",
+        status: "completed",
+        donationType: "one_time",
+        paymentMethod: "card",
+        isRecurring: false,
+        recurringInterval: null,
+        notes: null,
+        stripePaymentIntentId: "pi_123",
+        stripeChargeId: "ch_123",
+        giftDate: "2026-05-01T00:00:00.000Z",
+        campaignId: null,
+        pledgeId: null,
+        processedAt: null,
+        completedAt: "2026-05-01T00:02:00.000Z",
+        failedAt: null,
+        errorCode: null,
+        errorMessage: null,
+        refundedAt: "2026-05-02T00:00:00.000Z",
+        refundAmount: 2500,
+        source: "online",
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      },
+    });
+
+    expect(detail.refund.status).toBe("partial_refund");
+    expect(detail.donorVisible.status).toBe("Partially Refunded");
+  });
+
+  it("embeds the shared contribution row contract so detail and rows cannot drift", () => {
+    const detail = buildContributionDetail({
+      donation: {
+        id: "donation_2",
+        tenantId: "tenant_1",
+        donorId: "donor_1",
+        missionaryId: "missionary_1",
+        fundId: "fund_1",
+        amount: 25_000,
+        currency: "usd",
+        status: "completed",
+        donationType: "one_time",
+        paymentMethod: "card",
+        isRecurring: false,
+        recurringInterval: null,
+        notes: null,
+        stripePaymentIntentId: "pi_900",
+        stripeChargeId: null,
+        giftDate: "2026-05-10",
+        campaignId: null,
+        pledgeId: null,
+        processedAt: null,
+        completedAt: null,
+        failedAt: null,
+        errorCode: null,
+        errorMessage: null,
+        refundedAt: null,
+        refundAmount: 0,
+        source: "online",
+        createdAt: "2026-05-10T08:00:00.000Z",
+        updatedAt: "2026-05-10T08:00:00.000Z",
+      },
+      donor: {
+        id: "donor_1",
+        profileId: null,
+        name: "Alice Johnson",
+        email: "alice@example.com",
+        phone: null,
+        location: null,
+        organization: null,
+      },
+      fund: { id: "fund_1", name: "Clean Water Initiative" },
+      missionary: { id: "missionary_1", name: "John Martinez" },
+      stagedGift: {
+        id: "staged_1",
+        status: "posted",
+        receiptStatus: "sent",
+        crmPostStatus: "posted",
+        reviewReason: null,
+        twentyRecordId: null,
+      },
+      corrections: [
+        { id: "c1", correctionType: "amount_correction", status: "pending" },
+      ],
+    });
+
+    expect(detail.actionAvailability).toEqual([
+      expect.objectContaining({
+        actionType: "approve_staged_gift",
+        available: false,
+      }),
+      expect.objectContaining({
+        actionType: "retry_staged_gift",
+        available: false,
+      }),
+      expect.objectContaining({
+        actionType: "resend_receipt",
+        available: true,
+      }),
+      expect.objectContaining({
+        actionType: "refund",
+        available: false,
+      }),
+    ]);
+
+    expect(detail.shared).toEqual({
+      donationId: "donation_2",
+      amountCents: 25_000,
+      currencyCode: "USD",
+      giftDate: "2026-05-10",
+      donorId: "donor_1",
+      donorName: "Alice Johnson",
+      designationSummary: {
+        fundId: "fund_1",
+        fundName: "Clean Water Initiative",
+        missionaryId: "missionary_1",
+        missionaryName: "John Martinez",
+        lineCount: 1,
+      },
+      paymentStatus: "completed",
+      receiptStatus: "sent",
+      crmPostStatus: "posted",
+      refundState: "none",
+      refundedAmountCents: 0,
+      correctionState: "pending",
+      recurringLinkState: "none",
+    });
+  });
+
+  it("returns read-only truth with blocked workflow actions for gifts without staged gifts", () => {
+    const detail = buildContributionDetail({
+      donation: {
+        id: "donation_3",
+        tenantId: "tenant_1",
+        donorId: "donor_1",
+        missionaryId: null,
+        fundId: null,
+        amount: 7_500,
+        currency: "usd",
+        status: "completed",
+        donationType: "one_time",
+        paymentMethod: "check",
+        isRecurring: false,
+        recurringInterval: null,
+        notes: null,
+        stripePaymentIntentId: null,
+        stripeChargeId: null,
+        giftDate: "2026-03-15",
+        campaignId: null,
+        pledgeId: null,
+        processedAt: null,
+        completedAt: "2026-03-15T00:00:00.000Z",
+        failedAt: null,
+        errorCode: null,
+        errorMessage: null,
+        refundedAt: null,
+        refundAmount: 0,
+        source: "mail",
+        createdAt: "2026-03-15T00:00:00.000Z",
+        updatedAt: "2026-03-15T00:00:00.000Z",
+      },
+      donor: {
+        id: "donor_1",
+        profileId: null,
+        name: "Legacy Donor",
+        email: null,
+        phone: null,
+        location: null,
+        organization: null,
+      },
+    });
+
+    expect(detail.stagedGift).toBeNull();
+    expect(detail.shared.amountCents).toBe(7_500);
+    expect(detail.shared.designationSummary.fundName).toBe("General Fund");
+
+    const workflowEntries = detail.actionAvailability.filter((entry) =>
+      ["approve_staged_gift", "retry_staged_gift", "resend_receipt"].includes(
+        entry.actionType,
+      ),
+    );
+    for (const entry of workflowEntries) {
+      expect(entry.available).toBe(false);
+      expect(entry.blockedReason).toMatch(/no staged gift/i);
+      expect(entry.nextStep).toMatch(/valid/i);
+    }
+
+    // A check gift with no provider charge cannot use provider refunds.
+    const refundEntry = detail.actionAvailability.find(
+      (entry) => entry.actionType === "refund",
+    );
+    expect(refundEntry?.available).toBe(false);
+    expect(refundEntry?.blockedReason).toMatch(/no payment provider charge/i);
+  });
+
+  it("exposes a first-class designation set for split gifts that reconciles to the gift amount", () => {
+    const detail = buildContributionDetail({
+      donation: {
+        id: "donation_4",
+        tenantId: "tenant_1",
+        donorId: "donor_1",
+        missionaryId: null,
+        fundId: "fund_1",
+        amount: 30_000,
+        currency: "usd",
+        status: "completed",
+        donationType: "one_time",
+        paymentMethod: "card",
+        isRecurring: false,
+        recurringInterval: null,
+        notes: null,
+        stripePaymentIntentId: "pi_1",
+        stripeChargeId: null,
+        giftDate: "2026-05-20",
+        campaignId: null,
+        pledgeId: null,
+        processedAt: null,
+        completedAt: "2026-05-20T00:00:00.000Z",
+        failedAt: null,
+        errorCode: null,
+        errorMessage: null,
+        refundedAt: null,
+        refundAmount: 0,
+        source: "online",
+        createdAt: "2026-05-20T00:00:00.000Z",
+        updatedAt: "2026-05-20T00:00:00.000Z",
+      },
+      donor: {
+        id: "donor_1",
+        profileId: null,
+        name: "Split Donor",
+        email: "split@example.com",
+        phone: null,
+        location: null,
+        organization: null,
+      },
+      fund: { id: "fund_1", name: "Clean Water Initiative" },
+      allocations: [
+        {
+          id: "alloc_1",
+          amount: 10_000,
+          fund_id: "fund_1",
+          missionary_id: null,
+          memo: "water",
+        },
+        {
+          id: "alloc_2",
+          amount: 20_000,
+          fund_id: "fund_2",
+          missionary_id: "missionary_1",
+          memo: null,
+        },
+      ],
+      allocationFunds: [
+        {
+          id: "fund_1",
+          name: "Clean Water Initiative",
+          missionary_id: null,
+          goal_amount: 50_000,
+          start_date: null,
+          end_date: null,
+        },
+        {
+          id: "fund_2",
+          name: "Martinez Family Support",
+          missionary_id: "missionary_1",
+          goal_amount: 0,
+          start_date: null,
+          end_date: null,
+        },
+      ],
+      allocationMissionaries: [
+        { id: "missionary_1", display_name: "John Martinez" },
+      ],
+    });
+
+    expect(detail.designations.lines).toHaveLength(2);
+    expect(detail.designations.totalAmountCents).toBe(30_000);
+    expect(detail.designations.reconcilesToGiftAmount).toBe(true);
+    expect(detail.designations.lines[0]).toMatchObject({
+      fundName: "Clean Water Initiative",
+      fundType: "project",
+      memo: "water",
+    });
+    expect(detail.designations.lines[1]).toMatchObject({
+      fundName: "Martinez Family Support",
+      fundType: "missionary",
+      missionaryName: "John Martinez",
+    });
+
+    // The shared row summary derives from the same designation set.
+    expect(detail.shared.designationSummary).toEqual({
+      fundId: null,
+      fundName: "2 designations",
+      missionaryId: null,
+      missionaryName: null,
+      lineCount: 2,
+    });
+
+    // No designation is labeled primary anywhere in the payload.
+    expect(detail).not.toHaveProperty("designation");
+  });
+
+  it("links the internal recurring agreement first and warns on provider-only recurrence", () => {
+    const base = {
+      id: "donation_r",
+      tenantId: "tenant_1",
+      donorId: "donor_1",
+      missionaryId: null,
+      fundId: null,
+      amount: 5_000,
+      currency: "usd",
+      status: "completed",
+      donationType: "recurring",
+      paymentMethod: "card",
+      notes: null,
+      stripePaymentIntentId: "pi_r",
+      stripeChargeId: null,
+      giftDate: "2026-06-01",
+      campaignId: null,
+      processedAt: null,
+      completedAt: null,
+      failedAt: null,
+      errorCode: null,
+      errorMessage: null,
+      refundedAt: null,
+      refundAmount: 0,
+      source: "online",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    };
+
+    const linked = buildContributionDetail({
+      donation: {
+        ...base,
+        isRecurring: true,
+        recurringInterval: "month",
+        pledgeId: "pledge_1",
+      },
+      recurringAgreement: {
+        id: "pledge_1",
+        status: "active",
+        frequency: "monthly",
+        amountCents: 5_000,
+        currencyCode: "USD",
+        fundId: "fund_1",
+        fundName: "General Fund",
+        missionaryId: null,
+        nextExpectedGiftAt: "2026-07-01T00:00:00.000Z",
+        stripeSubscriptionId: "sub_1",
+      },
+    });
+    expect(linked.recurring.agreement?.id).toBe("pledge_1");
+    expect(linked.recurring.providerRecurrenceWithoutAgreement).toBe(false);
+    expect(linked.shared.recurringLinkState).toBe("agreement_linked");
+
+    const providerOnly = buildContributionDetail({
+      donation: {
+        ...base,
+        isRecurring: true,
+        recurringInterval: "month",
+        pledgeId: null,
+      },
+    });
+    expect(providerOnly.recurring.agreement).toBeNull();
+    expect(providerOnly.recurring.providerRecurrenceWithoutAgreement).toBe(
+      true,
+    );
+    expect(providerOnly.shared.recurringLinkState).toBe("provider_only");
+
+    const oneTime = buildContributionDetail({
+      donation: {
+        ...base,
+        isRecurring: false,
+        recurringInterval: null,
+        pledgeId: null,
+      },
+    });
+    expect(oneTime.recurring.providerRecurrenceWithoutAgreement).toBe(false);
+    expect(oneTime.shared.recurringLinkState).toBe("none");
+  });
+
+  it("derives effective values from applied adjustments while preserving the original", () => {
+    const detail = buildContributionDetail({
+      donation: {
+        id: "donation_5",
+        tenantId: "tenant_1",
+        donorId: "donor_1",
+        missionaryId: null,
+        fundId: "fund_1",
+        amount: 25_000,
+        currency: "usd",
+        status: "completed",
+        donationType: "one_time",
+        paymentMethod: "card",
+        isRecurring: false,
+        recurringInterval: null,
+        notes: null,
+        stripePaymentIntentId: "pi_1",
+        stripeChargeId: null,
+        giftDate: "2026-05-20",
+        campaignId: null,
+        pledgeId: null,
+        processedAt: null,
+        completedAt: "2026-05-20T00:00:00.000Z",
+        failedAt: null,
+        errorCode: null,
+        errorMessage: null,
+        refundedAt: null,
+        refundAmount: 0,
+        source: "online",
+        createdAt: "2026-05-20T00:00:00.000Z",
+        updatedAt: "2026-05-21T00:00:00.000Z",
+      },
+      donor: {
+        id: "donor_1",
+        profileId: null,
+        name: "Adjusted Donor",
+        email: "adjusted@example.com",
+        phone: null,
+        location: null,
+        organization: null,
+      },
+      fund: { id: "fund_1", name: "Clean Water Initiative" },
+      allocationFunds: [
+        {
+          id: "fund_1",
+          name: "Clean Water Initiative",
+          missionary_id: null,
+          goal_amount: 0,
+          start_date: null,
+          end_date: null,
+        },
+        {
+          id: "fund_2",
+          name: "Disaster Relief",
+          missionary_id: null,
+          goal_amount: 0,
+          start_date: null,
+          end_date: null,
+        },
+      ],
+      adjustments: [
+        {
+          id: "adj_1",
+          adjustmentType: "amount_correction",
+          status: "applied",
+          effectiveValues: { amountCents: 20_000 },
+          reason: "data entry error",
+          actorProfileId: "profile_1",
+          sourceSurface: "contribution_hub",
+          createdAt: "2026-05-21T00:00:00.000Z",
+        },
+        {
+          id: "adj_2",
+          adjustmentType: "fund_correction",
+          status: "applied",
+          effectiveValues: { fundId: "fund_2" },
+          reason: "donor intent clarified",
+          actorProfileId: "profile_1",
+          sourceSurface: "donor_crm_record",
+          createdAt: "2026-05-22T00:00:00.000Z",
+        },
+      ],
+    });
+
+    // Original donation truth is preserved and visible.
+    expect(detail.original).toEqual({
+      amountCents: 25_000,
+      fundId: "fund_1",
+      missionaryId: null,
+      paymentStatus: "completed",
+    });
+
+    // Effective values derive from original + applied adjustments.
+    expect(detail.effective.amountCents).toBe(20_000);
+    expect(detail.effective.fundId).toBe("fund_2");
+    expect(detail.effective.materiallyDiffers).toBe(true);
+    expect(detail.amount.value).toBe(20_000);
+    expect(detail.shared.amountCents).toBe(20_000);
+    expect(detail.shared.designationSummary.fundName).toBe("Disaster Relief");
+    expect(detail.designations.totalAmountCents).toBe(20_000);
+
+    // Adjustment history and version metadata are part of the contract.
+    expect(detail.adjustments).toHaveLength(2);
+    expect(detail.revision).toBe("2026-05-21T00:00:00.000Z#2");
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts
+++ b/tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeReceiptAffectedFields,
+  evaluateReceiptDeliveryOptions,
+  resolveConfirmedReceiptDelivery,
+  resolveTenantReceiptDeliveryPolicy,
+  validateReceiptDeliverySelection,
+} from "../../../../../packages/api/src/admin/contribution-operations/receipt-delivery";
+
+const MANAGE_RECEIPTS = "contributions.manage_receipts";
+
+describe("admin/contribution-operations/receipt-delivery", () => {
+  it("resolves conservative tenant policy defaults", () => {
+    const policy = resolveTenantReceiptDeliveryPolicy(null);
+
+    expect(policy).toEqual({
+      defaultChoice: "email",
+      allowDefer: true,
+      deferReasonRequired: true,
+      requireDeliveryAction: false,
+      emailCapability: MANAGE_RECEIPTS,
+      pdfCapability: MANAGE_RECEIPTS,
+    });
+  });
+
+  it("computes which receipt fields a correction changes", () => {
+    expect(computeReceiptAffectedFields({ amountCents: 20_000 })).toEqual([
+      "amount",
+    ]);
+    expect(
+      computeReceiptAffectedFields({ fundId: "fund-2" }).includes(
+        "designation",
+      ),
+    ).toBe(true);
+    expect(
+      computeReceiptAffectedFields({
+        designationLines: [
+          {
+            id: "l1",
+            amountCents: 1,
+            fundId: "f",
+            missionaryId: null,
+            memo: null,
+          },
+        ],
+      }),
+    ).toEqual(["designation"]);
+    expect(computeReceiptAffectedFields({})).toEqual([]);
+  });
+
+  it("blocks email when the donor has no address or opted out, guiding staff to PDF", () => {
+    const policy = resolveTenantReceiptDeliveryPolicy(null);
+
+    const optedOut = evaluateReceiptDeliveryOptions({
+      policy,
+      donor: { email: "donor@example.com", doNotEmail: true },
+      actorCapabilities: [MANAGE_RECEIPTS],
+    });
+    const emailOption = optedOut.options.find(
+      (option) => option.choice === "email",
+    )!;
+    expect(emailOption.available).toBe(false);
+    expect(emailOption.blockedReason).toMatch(/opted out/i);
+    expect(optedOut.defaultChoice).toBe("pdf");
+
+    const noEmail = evaluateReceiptDeliveryOptions({
+      policy,
+      donor: { email: null, doNotEmail: false },
+      actorCapabilities: [MANAGE_RECEIPTS],
+    });
+    expect(
+      noEmail.options.find((option) => option.choice === "email")!.available,
+    ).toBe(false);
+    expect(noEmail.defaultChoice).toBe("pdf");
+
+    const allowed = evaluateReceiptDeliveryOptions({
+      policy,
+      donor: { email: "donor@example.com", doNotEmail: false },
+      actorCapabilities: [MANAGE_RECEIPTS],
+    });
+    expect(
+      allowed.options.find((option) => option.choice === "email")!.available,
+    ).toBe(true);
+    expect(allowed.defaultChoice).toBe("email");
+  });
+
+  it("enforces selection rules server-side", () => {
+    const policy = resolveTenantReceiptDeliveryPolicy(null);
+    const donor = { email: "donor@example.com", doNotEmail: true };
+
+    expect(() =>
+      validateReceiptDeliverySelection({
+        policy,
+        donor,
+        actorCapabilities: [MANAGE_RECEIPTS],
+        selection: { choice: "email" },
+      }),
+    ).toThrowError(/opted out/i);
+
+    expect(() =>
+      validateReceiptDeliverySelection({
+        policy,
+        donor,
+        actorCapabilities: [MANAGE_RECEIPTS],
+        selection: { choice: "defer" },
+      }),
+    ).toThrowError(/reason/i);
+
+    expect(() =>
+      validateReceiptDeliverySelection({
+        policy,
+        donor,
+        actorCapabilities: [MANAGE_RECEIPTS],
+        selection: { choice: "defer", deferReason: "Donor asked us to wait" },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      validateReceiptDeliverySelection({
+        policy: resolveTenantReceiptDeliveryPolicy({ allow_defer: false }),
+        donor,
+        actorCapabilities: [MANAGE_RECEIPTS],
+        selection: { choice: "defer", deferReason: "any" },
+      }),
+    ).toThrowError(/defer/i);
+
+    expect(() =>
+      validateReceiptDeliverySelection({
+        policy,
+        donor: { email: "donor@example.com", doNotEmail: false },
+        actorCapabilities: [],
+        selection: { choice: "email" },
+      }),
+    ).toThrowError(/manage_receipts/);
+  });
+
+  it("lets the approver confirm or change the requester proposal", () => {
+    const proposal = { choice: "email" as const, deferReason: null };
+
+    const confirmed = resolveConfirmedReceiptDelivery({
+      proposal,
+      approverSelection: null,
+    });
+    expect(confirmed.confirmed).toEqual(proposal);
+    expect(confirmed.changedByApprover).toBe(false);
+
+    const changed = resolveConfirmedReceiptDelivery({
+      proposal,
+      approverSelection: { choice: "pdf", deferReason: null },
+    });
+    expect(changed.requested).toEqual(proposal);
+    expect(changed.confirmed.choice).toBe("pdf");
+    expect(changed.changedByApprover).toBe(true);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts
+++ b/tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts
@@ -135,6 +135,47 @@ describe("admin/contribution-operations/receipt-delivery", () => {
     ).toThrowError(/manage_receipts/);
   });
 
+  it("rejects defer when tenant policy requires an email or PDF action", () => {
+    const policy = resolveTenantReceiptDeliveryPolicy({
+      default_choice: "defer",
+      allow_defer: true,
+      require_delivery_action: true,
+    });
+    const donor = { email: "donor@example.com", doNotEmail: false };
+
+    const evaluated = evaluateReceiptDeliveryOptions({
+      policy,
+      donor,
+      actorCapabilities: [MANAGE_RECEIPTS],
+    });
+
+    expect(
+      evaluated.options.find((option) => option.choice === "defer"),
+    ).toMatchObject({
+      available: false,
+      blockedReason: expect.stringMatching(/requires email delivery or pdf/i),
+    });
+    expect(evaluated.defaultChoice).toBe("pdf");
+
+    expect(() =>
+      validateReceiptDeliverySelection({
+        policy,
+        donor,
+        actorCapabilities: [MANAGE_RECEIPTS],
+        selection: { choice: "defer", deferReason: "Handle later" },
+      }),
+    ).toThrowError(/requires email delivery or PDF generation/i);
+
+    expect(() =>
+      validateReceiptDeliverySelection({
+        policy,
+        donor,
+        actorCapabilities: [MANAGE_RECEIPTS],
+        selection: { choice: "pdf" },
+      }),
+    ).not.toThrow();
+  });
+
   it("lets the approver confirm or change the requester proposal", () => {
     const proposal = { choice: "email" as const, deferReason: null };
 

--- a/tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts
+++ b/tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts
@@ -176,6 +176,42 @@ describe("admin/contribution-operations/receipt-delivery", () => {
     ).not.toThrow();
   });
 
+  it("returns no default choice when every delivery option is unavailable", () => {
+    const policy = resolveTenantReceiptDeliveryPolicy({
+      default_choice: "defer",
+      allow_defer: true,
+      require_delivery_action: true,
+    });
+
+    const evaluated = evaluateReceiptDeliveryOptions({
+      policy,
+      donor: { email: null, doNotEmail: false },
+      actorCapabilities: [],
+    });
+
+    expect(evaluated.options).toEqual([
+      {
+        choice: "email",
+        available: false,
+        blockedReason: "The donor has no email address on file.",
+      },
+      {
+        choice: "pdf",
+        available: false,
+        blockedReason:
+          "Generating updated receipt PDFs requires contributions.manage_receipts.",
+      },
+      {
+        choice: "defer",
+        available: false,
+        blockedReason: expect.stringMatching(
+          /requires email delivery or pdf generation/i,
+        ),
+      },
+    ]);
+    expect(evaluated.defaultChoice).toBeNull();
+  });
+
   it("lets the approver confirm or change the requester proposal", () => {
     const proposal = { choice: "email" as const, deferReason: null };
 

--- a/tests/unit/packages/api/admin/contribution-viewer-projection.test.ts
+++ b/tests/unit/packages/api/admin/contribution-viewer-projection.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributionDetail } from "../../../../../packages/api/src/admin/contribution-operations/detail-read-model";
+import { projectContributionDetailForViewer } from "../../../../../packages/api/src/admin/contribution-operations/viewer-projection";
+
+function makeDetail() {
+  return buildContributionDetail({
+    donation: {
+      id: "donation_1",
+      tenantId: "tenant_1",
+      donorId: "donor_1",
+      missionaryId: null,
+      fundId: "fund_1",
+      amount: 25_000,
+      currency: "usd",
+      status: "completed",
+      donationType: "one_time",
+      paymentMethod: "card",
+      isRecurring: false,
+      recurringInterval: null,
+      notes: null,
+      stripePaymentIntentId: "pi_proof",
+      stripeChargeId: "ch_proof",
+      giftDate: "2026-05-10",
+      campaignId: null,
+      pledgeId: null,
+      processedAt: null,
+      completedAt: "2026-05-10T00:00:00.000Z",
+      failedAt: null,
+      errorCode: null,
+      errorMessage: null,
+      refundedAt: null,
+      refundAmount: 0,
+      source: "online",
+      createdAt: "2026-05-10T00:00:00.000Z",
+      updatedAt: "2026-05-10T00:00:00.000Z",
+    },
+    donor: {
+      id: "donor_1",
+      profileId: null,
+      name: "Proof Donor",
+      email: "proof@example.com",
+      phone: null,
+      location: null,
+      organization: null,
+    },
+    fund: { id: "fund_1", name: "General Fund" },
+  });
+}
+
+describe("admin/contribution-operations/viewer-projection", () => {
+  it("redacts provider identifiers and provider actions for normal staff", () => {
+    const projected = projectContributionDetailForViewer(makeDetail(), [
+      "contributions.view_detail",
+      "contributions.request_corrections",
+    ]);
+
+    expect(projected.payment.stripe.paymentIntentId).toBeNull();
+    expect(projected.payment.stripe.chargeId).toBeNull();
+    expect(projected.payment.stripe.refundIds).toEqual([]);
+    expect(projected.payment.stripe.replayContext).toBeNull();
+    expect(projected.providerProof).toBeNull();
+    expect(
+      projected.actionAvailability.some(
+        (entry) => entry.actionType === "stripe_replay",
+      ),
+    ).toBe(false);
+
+    // Payment summary stays available for routine workflows.
+    expect(projected.payment.status).toBe("completed");
+    expect(projected.amount.value).toBe(25_000);
+    expect(projected.shared.refundState).toBe("none");
+  });
+
+  it("exposes provider proof, dashboard links, and safe provider actions to authorized operators", () => {
+    const projected = projectContributionDetailForViewer(makeDetail(), [
+      "contributions.use_provider_actions",
+    ]);
+
+    expect(projected.providerProof).toMatchObject({
+      paymentIntentId: "pi_proof",
+      chargeId: "ch_proof",
+      dashboardUrls: {
+        paymentIntent: "https://dashboard.stripe.com/payments/pi_proof",
+        charge: "https://dashboard.stripe.com/charges/ch_proof",
+      },
+    });
+
+    const replayEntry = projected.actionAvailability.find(
+      (entry) => entry.actionType === "stripe_replay",
+    );
+    expect(replayEntry?.available).toBe(true);
+    expect(replayEntry?.riskLevel).toBe("high");
+  });
+
+  it("blocks webhook replay with a clear reason when no provider events exist", () => {
+    const detail = makeDetail();
+    detail.payment.stripe.paymentIntentId = null;
+
+    const projected = projectContributionDetailForViewer(detail, [
+      "contributions.use_provider_actions",
+    ]);
+
+    const replayEntry = projected.actionAvailability.find(
+      (entry) => entry.actionType === "stripe_replay",
+    );
+    expect(replayEntry?.available).toBe(false);
+    expect(replayEntry?.blockedReason).toMatch(/no provider payment events/i);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-viewer-projection.test.ts
+++ b/tests/unit/packages/api/admin/contribution-viewer-projection.test.ts
@@ -96,6 +96,7 @@ describe("admin/contribution-operations/viewer-projection", () => {
   it("blocks webhook replay with a clear reason when no provider events exist", () => {
     const detail = makeDetail();
     detail.payment.stripe.paymentIntentId = null;
+    detail.payment.stripe.chargeId = null;
 
     const projected = projectContributionDetailForViewer(detail, [
       "contributions.use_provider_actions",
@@ -106,5 +107,24 @@ describe("admin/contribution-operations/viewer-projection", () => {
     );
     expect(replayEntry?.available).toBe(false);
     expect(replayEntry?.blockedReason).toMatch(/no provider payment events/i);
+  });
+
+  it("allows webhook replay when only a charge id is available", () => {
+    const detail = makeDetail();
+    detail.payment.stripe.paymentIntentId = null;
+    detail.payment.stripe.chargeId = "ch_only";
+
+    const projected = projectContributionDetailForViewer(detail, [
+      "contributions.use_provider_actions",
+    ]);
+
+    const replayEntry = projected.actionAvailability.find(
+      (entry) => entry.actionType === "stripe_replay",
+    );
+    expect(replayEntry?.available).toBe(true);
+    expect(projected.providerProof?.dashboardUrls).toMatchObject({
+      paymentIntent: null,
+      charge: "https://dashboard.stripe.com/charges/ch_only",
+    });
   });
 });

--- a/tests/unit/supabase/contribution-operations-core-migration.test.ts
+++ b/tests/unit/supabase/contribution-operations-core-migration.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL(
+    "../../../supabase/migrations/20260526132000_contribution_operations_core.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("contribution operations core migration", () => {
+  it("enforces tenant ownership for contribution operation references", () => {
+    expect(migrationSql).toContain(
+      "CREATE OR REPLACE FUNCTION public.enforce_contribution_operation_tenant_refs()",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TRIGGER enforce_contribution_corrections_tenant_refs",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TRIGGER enforce_contribution_operation_audit_events_tenant_refs",
+    );
+
+    for (const parentTable of [
+      "public.donations",
+      "public.staged_gifts",
+      "public.contribution_corrections",
+      "public.contribution_operation_audit_events",
+    ]) {
+      expect(migrationSql).toContain(`FROM ${parentTable}`);
+    }
+
+    for (const mismatchMessage of [
+      "contribution operation donation tenant mismatch",
+      "contribution operation staged gift tenant mismatch",
+      "contribution operation correction tenant mismatch",
+      "contribution operation audit event tenant mismatch",
+    ]) {
+      expect(migrationSql).toContain(mismatchMessage);
+    }
+  });
+});

--- a/tests/unit/supabase/contribution-operations-core-migration.test.ts
+++ b/tests/unit/supabase/contribution-operations-core-migration.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
+import { CONTRIBUTION_ACTION_TYPES } from "../../../packages/api/src/admin/contribution-operations/types";
+
 const migrationSql = readFileSync(
   new URL(
     "../../../supabase/migrations/20260526132000_contribution_operations_core.sql",
@@ -52,5 +54,27 @@ describe("contribution operations core migration", () => {
     expect(migrationSql).toContain(
       "SELECT ae.tenant_id, ae.donation_id, ae.staged_gift_id",
     );
+  });
+
+  it("constrains contribution correction types to the operation action contract", () => {
+    const correctionTypeStart = migrationSql.indexOf(
+      "correction_type TEXT NOT NULL",
+    );
+    const statusStart = migrationSql.indexOf(
+      "status TEXT NOT NULL DEFAULT 'applied'",
+    );
+    const correctionTypeConstraint = migrationSql.slice(
+      correctionTypeStart,
+      statusStart,
+    );
+
+    expect(correctionTypeStart).toBeGreaterThanOrEqual(0);
+    expect(statusStart).toBeGreaterThan(correctionTypeStart);
+    expect(correctionTypeConstraint).toContain("CHECK (");
+    expect(correctionTypeConstraint).toContain("correction_type IN");
+
+    for (const actionType of CONTRIBUTION_ACTION_TYPES) {
+      expect(correctionTypeConstraint).toContain(`'${actionType}'`);
+    }
   });
 });

--- a/tests/unit/supabase/contribution-operations-core-migration.test.ts
+++ b/tests/unit/supabase/contribution-operations-core-migration.test.ts
@@ -34,10 +34,13 @@ describe("contribution operations core migration", () => {
     for (const mismatchMessage of [
       "contribution operation donation tenant mismatch",
       "contribution operation staged gift tenant mismatch",
+      "contribution operation staged gift donation mismatch",
       "contribution operation correction tenant mismatch",
       "contribution operation audit event tenant mismatch",
     ]) {
       expect(migrationSql).toContain(mismatchMessage);
     }
+
+    expect(migrationSql).toContain("SELECT sg.tenant_id, sg.donation_id");
   });
 });

--- a/tests/unit/supabase/contribution-operations-core-migration.test.ts
+++ b/tests/unit/supabase/contribution-operations-core-migration.test.ts
@@ -36,11 +36,21 @@ describe("contribution operations core migration", () => {
       "contribution operation staged gift tenant mismatch",
       "contribution operation staged gift donation mismatch",
       "contribution operation correction tenant mismatch",
+      "contribution operation correction donation mismatch",
+      "contribution operation correction staged gift mismatch",
       "contribution operation audit event tenant mismatch",
+      "contribution operation audit event donation mismatch",
+      "contribution operation audit event staged gift mismatch",
     ]) {
       expect(migrationSql).toContain(mismatchMessage);
     }
 
     expect(migrationSql).toContain("SELECT sg.tenant_id, sg.donation_id");
+    expect(migrationSql).toContain(
+      "SELECT cc.tenant_id, cc.donation_id, cc.staged_gift_id",
+    );
+    expect(migrationSql).toContain(
+      "SELECT ae.tenant_id, ae.donation_id, ae.staged_gift_id",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add additive core contribution operation database tables, RLS posture, and service-role grants.
- Add pure policy, projection, detail read-model, action availability, CRM post-state, and receipt-delivery utilities under `@asym/api/admin/contribution-operations`.
- Keep this slice self-contained by deferring DB store methods, route handlers, action execution, correction requests, notifications, and batch flows to later PRs with their dependent migrations.

## Verification

- `bun run test:unit -- tests/unit/packages/api/admin/contribution-action-availability.test.ts tests/unit/packages/api/admin/contribution-approval-policy.test.ts tests/unit/packages/api/admin/contribution-crm-post-state.test.ts tests/unit/packages/api/admin/contribution-operations-policy.test.ts tests/unit/packages/api/admin/contribution-operations-read-model.test.ts tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts tests/unit/packages/api/admin/contribution-viewer-projection.test.ts`
- `bunx turbo run typecheck --filter=@asym/api`
- `bunx turbo run lint --filter=@asym/api`
- `bun run ci:preflight`
- Pre-push guard reran `bun run ci:preflight` before publishing this branch.

## Migration note

I could not run a local Supabase reset because Docker is unavailable on this machine (`/Users/blake/.docker/run/docker.sock` is not accepting connections). The migrations are additive and should be exercised by the GitHub integration migration gate.

## QA smoke

No `qa:smoke` label on this PR: this slice adds package-level pure read-model utilities and additive schema only, with no app route or UI surface wired to production runtime yet.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `@asym/api/admin/contribution-operations` slice: four new Supabase tables with service-role-only RLS, a cross-tenant integrity trigger, and a suite of pure read-model utilities (effective-value projection, action availability, CRM post state, receipt delivery validation, approval policy, and viewer projection). It also patches the designation-set builder to preserve `fundId` when fund metadata is absent instead of silently collapsing it to `null`.

- **Schema:** four additive tables (`contribution_corrections`, `contribution_operation_audit_events`, `contribution_operation_prompt_settings`, `contribution_operation_user_preferences`) with a PL/pgSQL trigger that enforces tenant, donation, and staged-gift consistency across cross-table references; `correction_type` CHECK constraint mirrors the TypeScript enum; RLS enabled with anon/authenticated revoked and service-role granted in a follow-on migration.
- **Read model:** `buildContributionDetail` derives all displayed values from `effective` (post-adjustment) state — payment status, amounts, refund labels, donor-visible status, action availability, and the optimistic-concurrency revision token all consistently use the corrected effective values rather than raw donation columns.
- **Receipt delivery:** `evaluateReceiptDeliveryOptions` correctly blocks `defer` when `requireDeliveryAction` is true and returns `null` for `defaultChoice` when every option is unavailable; `validateReceiptDeliverySelection` enforces the policy server-side independent of UI state.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — additive schema only, no route or UI surface wired to production yet, and all read-model logic is covered by unit tests.

All 17 prior-round concerns are demonstrably addressed in the code: effective values are used throughout the read model, the CRM post state correctly prefers link-record data, the receipt delivery policy blocks defer when requireDeliveryAction is true, the tenant-ref trigger validates cross-donation links, correction_type is constrained, and stripeReplayAvailability accepts either charge or intent id. The one new observation (audit-event cascade on donation deletion) is a schema design trade-off rather than a defect in the current additive slice.

supabase/migrations/20260526132000_contribution_operations_core.sql — specifically the ON DELETE CASCADE on contribution_operation_audit_events.donation_id, worth confirming against the repo's donation-deletion policy before the store layer is wired up.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-operations/detail-read-model.ts | Large new read-model builder; uses effective values for action availability, refund status, donor-visible status, and revision hashing — all correctly wired to the corrected effective state. |
| packages/api/src/admin/contribution-operations/action-availability.ts | Availability checks now use isCompletedPaymentStatus() normalizing "succeeded"/"success"/"completed"; hasProviderCharge accepts both stripeChargeId and stripePaymentIntentId. |
| packages/api/src/admin/contribution-operations/receipt-delivery.ts | requireDeliveryAction blocks defer at evaluateReceiptDeliveryOptions; defaultChoice falls back to null when all options are blocked; validateReceiptDeliverySelection enforces server-side. |
| supabase/migrations/20260526132000_contribution_operations_core.sql | New tables with RLS enabled and service-role-only access; tenant-ref trigger validates cross-contribution links; correction_type CHECK constraint matches TypeScript enum; audit events table uses ON DELETE CASCADE on donation_id which would destroy audit history if donations are ever hard-deleted. |
| packages/api/src/admin/contribution-shared/designation-set.ts | One-line fix: fundId now falls back to input.fundId instead of null when fund metadata row is missing, preserving corrected fund references when metadata load is partial. |
| packages/api/src/admin/contribution-operations/crm-post-state.ts | Parent status prefers link-record status over stale aggregate column; parent link's twentyRecordId takes precedence over staged gift aggregate column. |
| packages/api/src/admin/contribution-operations/viewer-projection.ts | stripeReplayAvailability now accepts either paymentIntentId or chargeId; provider identifiers are correctly stripped for unauthorized viewers. |
| supabase/migrations/20260526203000_contribution_operations_service_role_grants.sql | Additive GRANT ALL to service_role for the four new tables; correctly separated from the core migration. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Store as DB / Store Layer
    participant Detail as buildContributionDetail
    participant Effective as deriveEffectiveContribution
    participant CRM as buildContributionCrmPostState
    participant Actions as buildContributionActionAvailability
    participant Revision as buildContributionRevision
    participant Viewer as projectContributionDetailForViewer

    Store->>Detail: ContributionDetailInput
    Detail->>Effective: original values + adjustments
    Effective-->>Detail: effective (amountCents, fundId, paymentStatus)
    Detail->>CRM: stagedGiftCrmPostStatus + links
    CRM-->>Detail: ContributionCrmPostState (parent status, failedScopes)
    Detail->>Actions: effective.paymentStatus, stagedGift, hasProviderCharge
    Actions-->>Detail: ContributionActionAvailability[]
    Detail->>Revision: donationUpdatedAt + adjustments + workflow fingerprint
    Revision-->>Detail: sha256 revision token
    Detail-->>Store: ContributionDetail
    Store->>Viewer: ContributionDetail + viewerCapabilities
    Viewer-->>Store: ViewerProjectedContributionDetail (providerProof gated)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Store as DB / Store Layer
    participant Detail as buildContributionDetail
    participant Effective as deriveEffectiveContribution
    participant CRM as buildContributionCrmPostState
    participant Actions as buildContributionActionAvailability
    participant Revision as buildContributionRevision
    participant Viewer as projectContributionDetailForViewer

    Store->>Detail: ContributionDetailInput
    Detail->>Effective: original values + adjustments
    Effective-->>Detail: effective (amountCents, fundId, paymentStatus)
    Detail->>CRM: stagedGiftCrmPostStatus + links
    CRM-->>Detail: ContributionCrmPostState (parent status, failedScopes)
    Detail->>Actions: effective.paymentStatus, stagedGift, hasProviderCharge
    Actions-->>Detail: ContributionActionAvailability[]
    Detail->>Revision: donationUpdatedAt + adjustments + workflow fingerprint
    Revision-->>Detail: sha256 revision token
    Detail-->>Store: ContributionDetail
    Store->>Viewer: ContributionDetail + viewerCapabilities
    Viewer-->>Store: ViewerProjectedContributionDetail (providerProof gated)
```

</a>
</details>

<sub>Reviews (8): Last reviewed commit: ["fix(db): constrain contribution correcti..."](https://github.com/asymmetric-al/core/commit/a3b741947baf333135f776460a0cae39eef2a938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38874351)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/asymmetric-al/github/asymmetric-al/core/-/custom-context?memory=009f2e3e-315a-4b6b-987d-828e444ffa70))
- Context used - supabase/AGENTS.md ([source](https://app.greptile.com/asymmetric-al/github/asymmetric-al/core/-/custom-context?memory=960f86f9-fcd1-470b-a40d-3db9b34f89db))

<!-- /greptile_comment -->