### PR TITLE
feat(api): add contribution action executor

### DIFF
--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -455,7 +455,10 @@ function sanitizeProviderOutcome(
   }
 
   if ("errorMessage" in outcome) {
-    sanitized.errorMessage = outcome.errorMessage ? redactedErrorMessage : null;
+    sanitized.errorMessage =
+      outcome.errorMessage && isFailedProviderOutcome(outcome)
+        ? redactedErrorMessage
+        : null;
   }
 
   return sanitized;

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -436,8 +436,18 @@ function normalizedToken(value: string | null | undefined): string | null {
   return trimmedValue ? trimmedValue : null;
 }
 
-function contributionActionIdempotencyContext(
+function directMutationIdempotencyContext(
   input: ExecuteContributionActionInput,
+) {
+  return {
+    confirmationToken: normalizedToken(input.confirmationToken),
+    payload: input.payload ?? {},
+  };
+}
+
+function correctionRequestContext(
+  input: ExecuteContributionActionInput,
+  extra: { receiptDeliveryProposal?: Record<string, unknown> | null },
 ) {
   return {
     actorProfileId: input.actorProfileId,
@@ -447,15 +457,6 @@ function contributionActionIdempotencyContext(
     reason: input.reason ?? "",
     sourceSurface: input.sourceSurface,
     stagedGiftId: input.stagedGiftId ?? null,
-  };
-}
-
-function correctionRequestContext(
-  input: ExecuteContributionActionInput,
-  extra: { receiptDeliveryProposal?: Record<string, unknown> | null },
-) {
-  return {
-    ...contributionActionIdempotencyContext(input),
     receiptDeliveryProposal: extra.receiptDeliveryProposal ?? null,
   };
 }
@@ -554,9 +555,7 @@ function providerIdempotencyKey(input: ExecuteContributionActionInput): string {
       input.tenantId,
       input.contributionId,
       input.actionType,
-      `confirmation-${stableFingerprint(
-        contributionActionIdempotencyContext(input),
-      )}`,
+      `confirmation-${stableFingerprint(directMutationIdempotencyContext(input))}`,
     ].join("/");
   }
 
@@ -591,9 +590,7 @@ function correctionIdempotencyKey(
       input.tenantId,
       input.contributionId,
       input.actionType,
-      `confirmation-${stableFingerprint(
-        contributionActionIdempotencyContext(input),
-      )}`,
+      `confirmation-${stableFingerprint(directMutationIdempotencyContext(input))}`,
     ].join("/");
   }
 
@@ -657,6 +654,7 @@ export async function executeContributionAction<TContribution = unknown>(
       const sendReceipt = requireDependency(input.dependencies, "sendReceipt");
       const receipt = await sendReceipt({
         tenantId: input.tenantId,
+        contributionId: input.contributionId,
         stagedGiftId,
       });
       const providerOutcome = {
@@ -693,6 +691,7 @@ export async function executeContributionAction<TContribution = unknown>(
       );
       await approve({
         tenantId: input.tenantId,
+        contributionId: input.contributionId,
         stagedGiftId,
         actorProfileId: input.actorProfileId,
         note: input.reason ?? null,
@@ -739,6 +738,7 @@ export async function executeContributionAction<TContribution = unknown>(
         }
         await retryDesignation({
           tenantId: input.tenantId,
+          contributionId: input.contributionId,
           stagedGiftId,
           allocationId,
           actorProfileId: input.actorProfileId,
@@ -766,6 +766,7 @@ export async function executeContributionAction<TContribution = unknown>(
       const retry = requireDependency(input.dependencies, "retryStagedGift");
       await retry({
         tenantId: input.tenantId,
+        contributionId: input.contributionId,
         stagedGiftId,
         actorProfileId: input.actorProfileId,
         note: input.reason ?? null,
@@ -866,7 +867,9 @@ export async function executeContributionAction<TContribution = unknown>(
         amount,
         reason: input.reason ?? "",
         confirmationToken:
-          input.confirmationToken ?? input.approvedRequestId ?? "",
+          normalizedToken(input.confirmationToken) ??
+          normalizedToken(input.approvedRequestId) ??
+          "",
         expectedRevision: input.expectedRevision ?? null,
         idempotencyKey: providerIdempotencyKey(input),
       });

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   correctionRequiresApproval,
   resolveCorrectionApprovalPolicy,
@@ -135,18 +137,10 @@ function hasLegacyDirectActionPermission(
   );
 }
 
-function providerCapabilityForApprovedRequest(
+function directCapabilityForApprovedRequest(
   actionType: ContributionActionType,
-): string | null {
-  if (actionType === "refund") {
-    return DIRECT_ACTION_CAPABILITY.refund;
-  }
-
-  if (actionType === "stripe_replay") {
-    return DIRECT_ACTION_CAPABILITY.stripe_replay;
-  }
-
-  return null;
+): string {
+  return DIRECT_ACTION_CAPABILITY[actionType];
 }
 
 function assertApprovedRequestCapabilities(
@@ -162,11 +156,9 @@ function assertApprovedRequestCapabilities(
     );
   }
 
-  const providerCapability = providerCapabilityForApprovedRequest(
-    input.actionType,
-  );
-  if (providerCapability && !hasActorCapability(input, providerCapability)) {
-    throw new ApiHttpError(403, `Forbidden: requires ${providerCapability}`);
+  const directCapability = directCapabilityForApprovedRequest(input.actionType);
+  if (!hasActorCapability(input, directCapability)) {
+    throw new ApiHttpError(403, `Forbidden: requires ${directCapability}`);
   }
 }
 
@@ -408,6 +400,65 @@ async function applyApprovedCorrectionRequest<TContribution>(
   };
 }
 
+function stableSerialize(value: unknown): string {
+  if (value === undefined) {
+    return '"__undefined__"';
+  }
+
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+  const serializedEntries = entries.map(
+    ([key, entryValue]) =>
+      `${JSON.stringify(key)}:${stableSerialize(entryValue)}`,
+  );
+
+  return `{${serializedEntries.join(",")}}`;
+}
+
+function payloadFingerprint(
+  payload: Record<string, unknown> | undefined,
+): string {
+  return createHash("sha256")
+    .update(stableSerialize(payload ?? {}))
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function correctionRequestIdempotencyKey(
+  input: ExecuteContributionActionInput,
+): string {
+  if (input.idempotencyKey?.trim()) {
+    return input.idempotencyKey;
+  }
+
+  if (input.confirmationToken?.trim()) {
+    return [
+      "correction-request",
+      input.tenantId,
+      input.contributionId,
+      input.actionType,
+      input.confirmationToken,
+    ].join("/");
+  }
+
+  return [
+    "correction-request",
+    input.tenantId,
+    input.contributionId,
+    input.actionType,
+    `payload-${payloadFingerprint(input.payload)}`,
+  ].join("/");
+}
+
 async function createPendingCorrectionRequest<TContribution>(
   input: ExecuteContributionActionInput<TContribution>,
   extra: { receiptDeliveryProposal?: Record<string, unknown> | null } = {},
@@ -427,7 +478,7 @@ async function createPendingCorrectionRequest<TContribution>(
     requestedByProfileId: input.actorProfileId,
     sourceSurface: input.sourceSurface,
     expectedRevision: input.expectedRevision ?? null,
-    idempotencyKey: input.idempotencyKey ?? null,
+    idempotencyKey: correctionRequestIdempotencyKey(input),
     ...extra,
   });
   const auditEventId = await appendAuditEvent(

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -424,17 +424,16 @@ function stableSerialize(value: unknown): string {
   return `{${serializedEntries.join(",")}}`;
 }
 
-function payloadFingerprint(
-  payload: Record<string, unknown> | undefined,
-): string {
+function stableFingerprint(value: unknown): string {
   return createHash("sha256")
-    .update(stableSerialize(payload ?? {}))
+    .update(stableSerialize(value))
     .digest("hex")
     .slice(0, 32);
 }
 
 function correctionRequestIdempotencyKey(
   input: ExecuteContributionActionInput,
+  extra: { receiptDeliveryProposal?: Record<string, unknown> | null },
 ): string {
   if (input.idempotencyKey?.trim()) {
     return input.idempotencyKey;
@@ -450,12 +449,22 @@ function correctionRequestIdempotencyKey(
     ].join("/");
   }
 
+  const requestContext = {
+    actorProfileId: input.actorProfileId,
+    expectedRevision: input.expectedRevision ?? null,
+    payload: input.payload ?? {},
+    reason: input.reason ?? "",
+    receiptDeliveryProposal: extra.receiptDeliveryProposal ?? null,
+    sourceSurface: input.sourceSurface,
+    stagedGiftId: input.stagedGiftId ?? null,
+  };
+
   return [
     "correction-request",
     input.tenantId,
     input.contributionId,
     input.actionType,
-    `payload-${payloadFingerprint(input.payload)}`,
+    `context-${stableFingerprint(requestContext)}`,
   ].join("/");
 }
 
@@ -478,7 +487,7 @@ async function createPendingCorrectionRequest<TContribution>(
     requestedByProfileId: input.actorProfileId,
     sourceSurface: input.sourceSurface,
     expectedRevision: input.expectedRevision ?? null,
-    idempotencyKey: correctionRequestIdempotencyKey(input),
+    idempotencyKey: correctionRequestIdempotencyKey(input, extra),
     ...extra,
   });
   const auditEventId = await appendAuditEvent(

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -1,0 +1,802 @@
+import {
+  correctionRequiresApproval,
+  resolveCorrectionApprovalPolicy,
+} from "./approval-policy";
+import { getContributionActionPolicy } from "./policy";
+import { ApiHttpError } from "../../shared/http-errors";
+
+import type {
+  ContributionActionDependencies,
+  ContributionActionResult,
+  ContributionActionType,
+  ContributionCorrectionRecordInput,
+  ContributionOperationAuditEventInput,
+  ContributionProviderOutcome,
+  ExecuteContributionActionInput,
+} from "./types";
+
+function requireDependency<TKey extends keyof ContributionActionDependencies>(
+  dependencies: ContributionActionDependencies | undefined,
+  key: TKey,
+): NonNullable<ContributionActionDependencies[TKey]> {
+  const dependency = dependencies?.[key];
+  if (!dependency) {
+    throw new ApiHttpError(
+      501,
+      `Contribution operation dependency missing: ${key}`,
+    );
+  }
+  return dependency as NonNullable<ContributionActionDependencies[TKey]>;
+}
+
+function requireStringPayload(
+  payload: Record<string, unknown> | undefined,
+  key: string,
+): string {
+  const value = payload?.[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ApiHttpError(400, `${key} is required.`);
+  }
+  return value;
+}
+
+function requireNumberPayload(
+  payload: Record<string, unknown> | undefined,
+  key: string,
+): number {
+  const value = payload?.[key];
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new ApiHttpError(400, `${key} must be a positive number.`);
+  }
+  return value;
+}
+
+function assertReasonAndConfirmation(
+  input: Pick<
+    ExecuteContributionActionInput,
+    "reason" | "confirmationToken" | "actionType"
+  >,
+  policy: ReturnType<typeof getContributionActionPolicy>,
+) {
+  if (policy.requiresReason && !input.reason?.trim()) {
+    throw new ApiHttpError(
+      400,
+      `A reason is required for ${input.actionType}.`,
+    );
+  }
+
+  if (policy.requiresConfirmation && !input.confirmationToken?.trim()) {
+    throw new ApiHttpError(
+      400,
+      `A confirmation token is required for ${input.actionType}.`,
+    );
+  }
+}
+
+/**
+ * Granular capability that satisfies the legacy broad permission per
+ * high-risk action (ADR-CD-024 capability split).
+ */
+const HIGH_RISK_CAPABILITY: Partial<Record<ContributionActionType, string>> = {
+  refund: "contributions.run_refunds",
+  stripe_replay: "contributions.use_provider_actions",
+  donor_relink: "contributions.apply_corrections",
+  amount_correction: "contributions.apply_corrections",
+  designation_correction: "contributions.apply_corrections",
+  fund_correction: "contributions.apply_corrections",
+  payment_state_correction: "contributions.apply_corrections",
+};
+
+function assertActorPermissions(
+  input: Pick<
+    ExecuteContributionActionInput,
+    "actorPermissions" | "actorCapabilities" | "actionType"
+  >,
+  policy: ReturnType<typeof getContributionActionPolicy>,
+) {
+  if (!policy.requiredPermission) {
+    return;
+  }
+
+  if (input.actorPermissions.includes(policy.requiredPermission)) {
+    return;
+  }
+
+  const acceptedCapability = HIGH_RISK_CAPABILITY[input.actionType];
+  if (
+    acceptedCapability &&
+    (input.actorCapabilities ?? []).includes(acceptedCapability)
+  ) {
+    return;
+  }
+
+  // Correction/refund requests are gated separately by the request capability.
+  if (
+    (isCorrectionAction(input.actionType) || input.actionType === "refund") &&
+    (input.actorCapabilities ?? []).includes(
+      "contributions.request_corrections",
+    )
+  ) {
+    return;
+  }
+
+  throw new ApiHttpError(
+    403,
+    `Forbidden: requires ${policy.requiredPermission}`,
+  );
+}
+
+async function loadCanonicalContribution<TContribution>(
+  input: ExecuteContributionActionInput<TContribution>,
+): Promise<TContribution> {
+  const loadContributionDetail = requireDependency(
+    input.dependencies,
+    "loadContributionDetail",
+  );
+
+  return loadContributionDetail({
+    tenantId: input.tenantId,
+    contributionId: input.contributionId,
+  }) as Promise<TContribution>;
+}
+
+function auditInput(
+  input: ExecuteContributionActionInput,
+  extra: Partial<ContributionOperationAuditEventInput> = {},
+): ContributionOperationAuditEventInput {
+  return {
+    tenantId: input.tenantId,
+    actorProfileId: input.actorProfileId,
+    contributionId: input.contributionId,
+    stagedGiftId: input.stagedGiftId ?? null,
+    actionType: input.actionType,
+    sourceSurface: input.sourceSurface,
+    reason: input.reason ?? null,
+    downstreamEffects: {},
+    ...extra,
+  };
+}
+
+async function appendAuditEvent(
+  input: ExecuteContributionActionInput,
+  event: ContributionOperationAuditEventInput,
+): Promise<string> {
+  const append = requireDependency(input.dependencies, "appendAuditEvent");
+  return append(event);
+}
+
+async function createCorrectionRecord(
+  input: ExecuteContributionActionInput,
+  correction: ContributionCorrectionRecordInput,
+): Promise<string> {
+  const create = requireDependency(
+    input.dependencies,
+    "createCorrectionRecord",
+  );
+  return create(correction);
+}
+
+function correctionInput(
+  input: ExecuteContributionActionInput,
+  extra: Partial<ContributionCorrectionRecordInput> = {},
+): ContributionCorrectionRecordInput {
+  if (!input.reason?.trim()) {
+    throw new ApiHttpError(
+      400,
+      `A reason is required for ${input.actionType}.`,
+    );
+  }
+
+  return {
+    tenantId: input.tenantId,
+    contributionId: input.contributionId,
+    stagedGiftId: input.stagedGiftId ?? null,
+    actorProfileId: input.actorProfileId,
+    sourceSurface: input.sourceSurface,
+    correctionType: input.actionType,
+    status: "applied",
+    reason: input.reason,
+    ...extra,
+  };
+}
+
+function isFailedProviderOutcome(
+  outcome: { status?: string | null } | null | undefined,
+): boolean {
+  return (
+    outcome?.status === "failed" ||
+    outcome?.status === "local_update_failed" ||
+    outcome?.status === "canceled" ||
+    outcome?.status === "requires_action"
+  );
+}
+
+function isCorrectionAction(actionType: ContributionActionType): boolean {
+  return (
+    actionType === "amount_correction" ||
+    actionType === "designation_correction" ||
+    actionType === "fund_correction" ||
+    actionType === "allocation_correction" ||
+    actionType === "receipt_correction" ||
+    actionType === "statement_correction" ||
+    actionType === "payment_state_correction" ||
+    actionType === "stripe_replay"
+  );
+}
+
+async function sendCorrectionNotification(
+  input: ExecuteContributionActionInput,
+  result: {
+    auditEventId: string;
+    correctionId: string | null;
+    providerOutcome?: ContributionProviderOutcome | null;
+    beforeSummary?: Record<string, unknown> | null;
+    afterSummary?: Record<string, unknown> | null;
+  },
+) {
+  const sendNotification = input.dependencies?.sendCorrectionNotification;
+  if (!sendNotification) {
+    return { decision: "not_required" as const, taskIds: [] };
+  }
+
+  return sendNotification({
+    tenantId: input.tenantId,
+    actionType: input.actionType,
+    contributionId: input.contributionId,
+    correctionId: result.correctionId,
+    auditEventId: result.auditEventId,
+    actorProfileId: input.actorProfileId,
+    providerOutcome: result.providerOutcome ?? null,
+    beforeSummary: result.beforeSummary ?? null,
+    afterSummary: result.afterSummary ?? null,
+  });
+}
+
+export async function executeContributionAction<TContribution = unknown>(
+  input: ExecuteContributionActionInput<TContribution>,
+): Promise<ContributionActionResult<TContribution>> {
+  const policy = getContributionActionPolicy({
+    actionType: input.actionType,
+    organizationSettings: input.organizationSettings,
+    userPreferences: input.userPreferences,
+  });
+
+  assertActorPermissions(input, policy);
+  assertReasonAndConfirmation(input, policy);
+
+  switch (input.actionType) {
+    case "resend_receipt": {
+      const stagedGiftId =
+        input.stagedGiftId ??
+        requireStringPayload(input.payload, "stagedGiftId");
+      const sendReceipt = requireDependency(input.dependencies, "sendReceipt");
+      const receipt = await sendReceipt({
+        tenantId: input.tenantId,
+        stagedGiftId,
+      });
+      const providerOutcome = {
+        provider: "resend" as const,
+        status: receipt.status,
+        referenceId: receipt.sendLogId ?? null,
+      };
+      const auditEventId = await appendAuditEvent(
+        input,
+        auditInput(input, {
+          stagedGiftId,
+          providerOutcome,
+          downstreamEffects: {
+            receiptStatus: receipt.status,
+          },
+        }),
+      );
+
+      return {
+        canonicalContribution: await loadCanonicalContribution(input),
+        auditEventId,
+        taskIds: [],
+        providerOutcome,
+      };
+    }
+
+    case "approve_staged_gift": {
+      const stagedGiftId =
+        input.stagedGiftId ??
+        requireStringPayload(input.payload, "stagedGiftId");
+      const approve = requireDependency(
+        input.dependencies,
+        "approveStagedGift",
+      );
+      await approve({
+        tenantId: input.tenantId,
+        stagedGiftId,
+        actorProfileId: input.actorProfileId,
+        note: input.reason ?? null,
+      });
+      const auditEventId = await appendAuditEvent(
+        input,
+        auditInput(input, {
+          stagedGiftId,
+          downstreamEffects: {
+            stagedGiftStatus: "queued_for_posting",
+          },
+        }),
+      );
+
+      return {
+        canonicalContribution: await loadCanonicalContribution(input),
+        auditEventId,
+        taskIds: [],
+      };
+    }
+
+    case "retry_staged_gift":
+    case "crm_repost": {
+      const stagedGiftId =
+        input.stagedGiftId ??
+        requireStringPayload(input.payload, "stagedGiftId");
+      const retryScope =
+        input.payload?.scope === "designation" ? "designation" : "parent";
+
+      if (retryScope === "designation") {
+        // Targeted child-record retry (ADR-CD-012): only the failed line is
+        // reposted. When the adapter cannot post child records, surface the
+        // limitation rather than silently reposting the whole gift.
+        const allocationId = requireStringPayload(
+          input.payload,
+          "allocationId",
+        );
+        const retryDesignation = input.dependencies?.retryDesignationPost;
+        if (!retryDesignation) {
+          throw new ApiHttpError(
+            501,
+            "The connected CRM adapter does not support posting designation child records yet. Retry the parent gift record instead, or resolve the line in the CRM directly.",
+          );
+        }
+        await retryDesignation({
+          tenantId: input.tenantId,
+          stagedGiftId,
+          allocationId,
+          actorProfileId: input.actorProfileId,
+          note: input.reason ?? null,
+        });
+        const auditEventId = await appendAuditEvent(
+          input,
+          auditInput(input, {
+            stagedGiftId,
+            downstreamEffects: {
+              crmPostStatus: "queued",
+              retryScope: "designation",
+              allocationId,
+            },
+          }),
+        );
+
+        return {
+          canonicalContribution: await loadCanonicalContribution(input),
+          auditEventId,
+          taskIds: [],
+        };
+      }
+
+      const retry = requireDependency(input.dependencies, "retryStagedGift");
+      await retry({
+        tenantId: input.tenantId,
+        stagedGiftId,
+        actorProfileId: input.actorProfileId,
+        note: input.reason ?? null,
+      });
+      const auditEventId = await appendAuditEvent(
+        input,
+        auditInput(input, {
+          stagedGiftId,
+          downstreamEffects: {
+            crmPostStatus: "queued",
+            retryScope: "parent",
+          },
+        }),
+      );
+
+      return {
+        canonicalContribution: await loadCanonicalContribution(input),
+        auditEventId,
+        taskIds: [],
+      };
+    }
+
+    case "donor_relink": {
+      const donorId = requireStringPayload(input.payload, "donorId");
+      const relinkDonor = requireDependency(input.dependencies, "relinkDonor");
+      const relink = await relinkDonor({
+        tenantId: input.tenantId,
+        contributionId: input.contributionId,
+        donorId,
+      });
+      const correctionId = await createCorrectionRecord(
+        input,
+        correctionInput(input, {
+          correctionType: "donor_relink",
+          beforeSummary: relink.before ?? null,
+          afterSummary: relink.after ?? { donorId },
+        }),
+      );
+      const auditEventId = await appendAuditEvent(
+        input,
+        auditInput(input, {
+          correctionId,
+          beforeSummary: relink.before ?? null,
+          afterSummary: relink.after ?? { donorId },
+        }),
+      );
+      const notification = await sendCorrectionNotification(input, {
+        auditEventId,
+        correctionId,
+        beforeSummary: relink.before ?? null,
+        afterSummary: relink.after ?? { donorId },
+      });
+
+      return {
+        canonicalContribution: await loadCanonicalContribution(input),
+        auditEventId,
+        correctionId,
+        notification,
+        taskIds: notification.taskIds ?? [],
+      };
+    }
+
+    case "refund": {
+      const amount = requireNumberPayload(input.payload, "amount");
+
+      // Refunds follow the same tenant approval policy as other high-risk
+      // corrections (ADR-CD-005 / ADR-CD-025): create a request unless the
+      // gate is suppressed or this apply comes from an approved request.
+      const refundApprovalPolicy =
+        input.approvalPolicy ?? resolveCorrectionApprovalPolicy(null);
+      const refundRequiresApproval =
+        !input.approvedRequestId &&
+        correctionRequiresApproval({
+          actionType: "refund",
+          policy: refundApprovalPolicy,
+        });
+
+      if (refundRequiresApproval) {
+        const canRequest =
+          input.actorPermissions.includes("finance:manage_contributions") ||
+          (input.actorCapabilities ?? []).includes(
+            "contributions.request_corrections",
+          );
+        if (!canRequest) {
+          throw new ApiHttpError(
+            403,
+            "Forbidden: requires contributions.request_corrections",
+          );
+        }
+
+        const createCorrectionRequest = requireDependency(
+          input.dependencies,
+          "createCorrectionRequest",
+        );
+        const correctionRequestId = await createCorrectionRequest({
+          tenantId: input.tenantId,
+          contributionId: input.contributionId,
+          actionType: "refund",
+          payload: input.payload ?? {},
+          reason: input.reason ?? "",
+          requestedByProfileId: input.actorProfileId,
+          sourceSurface: input.sourceSurface,
+          expectedRevision: input.expectedRevision ?? null,
+          idempotencyKey: input.idempotencyKey ?? null,
+        });
+        const auditEventId = await appendAuditEvent(
+          input,
+          auditInput(input, {
+            downstreamEffects: {
+              correctionRequestId,
+              approvalStatus: "pending_approval",
+            },
+          }),
+        );
+
+        return {
+          canonicalContribution: await loadCanonicalContribution(input),
+          auditEventId,
+          correctionRequestId,
+          approvalStatus: "pending_approval",
+          taskIds: [],
+        };
+      }
+
+      const canRunRefund =
+        input.actorPermissions.includes("finance:manage_contributions") ||
+        (input.actorCapabilities ?? []).includes("contributions.run_refunds");
+      if (!canRunRefund) {
+        throw new ApiHttpError(
+          403,
+          "Forbidden: requires contributions.run_refunds",
+        );
+      }
+
+      const refund = requireDependency(
+        input.dependencies,
+        "refundContribution",
+      );
+      const providerOutcome = await refund({
+        tenantId: input.tenantId,
+        contributionId: input.contributionId,
+        amount,
+        reason: input.reason ?? "",
+        confirmationToken: input.confirmationToken ?? "",
+      });
+      const correctionId = await createCorrectionRecord(
+        input,
+        correctionInput(input, {
+          correctionType: "refund",
+          status: isFailedProviderOutcome(providerOutcome)
+            ? "failed"
+            : "applied",
+          providerOutcome,
+          afterSummary: { refundAmount: amount },
+        }),
+      );
+      const auditEventId = await appendAuditEvent(
+        input,
+        auditInput(input, {
+          correctionId,
+          providerOutcome,
+          afterSummary: { refundAmount: amount },
+        }),
+      );
+      const notification = await sendCorrectionNotification(input, {
+        auditEventId,
+        correctionId,
+        providerOutcome,
+        afterSummary: { refundAmount: amount },
+      });
+
+      return {
+        canonicalContribution: await loadCanonicalContribution(input),
+        auditEventId,
+        correctionId,
+        notification,
+        taskIds: notification.taskIds ?? [],
+        providerOutcome,
+      };
+    }
+
+    case "stripe_replay": {
+      const replayStripeEvent = requireDependency(
+        input.dependencies,
+        "replayStripeEvent",
+      );
+      const providerOutcome = await replayStripeEvent({
+        tenantId: input.tenantId,
+        contributionId: input.contributionId,
+        payload: input.payload ?? {},
+      });
+      const correctionId = await createCorrectionRecord(
+        input,
+        correctionInput(input, {
+          correctionType: "stripe_replay",
+          status: isFailedProviderOutcome(providerOutcome)
+            ? "failed"
+            : "applied",
+          providerOutcome,
+        }),
+      );
+      const auditEventId = await appendAuditEvent(
+        input,
+        auditInput(input, {
+          correctionId,
+          providerOutcome,
+        }),
+      );
+      const notification = await sendCorrectionNotification(input, {
+        auditEventId,
+        correctionId,
+        providerOutcome,
+      });
+
+      return {
+        canonicalContribution: await loadCanonicalContribution(input),
+        auditEventId,
+        correctionId,
+        notification,
+        taskIds: notification.taskIds ?? [],
+        providerOutcome,
+      };
+    }
+
+    default: {
+      if (isCorrectionAction(input.actionType)) {
+        if (!input.reason?.trim()) {
+          throw new ApiHttpError(
+            400,
+            `A reason is required for ${input.actionType}.`,
+          );
+        }
+
+        const approvalPolicy =
+          input.approvalPolicy ?? resolveCorrectionApprovalPolicy(null);
+        const hasLegacyManagePermission = input.actorPermissions.includes(
+          "finance:manage_contributions",
+        );
+        const requiresApproval =
+          !input.approvedRequestId &&
+          correctionRequiresApproval({
+            actionType: input.actionType,
+            policy: approvalPolicy,
+          });
+
+        if (requiresApproval) {
+          const canRequest =
+            hasLegacyManagePermission ||
+            (input.actorCapabilities ?? []).includes(
+              "contributions.request_corrections",
+            );
+          if (!canRequest) {
+            throw new ApiHttpError(
+              403,
+              "Forbidden: requires contributions.request_corrections",
+            );
+          }
+
+          const createCorrectionRequest = requireDependency(
+            input.dependencies,
+            "createCorrectionRequest",
+          );
+          const correctionRequestId = await createCorrectionRequest({
+            tenantId: input.tenantId,
+            contributionId: input.contributionId,
+            actionType: input.actionType,
+            payload: input.payload ?? {},
+            reason: input.reason,
+            requestedByProfileId: input.actorProfileId,
+            sourceSurface: input.sourceSurface,
+            expectedRevision: input.expectedRevision ?? null,
+            idempotencyKey: input.idempotencyKey ?? null,
+            receiptDeliveryProposal:
+              input.payload &&
+              typeof input.payload.receiptDelivery === "object" &&
+              input.payload.receiptDelivery !== null
+                ? (input.payload.receiptDelivery as Record<string, unknown>)
+                : null,
+          });
+          const auditEventId = await appendAuditEvent(
+            input,
+            auditInput(input, {
+              downstreamEffects: {
+                correctionRequestId,
+                approvalStatus: "pending_approval",
+              },
+            }),
+          );
+
+          return {
+            canonicalContribution: await loadCanonicalContribution(input),
+            auditEventId,
+            correctionRequestId,
+            approvalStatus: "pending_approval",
+            taskIds: [],
+          };
+        }
+
+        const canApply =
+          hasLegacyManagePermission ||
+          (input.actorCapabilities ?? []).includes(
+            "contributions.apply_corrections",
+          );
+        if (!canApply) {
+          throw new ApiHttpError(
+            403,
+            "Forbidden: requires contributions.apply_corrections",
+          );
+        }
+
+        const applyCorrection = requireDependency(
+          input.dependencies,
+          "applyCorrection",
+        );
+        const correction = await applyCorrection({
+          tenantId: input.tenantId,
+          contributionId: input.contributionId,
+          actionType: input.actionType,
+          payload: input.payload ?? {},
+          reason: input.reason,
+          actorProfileId: input.actorProfileId,
+          sourceSurface: input.sourceSurface,
+          actorCapabilities: input.actorCapabilities,
+          expectedRevision: input.expectedRevision ?? null,
+          idempotencyKey:
+            input.idempotencyKey ??
+            (input.confirmationToken
+              ? `correction/${input.tenantId}/${input.contributionId}/${input.actionType}/${input.confirmationToken}`
+              : null),
+        });
+
+        if (correction.idempotentReplay) {
+          const auditEventId = await appendAuditEvent(
+            input,
+            auditInput(input, {
+              beforeSummary: correction.before ?? null,
+              afterSummary: correction.after ?? null,
+              downstreamEffects: { idempotentReplay: true },
+            }),
+          );
+
+          return {
+            canonicalContribution: await loadCanonicalContribution(input),
+            auditEventId,
+            correctionId: null,
+            adjustmentId: correction.adjustmentId ?? null,
+            idempotentReplay: true,
+            taskIds: [],
+          };
+        }
+
+        const correctionId = await createCorrectionRecord(
+          input,
+          correctionInput(input, {
+            beforeSummary: correction.before ?? null,
+            afterSummary: correction.after ?? null,
+            status: correction.status ?? "applied",
+          }),
+        );
+        const auditEventId = await appendAuditEvent(
+          input,
+          auditInput(input, {
+            beforeSummary: correction.before ?? null,
+            afterSummary: correction.after ?? null,
+            correctionId,
+            downstreamEffects: {
+              receiptOutcome:
+                correction.receiptOutcome?.status ?? "not_required",
+              receiptAffectedFields:
+                correction.receiptOutcome?.affectedFields ?? [],
+            },
+          }),
+        );
+        const notification = await sendCorrectionNotification(input, {
+          auditEventId,
+          correctionId,
+          beforeSummary: correction.before ?? null,
+          afterSummary: correction.after ?? null,
+        });
+
+        return {
+          canonicalContribution: await loadCanonicalContribution(input),
+          auditEventId,
+          correctionId,
+          adjustmentId: correction.adjustmentId ?? null,
+          receiptOutcome: correction.receiptOutcome ?? null,
+          approvalStatus: "applied",
+          notification,
+          taskIds: notification.taskIds ?? [],
+        };
+      }
+
+      if (policy.riskLevel === "low") {
+        const auditEventId = await appendAuditEvent(input, auditInput(input));
+        return {
+          canonicalContribution: await loadCanonicalContribution(input),
+          auditEventId,
+          taskIds: [],
+        };
+      }
+
+      const correctionId = await createCorrectionRecord(
+        input,
+        correctionInput(input),
+      );
+      const auditEventId = await appendAuditEvent(
+        input,
+        auditInput(input, { correctionId }),
+      );
+
+      return {
+        canonicalContribution: await loadCanonicalContribution(input),
+        auditEventId,
+        correctionId,
+        taskIds: [],
+      };
+    }
+  }
+}

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -431,6 +431,22 @@ function stableFingerprint(value: unknown): string {
     .slice(0, 32);
 }
 
+function correctionRequestContext(
+  input: ExecuteContributionActionInput,
+  extra: { receiptDeliveryProposal?: Record<string, unknown> | null },
+) {
+  return {
+    actorProfileId: input.actorProfileId,
+    confirmationToken: input.confirmationToken?.trim() || null,
+    expectedRevision: input.expectedRevision ?? null,
+    payload: input.payload ?? {},
+    reason: input.reason ?? "",
+    receiptDeliveryProposal: extra.receiptDeliveryProposal ?? null,
+    sourceSurface: input.sourceSurface,
+    stagedGiftId: input.stagedGiftId ?? null,
+  };
+}
+
 function correctionRequestIdempotencyKey(
   input: ExecuteContributionActionInput,
   extra: { receiptDeliveryProposal?: Record<string, unknown> | null },
@@ -439,25 +455,17 @@ function correctionRequestIdempotencyKey(
     return input.idempotencyKey;
   }
 
+  const requestContext = correctionRequestContext(input, extra);
+
   if (input.confirmationToken?.trim()) {
     return [
       "correction-request",
       input.tenantId,
       input.contributionId,
       input.actionType,
-      input.confirmationToken,
+      `confirmation-${stableFingerprint(requestContext)}`,
     ].join("/");
   }
-
-  const requestContext = {
-    actorProfileId: input.actorProfileId,
-    expectedRevision: input.expectedRevision ?? null,
-    payload: input.payload ?? {},
-    reason: input.reason ?? "",
-    receiptDeliveryProposal: extra.receiptDeliveryProposal ?? null,
-    sourceSurface: input.sourceSurface,
-    stagedGiftId: input.stagedGiftId ?? null,
-  };
 
   return [
     "correction-request",

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -73,19 +73,51 @@ function assertReasonAndConfirmation(
   }
 }
 
+const LEGACY_MANAGE_PERMISSION = "finance:manage_contributions" as const;
+const REQUEST_CORRECTION_CAPABILITY = "contributions.request_corrections";
+
 /**
- * Granular capability that satisfies the legacy broad permission per
- * high-risk action (ADR-CD-024 capability split).
+ * Granular capability required to execute an action immediately. Approval
+ * request creation is handled separately for approval-gated corrections.
  */
-const HIGH_RISK_CAPABILITY: Partial<Record<ContributionActionType, string>> = {
+const DIRECT_ACTION_CAPABILITY: Record<ContributionActionType, string> = {
+  resend_receipt: "contributions.manage_receipts",
+  approve_staged_gift: "contributions.apply_corrections",
+  retry_staged_gift: "contributions.retry_crm_post",
+  crm_repost: "contributions.retry_crm_post",
+  metadata_update: "contributions.apply_corrections",
   refund: "contributions.run_refunds",
   stripe_replay: "contributions.use_provider_actions",
   donor_relink: "contributions.apply_corrections",
   amount_correction: "contributions.apply_corrections",
   designation_correction: "contributions.apply_corrections",
   fund_correction: "contributions.apply_corrections",
+  allocation_correction: "contributions.apply_corrections",
+  receipt_correction: "contributions.apply_corrections",
+  statement_correction: "contributions.apply_corrections",
   payment_state_correction: "contributions.apply_corrections",
 };
+
+function hasLegacyManagePermission(
+  input: Pick<ExecuteContributionActionInput, "actorPermissions">,
+): boolean {
+  return input.actorPermissions.includes(LEGACY_MANAGE_PERMISSION);
+}
+
+function hasActorCapability(
+  input: Pick<ExecuteContributionActionInput, "actorCapabilities">,
+  capability: string,
+): boolean {
+  return (input.actorCapabilities ?? []).includes(capability);
+}
+
+function isApprovalRequestAction(actionType: ContributionActionType): boolean {
+  return (
+    actionType === "refund" ||
+    actionType === "donor_relink" ||
+    isCorrectionAction(actionType)
+  );
+}
 
 function assertActorPermissions(
   input: Pick<
@@ -93,37 +125,64 @@ function assertActorPermissions(
     "actorPermissions" | "actorCapabilities" | "actionType"
   >,
   policy: ReturnType<typeof getContributionActionPolicy>,
+  options: { requiresApproval: boolean },
 ) {
-  if (!policy.requiredPermission) {
+  if (hasLegacyManagePermission(input)) {
     return;
   }
 
-  if (input.actorPermissions.includes(policy.requiredPermission)) {
+  const directCapability = DIRECT_ACTION_CAPABILITY[input.actionType];
+  if (hasActorCapability(input, directCapability)) {
     return;
   }
 
-  const acceptedCapability = HIGH_RISK_CAPABILITY[input.actionType];
+  if (isApprovalRequestAction(input.actionType)) {
+    if (hasActorCapability(input, REQUEST_CORRECTION_CAPABILITY)) {
+      return;
+    }
+
+    throw new ApiHttpError(
+      403,
+      `Forbidden: requires ${
+        options.requiresApproval
+          ? REQUEST_CORRECTION_CAPABILITY
+          : directCapability
+      }`,
+    );
+  }
+
+  throw new ApiHttpError(
+    403,
+    `Forbidden: requires ${policy.requiredPermission ?? directCapability}`,
+  );
+}
+
+function assertCanRequestCorrection(input: ExecuteContributionActionInput) {
   if (
-    acceptedCapability &&
-    (input.actorCapabilities ?? []).includes(acceptedCapability)
-  ) {
-    return;
-  }
-
-  // Correction/refund requests are gated separately by the request capability.
-  if (
-    (isCorrectionAction(input.actionType) || input.actionType === "refund") &&
-    (input.actorCapabilities ?? []).includes(
-      "contributions.request_corrections",
-    )
+    hasLegacyManagePermission(input) ||
+    hasActorCapability(input, REQUEST_CORRECTION_CAPABILITY)
   ) {
     return;
   }
 
   throw new ApiHttpError(
     403,
-    `Forbidden: requires ${policy.requiredPermission}`,
+    `Forbidden: requires ${REQUEST_CORRECTION_CAPABILITY}`,
   );
+}
+
+function assertCanExecuteDirectly(
+  input: ExecuteContributionActionInput,
+  capability: string,
+) {
+  if (
+    hasLegacyManagePermission(input) ||
+    hasActorCapability(input, capability)
+  ) {
+    return;
+  }
+
+  throw new ApiHttpError(403, `Forbidden: requires ${capability}`);
 }
 
 async function loadCanonicalContribution<TContribution>(
@@ -224,6 +283,81 @@ function isCorrectionAction(actionType: ContributionActionType): boolean {
   );
 }
 
+function requiresCorrectionApproval(input: ExecuteContributionActionInput) {
+  const approvalPolicy =
+    input.approvalPolicy ?? resolveCorrectionApprovalPolicy(null);
+
+  return (
+    !input.approvedRequestId &&
+    correctionRequiresApproval({
+      actionType: input.actionType,
+      policy: approvalPolicy,
+    })
+  );
+}
+
+async function createPendingCorrectionRequest<TContribution>(
+  input: ExecuteContributionActionInput<TContribution>,
+  extra: { receiptDeliveryProposal?: Record<string, unknown> | null } = {},
+): Promise<ContributionActionResult<TContribution>> {
+  assertCanRequestCorrection(input);
+
+  const createCorrectionRequest = requireDependency(
+    input.dependencies,
+    "createCorrectionRequest",
+  );
+  const correctionRequestId = await createCorrectionRequest({
+    tenantId: input.tenantId,
+    contributionId: input.contributionId,
+    actionType: input.actionType,
+    payload: input.payload ?? {},
+    reason: input.reason ?? "",
+    requestedByProfileId: input.actorProfileId,
+    sourceSurface: input.sourceSurface,
+    expectedRevision: input.expectedRevision ?? null,
+    idempotencyKey: input.idempotencyKey ?? null,
+    ...extra,
+  });
+  const auditEventId = await appendAuditEvent(
+    input,
+    auditInput(input, {
+      downstreamEffects: {
+        correctionRequestId,
+        approvalStatus: "pending_approval",
+      },
+    }),
+  );
+
+  return {
+    canonicalContribution: await loadCanonicalContribution(input),
+    auditEventId,
+    correctionRequestId,
+    approvalStatus: "pending_approval",
+    taskIds: [],
+  };
+}
+
+function providerIdempotencyKey(input: ExecuteContributionActionInput): string {
+  if (input.idempotencyKey?.trim()) {
+    return input.idempotencyKey;
+  }
+
+  if (input.confirmationToken?.trim()) {
+    return [
+      "contribution-action",
+      input.tenantId,
+      input.contributionId,
+      input.actionType,
+      input.confirmationToken,
+    ].join("/");
+  }
+
+  throw new ApiHttpError(
+    400,
+    `An idempotency key is required for ${input.actionType}.`,
+  );
+}
+
 async function sendCorrectionNotification(
   input: ExecuteContributionActionInput,
   result: {
@@ -260,8 +394,13 @@ export async function executeContributionAction<TContribution = unknown>(
     organizationSettings: input.organizationSettings,
     userPreferences: input.userPreferences,
   });
+  const actionRequiresApproval =
+    isApprovalRequestAction(input.actionType) &&
+    requiresCorrectionApproval(input);
 
-  assertActorPermissions(input, policy);
+  assertActorPermissions(input, policy, {
+    requiresApproval: actionRequiresApproval,
+  });
   assertReasonAndConfirmation(input, policy);
 
   switch (input.actionType) {
@@ -405,6 +544,13 @@ export async function executeContributionAction<TContribution = unknown>(
 
     case "donor_relink": {
       const donorId = requireStringPayload(input.payload, "donorId");
+
+      if (requiresCorrectionApproval(input)) {
+        return createPendingCorrectionRequest(input);
+      }
+
+      assertCanExecuteDirectly(input, DIRECT_ACTION_CAPABILITY.donor_relink);
+
       const relinkDonor = requireDependency(input.dependencies, "relinkDonor");
       const relink = await relinkDonor({
         tenantId: input.tenantId,
@@ -449,71 +595,11 @@ export async function executeContributionAction<TContribution = unknown>(
       // Refunds follow the same tenant approval policy as other high-risk
       // corrections (ADR-CD-005 / ADR-CD-025): create a request unless the
       // gate is suppressed or this apply comes from an approved request.
-      const refundApprovalPolicy =
-        input.approvalPolicy ?? resolveCorrectionApprovalPolicy(null);
-      const refundRequiresApproval =
-        !input.approvedRequestId &&
-        correctionRequiresApproval({
-          actionType: "refund",
-          policy: refundApprovalPolicy,
-        });
-
-      if (refundRequiresApproval) {
-        const canRequest =
-          input.actorPermissions.includes("finance:manage_contributions") ||
-          (input.actorCapabilities ?? []).includes(
-            "contributions.request_corrections",
-          );
-        if (!canRequest) {
-          throw new ApiHttpError(
-            403,
-            "Forbidden: requires contributions.request_corrections",
-          );
-        }
-
-        const createCorrectionRequest = requireDependency(
-          input.dependencies,
-          "createCorrectionRequest",
-        );
-        const correctionRequestId = await createCorrectionRequest({
-          tenantId: input.tenantId,
-          contributionId: input.contributionId,
-          actionType: "refund",
-          payload: input.payload ?? {},
-          reason: input.reason ?? "",
-          requestedByProfileId: input.actorProfileId,
-          sourceSurface: input.sourceSurface,
-          expectedRevision: input.expectedRevision ?? null,
-          idempotencyKey: input.idempotencyKey ?? null,
-        });
-        const auditEventId = await appendAuditEvent(
-          input,
-          auditInput(input, {
-            downstreamEffects: {
-              correctionRequestId,
-              approvalStatus: "pending_approval",
-            },
-          }),
-        );
-
-        return {
-          canonicalContribution: await loadCanonicalContribution(input),
-          auditEventId,
-          correctionRequestId,
-          approvalStatus: "pending_approval",
-          taskIds: [],
-        };
+      if (requiresCorrectionApproval(input)) {
+        return createPendingCorrectionRequest(input);
       }
 
-      const canRunRefund =
-        input.actorPermissions.includes("finance:manage_contributions") ||
-        (input.actorCapabilities ?? []).includes("contributions.run_refunds");
-      if (!canRunRefund) {
-        throw new ApiHttpError(
-          403,
-          "Forbidden: requires contributions.run_refunds",
-        );
-      }
+      assertCanExecuteDirectly(input, DIRECT_ACTION_CAPABILITY.refund);
 
       const refund = requireDependency(
         input.dependencies,
@@ -525,6 +611,8 @@ export async function executeContributionAction<TContribution = unknown>(
         amount,
         reason: input.reason ?? "",
         confirmationToken: input.confirmationToken ?? "",
+        expectedRevision: input.expectedRevision ?? null,
+        idempotencyKey: providerIdempotencyKey(input),
       });
       const correctionId = await createCorrectionRecord(
         input,
@@ -563,6 +651,12 @@ export async function executeContributionAction<TContribution = unknown>(
     }
 
     case "stripe_replay": {
+      if (requiresCorrectionApproval(input)) {
+        return createPendingCorrectionRequest(input);
+      }
+
+      assertCanExecuteDirectly(input, DIRECT_ACTION_CAPABILITY.stripe_replay);
+
       const replayStripeEvent = requireDependency(
         input.dependencies,
         "replayStripeEvent",
@@ -614,45 +708,8 @@ export async function executeContributionAction<TContribution = unknown>(
           );
         }
 
-        const approvalPolicy =
-          input.approvalPolicy ?? resolveCorrectionApprovalPolicy(null);
-        const hasLegacyManagePermission = input.actorPermissions.includes(
-          "finance:manage_contributions",
-        );
-        const requiresApproval =
-          !input.approvedRequestId &&
-          correctionRequiresApproval({
-            actionType: input.actionType,
-            policy: approvalPolicy,
-          });
-
-        if (requiresApproval) {
-          const canRequest =
-            hasLegacyManagePermission ||
-            (input.actorCapabilities ?? []).includes(
-              "contributions.request_corrections",
-            );
-          if (!canRequest) {
-            throw new ApiHttpError(
-              403,
-              "Forbidden: requires contributions.request_corrections",
-            );
-          }
-
-          const createCorrectionRequest = requireDependency(
-            input.dependencies,
-            "createCorrectionRequest",
-          );
-          const correctionRequestId = await createCorrectionRequest({
-            tenantId: input.tenantId,
-            contributionId: input.contributionId,
-            actionType: input.actionType,
-            payload: input.payload ?? {},
-            reason: input.reason,
-            requestedByProfileId: input.actorProfileId,
-            sourceSurface: input.sourceSurface,
-            expectedRevision: input.expectedRevision ?? null,
-            idempotencyKey: input.idempotencyKey ?? null,
+        if (requiresCorrectionApproval(input)) {
+          return createPendingCorrectionRequest(input, {
             receiptDeliveryProposal:
               input.payload &&
               typeof input.payload.receiptDelivery === "object" &&
@@ -660,36 +717,12 @@ export async function executeContributionAction<TContribution = unknown>(
                 ? (input.payload.receiptDelivery as Record<string, unknown>)
                 : null,
           });
-          const auditEventId = await appendAuditEvent(
-            input,
-            auditInput(input, {
-              downstreamEffects: {
-                correctionRequestId,
-                approvalStatus: "pending_approval",
-              },
-            }),
-          );
-
-          return {
-            canonicalContribution: await loadCanonicalContribution(input),
-            auditEventId,
-            correctionRequestId,
-            approvalStatus: "pending_approval",
-            taskIds: [],
-          };
         }
 
-        const canApply =
-          hasLegacyManagePermission ||
-          (input.actorCapabilities ?? []).includes(
-            "contributions.apply_corrections",
-          );
-        if (!canApply) {
-          throw new ApiHttpError(
-            403,
-            "Forbidden: requires contributions.apply_corrections",
-          );
-        }
+        assertCanExecuteDirectly(
+          input,
+          DIRECT_ACTION_CAPABILITY[input.actionType],
+        );
 
         const applyCorrection = requireDependency(
           input.dependencies,

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -131,6 +131,41 @@ function hasLegacyDirectActionPermission(
   );
 }
 
+function providerCapabilityForApprovedRequest(
+  actionType: ContributionActionType,
+): string | null {
+  if (actionType === "refund") {
+    return DIRECT_ACTION_CAPABILITY.refund;
+  }
+
+  if (actionType === "stripe_replay") {
+    return DIRECT_ACTION_CAPABILITY.stripe_replay;
+  }
+
+  return null;
+}
+
+function assertApprovedRequestCapabilities(
+  input: Pick<
+    ExecuteContributionActionInput,
+    "actorCapabilities" | "actionType"
+  >,
+) {
+  if (!hasActorCapability(input, APPROVE_CORRECTION_CAPABILITY)) {
+    throw new ApiHttpError(
+      403,
+      `Forbidden: requires ${APPROVE_CORRECTION_CAPABILITY}`,
+    );
+  }
+
+  const providerCapability = providerCapabilityForApprovedRequest(
+    input.actionType,
+  );
+  if (providerCapability && !hasActorCapability(input, providerCapability)) {
+    throw new ApiHttpError(403, `Forbidden: requires ${providerCapability}`);
+  }
+}
+
 function isApprovalRequestAction(actionType: ContributionActionType): boolean {
   return (
     actionType === "refund" ||
@@ -151,14 +186,8 @@ function assertActorPermissions(
   options: { requiresApproval: boolean },
 ) {
   if (input.approvedRequestId) {
-    if (hasActorCapability(input, APPROVE_CORRECTION_CAPABILITY)) {
-      return;
-    }
-
-    throw new ApiHttpError(
-      403,
-      `Forbidden: requires ${APPROVE_CORRECTION_CAPABILITY}`,
-    );
+    assertApprovedRequestCapabilities(input);
+    return;
   }
 
   if (hasLegacyDirectActionPermission(input)) {
@@ -213,14 +242,8 @@ function assertCanExecuteDirectly(
   capability: string,
 ) {
   if (input.approvedRequestId) {
-    if (hasActorCapability(input, APPROVE_CORRECTION_CAPABILITY)) {
-      return;
-    }
-
-    throw new ApiHttpError(
-      403,
-      `Forbidden: requires ${APPROVE_CORRECTION_CAPABILITY}`,
-    );
+    assertApprovedRequestCapabilities(input);
+    return;
   }
 
   if (hasLegacyDirectActionPermission(input)) {

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -48,6 +48,98 @@ function requireStringPayload(
   return trimmedValue;
 }
 
+function normalizeOptionalStringValue(
+  value: string | null | undefined,
+  key: string,
+): string | null | undefined {
+  if (value == null) {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    throw new ApiHttpError(400, `${key} is required.`);
+  }
+
+  return trimmedValue;
+}
+
+function normalizeStringPayloadField(
+  payload: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  if (!payload || !(key in payload)) {
+    return payload;
+  }
+
+  const normalizedValue = requireStringPayload(payload, key);
+  if (payload[key] === normalizedValue) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    [key]: normalizedValue,
+  };
+}
+
+function normalizeActionPayload(
+  input: ExecuteContributionActionInput,
+): Record<string, unknown> | undefined {
+  let normalizedPayload = input.payload;
+
+  if (
+    input.actionType === "resend_receipt" ||
+    input.actionType === "approve_staged_gift" ||
+    input.actionType === "retry_staged_gift" ||
+    input.actionType === "crm_repost"
+  ) {
+    normalizedPayload = normalizeStringPayloadField(
+      normalizedPayload,
+      "stagedGiftId",
+    );
+  }
+
+  if (
+    input.actionType === "retry_staged_gift" ||
+    input.actionType === "crm_repost"
+  ) {
+    normalizedPayload = normalizeStringPayloadField(
+      normalizedPayload,
+      "allocationId",
+    );
+  }
+
+  if (input.actionType === "donor_relink") {
+    normalizedPayload = normalizeStringPayloadField(
+      normalizedPayload,
+      "donorId",
+    );
+  }
+
+  if (input.actionType === "stripe_replay") {
+    normalizedPayload = normalizeStringPayloadField(
+      normalizedPayload,
+      "stripeEventId",
+    );
+  }
+
+  return normalizedPayload;
+}
+
+function normalizeActionInput<TContribution>(
+  input: ExecuteContributionActionInput<TContribution>,
+): ExecuteContributionActionInput<TContribution> {
+  return {
+    ...input,
+    stagedGiftId: normalizeOptionalStringValue(
+      input.stagedGiftId,
+      "stagedGiftId",
+    ),
+    payload: normalizeActionPayload(input),
+  };
+}
+
 function requirePositiveSafeIntegerPayload(
   payload: Record<string, unknown> | undefined,
   key: string,
@@ -347,6 +439,8 @@ function isFailedProviderOutcome(
 function sanitizeProviderOutcome(
   outcome: ContributionProviderOutcome,
 ): ContributionProviderOutcome {
+  const redactedErrorMessage =
+    "Provider action failed. Check provider logs for details.";
   const sanitized: ContributionProviderOutcome = {
     provider: outcome.provider,
     status: outcome.status,
@@ -361,7 +455,7 @@ function sanitizeProviderOutcome(
   }
 
   if ("errorMessage" in outcome) {
-    sanitized.errorMessage = outcome.errorMessage ?? null;
+    sanitized.errorMessage = outcome.errorMessage ? redactedErrorMessage : null;
   }
 
   return sanitized;
@@ -672,7 +766,9 @@ export async function executeContributionAction<TContribution = unknown>(
   assertActorPermissions(rawInput, policy, {
     requiresApproval: actionRequiresApproval,
   });
-  const input = await applyApprovedCorrectionRequest(rawInput);
+  const input = normalizeActionInput(
+    await applyApprovedCorrectionRequest(rawInput),
+  );
   assertReasonAndConfirmation(input, policy);
 
   switch (input.actionType) {

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -36,10 +36,16 @@ function requireStringPayload(
   key: string,
 ): string {
   const value = payload?.[key];
-  if (typeof value !== "string" || value.trim().length === 0) {
+  if (typeof value !== "string") {
     throw new ApiHttpError(400, `${key} is required.`);
   }
-  return value;
+
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    throw new ApiHttpError(400, `${key} is required.`);
+  }
+
+  return trimmedValue;
 }
 
 function requirePositiveSafeIntegerPayload(
@@ -336,6 +342,29 @@ function isFailedProviderOutcome(
     outcome?.status === "canceled" ||
     outcome?.status === "requires_action"
   );
+}
+
+function sanitizeProviderOutcome(
+  outcome: ContributionProviderOutcome,
+): ContributionProviderOutcome {
+  const sanitized: ContributionProviderOutcome = {
+    provider: outcome.provider,
+    status: outcome.status,
+  };
+
+  if ("referenceId" in outcome) {
+    sanitized.referenceId = outcome.referenceId ?? null;
+  }
+
+  if ("errorCode" in outcome) {
+    sanitized.errorCode = outcome.errorCode ?? null;
+  }
+
+  if ("errorMessage" in outcome) {
+    sanitized.errorMessage = outcome.errorMessage ?? null;
+  }
+
+  return sanitized;
 }
 
 function isCorrectionAction(actionType: ContributionActionType): boolean {
@@ -861,18 +890,20 @@ export async function executeContributionAction<TContribution = unknown>(
         input.dependencies,
         "refundContribution",
       );
-      const providerOutcome = await refund({
-        tenantId: input.tenantId,
-        contributionId: input.contributionId,
-        amount,
-        reason: input.reason ?? "",
-        confirmationToken:
-          normalizedToken(input.confirmationToken) ??
-          normalizedToken(input.approvedRequestId) ??
-          "",
-        expectedRevision: input.expectedRevision ?? null,
-        idempotencyKey: providerIdempotencyKey(input),
-      });
+      const providerOutcome = sanitizeProviderOutcome(
+        await refund({
+          tenantId: input.tenantId,
+          contributionId: input.contributionId,
+          amount,
+          reason: input.reason ?? "",
+          confirmationToken:
+            normalizedToken(input.confirmationToken) ??
+            normalizedToken(input.approvedRequestId) ??
+            "",
+          expectedRevision: input.expectedRevision ?? null,
+          idempotencyKey: providerIdempotencyKey(input),
+        }),
+      );
       const correctionId = await createCorrectionRecord(
         input,
         correctionInput(input, {
@@ -920,13 +951,15 @@ export async function executeContributionAction<TContribution = unknown>(
         input.dependencies,
         "replayStripeEvent",
       );
-      const providerOutcome = await replayStripeEvent({
-        tenantId: input.tenantId,
-        contributionId: input.contributionId,
-        payload: input.payload ?? {},
-        expectedRevision: input.expectedRevision ?? null,
-        idempotencyKey: providerIdempotencyKey(input),
-      });
+      const providerOutcome = sanitizeProviderOutcome(
+        await replayStripeEvent({
+          tenantId: input.tenantId,
+          contributionId: input.contributionId,
+          payload: input.payload ?? {},
+          expectedRevision: input.expectedRevision ?? null,
+          idempotencyKey: providerIdempotencyKey(input),
+        }),
+      );
       const correctionId = await createCorrectionRecord(
         input,
         correctionInput(input, {

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -75,6 +75,7 @@ function assertReasonAndConfirmation(
 
 const LEGACY_MANAGE_PERMISSION = "finance:manage_contributions" as const;
 const REQUEST_CORRECTION_CAPABILITY = "contributions.request_corrections";
+const APPROVE_CORRECTION_CAPABILITY = "contributions.approve_corrections";
 
 /**
  * Granular capability required to execute an action immediately. Approval
@@ -111,6 +112,25 @@ function hasActorCapability(
   return (input.actorCapabilities ?? []).includes(capability);
 }
 
+function legacyManageCoversDirectAction(
+  actionType: ContributionActionType,
+): boolean {
+  return actionType !== "refund" && actionType !== "stripe_replay";
+}
+
+function hasLegacyDirectActionPermission(
+  input: Pick<
+    ExecuteContributionActionInput,
+    "actorPermissions" | "actionType" | "approvedRequestId"
+  >,
+): boolean {
+  return (
+    !input.approvedRequestId &&
+    legacyManageCoversDirectAction(input.actionType) &&
+    hasLegacyManagePermission(input)
+  );
+}
+
 function isApprovalRequestAction(actionType: ContributionActionType): boolean {
   return (
     actionType === "refund" ||
@@ -122,12 +142,26 @@ function isApprovalRequestAction(actionType: ContributionActionType): boolean {
 function assertActorPermissions(
   input: Pick<
     ExecuteContributionActionInput,
-    "actorPermissions" | "actorCapabilities" | "actionType"
+    | "actorPermissions"
+    | "actorCapabilities"
+    | "actionType"
+    | "approvedRequestId"
   >,
   policy: ReturnType<typeof getContributionActionPolicy>,
   options: { requiresApproval: boolean },
 ) {
-  if (hasLegacyManagePermission(input)) {
+  if (input.approvedRequestId) {
+    if (hasActorCapability(input, APPROVE_CORRECTION_CAPABILITY)) {
+      return;
+    }
+
+    throw new ApiHttpError(
+      403,
+      `Forbidden: requires ${APPROVE_CORRECTION_CAPABILITY}`,
+    );
+  }
+
+  if (hasLegacyDirectActionPermission(input)) {
     return;
   }
 
@@ -178,10 +212,22 @@ function assertCanExecuteDirectly(
   input: ExecuteContributionActionInput,
   capability: string,
 ) {
-  if (
-    hasLegacyManagePermission(input) ||
-    hasActorCapability(input, capability)
-  ) {
+  if (input.approvedRequestId) {
+    if (hasActorCapability(input, APPROVE_CORRECTION_CAPABILITY)) {
+      return;
+    }
+
+    throw new ApiHttpError(
+      403,
+      `Forbidden: requires ${APPROVE_CORRECTION_CAPABILITY}`,
+    );
+  }
+
+  if (hasLegacyDirectActionPermission(input)) {
+    return;
+  }
+
+  if (hasActorCapability(input, capability)) {
     return;
   }
 
@@ -331,7 +377,7 @@ async function applyApprovedCorrectionRequest<TContribution>(
   return {
     ...input,
     payload: approvedRequest.payload,
-    reason: input.reason ?? approvedRequest.reason ?? null,
+    reason: approvedRequest.reason ?? null,
   };
 }
 
@@ -603,6 +649,8 @@ export async function executeContributionAction<TContribution = unknown>(
         tenantId: input.tenantId,
         contributionId: input.contributionId,
         donorId,
+        expectedRevision: input.expectedRevision ?? null,
+        idempotencyKey: providerIdempotencyKey(input),
       });
       const correctionId = await createCorrectionRecord(
         input,

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -431,19 +431,32 @@ function stableFingerprint(value: unknown): string {
     .slice(0, 32);
 }
 
+function normalizedToken(value: string | null | undefined): string | null {
+  const trimmedValue = value?.trim();
+  return trimmedValue ? trimmedValue : null;
+}
+
+function contributionActionIdempotencyContext(
+  input: ExecuteContributionActionInput,
+) {
+  return {
+    actorProfileId: input.actorProfileId,
+    confirmationToken: normalizedToken(input.confirmationToken),
+    expectedRevision: input.expectedRevision ?? null,
+    payload: input.payload ?? {},
+    reason: input.reason ?? "",
+    sourceSurface: input.sourceSurface,
+    stagedGiftId: input.stagedGiftId ?? null,
+  };
+}
+
 function correctionRequestContext(
   input: ExecuteContributionActionInput,
   extra: { receiptDeliveryProposal?: Record<string, unknown> | null },
 ) {
   return {
-    actorProfileId: input.actorProfileId,
-    confirmationToken: input.confirmationToken?.trim() || null,
-    expectedRevision: input.expectedRevision ?? null,
-    payload: input.payload ?? {},
-    reason: input.reason ?? "",
+    ...contributionActionIdempotencyContext(input),
     receiptDeliveryProposal: extra.receiptDeliveryProposal ?? null,
-    sourceSurface: input.sourceSurface,
-    stagedGiftId: input.stagedGiftId ?? null,
   };
 }
 
@@ -451,13 +464,14 @@ function correctionRequestIdempotencyKey(
   input: ExecuteContributionActionInput,
   extra: { receiptDeliveryProposal?: Record<string, unknown> | null },
 ): string {
-  if (input.idempotencyKey?.trim()) {
-    return input.idempotencyKey;
+  const explicitIdempotencyKey = normalizedToken(input.idempotencyKey);
+  if (explicitIdempotencyKey) {
+    return explicitIdempotencyKey;
   }
 
   const requestContext = correctionRequestContext(input, extra);
 
-  if (input.confirmationToken?.trim()) {
+  if (normalizedToken(input.confirmationToken)) {
     return [
       "correction-request",
       input.tenantId,
@@ -518,27 +532,31 @@ async function createPendingCorrectionRequest<TContribution>(
 }
 
 function providerIdempotencyKey(input: ExecuteContributionActionInput): string {
-  if (input.idempotencyKey?.trim()) {
-    return input.idempotencyKey;
+  const explicitIdempotencyKey = normalizedToken(input.idempotencyKey);
+  if (explicitIdempotencyKey) {
+    return explicitIdempotencyKey;
   }
 
-  if (input.approvedRequestId?.trim()) {
+  const approvedRequestId = normalizedToken(input.approvedRequestId);
+  if (approvedRequestId) {
     return [
       "approved-contribution-action",
       input.tenantId,
       input.contributionId,
       input.actionType,
-      input.approvedRequestId,
+      approvedRequestId,
     ].join("/");
   }
 
-  if (input.confirmationToken?.trim()) {
+  if (normalizedToken(input.confirmationToken)) {
     return [
       "contribution-action",
       input.tenantId,
       input.contributionId,
       input.actionType,
-      input.confirmationToken,
+      `confirmation-${stableFingerprint(
+        contributionActionIdempotencyContext(input),
+      )}`,
     ].join("/");
   }
 
@@ -551,27 +569,31 @@ function providerIdempotencyKey(input: ExecuteContributionActionInput): string {
 function correctionIdempotencyKey(
   input: ExecuteContributionActionInput,
 ): string {
-  if (input.idempotencyKey?.trim()) {
-    return input.idempotencyKey;
+  const explicitIdempotencyKey = normalizedToken(input.idempotencyKey);
+  if (explicitIdempotencyKey) {
+    return explicitIdempotencyKey;
   }
 
-  if (input.approvedRequestId?.trim()) {
+  const approvedRequestId = normalizedToken(input.approvedRequestId);
+  if (approvedRequestId) {
     return [
       "approved-correction",
       input.tenantId,
       input.contributionId,
       input.actionType,
-      input.approvedRequestId,
+      approvedRequestId,
     ].join("/");
   }
 
-  if (input.confirmationToken?.trim()) {
+  if (normalizedToken(input.confirmationToken)) {
     return [
       "correction",
       input.tenantId,
       input.contributionId,
       input.actionType,
-      input.confirmationToken,
+      `confirmation-${stableFingerprint(
+        contributionActionIdempotencyContext(input),
+      )}`,
     ].join("/");
   }
 

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -40,13 +40,13 @@ function requireStringPayload(
   return value;
 }
 
-function requireNumberPayload(
+function requirePositiveSafeIntegerPayload(
   payload: Record<string, unknown> | undefined,
   key: string,
 ): number {
   const value = payload?.[key];
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-    throw new ApiHttpError(400, `${key} must be a positive number.`);
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new ApiHttpError(400, `${key} must be a positive safe integer.`);
   }
   return value;
 }
@@ -137,7 +137,10 @@ function assertActorPermissions(
   }
 
   if (isApprovalRequestAction(input.actionType)) {
-    if (hasActorCapability(input, REQUEST_CORRECTION_CAPABILITY)) {
+    if (
+      options.requiresApproval &&
+      hasActorCapability(input, REQUEST_CORRECTION_CAPABILITY)
+    ) {
       return;
     }
 
@@ -296,6 +299,42 @@ function requiresCorrectionApproval(input: ExecuteContributionActionInput) {
   );
 }
 
+async function applyApprovedCorrectionRequest<TContribution>(
+  input: ExecuteContributionActionInput<TContribution>,
+): Promise<ExecuteContributionActionInput<TContribution>> {
+  if (!input.approvedRequestId) {
+    return input;
+  }
+
+  if (!isApprovalRequestAction(input.actionType)) {
+    throw new ApiHttpError(
+      400,
+      "approvedRequestId is only valid for approval-gated contribution actions.",
+    );
+  }
+
+  const validateApprovedCorrectionRequest = requireDependency(
+    input.dependencies,
+    "validateApprovedCorrectionRequest",
+  );
+  const approvedRequest = await validateApprovedCorrectionRequest({
+    tenantId: input.tenantId,
+    contributionId: input.contributionId,
+    actionType: input.actionType,
+    approvedRequestId: input.approvedRequestId,
+    actorProfileId: input.actorProfileId,
+    actorCapabilities: input.actorCapabilities,
+    expectedRevision: input.expectedRevision ?? null,
+    requestedPayload: input.payload ?? {},
+  });
+
+  return {
+    ...input,
+    payload: approvedRequest.payload,
+    reason: input.reason ?? approvedRequest.reason ?? null,
+  };
+}
+
 async function createPendingCorrectionRequest<TContribution>(
   input: ExecuteContributionActionInput<TContribution>,
   extra: { receiptDeliveryProposal?: Record<string, unknown> | null } = {},
@@ -387,20 +426,21 @@ async function sendCorrectionNotification(
 }
 
 export async function executeContributionAction<TContribution = unknown>(
-  input: ExecuteContributionActionInput<TContribution>,
+  rawInput: ExecuteContributionActionInput<TContribution>,
 ): Promise<ContributionActionResult<TContribution>> {
   const policy = getContributionActionPolicy({
-    actionType: input.actionType,
-    organizationSettings: input.organizationSettings,
-    userPreferences: input.userPreferences,
+    actionType: rawInput.actionType,
+    organizationSettings: rawInput.organizationSettings,
+    userPreferences: rawInput.userPreferences,
   });
   const actionRequiresApproval =
-    isApprovalRequestAction(input.actionType) &&
-    requiresCorrectionApproval(input);
+    isApprovalRequestAction(rawInput.actionType) &&
+    requiresCorrectionApproval(rawInput);
 
-  assertActorPermissions(input, policy, {
+  assertActorPermissions(rawInput, policy, {
     requiresApproval: actionRequiresApproval,
   });
+  const input = await applyApprovedCorrectionRequest(rawInput);
   assertReasonAndConfirmation(input, policy);
 
   switch (input.actionType) {
@@ -542,6 +582,13 @@ export async function executeContributionAction<TContribution = unknown>(
       };
     }
 
+    case "metadata_update": {
+      throw new ApiHttpError(
+        501,
+        "metadata_update is not implemented by the contribution action executor yet.",
+      );
+    }
+
     case "donor_relink": {
       const donorId = requireStringPayload(input.payload, "donorId");
 
@@ -590,7 +637,7 @@ export async function executeContributionAction<TContribution = unknown>(
     }
 
     case "refund": {
-      const amount = requireNumberPayload(input.payload, "amount");
+      const amount = requirePositiveSafeIntegerPayload(input.payload, "amount");
 
       // Refunds follow the same tenant approval policy as other high-risk
       // corrections (ADR-CD-005 / ADR-CD-025): create a request unless the
@@ -665,6 +712,8 @@ export async function executeContributionAction<TContribution = unknown>(
         tenantId: input.tenantId,
         contributionId: input.contributionId,
         payload: input.payload ?? {},
+        expectedRevision: input.expectedRevision ?? null,
+        idempotencyKey: providerIdempotencyKey(input),
       });
       const correctionId = await createCorrectionRecord(
         input,

--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -54,7 +54,7 @@ function requirePositiveSafeIntegerPayload(
 function assertReasonAndConfirmation(
   input: Pick<
     ExecuteContributionActionInput,
-    "reason" | "confirmationToken" | "actionType"
+    "reason" | "confirmationToken" | "approvedRequestId" | "actionType"
   >,
   policy: ReturnType<typeof getContributionActionPolicy>,
 ) {
@@ -66,6 +66,10 @@ function assertReasonAndConfirmation(
   }
 
   if (policy.requiresConfirmation && !input.confirmationToken?.trim()) {
+    if (input.approvedRequestId?.trim()) {
+      return;
+    }
+
     throw new ApiHttpError(
       400,
       `A confirmation token is required for ${input.actionType}.`,
@@ -450,9 +454,52 @@ function providerIdempotencyKey(input: ExecuteContributionActionInput): string {
     return input.idempotencyKey;
   }
 
+  if (input.approvedRequestId?.trim()) {
+    return [
+      "approved-contribution-action",
+      input.tenantId,
+      input.contributionId,
+      input.actionType,
+      input.approvedRequestId,
+    ].join("/");
+  }
+
   if (input.confirmationToken?.trim()) {
     return [
       "contribution-action",
+      input.tenantId,
+      input.contributionId,
+      input.actionType,
+      input.confirmationToken,
+    ].join("/");
+  }
+
+  throw new ApiHttpError(
+    400,
+    `An idempotency key is required for ${input.actionType}.`,
+  );
+}
+
+function correctionIdempotencyKey(
+  input: ExecuteContributionActionInput,
+): string {
+  if (input.idempotencyKey?.trim()) {
+    return input.idempotencyKey;
+  }
+
+  if (input.approvedRequestId?.trim()) {
+    return [
+      "approved-correction",
+      input.tenantId,
+      input.contributionId,
+      input.actionType,
+      input.approvedRequestId,
+    ].join("/");
+  }
+
+  if (input.confirmationToken?.trim()) {
+    return [
+      "correction",
       input.tenantId,
       input.contributionId,
       input.actionType,
@@ -728,7 +775,8 @@ export async function executeContributionAction<TContribution = unknown>(
         contributionId: input.contributionId,
         amount,
         reason: input.reason ?? "",
-        confirmationToken: input.confirmationToken ?? "",
+        confirmationToken:
+          input.confirmationToken ?? input.approvedRequestId ?? "",
         expectedRevision: input.expectedRevision ?? null,
         idempotencyKey: providerIdempotencyKey(input),
       });
@@ -848,6 +896,7 @@ export async function executeContributionAction<TContribution = unknown>(
           input.dependencies,
           "applyCorrection",
         );
+        const idempotencyKey = correctionIdempotencyKey(input);
         const correction = await applyCorrection({
           tenantId: input.tenantId,
           contributionId: input.contributionId,
@@ -858,11 +907,7 @@ export async function executeContributionAction<TContribution = unknown>(
           sourceSurface: input.sourceSurface,
           actorCapabilities: input.actorCapabilities,
           expectedRevision: input.expectedRevision ?? null,
-          idempotencyKey:
-            input.idempotencyKey ??
-            (input.confirmationToken
-              ? `correction/${input.tenantId}/${input.contributionId}/${input.actionType}/${input.confirmationToken}`
-              : null),
+          idempotencyKey,
         });
 
         if (correction.idempotentReplay) {

--- a/packages/api/src/admin/contribution-operations/index.ts
+++ b/packages/api/src/admin/contribution-operations/index.ts
@@ -2,6 +2,7 @@ export {
   buildContributionActionAvailability,
   type ContributionActionAvailability,
 } from "./action-availability";
+export { executeContributionAction } from "./actions";
 export {
   assertCanDecideCorrectionRequest,
   correctionRequiresApproval,
@@ -18,6 +19,20 @@ export {
   type CrmPostLinkInput,
 } from "./crm-post-state";
 export { buildContributionDetail } from "./detail-read-model";
+export {
+  buildInlineContributionActions,
+  INLINE_ACTION_CAPABILITY,
+  isInlineContributionActionType,
+  pickNextBestInlineContributionAction,
+  type BuildInlineContributionActionsInput,
+} from "./inline-actions";
+export {
+  assertContributionActionPermission,
+  assertContributionPermission,
+  hasContributionPermission,
+  resolveContributionCapabilities,
+  type ContributionCapability,
+} from "./permissions";
 export {
   getContributionActionPolicy,
   getContributionActionRiskLevel,

--- a/packages/api/src/admin/contribution-operations/inline-actions.ts
+++ b/packages/api/src/admin/contribution-operations/inline-actions.ts
@@ -8,6 +8,7 @@ import { stripeReplayAvailability } from "./viewer-projection";
 import type { ContributionActionAvailability } from "./action-availability";
 import type { CorrectionApprovalPolicy } from "./approval-policy";
 import type { ContributionCapability } from "./permissions";
+import type { ContributionActionType } from "./types";
 import type {
   CrmGiftInlineActionEntry,
   CrmGiftInlineActions,
@@ -36,6 +37,16 @@ export const INLINE_ACTION_CAPABILITY: Record<
   refund: "contributions.run_refunds",
   stripe_replay: "contributions.use_provider_actions",
 };
+
+const INLINE_REQUEST_CAPABILITY: ContributionCapability =
+  "contributions.request_corrections";
+
+const INLINE_APPROVAL_REQUEST_ACTION_TYPES = new Set<CrmGiftInlineActionType>([
+  "amount_correction",
+  "fund_correction",
+  "refund",
+  "stripe_replay",
+]);
 
 /**
  * Only low-risk workflow actions are ever promoted to the row's single
@@ -67,6 +78,25 @@ function correctionRequestEntry(
     nextStep: null,
     riskLevel: getContributionActionRiskLevel(actionType),
   };
+}
+
+function requiredCapabilitiesForInlineAction(
+  actionType: CrmGiftInlineActionType,
+  approvalPolicy: CorrectionApprovalPolicy,
+): ContributionCapability[] {
+  const directCapability = INLINE_ACTION_CAPABILITY[actionType];
+  const canRequestApproval =
+    INLINE_APPROVAL_REQUEST_ACTION_TYPES.has(actionType) &&
+    correctionRequiresApproval({
+      actionType: actionType as ContributionActionType,
+      policy: approvalPolicy,
+    });
+
+  if (!canRequestApproval || directCapability === INLINE_REQUEST_CAPABILITY) {
+    return [directCapability];
+  }
+
+  return [directCapability, INLINE_REQUEST_CAPABILITY];
 }
 
 export function pickNextBestInlineContributionAction(
@@ -131,10 +161,13 @@ export function buildInlineContributionActions(
   ];
 
   const entries = allEntries.filter((entry) => {
-    const requiredCapability = INLINE_ACTION_CAPABILITY[entry.actionType];
-    return requiredCapability
-      ? input.viewerCapabilities.includes(requiredCapability)
-      : false;
+    const requiredCapabilities = requiredCapabilitiesForInlineAction(
+      entry.actionType,
+      approvalPolicy,
+    );
+    return requiredCapabilities.some((capability) =>
+      input.viewerCapabilities.includes(capability),
+    );
   });
 
   return {

--- a/packages/api/src/admin/contribution-operations/inline-actions.ts
+++ b/packages/api/src/admin/contribution-operations/inline-actions.ts
@@ -41,6 +41,10 @@ export const INLINE_ACTION_CAPABILITY: Record<
 const INLINE_REQUEST_CAPABILITY: ContributionCapability =
   "contributions.request_corrections";
 
+const INLINE_CORRECTION_REQUEST_ACTION_TYPES = new Set<CrmGiftInlineActionType>(
+  ["amount_correction", "fund_correction"],
+);
+
 const INLINE_APPROVAL_REQUEST_ACTION_TYPES = new Set<CrmGiftInlineActionType>([
   "amount_correction",
   "fund_correction",
@@ -131,13 +135,17 @@ export interface BuildInlineContributionActionsInput {
 export function buildInlineContributionActions(
   input: BuildInlineContributionActionsInput,
 ): CrmGiftInlineActions {
-  const workflowEntries = input.availability.filter(
-    (
-      entry,
-    ): entry is ContributionActionAvailability & CrmGiftInlineActionEntry =>
-      isInlineContributionActionType(entry.actionType) &&
-      entry.actionType !== "stripe_replay",
-  );
+  const workflowEntries = input.availability
+    .filter(
+      (
+        entry,
+      ): entry is ContributionActionAvailability & CrmGiftInlineActionEntry =>
+        isInlineContributionActionType(entry.actionType) &&
+        entry.actionType !== "stripe_replay",
+    )
+    .filter(
+      (entry) => !INLINE_CORRECTION_REQUEST_ACTION_TYPES.has(entry.actionType),
+    );
   const approvalPolicy =
     input.approvalPolicy ?? resolveCorrectionApprovalPolicy(null);
   const correctionRequestEntries = (

--- a/packages/api/src/admin/contribution-operations/inline-actions.ts
+++ b/packages/api/src/admin/contribution-operations/inline-actions.ts
@@ -1,7 +1,12 @@
+import {
+  correctionRequiresApproval,
+  resolveCorrectionApprovalPolicy,
+} from "./approval-policy";
 import { getContributionActionRiskLevel } from "./policy";
 import { stripeReplayAvailability } from "./viewer-projection";
 
 import type { ContributionActionAvailability } from "./action-availability";
+import type { CorrectionApprovalPolicy } from "./approval-policy";
 import type { ContributionCapability } from "./permissions";
 import type {
   CrmGiftInlineActionEntry,
@@ -85,6 +90,11 @@ export interface BuildInlineContributionActionsInput {
   /** Provider payment proof drives replay availability (ADR-CD-015). */
   providerPaymentIntentId: string | null;
   providerChargeId?: string | null;
+  /**
+   * Tenant correction approval policy. When omitted, use the same conservative
+   * default as the executor so request-only inline actions do not overpromise.
+   */
+  approvalPolicy?: CorrectionApprovalPolicy | null;
   viewerCapabilities: string[];
 }
 
@@ -98,10 +108,18 @@ export function buildInlineContributionActions(
       isInlineContributionActionType(entry.actionType) &&
       entry.actionType !== "stripe_replay",
   );
+  const approvalPolicy =
+    input.approvalPolicy ?? resolveCorrectionApprovalPolicy(null);
+  const correctionRequestEntries = (
+    ["amount_correction", "fund_correction"] as const
+  )
+    .filter((actionType) =>
+      correctionRequiresApproval({ actionType, policy: approvalPolicy }),
+    )
+    .map(correctionRequestEntry);
 
   const allEntries: CrmGiftInlineActionEntry[] = [
-    correctionRequestEntry("amount_correction"),
-    correctionRequestEntry("fund_correction"),
+    ...correctionRequestEntries,
     ...workflowEntries,
     {
       ...stripeReplayAvailability(

--- a/packages/api/src/admin/contribution-operations/inline-actions.ts
+++ b/packages/api/src/admin/contribution-operations/inline-actions.ts
@@ -95,7 +95,8 @@ export function buildInlineContributionActions(
     (
       entry,
     ): entry is ContributionActionAvailability & CrmGiftInlineActionEntry =>
-      isInlineContributionActionType(entry.actionType),
+      isInlineContributionActionType(entry.actionType) &&
+      entry.actionType !== "stripe_replay",
   );
 
   const allEntries: CrmGiftInlineActionEntry[] = [

--- a/packages/api/src/admin/contribution-operations/inline-actions.ts
+++ b/packages/api/src/admin/contribution-operations/inline-actions.ts
@@ -1,0 +1,125 @@
+import { getContributionActionRiskLevel } from "./policy";
+import { stripeReplayAvailability } from "./viewer-projection";
+
+import type { ContributionActionAvailability } from "./action-availability";
+import type { ContributionCapability } from "./permissions";
+import type {
+  CrmGiftInlineActionEntry,
+  CrmGiftInlineActions,
+  CrmGiftInlineActionType,
+} from "@asym/database/types";
+
+/**
+ * Inline operation parity (issue #270, ADR-CD-033).
+ *
+ * CRM gift rows surface the same contribution-detail operations inline.
+ * Entries reuse the shared availability derivation verbatim so blocked
+ * reasons, next steps, and risk levels match contribution detail exactly,
+ * then get filtered to what the viewer's capabilities allow (ADR-CD-024).
+ */
+
+/** Capability a viewer needs before an operation is surfaced inline. */
+export const INLINE_ACTION_CAPABILITY: Record<
+  CrmGiftInlineActionType,
+  ContributionCapability
+> = {
+  amount_correction: "contributions.request_corrections",
+  fund_correction: "contributions.request_corrections",
+  resend_receipt: "contributions.manage_receipts",
+  approve_staged_gift: "contributions.apply_corrections",
+  retry_staged_gift: "contributions.retry_crm_post",
+  refund: "contributions.run_refunds",
+  stripe_replay: "contributions.use_provider_actions",
+};
+
+/**
+ * Only low-risk workflow actions are ever promoted to the row's single
+ * next-best slot. High-risk operations (corrections, refunds, provider
+ * replay) always stay behind the grouped menu and the operation shell.
+ */
+const NEXT_BEST_PRIORITY: CrmGiftInlineActionType[] = [
+  "approve_staged_gift",
+  "retry_staged_gift",
+  "resend_receipt",
+];
+
+export function isInlineContributionActionType(
+  actionType: string,
+): actionType is CrmGiftInlineActionType {
+  return actionType in INLINE_ACTION_CAPABILITY;
+}
+
+function correctionRequestEntry(
+  actionType: "amount_correction" | "fund_correction",
+): CrmGiftInlineActionEntry {
+  // Corrections are adjustment-record requests over the original donation
+  // truth, so they have no state precondition; approval policy gates the
+  // apply step server-side (ADR-CD-004 / ADR-CD-005).
+  return {
+    actionType,
+    available: true,
+    blockedReason: null,
+    nextStep: null,
+    riskLevel: getContributionActionRiskLevel(actionType),
+  };
+}
+
+export function pickNextBestInlineContributionAction(
+  entries: CrmGiftInlineActionEntry[],
+): CrmGiftInlineActionType | null {
+  for (const actionType of NEXT_BEST_PRIORITY) {
+    const entry = entries.find(
+      (candidate) => candidate.actionType === actionType,
+    );
+    if (entry?.available) {
+      return actionType;
+    }
+  }
+
+  return null;
+}
+
+export interface BuildInlineContributionActionsInput {
+  /** Shared state availability — the same derivation contribution detail uses. */
+  availability: ContributionActionAvailability[];
+  /** Provider payment proof drives replay availability (ADR-CD-015). */
+  providerPaymentIntentId: string | null;
+  providerChargeId?: string | null;
+  viewerCapabilities: string[];
+}
+
+export function buildInlineContributionActions(
+  input: BuildInlineContributionActionsInput,
+): CrmGiftInlineActions {
+  const workflowEntries = input.availability.filter(
+    (
+      entry,
+    ): entry is ContributionActionAvailability & CrmGiftInlineActionEntry =>
+      isInlineContributionActionType(entry.actionType),
+  );
+
+  const allEntries: CrmGiftInlineActionEntry[] = [
+    correctionRequestEntry("amount_correction"),
+    correctionRequestEntry("fund_correction"),
+    ...workflowEntries,
+    {
+      ...stripeReplayAvailability(
+        input.providerPaymentIntentId,
+        input.providerChargeId ?? null,
+      ),
+      actionType: "stripe_replay",
+    },
+  ];
+
+  const entries = allEntries.filter((entry) => {
+    const requiredCapability = INLINE_ACTION_CAPABILITY[entry.actionType];
+    return requiredCapability
+      ? input.viewerCapabilities.includes(requiredCapability)
+      : false;
+  });
+
+  return {
+    nextBestActionType: pickNextBestInlineContributionAction(entries),
+    entries,
+  };
+}

--- a/packages/api/src/admin/contribution-operations/permissions.ts
+++ b/packages/api/src/admin/contribution-operations/permissions.ts
@@ -1,0 +1,114 @@
+import { isHighRiskContributionAction } from "./policy";
+import { ApiHttpError } from "../../shared/http-errors";
+
+import type { ContributionActionType, ContributionPermission } from "./types";
+import type { AuthenticatedContext } from "@asym/auth/context";
+
+function hasFinanceStaffMembership(auth: AuthenticatedContext): boolean {
+  return auth.memberships.some(
+    (membership) =>
+      membership.isActive &&
+      membership.tenantId === auth.tenantId &&
+      membership.role === "staff" &&
+      membership.staffRole === "finance",
+  );
+}
+
+export function hasContributionPermission(
+  auth: AuthenticatedContext,
+  permission: ContributionPermission,
+): boolean {
+  if (permission !== "finance:manage_contributions") {
+    return false;
+  }
+
+  return (
+    auth.role === "super_admin" ||
+    auth.role === "admin" ||
+    auth.profileRole === "super_admin" ||
+    auth.profileRole === "admin" ||
+    hasFinanceStaffMembership(auth)
+  );
+}
+
+export function assertContributionPermission(
+  auth: AuthenticatedContext,
+  permission: ContributionPermission,
+): void {
+  if (!hasContributionPermission(auth, permission)) {
+    throw new ApiHttpError(403, `Forbidden: requires ${permission}`);
+  }
+}
+
+export function assertContributionActionPermission(
+  auth: AuthenticatedContext,
+  actionType: ContributionActionType,
+): void {
+  if (!isHighRiskContributionAction(actionType)) {
+    return;
+  }
+
+  assertContributionPermission(auth, "finance:manage_contributions");
+}
+
+/**
+ * Granular backend capabilities backing the staff-friendly roles
+ * (ADR-CD-024). Server-side authority for every contribution action; the UI
+ * never infers access from role names.
+ */
+export type ContributionCapability =
+  | "contributions.view_detail"
+  | "contributions.request_corrections"
+  | "contributions.apply_corrections"
+  | "contributions.approve_corrections"
+  | "contributions.manage_receipts"
+  | "contributions.run_refunds"
+  | "contributions.retry_crm_post"
+  | "contributions.use_provider_actions"
+  | "contributions.manage_settings"
+  | "contributions.manage_table_preferences"
+  | "crm.gift_history.manage_view_defaults";
+
+const DONOR_CARE_CAPABILITIES: ContributionCapability[] = [
+  "contributions.view_detail",
+  "contributions.request_corrections",
+  "contributions.manage_table_preferences",
+];
+
+const FINANCE_STAFF_CAPABILITIES: ContributionCapability[] = [
+  ...DONOR_CARE_CAPABILITIES,
+  "contributions.apply_corrections",
+  "contributions.manage_receipts",
+  "contributions.retry_crm_post",
+];
+
+const FINANCE_APPROVER_CAPABILITIES: ContributionCapability[] = [
+  ...FINANCE_STAFF_CAPABILITIES,
+  "contributions.approve_corrections",
+  "contributions.run_refunds",
+  "contributions.use_provider_actions",
+];
+
+const SUPER_ADMIN_CAPABILITIES: ContributionCapability[] = [
+  ...FINANCE_APPROVER_CAPABILITIES,
+  "contributions.manage_settings",
+  "crm.gift_history.manage_view_defaults",
+];
+
+export function resolveContributionCapabilities(
+  auth: AuthenticatedContext,
+): ContributionCapability[] {
+  if (auth.role === "super_admin" || auth.profileRole === "super_admin") {
+    return [...SUPER_ADMIN_CAPABILITIES];
+  }
+
+  if (auth.role === "admin" || auth.profileRole === "admin") {
+    return [...FINANCE_APPROVER_CAPABILITIES];
+  }
+
+  if (hasFinanceStaffMembership(auth)) {
+    return [...FINANCE_STAFF_CAPABILITIES];
+  }
+
+  return [...DONOR_CARE_CAPABILITIES];
+}

--- a/packages/api/src/admin/contribution-operations/permissions.ts
+++ b/packages/api/src/admin/contribution-operations/permissions.ts
@@ -112,9 +112,17 @@ const CONTRIBUTION_ACTION_REQUIRED_CAPABILITY: Record<
   payment_state_correction: "contributions.apply_corrections",
 };
 
-const INLINE_CORRECTION_REQUEST_ACTION_TYPES = new Set<ContributionActionType>([
+const APPROVAL_REQUEST_ACTION_TYPES = new Set<ContributionActionType>([
+  "refund",
+  "stripe_replay",
+  "donor_relink",
   "amount_correction",
+  "designation_correction",
   "fund_correction",
+  "allocation_correction",
+  "receipt_correction",
+  "statement_correction",
+  "payment_state_correction",
 ]);
 
 function requiredCapabilitiesForAction(
@@ -125,7 +133,7 @@ function requiredCapabilitiesForAction(
 
   if (
     options.mode === "request" &&
-    INLINE_CORRECTION_REQUEST_ACTION_TYPES.has(actionType)
+    APPROVAL_REQUEST_ACTION_TYPES.has(actionType)
   ) {
     return [directCapability, "contributions.request_corrections"];
   }

--- a/packages/api/src/admin/contribution-operations/permissions.ts
+++ b/packages/api/src/admin/contribution-operations/permissions.ts
@@ -14,10 +14,12 @@ function hasFinanceStaffMembership(auth: AuthenticatedContext): boolean {
   );
 }
 
-function hasActiveTenantMembership(auth: AuthenticatedContext): boolean {
+function hasActiveStaffMembership(auth: AuthenticatedContext): boolean {
   return auth.memberships.some(
     (membership) =>
-      membership.isActive && membership.tenantId === auth.tenantId,
+      membership.isActive &&
+      membership.tenantId === auth.tenantId &&
+      membership.role === "staff",
   );
 }
 
@@ -117,7 +119,7 @@ export function resolveContributionCapabilities(
     return [...FINANCE_STAFF_CAPABILITIES];
   }
 
-  if (hasActiveTenantMembership(auth)) {
+  if (hasActiveStaffMembership(auth)) {
     return [...DONOR_CARE_CAPABILITIES];
   }
 

--- a/packages/api/src/admin/contribution-operations/permissions.ts
+++ b/packages/api/src/admin/contribution-operations/permissions.ts
@@ -51,8 +51,12 @@ export function assertContributionPermission(
 export function assertContributionActionPermission(
   auth: AuthenticatedContext,
   actionType: ContributionActionType,
+  options: { mode?: "direct" | "request" } = {},
 ): void {
-  const requiredCapabilities = requiredCapabilitiesForAction(actionType);
+  const requiredCapabilities = requiredCapabilitiesForAction(
+    actionType,
+    options,
+  );
   const actorCapabilities = resolveContributionCapabilities(auth);
 
   if (
@@ -115,10 +119,14 @@ const INLINE_CORRECTION_REQUEST_ACTION_TYPES = new Set<ContributionActionType>([
 
 function requiredCapabilitiesForAction(
   actionType: ContributionActionType,
+  options: { mode?: "direct" | "request" },
 ): ContributionCapability[] {
   const directCapability = CONTRIBUTION_ACTION_REQUIRED_CAPABILITY[actionType];
 
-  if (INLINE_CORRECTION_REQUEST_ACTION_TYPES.has(actionType)) {
+  if (
+    options.mode === "request" &&
+    INLINE_CORRECTION_REQUEST_ACTION_TYPES.has(actionType)
+  ) {
     return [directCapability, "contributions.request_corrections"];
   }
 

--- a/packages/api/src/admin/contribution-operations/permissions.ts
+++ b/packages/api/src/admin/contribution-operations/permissions.ts
@@ -52,15 +52,21 @@ export function assertContributionActionPermission(
   auth: AuthenticatedContext,
   actionType: ContributionActionType,
 ): void {
-  const requiredCapability =
-    CONTRIBUTION_ACTION_REQUIRED_CAPABILITY[actionType];
-  const capabilities = resolveContributionCapabilities(auth);
+  const requiredCapabilities = requiredCapabilitiesForAction(actionType);
+  const actorCapabilities = resolveContributionCapabilities(auth);
 
-  if (capabilities.includes(requiredCapability)) {
+  if (
+    requiredCapabilities.some((capability) =>
+      actorCapabilities.includes(capability),
+    )
+  ) {
     return;
   }
 
-  throw new ApiHttpError(403, `Forbidden: requires ${requiredCapability}`);
+  throw new ApiHttpError(
+    403,
+    `Forbidden: requires ${formatRequiredCapabilities(requiredCapabilities)}`,
+  );
 }
 
 /**
@@ -101,6 +107,29 @@ const CONTRIBUTION_ACTION_REQUIRED_CAPABILITY: Record<
   statement_correction: "contributions.apply_corrections",
   payment_state_correction: "contributions.apply_corrections",
 };
+
+const INLINE_CORRECTION_REQUEST_ACTION_TYPES = new Set<ContributionActionType>([
+  "amount_correction",
+  "fund_correction",
+]);
+
+function requiredCapabilitiesForAction(
+  actionType: ContributionActionType,
+): ContributionCapability[] {
+  const directCapability = CONTRIBUTION_ACTION_REQUIRED_CAPABILITY[actionType];
+
+  if (INLINE_CORRECTION_REQUEST_ACTION_TYPES.has(actionType)) {
+    return [directCapability, "contributions.request_corrections"];
+  }
+
+  return [directCapability];
+}
+
+function formatRequiredCapabilities(
+  capabilities: ContributionCapability[],
+): string {
+  return capabilities.join(" or ");
+}
 
 const DONOR_CARE_CAPABILITIES: ContributionCapability[] = [
   "contributions.view_detail",

--- a/packages/api/src/admin/contribution-operations/permissions.ts
+++ b/packages/api/src/admin/contribution-operations/permissions.ts
@@ -1,4 +1,3 @@
-import { isHighRiskContributionAction } from "./policy";
 import { ApiHttpError } from "../../shared/http-errors";
 
 import type { ContributionActionType, ContributionPermission } from "./types";
@@ -53,11 +52,15 @@ export function assertContributionActionPermission(
   auth: AuthenticatedContext,
   actionType: ContributionActionType,
 ): void {
-  if (!isHighRiskContributionAction(actionType)) {
+  const requiredCapability =
+    CONTRIBUTION_ACTION_REQUIRED_CAPABILITY[actionType];
+  const capabilities = resolveContributionCapabilities(auth);
+
+  if (capabilities.includes(requiredCapability)) {
     return;
   }
 
-  assertContributionPermission(auth, "finance:manage_contributions");
+  throw new ApiHttpError(403, `Forbidden: requires ${requiredCapability}`);
 }
 
 /**
@@ -77,6 +80,27 @@ export type ContributionCapability =
   | "contributions.manage_settings"
   | "contributions.manage_table_preferences"
   | "crm.gift_history.manage_view_defaults";
+
+const CONTRIBUTION_ACTION_REQUIRED_CAPABILITY: Record<
+  ContributionActionType,
+  ContributionCapability
+> = {
+  resend_receipt: "contributions.manage_receipts",
+  approve_staged_gift: "contributions.apply_corrections",
+  retry_staged_gift: "contributions.retry_crm_post",
+  crm_repost: "contributions.retry_crm_post",
+  metadata_update: "contributions.apply_corrections",
+  refund: "contributions.run_refunds",
+  stripe_replay: "contributions.use_provider_actions",
+  donor_relink: "contributions.apply_corrections",
+  amount_correction: "contributions.apply_corrections",
+  designation_correction: "contributions.apply_corrections",
+  fund_correction: "contributions.apply_corrections",
+  allocation_correction: "contributions.apply_corrections",
+  receipt_correction: "contributions.apply_corrections",
+  statement_correction: "contributions.apply_corrections",
+  payment_state_correction: "contributions.apply_corrections",
+};
 
 const DONOR_CARE_CAPABILITIES: ContributionCapability[] = [
   "contributions.view_detail",

--- a/packages/api/src/admin/contribution-operations/permissions.ts
+++ b/packages/api/src/admin/contribution-operations/permissions.ts
@@ -14,6 +14,13 @@ function hasFinanceStaffMembership(auth: AuthenticatedContext): boolean {
   );
 }
 
+function hasActiveTenantMembership(auth: AuthenticatedContext): boolean {
+  return auth.memberships.some(
+    (membership) =>
+      membership.isActive && membership.tenantId === auth.tenantId,
+  );
+}
+
 export function hasContributionPermission(
   auth: AuthenticatedContext,
   permission: ContributionPermission,
@@ -110,5 +117,9 @@ export function resolveContributionCapabilities(
     return [...FINANCE_STAFF_CAPABILITIES];
   }
 
-  return [...DONOR_CARE_CAPABILITIES];
+  if (hasActiveTenantMembership(auth)) {
+    return [...DONOR_CARE_CAPABILITIES];
+  }
+
+  return [];
 }

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -147,6 +147,8 @@ export interface ContributionActionDependencies<TContribution = unknown> {
     tenantId: string;
     contributionId: string;
     donorId: string;
+    expectedRevision?: string | null;
+    idempotencyKey: string;
   }) => Promise<{
     before?: Record<string, unknown> | null;
     after?: Record<string, unknown> | null;

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -195,6 +195,8 @@ export interface ContributionActionDependencies<TContribution = unknown> {
     amount: number;
     reason: string;
     confirmationToken: string;
+    expectedRevision?: string | null;
+    idempotencyKey: string;
   }) => Promise<ContributionProviderOutcome>;
   appendAuditEvent?: (
     input: ContributionOperationAuditEventInput,

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -174,6 +174,8 @@ export interface ContributionActionDependencies<TContribution = unknown> {
     tenantId: string;
     contributionId: string;
     payload: Record<string, unknown>;
+    expectedRevision?: string | null;
+    idempotencyKey: string;
   }) => Promise<ContributionProviderOutcome>;
   sendCorrectionNotification?: (input: {
     tenantId: string;
@@ -222,6 +224,25 @@ export interface ContributionActionDependencies<TContribution = unknown> {
     /** Requester's proposed updated receipt delivery action (ADR-CD-030). */
     receiptDeliveryProposal?: Record<string, unknown> | null;
   }) => Promise<string>;
+  /**
+   * Validates that an approved request can be applied and returns the
+   * persisted payload/reason. The implementation must verify tenant,
+   * contribution, action type, approved status, ownership policy, and payload
+   * consistency before the executor bypasses request creation.
+   */
+  validateApprovedCorrectionRequest?: (input: {
+    tenantId: string;
+    contributionId: string;
+    actionType: ContributionActionType;
+    approvedRequestId: string;
+    actorProfileId: string | null;
+    actorCapabilities?: string[];
+    expectedRevision?: string | null;
+    requestedPayload: Record<string, unknown>;
+  }) => Promise<{
+    payload: Record<string, unknown>;
+    reason?: string | null;
+  }>;
 }
 
 export interface ExecuteContributionActionInput<TContribution = unknown> {

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -117,16 +117,19 @@ export interface ContributionActionResult<TContribution = unknown> {
 export interface ContributionActionDependencies<TContribution = unknown> {
   sendReceipt?: (input: {
     tenantId: string;
+    contributionId: string;
     stagedGiftId: string;
   }) => Promise<{ status: string; sendLogId?: string | null }>;
   approveStagedGift?: (input: {
     tenantId: string;
+    contributionId: string;
     stagedGiftId: string;
     actorProfileId: string | null;
     note?: string | null;
   }) => Promise<unknown>;
   retryStagedGift?: (input: {
     tenantId: string;
+    contributionId: string;
     stagedGiftId: string;
     actorProfileId: string | null;
     note?: string | null;
@@ -138,6 +141,7 @@ export interface ContributionActionDependencies<TContribution = unknown> {
    */
   retryDesignationPost?: (input: {
     tenantId: string;
+    contributionId: string;
     stagedGiftId: string;
     allocationId: string;
     actorProfileId: string | null;

--- a/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildContributionActionAvailability } from "../../../../../packages/api/src/admin/contribution-operations/action-availability";
+import { resolveCorrectionApprovalPolicy } from "../../../../../packages/api/src/admin/contribution-operations/approval-policy";
 import {
   buildInlineContributionActions,
   pickNextBestInlineContributionAction,
@@ -32,6 +33,12 @@ const FINANCE_STAFF_CAPABILITIES = [
   "contributions.manage_receipts",
   "contributions.retry_crm_post",
 ];
+
+const APPROVAL_SUPPRESSED_POLICY = resolveCorrectionApprovalPolicy({
+  ownership_mode: "no_approval_required",
+  suppressed_gates: [],
+  stronger_approval_categories: [],
+});
 
 const postedStagedGift = {
   id: "staged-1",
@@ -189,6 +196,18 @@ describe("admin/contribution-operations/inline-actions", () => {
       "amount_correction",
       "fund_correction",
     ]);
+  });
+
+  it("hides request-only correction entries when approval policy allows direct apply", () => {
+    const inline = buildInlineContributionActions({
+      availability: availabilityFor(),
+      providerPaymentIntentId: "pi_1",
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+      viewerCapabilities: DONOR_CARE_CAPABILITIES,
+    });
+
+    expect(inline.entries).toEqual([]);
+    expect(inline.nextBestActionType).toBeNull();
   });
 
   it("filters refund and provider actions away from finance staff", () => {

--- a/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
@@ -130,6 +130,34 @@ describe("admin/contribution-operations/inline-actions", () => {
     });
   });
 
+  it("deduplicates provider replay when availability already includes it", () => {
+    const staleReplayEntry = {
+      actionType: "stripe_replay",
+      available: false,
+      blockedReason: "Stale projected availability",
+      nextStep: "Reload contribution detail",
+      riskLevel: "high",
+    } satisfies ReturnType<typeof availabilityFor>[number];
+
+    const inline = buildInlineContributionActions({
+      availability: [...availabilityFor(), staleReplayEntry],
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+
+    const replayEntries = inline.entries.filter(
+      (entry) => entry.actionType === "stripe_replay",
+    );
+
+    expect(replayEntries).toEqual([
+      expect.objectContaining({
+        actionType: "stripe_replay",
+        available: true,
+        blockedReason: null,
+      }),
+    ]);
+  });
+
   it("includes high-risk correction operations as request entries", () => {
     const inline = buildInlineContributionActions({
       availability: availabilityFor(),

--- a/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
@@ -165,6 +165,52 @@ describe("admin/contribution-operations/inline-actions", () => {
     ]);
   });
 
+  it("deduplicates correction request entries when availability already includes them", () => {
+    const staleAmountCorrection = {
+      actionType: "amount_correction",
+      available: false,
+      blockedReason: "Stale projected availability",
+      nextStep: "Reload contribution detail",
+      riskLevel: "high",
+    } satisfies ReturnType<typeof availabilityFor>[number];
+    const staleFundCorrection = {
+      actionType: "fund_correction",
+      available: false,
+      blockedReason: "Stale projected availability",
+      nextStep: "Reload contribution detail",
+      riskLevel: "high",
+    } satisfies ReturnType<typeof availabilityFor>[number];
+
+    const inline = buildInlineContributionActions({
+      availability: [
+        ...availabilityFor(),
+        staleAmountCorrection,
+        staleFundCorrection,
+      ],
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+
+    const correctionEntries = inline.entries.filter(
+      (entry) =>
+        entry.actionType === "amount_correction" ||
+        entry.actionType === "fund_correction",
+    );
+
+    expect(correctionEntries).toEqual([
+      expect.objectContaining({
+        actionType: "amount_correction",
+        available: true,
+        blockedReason: null,
+      }),
+      expect.objectContaining({
+        actionType: "fund_correction",
+        available: true,
+        blockedReason: null,
+      }),
+    ]);
+  });
+
   it("includes high-risk correction operations as request entries", () => {
     const inline = buildInlineContributionActions({
       availability: availabilityFor(),

--- a/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributionActionAvailability } from "../../../../../packages/api/src/admin/contribution-operations/action-availability";
+import {
+  buildInlineContributionActions,
+  pickNextBestInlineContributionAction,
+} from "../../../../../packages/api/src/admin/contribution-operations/inline-actions";
+import { projectContributionDetailForViewer } from "../../../../../packages/api/src/admin/contribution-operations/viewer-projection";
+
+import type { ContributionDetail } from "../../../../../packages/api/src/admin/contribution-operations/detail-read-model";
+
+const ALL_CAPABILITIES = [
+  "contributions.view_detail",
+  "contributions.request_corrections",
+  "contributions.apply_corrections",
+  "contributions.approve_corrections",
+  "contributions.manage_receipts",
+  "contributions.run_refunds",
+  "contributions.retry_crm_post",
+  "contributions.use_provider_actions",
+];
+
+const DONOR_CARE_CAPABILITIES = [
+  "contributions.view_detail",
+  "contributions.request_corrections",
+  "contributions.manage_table_preferences",
+];
+
+const FINANCE_STAFF_CAPABILITIES = [
+  ...DONOR_CARE_CAPABILITIES,
+  "contributions.apply_corrections",
+  "contributions.manage_receipts",
+  "contributions.retry_crm_post",
+];
+
+const postedStagedGift = {
+  id: "staged-1",
+  status: "posted",
+  receiptStatus: "sent",
+  crmPostStatus: "posted",
+};
+
+function availabilityFor(input?: {
+  stagedGift?: typeof postedStagedGift | null;
+  paymentStatus?: string;
+  hasProviderCharge?: boolean;
+}) {
+  return buildContributionActionAvailability({
+    stagedGift:
+      input?.stagedGift === undefined ? postedStagedGift : input.stagedGift,
+    paymentStatus: input?.paymentStatus ?? "completed",
+    refund: {
+      amountCents: 25_000,
+      refundedAmountCents: 0,
+      hasProviderCharge: input?.hasProviderCharge ?? true,
+    },
+  });
+}
+
+describe("admin/contribution-operations/inline-actions", () => {
+  it("reuses the exact detail availability entries for workflow actions", () => {
+    const availability = availabilityFor();
+    const inline = buildInlineContributionActions({
+      availability,
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+
+    // Blocked reasons, next steps, and risk levels match contribution detail
+    // because the entries ARE the shared derivation output (issue #270).
+    for (const detailEntry of availability) {
+      const inlineEntry = inline.entries.find(
+        (entry) => entry.actionType === detailEntry.actionType,
+      );
+      expect(inlineEntry).toEqual(detailEntry);
+    }
+  });
+
+  it("matches the viewer projection for provider replay availability", () => {
+    const detailBase = {
+      actionAvailability: availabilityFor(),
+      payment: {
+        stripe: {
+          paymentIntentId: null,
+          chargeId: null,
+          refundIds: [],
+          replayContext: null,
+        },
+      },
+      recurring: { agreement: null },
+    } as unknown as ContributionDetail;
+
+    const projected = projectContributionDetailForViewer(
+      detailBase,
+      ALL_CAPABILITIES,
+    );
+    const projectedReplay = projected.actionAvailability.find(
+      (entry) => entry.actionType === "stripe_replay",
+    );
+
+    const inline = buildInlineContributionActions({
+      availability: availabilityFor(),
+      providerPaymentIntentId: null,
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+    const inlineReplay = inline.entries.find(
+      (entry) => entry.actionType === "stripe_replay",
+    );
+
+    expect(inlineReplay).toEqual(projectedReplay);
+    expect(inlineReplay?.available).toBe(false);
+  });
+
+  it("allows provider replay when only a charge id is available", () => {
+    const inline = buildInlineContributionActions({
+      availability: availabilityFor(),
+      providerPaymentIntentId: null,
+      providerChargeId: "ch_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+
+    const inlineReplay = inline.entries.find(
+      (entry) => entry.actionType === "stripe_replay",
+    );
+
+    expect(inlineReplay).toMatchObject({
+      actionType: "stripe_replay",
+      available: true,
+      blockedReason: null,
+    });
+  });
+
+  it("includes high-risk correction operations as request entries", () => {
+    const inline = buildInlineContributionActions({
+      availability: availabilityFor(),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+
+    for (const actionType of ["amount_correction", "fund_correction"]) {
+      const entry = inline.entries.find(
+        (candidate) => candidate.actionType === actionType,
+      );
+      expect(entry).toMatchObject({
+        actionType,
+        available: true,
+        blockedReason: null,
+        riskLevel: "high",
+      });
+    }
+  });
+
+  it("filters entries by viewer capability (donor-care sees corrections only)", () => {
+    const inline = buildInlineContributionActions({
+      availability: availabilityFor(),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: DONOR_CARE_CAPABILITIES,
+    });
+
+    expect(inline.entries.map((entry) => entry.actionType).sort()).toEqual([
+      "amount_correction",
+      "fund_correction",
+    ]);
+  });
+
+  it("filters refund and provider actions away from finance staff", () => {
+    const inline = buildInlineContributionActions({
+      availability: availabilityFor(),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: FINANCE_STAFF_CAPABILITIES,
+    });
+
+    const actionTypes = inline.entries.map((entry) => entry.actionType);
+    expect(actionTypes).toContain("resend_receipt");
+    expect(actionTypes).toContain("approve_staged_gift");
+    expect(actionTypes).toContain("retry_staged_gift");
+    expect(actionTypes).not.toContain("refund");
+    expect(actionTypes).not.toContain("stripe_replay");
+  });
+
+  it("promotes approval, then retry, then receipt as the next-best action", () => {
+    const needsReview = buildInlineContributionActions({
+      availability: availabilityFor({
+        stagedGift: { ...postedStagedGift, status: "needs_review" },
+      }),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+    expect(needsReview.nextBestActionType).toBe("approve_staged_gift");
+
+    const failedPost = buildInlineContributionActions({
+      availability: availabilityFor({
+        stagedGift: { ...postedStagedGift, crmPostStatus: "failed" },
+      }),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+    expect(failedPost.nextBestActionType).toBe("retry_staged_gift");
+
+    const settled = buildInlineContributionActions({
+      availability: availabilityFor(),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+    expect(settled.nextBestActionType).toBe("resend_receipt");
+  });
+
+  it("never promotes high-risk operations as the next-best action", () => {
+    // Refund and corrections are available, but every low-risk workflow
+    // action is blocked (no staged gift, payment pending).
+    const inline = buildInlineContributionActions({
+      availability: availabilityFor({
+        stagedGift: null,
+        paymentStatus: "completed",
+      }),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: ALL_CAPABILITIES,
+    });
+
+    const refundEntry = inline.entries.find(
+      (entry) => entry.actionType === "refund",
+    );
+    expect(refundEntry?.available).toBe(true);
+    expect(inline.nextBestActionType).toBeNull();
+  });
+
+  it("respects capability when picking the next-best action", () => {
+    const entries = buildInlineContributionActions({
+      availability: availabilityFor({
+        stagedGift: { ...postedStagedGift, status: "needs_review" },
+      }),
+      providerPaymentIntentId: "pi_1",
+      viewerCapabilities: DONOR_CARE_CAPABILITIES,
+    });
+
+    // Donor care cannot approve, so nothing is promoted even though the
+    // gift needs review.
+    expect(entries.nextBestActionType).toBeNull();
+    expect(pickNextBestInlineContributionAction(entries.entries)).toBeNull();
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-inline-actions.test.ts
@@ -185,7 +185,7 @@ describe("admin/contribution-operations/inline-actions", () => {
     }
   });
 
-  it("filters entries by viewer capability (donor-care sees corrections only)", () => {
+  it("allows donor-care staff to request approval-gated inline actions", () => {
     const inline = buildInlineContributionActions({
       availability: availabilityFor(),
       providerPaymentIntentId: "pi_1",
@@ -195,6 +195,8 @@ describe("admin/contribution-operations/inline-actions", () => {
     expect(inline.entries.map((entry) => entry.actionType).sort()).toEqual([
       "amount_correction",
       "fund_correction",
+      "refund",
+      "stripe_replay",
     ]);
   });
 
@@ -210,10 +212,11 @@ describe("admin/contribution-operations/inline-actions", () => {
     expect(inline.nextBestActionType).toBeNull();
   });
 
-  it("filters refund and provider actions away from finance staff", () => {
+  it("filters refund and provider actions away from finance staff when approval is suppressed", () => {
     const inline = buildInlineContributionActions({
       availability: availabilityFor(),
       providerPaymentIntentId: "pi_1",
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
       viewerCapabilities: FINANCE_STAFF_CAPABILITIES,
     });
 

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -151,8 +151,9 @@ describe("contribution operations action executor", () => {
       contributionId: "donation_1",
       donorId: "donor_new",
       expectedRevision: "rev_relink",
-      idempotencyKey:
-        "contribution-action/tenant_1/donation_1/donor_relink/confirm",
+      idempotencyKey: expect.stringMatching(
+        /^contribution-action\/tenant_1\/donation_1\/donor_relink\/confirmation-[0-9a-f]{32}$/,
+      ),
     });
     expect(createCorrectionRecord).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -252,8 +253,9 @@ describe("contribution operations action executor", () => {
       actorProfileId: "profile_1",
       sourceSurface: "contribution_hub",
       expectedRevision: null,
-      idempotencyKey:
-        "correction/tenant_1/donation_1/amount_correction/confirm",
+      idempotencyKey: expect.stringMatching(
+        /^correction\/tenant_1\/donation_1\/amount_correction\/confirmation-[0-9a-f]{32}$/,
+      ),
     });
     expect(createCorrectionRecord).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -263,6 +265,61 @@ describe("contribution operations action executor", () => {
         status: "applied",
       }),
     );
+  });
+
+  it("normalizes and scopes direct correction fallback idempotency keys", async () => {
+    const applyCorrection = vi.fn().mockResolvedValue({
+      before: { amount: 1000 },
+      after: { amount: 1200 },
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+    const sharedDependencies = {
+      applyCorrection,
+      createCorrectionRecord,
+      appendAuditEvent,
+      loadContributionDetail,
+    };
+    const baseInput = {
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.apply_corrections"],
+      sourceSurface: "contribution_hub" as const,
+      contributionId: "donation_1",
+      actionType: "amount_correction" as const,
+      reason: "Corrected imported check amount",
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+      dependencies: sharedDependencies,
+    };
+
+    await executeContributionAction({
+      ...baseInput,
+      confirmationToken: " confirm ",
+      payload: { amount: 1200 },
+    });
+    await executeContributionAction({
+      ...baseInput,
+      confirmationToken: "confirm",
+      payload: { amount: 1200 },
+    });
+    await executeContributionAction({
+      ...baseInput,
+      confirmationToken: "confirm",
+      payload: { amount: 1300 },
+    });
+
+    const idempotencyKeys = applyCorrection.mock.calls.map(
+      ([call]) => call.idempotencyKey,
+    );
+    expect(idempotencyKeys[0]).toMatch(
+      /^correction\/tenant_1\/donation_1\/amount_correction\/confirmation-[0-9a-f]{32}$/,
+    );
+    expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
+    expect(idempotencyKeys[2]).not.toBe(idempotencyKeys[0]);
   });
 
   it("requires an idempotency key before direct generic corrections", async () => {
@@ -618,6 +675,62 @@ describe("contribution operations action executor", () => {
     expect(refundContribution).not.toHaveBeenCalled();
   });
 
+  it("normalizes and scopes direct provider fallback idempotency keys", async () => {
+    const refundContribution = vi.fn().mockResolvedValue({
+      provider: "stripe",
+      status: "succeeded",
+      referenceId: "refund_1",
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+    const sharedDependencies = {
+      refundContribution,
+      createCorrectionRecord,
+      appendAuditEvent,
+      loadContributionDetail,
+    };
+    const baseInput = {
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.run_refunds"],
+      sourceSurface: "contribution_hub" as const,
+      contributionId: "donation_1",
+      actionType: "refund" as const,
+      reason: "Duplicate payment",
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+      dependencies: sharedDependencies,
+    };
+
+    await executeContributionAction({
+      ...baseInput,
+      confirmationToken: " confirm ",
+      payload: { amount: 500 },
+    });
+    await executeContributionAction({
+      ...baseInput,
+      confirmationToken: "confirm",
+      payload: { amount: 500 },
+    });
+    await executeContributionAction({
+      ...baseInput,
+      confirmationToken: "confirm",
+      payload: { amount: 700 },
+    });
+
+    const idempotencyKeys = refundContribution.mock.calls.map(
+      ([call]) => call.idempotencyKey,
+    );
+    expect(idempotencyKeys[0]).toMatch(
+      /^contribution-action\/tenant_1\/donation_1\/refund\/confirmation-[0-9a-f]{32}$/,
+    );
+    expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
+    expect(idempotencyKeys[2]).not.toBe(idempotencyKeys[0]);
+  });
+
   it("routes Stripe replay through a dedicated provider adapter and audit trail", async () => {
     const replayStripeEvent = vi.fn().mockResolvedValue({
       provider: "stripe",
@@ -654,8 +767,9 @@ describe("contribution operations action executor", () => {
     expect(replayStripeEvent).toHaveBeenCalledWith({
       contributionId: "donation_1",
       expectedRevision: "rev_replay",
-      idempotencyKey:
-        "contribution-action/tenant_1/donation_1/stripe_replay/confirm",
+      idempotencyKey: expect.stringMatching(
+        /^contribution-action\/tenant_1\/donation_1\/stripe_replay\/confirmation-[0-9a-f]{32}$/,
+      ),
       payload: { stripeEventId: "evt_123" },
       tenantId: "tenant_1",
     });

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -344,6 +344,58 @@ describe("contribution operations action executor", () => {
     expect(validateApprovedCorrectionRequest).not.toHaveBeenCalled();
   });
 
+  it("requires provider capabilities before applying approved provider requests", async () => {
+    const validateApprovedCorrectionRequest = vi.fn();
+
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "approver_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.approve_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "refund",
+        reason: "Approved refund request",
+        confirmationToken: "confirm",
+        approvedRequestId: "request_refund",
+        payload: { amount: 500 },
+        dependencies: {
+          validateApprovedCorrectionRequest,
+          refundContribution: vi.fn(),
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/run_refunds/);
+
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "approver_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.approve_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "stripe_replay",
+        reason: "Approved replay request",
+        confirmationToken: "confirm",
+        approvedRequestId: "request_replay",
+        payload: { stripeEventId: "evt_123" },
+        dependencies: {
+          validateApprovedCorrectionRequest,
+          replayStripeEvent: vi.fn(),
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/use_provider_actions/);
+
+    expect(validateApprovedCorrectionRequest).not.toHaveBeenCalled();
+  });
+
   it("requires approved request validation before bypassing request creation", async () => {
     await expect(
       executeContributionAction({

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -40,6 +40,7 @@ describe("contribution operations action executor", () => {
       tenantId: "tenant_1",
       actorProfileId: "profile_1",
       actorPermissions: [],
+      actorCapabilities: ["contributions.manage_receipts"],
       sourceSurface: "donor_crm_record",
       contributionId: "donation_1",
       actionType: "resend_receipt",
@@ -73,6 +74,26 @@ describe("contribution operations action executor", () => {
     });
   });
 
+  it("requires the receipt management capability for receipt resends", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.view_detail"],
+        sourceSurface: "donor_crm_record",
+        contributionId: "donation_1",
+        actionType: "resend_receipt",
+        payload: { stagedGiftId: "staged_1" },
+        dependencies: {
+          sendReceipt: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/manage_receipts/);
+  });
+
   it("creates correction and audit records for donor relinking", async () => {
     const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
     const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
@@ -95,6 +116,7 @@ describe("contribution operations action executor", () => {
       reason: "Merged duplicate donor",
       confirmationToken: "confirm",
       payload: { donorId: "donor_new" },
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
       dependencies: {
         createCorrectionRecord,
         appendAuditEvent,
@@ -122,6 +144,45 @@ describe("contribution operations action executor", () => {
     );
     expect(result.correctionId).toBe("correction_1");
     expect(result.auditEventId).toBe("audit_1");
+  });
+
+  it("routes donor relinks through correction requests under default approval policy", async () => {
+    const relinkDonor = vi.fn();
+    const createCorrectionRequest = vi.fn().mockResolvedValue("request_7");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "donor_relink",
+      reason: "Merged duplicate donor",
+      confirmationToken: "confirm",
+      payload: { donorId: "donor_new" },
+      approvalPolicy: resolveCorrectionApprovalPolicy(null),
+      dependencies: {
+        relinkDonor,
+        createCorrectionRequest,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(relinkDonor).not.toHaveBeenCalled();
+    expect(createCorrectionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "donor_relink",
+        payload: { donorId: "donor_new" },
+      }),
+    );
+    expect(result.approvalStatus).toBe("pending_approval");
+    expect(result.correctionRequestId).toBe("request_7");
   });
 
   it("applies amount corrections before writing correction and audit records", async () => {
@@ -200,6 +261,8 @@ describe("contribution operations action executor", () => {
       reason: "Duplicate payment",
       confirmationToken: "confirm",
       payload: { amount: 500 },
+      expectedRevision: "rev_1",
+      idempotencyKey: "refund-key-1",
       approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
       dependencies: {
         refundContribution,
@@ -221,6 +284,8 @@ describe("contribution operations action executor", () => {
     expect(refundContribution).toHaveBeenCalledWith(
       expect.objectContaining({
         confirmationToken: "confirm",
+        expectedRevision: "rev_1",
+        idempotencyKey: "refund-key-1",
       }),
     );
     expect(result.providerOutcome?.status).toBe("failed");
@@ -248,6 +313,7 @@ describe("contribution operations action executor", () => {
       reason: "Recover missing webhook",
       confirmationToken: "confirm",
       payload: { stripeEventId: "evt_123" },
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
       dependencies: {
         replayStripeEvent,
         createCorrectionRecord,
@@ -271,6 +337,45 @@ describe("contribution operations action executor", () => {
       }),
     );
     expect(result.providerOutcome?.referenceId).toBe("evt_123");
+  });
+
+  it("routes Stripe replay through correction requests under default approval policy", async () => {
+    const replayStripeEvent = vi.fn();
+    const createCorrectionRequest = vi.fn().mockResolvedValue("request_8");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "stripe_replay",
+      reason: "Recover missing webhook",
+      confirmationToken: "confirm",
+      payload: { stripeEventId: "evt_123" },
+      approvalPolicy: resolveCorrectionApprovalPolicy(null),
+      dependencies: {
+        replayStripeEvent,
+        createCorrectionRequest,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(replayStripeEvent).not.toHaveBeenCalled();
+    expect(createCorrectionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "stripe_replay",
+        payload: { stripeEventId: "evt_123" },
+      }),
+    );
+    expect(result.approvalStatus).toBe("pending_approval");
+    expect(result.correctionRequestId).toBe("request_8");
   });
 
   it("routes refunds through correction requests under default approval policy", async () => {
@@ -333,6 +438,26 @@ describe("contribution operations action executor", () => {
     ).rejects.toThrow(/run_refunds/);
   });
 
+  it("requires the CRM retry capability for staged gift retries", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.view_detail"],
+        sourceSurface: "donor_crm_record",
+        contributionId: "donation_1",
+        actionType: "retry_staged_gift",
+        payload: { stagedGiftId: "staged_1" },
+        dependencies: {
+          retryStagedGift: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/retry_crm_post/);
+  });
+
   it("retries a single designation child record without reposting unrelated lines", async () => {
     const retryDesignationPost = vi.fn().mockResolvedValue(undefined);
     const retryStagedGift = vi.fn();
@@ -345,6 +470,7 @@ describe("contribution operations action executor", () => {
       tenantId: "tenant_1",
       actorProfileId: "profile_1",
       actorPermissions: [],
+      actorCapabilities: ["contributions.retry_crm_post"],
       sourceSurface: "donor_crm_record",
       contributionId: "donation_1",
       actionType: "retry_staged_gift",
@@ -381,6 +507,7 @@ describe("contribution operations action executor", () => {
         tenantId: "tenant_1",
         actorProfileId: "profile_1",
         actorPermissions: [],
+        actorCapabilities: ["contributions.retry_crm_post"],
         sourceSurface: "donor_crm_record",
         contributionId: "donation_1",
         actionType: "retry_staged_gift",

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -952,7 +952,7 @@ describe("contribution operations action executor", () => {
     expect(result.correctionId).toBeFalsy();
   });
 
-  it("derives stable idempotency for pending correction requests without confirmation tokens", async () => {
+  it("derives context-specific idempotency for pending correction requests without confirmation tokens", async () => {
     const applyCorrection = vi.fn();
     const createCorrectionRequest = vi.fn().mockResolvedValue("request_2");
     const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
@@ -987,16 +987,57 @@ describe("contribution operations action executor", () => {
         loadContributionDetail,
       },
     });
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_2",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "allocation_correction",
+      reason: "Same allocation requested by another staff member",
+      payload: {
+        allocations: [
+          { fundId: "fund_2", amount: 500 },
+          { amount: 250, fundId: "fund_3" },
+        ],
+      },
+      approvalPolicy: resolveCorrectionApprovalPolicy({
+        ownership_mode: "separation_of_duties",
+        suppressed_gates: [],
+        stronger_approval_categories: ["allocation_correction"],
+      }),
+      dependencies: {
+        applyCorrection,
+        createCorrectionRequest,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
 
     expect(applyCorrection).not.toHaveBeenCalled();
-    expect(createCorrectionRequest).toHaveBeenCalledWith(
+    expect(createCorrectionRequest).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         actionType: "allocation_correction",
         idempotencyKey: expect.stringMatching(
-          /^correction-request\/tenant_1\/donation_1\/allocation_correction\/payload-[0-9a-f]{32}$/,
+          /^correction-request\/tenant_1\/donation_1\/allocation_correction\/context-[0-9a-f]{32}$/,
         ),
       }),
     );
+    expect(createCorrectionRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        actionType: "allocation_correction",
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/allocation_correction\/context-[0-9a-f]{32}$/,
+        ),
+      }),
+    );
+    const firstKey = createCorrectionRequest.mock.calls[0]?.[0]?.idempotencyKey;
+    const secondKey =
+      createCorrectionRequest.mock.calls[1]?.[0]?.idempotencyKey;
+    expect(secondKey).not.toBe(firstKey);
   });
 
   it("requires the request capability to open a correction request", async () => {

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -202,6 +202,8 @@ describe("contribution operations action executor", () => {
     expect(createCorrectionRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         actionType: "donor_relink",
+        idempotencyKey:
+          "correction-request/tenant_1/donation_1/donor_relink/confirm",
         payload: { donorId: "donor_new" },
       }),
     );
@@ -308,7 +310,10 @@ describe("contribution operations action executor", () => {
       tenantId: "tenant_1",
       actorProfileId: "approver_1",
       actorPermissions: [],
-      actorCapabilities: ["contributions.approve_corrections"],
+      actorCapabilities: [
+        "contributions.approve_corrections",
+        "contributions.apply_corrections",
+      ],
       sourceSurface: "contribution_hub",
       contributionId: "donation_1",
       actionType: "amount_correction",
@@ -330,7 +335,10 @@ describe("contribution operations action executor", () => {
       actionType: "amount_correction",
       approvedRequestId: "request_1",
       actorProfileId: "approver_1",
-      actorCapabilities: ["contributions.approve_corrections"],
+      actorCapabilities: [
+        "contributions.approve_corrections",
+        "contributions.apply_corrections",
+      ],
       expectedRevision: null,
       requestedPayload: { amount: 9999 },
     });
@@ -371,7 +379,7 @@ describe("contribution operations action executor", () => {
     expect(validateApprovedCorrectionRequest).not.toHaveBeenCalled();
   });
 
-  it("requires provider capabilities before applying approved provider requests", async () => {
+  it("requires the direct apply capability before applying approved donor relinks", async () => {
     const validateApprovedCorrectionRequest = vi.fn();
 
     await expect(
@@ -380,6 +388,36 @@ describe("contribution operations action executor", () => {
         actorProfileId: "approver_1",
         actorPermissions: [],
         actorCapabilities: ["contributions.approve_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "donor_relink",
+        approvedRequestId: "request_relink",
+        payload: { donorId: "donor_new" },
+        dependencies: {
+          validateApprovedCorrectionRequest,
+          relinkDonor: vi.fn(),
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/apply_corrections/);
+
+    expect(validateApprovedCorrectionRequest).not.toHaveBeenCalled();
+  });
+
+  it("requires provider capabilities before applying approved provider requests", async () => {
+    const validateApprovedCorrectionRequest = vi.fn();
+
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "approver_1",
+        actorPermissions: [],
+        actorCapabilities: [
+          "contributions.approve_corrections",
+          "contributions.apply_corrections",
+        ],
         sourceSurface: "contribution_hub",
         contributionId: "donation_1",
         actionType: "refund",
@@ -478,7 +516,10 @@ describe("contribution operations action executor", () => {
         tenantId: "tenant_1",
         actorProfileId: "approver_1",
         actorPermissions: [],
-        actorCapabilities: ["contributions.approve_corrections"],
+        actorCapabilities: [
+          "contributions.approve_corrections",
+          "contributions.apply_corrections",
+        ],
         sourceSurface: "contribution_hub",
         contributionId: "donation_1",
         actionType: "amount_correction",
@@ -661,6 +702,8 @@ describe("contribution operations action executor", () => {
     expect(createCorrectionRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         actionType: "stripe_replay",
+        idempotencyKey:
+          "correction-request/tenant_1/donation_1/stripe_replay/confirm",
         payload: { stripeEventId: "evt_123" },
       }),
     );
@@ -698,7 +741,10 @@ describe("contribution operations action executor", () => {
 
     expect(refundContribution).not.toHaveBeenCalled();
     expect(createCorrectionRequest).toHaveBeenCalledWith(
-      expect.objectContaining({ actionType: "refund" }),
+      expect.objectContaining({
+        actionType: "refund",
+        idempotencyKey: "correction-request/tenant_1/donation_1/refund/confirm",
+      }),
     );
     expect(result.approvalStatus).toBe("pending_approval");
     expect(result.correctionRequestId).toBe("request_9");
@@ -893,6 +939,8 @@ describe("contribution operations action executor", () => {
         tenantId: "tenant_1",
         contributionId: "donation_1",
         actionType: "amount_correction",
+        idempotencyKey:
+          "correction-request/tenant_1/donation_1/amount_correction/confirm",
         payload: { amount: 1500 },
         reason: "Donor reported the wrong amount",
         requestedByProfileId: "profile_1",
@@ -902,6 +950,53 @@ describe("contribution operations action executor", () => {
     expect(result.correctionRequestId).toBe("request_1");
     expect(result.approvalStatus).toBe("pending_approval");
     expect(result.correctionId).toBeFalsy();
+  });
+
+  it("derives stable idempotency for pending correction requests without confirmation tokens", async () => {
+    const applyCorrection = vi.fn();
+    const createCorrectionRequest = vi.fn().mockResolvedValue("request_2");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "allocation_correction",
+      reason: "Split between two funds",
+      payload: {
+        allocations: [
+          { fundId: "fund_2", amount: 500 },
+          { amount: 250, fundId: "fund_3" },
+        ],
+      },
+      approvalPolicy: resolveCorrectionApprovalPolicy({
+        ownership_mode: "separation_of_duties",
+        suppressed_gates: [],
+        stronger_approval_categories: ["allocation_correction"],
+      }),
+      dependencies: {
+        applyCorrection,
+        createCorrectionRequest,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(applyCorrection).not.toHaveBeenCalled();
+    expect(createCorrectionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "allocation_correction",
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/allocation_correction\/payload-[0-9a-f]{32}$/,
+        ),
+      }),
+    );
   });
 
   it("requires the request capability to open a correction request", async () => {

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -94,6 +94,25 @@ describe("contribution operations action executor", () => {
     ).rejects.toThrow(/manage_receipts/);
   });
 
+  it("rejects metadata updates until the mutation adapter exists", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.apply_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "metadata_update",
+        payload: { note: "internal note" },
+        dependencies: {
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/metadata_update is not implemented/);
+  });
+
   it("creates correction and audit records for donor relinking", async () => {
     const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
     const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
@@ -238,6 +257,82 @@ describe("contribution operations action executor", () => {
     );
   });
 
+  it("validates approved correction requests and applies the persisted payload", async () => {
+    const validateApprovedCorrectionRequest = vi.fn().mockResolvedValue({
+      payload: { amount: 1200 },
+      reason: "Approved correction request",
+    });
+    const applyCorrection = vi.fn().mockResolvedValue({
+      before: { amount: 1000 },
+      after: { amount: 1200 },
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+      amount: { value: 1200 },
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "approver_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.apply_corrections"],
+      sourceSurface: "contribution_hub",
+      contributionId: "donation_1",
+      actionType: "amount_correction",
+      confirmationToken: "confirm",
+      approvedRequestId: "request_1",
+      payload: { amount: 9999 },
+      dependencies: {
+        validateApprovedCorrectionRequest,
+        applyCorrection,
+        createCorrectionRecord,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(validateApprovedCorrectionRequest).toHaveBeenCalledWith({
+      tenantId: "tenant_1",
+      contributionId: "donation_1",
+      actionType: "amount_correction",
+      approvedRequestId: "request_1",
+      actorProfileId: "approver_1",
+      actorCapabilities: ["contributions.apply_corrections"],
+      expectedRevision: null,
+      requestedPayload: { amount: 9999 },
+    });
+    expect(applyCorrection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { amount: 1200 },
+        reason: "Approved correction request",
+      }),
+    );
+  });
+
+  it("requires approved request validation before bypassing request creation", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "approver_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.apply_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "amount_correction",
+        confirmationToken: "confirm",
+        approvedRequestId: "request_1",
+        payload: { amount: 1200 },
+        dependencies: {
+          applyCorrection: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/validateApprovedCorrectionRequest/);
+  });
+
   it("records failed provider outcomes for refund attempts", async () => {
     const refundContribution = vi.fn().mockResolvedValue({
       provider: "stripe",
@@ -291,6 +386,33 @@ describe("contribution operations action executor", () => {
     expect(result.providerOutcome?.status).toBe("failed");
   });
 
+  it("rejects fractional refund amounts before calling the provider", async () => {
+    const refundContribution = vi.fn();
+
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: ["finance:manage_contributions"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "refund",
+        reason: "Duplicate payment",
+        confirmationToken: "confirm",
+        payload: { amount: 12.34 },
+        approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+        dependencies: {
+          refundContribution,
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/positive safe integer/);
+
+    expect(refundContribution).not.toHaveBeenCalled();
+  });
+
   it("routes Stripe replay through a dedicated provider adapter and audit trail", async () => {
     const replayStripeEvent = vi.fn().mockResolvedValue({
       provider: "stripe",
@@ -312,6 +434,7 @@ describe("contribution operations action executor", () => {
       actionType: "stripe_replay",
       reason: "Recover missing webhook",
       confirmationToken: "confirm",
+      expectedRevision: "rev_replay",
       payload: { stripeEventId: "evt_123" },
       approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
       dependencies: {
@@ -324,6 +447,9 @@ describe("contribution operations action executor", () => {
 
     expect(replayStripeEvent).toHaveBeenCalledWith({
       contributionId: "donation_1",
+      expectedRevision: "rev_replay",
+      idempotencyKey:
+        "contribution-action/tenant_1/donation_1/stripe_replay/confirm",
       payload: { stripeEventId: "evt_123" },
       tenantId: "tenant_1",
     });

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -262,6 +262,32 @@ describe("contribution operations action executor", () => {
     );
   });
 
+  it("requires an idempotency key before direct generic corrections", async () => {
+    const applyCorrection = vi.fn();
+
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.apply_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "allocation_correction",
+        reason: "Split between two funds",
+        payload: { allocations: [{ fundId: "fund_2", amount: 500 }] },
+        dependencies: {
+          applyCorrection,
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/idempotency key/);
+
+    expect(applyCorrection).not.toHaveBeenCalled();
+  });
+
   it("validates approved correction requests and applies the persisted payload", async () => {
     const validateApprovedCorrectionRequest = vi.fn().mockResolvedValue({
       payload: { amount: 1200 },
@@ -287,7 +313,6 @@ describe("contribution operations action executor", () => {
       contributionId: "donation_1",
       actionType: "amount_correction",
       reason: "Caller supplied override",
-      confirmationToken: "confirm",
       approvedRequestId: "request_1",
       payload: { amount: 9999 },
       dependencies: {
@@ -313,6 +338,8 @@ describe("contribution operations action executor", () => {
       expect.objectContaining({
         payload: { amount: 1200 },
         reason: "Approved correction request",
+        idempotencyKey:
+          "approved-correction/tenant_1/donation_1/amount_correction/request_1",
       }),
     );
   });
@@ -394,6 +421,55 @@ describe("contribution operations action executor", () => {
     ).rejects.toThrow(/use_provider_actions/);
 
     expect(validateApprovedCorrectionRequest).not.toHaveBeenCalled();
+  });
+
+  it("uses the approved request id as the idempotency key for approved provider applies", async () => {
+    const validateApprovedCorrectionRequest = vi.fn().mockResolvedValue({
+      payload: { amount: 500 },
+      reason: "Approved refund request",
+    });
+    const refundContribution = vi.fn().mockResolvedValue({
+      provider: "stripe",
+      status: "succeeded",
+      referenceId: "refund_1",
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "approver_1",
+      actorPermissions: [],
+      actorCapabilities: [
+        "contributions.approve_corrections",
+        "contributions.run_refunds",
+      ],
+      sourceSurface: "contribution_hub",
+      contributionId: "donation_1",
+      actionType: "refund",
+      approvedRequestId: "request_refund",
+      payload: { amount: 999 },
+      dependencies: {
+        validateApprovedCorrectionRequest,
+        refundContribution,
+        createCorrectionRecord,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(refundContribution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 500,
+        reason: "Approved refund request",
+        confirmationToken: "request_refund",
+        idempotencyKey:
+          "approved-contribution-action/tenant_1/donation_1/refund/request_refund",
+      }),
+    );
   });
 
   it("requires approved request validation before bypassing request creation", async () => {

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -111,6 +111,45 @@ describe("contribution operations action executor", () => {
     expect(result.auditEventId).toBe("audit_1");
   });
 
+  it("normalizes top-level staged gift IDs before calling staged adapters", async () => {
+    const retryStagedGift = vi.fn().mockResolvedValue(undefined);
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+      tenantId: "tenant_1",
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.retry_crm_post"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      stagedGiftId: " staged_1 ",
+      actionType: "retry_staged_gift",
+      reason: "Retry parent gift post",
+      payload: { scope: "parent" },
+      dependencies: {
+        retryStagedGift,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(retryStagedGift).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contributionId: "donation_1",
+        stagedGiftId: "staged_1",
+      }),
+    );
+    expect(appendAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stagedGiftId: "staged_1",
+      }),
+    );
+  });
+
   it("requires the receipt management capability for receipt resends", async () => {
     await expect(
       executeContributionAction({
@@ -249,6 +288,60 @@ describe("contribution operations action executor", () => {
     );
     expect(result.approvalStatus).toBe("pending_approval");
     expect(result.correctionRequestId).toBe("request_7");
+  });
+
+  it("uses normalized donor IDs for direct fallback idempotency keys", async () => {
+    const relinkDonor = vi.fn().mockResolvedValue({
+      before: { donorId: "donor_old" },
+      after: { donorId: "donor_new" },
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+      donor: { id: "donor_new" },
+    });
+    const sharedDependencies = {
+      relinkDonor,
+      createCorrectionRecord,
+      appendAuditEvent,
+      loadContributionDetail,
+    };
+    const baseInput = {
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.apply_corrections"],
+      sourceSurface: "contribution_hub" as const,
+      contributionId: "donation_1",
+      actionType: "donor_relink" as const,
+      reason: "Merged duplicate donor",
+      confirmationToken: "confirm",
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+      dependencies: sharedDependencies,
+    };
+
+    await executeContributionAction({
+      ...baseInput,
+      payload: { donorId: " donor_new " },
+    });
+    await executeContributionAction({
+      ...baseInput,
+      payload: { donorId: "donor_new" },
+    });
+    await executeContributionAction({
+      ...baseInput,
+      payload: { donorId: "donor_other" },
+    });
+
+    const idempotencyKeys = relinkDonor.mock.calls.map(
+      ([call]) => call.idempotencyKey,
+    );
+    expect(idempotencyKeys[0]).toMatch(
+      /^contribution-action\/tenant_1\/donation_1\/donor_relink\/confirmation-[0-9a-f]{32}$/,
+    );
+    expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
+    expect(idempotencyKeys[2]).not.toBe(idempotencyKeys[0]);
   });
 
   it("applies amount corrections before writing correction and audit records", async () => {
@@ -640,7 +733,7 @@ describe("contribution operations action executor", () => {
       provider: "stripe",
       status: "failed",
       errorCode: "card_error",
-      errorMessage: "Refund failed",
+      errorMessage: "Refund failed for donor@example.com",
       raw: { cardholderName: "Sensitive Name" },
     });
     const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
@@ -688,6 +781,12 @@ describe("contribution operations action executor", () => {
     expect(correctionProviderOutcome).not.toHaveProperty("raw");
     expect(auditProviderOutcome).not.toHaveProperty("raw");
     expect(result.providerOutcome).not.toHaveProperty("raw");
+    expect(correctionProviderOutcome?.errorMessage).toBe(
+      "Provider action failed. Check provider logs for details.",
+    );
+    expect(correctionProviderOutcome?.errorMessage).not.toContain(
+      "donor@example.com",
+    );
     expect(refundContribution).toHaveBeenCalledWith(
       expect.objectContaining({
         confirmationToken: "confirm",
@@ -794,6 +893,7 @@ describe("contribution operations action executor", () => {
       provider: "stripe",
       status: "queued_for_replay",
       referenceId: "evt_123",
+      errorMessage: "Replay queued for donor@example.com",
       raw: { customerEmail: "donor@example.com" },
     });
     const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
@@ -845,6 +945,12 @@ describe("contribution operations action executor", () => {
       createCorrectionRecord.mock.calls[0]?.[0]?.providerOutcome;
 
     expect(correctionProviderOutcome).not.toHaveProperty("raw");
+    expect(correctionProviderOutcome?.errorMessage).toBe(
+      "Provider action failed. Check provider logs for details.",
+    );
+    expect(correctionProviderOutcome?.errorMessage).not.toContain(
+      "donor@example.com",
+    );
     expect(result.providerOutcome).not.toHaveProperty("raw");
     expect(result.providerOutcome?.referenceId).toBe("evt_123");
   });

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -945,12 +945,7 @@ describe("contribution operations action executor", () => {
       createCorrectionRecord.mock.calls[0]?.[0]?.providerOutcome;
 
     expect(correctionProviderOutcome).not.toHaveProperty("raw");
-    expect(correctionProviderOutcome?.errorMessage).toBe(
-      "Provider action failed. Check provider logs for details.",
-    );
-    expect(correctionProviderOutcome?.errorMessage).not.toContain(
-      "donor@example.com",
-    );
+    expect(correctionProviderOutcome?.errorMessage).toBeNull();
     expect(result.providerOutcome).not.toHaveProperty("raw");
     expect(result.providerOutcome?.referenceId).toBe("evt_123");
   });

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -202,8 +202,9 @@ describe("contribution operations action executor", () => {
     expect(createCorrectionRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         actionType: "donor_relink",
-        idempotencyKey:
-          "correction-request/tenant_1/donation_1/donor_relink/confirm",
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/donor_relink\/confirmation-[0-9a-f]{32}$/,
+        ),
         payload: { donorId: "donor_new" },
       }),
     );
@@ -702,8 +703,9 @@ describe("contribution operations action executor", () => {
     expect(createCorrectionRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         actionType: "stripe_replay",
-        idempotencyKey:
-          "correction-request/tenant_1/donation_1/stripe_replay/confirm",
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/stripe_replay\/confirmation-[0-9a-f]{32}$/,
+        ),
         payload: { stripeEventId: "evt_123" },
       }),
     );
@@ -743,7 +745,9 @@ describe("contribution operations action executor", () => {
     expect(createCorrectionRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         actionType: "refund",
-        idempotencyKey: "correction-request/tenant_1/donation_1/refund/confirm",
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/refund\/confirmation-[0-9a-f]{32}$/,
+        ),
       }),
     );
     expect(result.approvalStatus).toBe("pending_approval");
@@ -939,8 +943,9 @@ describe("contribution operations action executor", () => {
         tenantId: "tenant_1",
         contributionId: "donation_1",
         actionType: "amount_correction",
-        idempotencyKey:
-          "correction-request/tenant_1/donation_1/amount_correction/confirm",
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/amount_correction\/confirmation-[0-9a-f]{32}$/,
+        ),
         payload: { amount: 1500 },
         reason: "Donor reported the wrong amount",
         requestedByProfileId: "profile_1",
@@ -950,6 +955,73 @@ describe("contribution operations action executor", () => {
     expect(result.correctionRequestId).toBe("request_1");
     expect(result.approvalStatus).toBe("pending_approval");
     expect(result.correctionId).toBeFalsy();
+  });
+
+  it("includes request context in confirmation-token correction request idempotency", async () => {
+    const applyCorrection = vi.fn();
+    const createCorrectionRequest = vi.fn().mockResolvedValue("request_2");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    const sharedDependencies = {
+      applyCorrection,
+      createCorrectionRequest,
+      appendAuditEvent,
+      loadContributionDetail,
+    };
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "amount_correction",
+      reason: "Donor reported the wrong amount",
+      confirmationToken: "confirm",
+      payload: { amount: 1500 },
+      approvalPolicy: resolveCorrectionApprovalPolicy(null),
+      dependencies: sharedDependencies,
+    });
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_2",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "amount_correction",
+      reason: "Different requester with the same acknowledgement token",
+      confirmationToken: "confirm",
+      payload: { amount: 1500 },
+      approvalPolicy: resolveCorrectionApprovalPolicy(null),
+      dependencies: sharedDependencies,
+    });
+
+    expect(applyCorrection).not.toHaveBeenCalled();
+    expect(createCorrectionRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/amount_correction\/confirmation-[0-9a-f]{32}$/,
+        ),
+      }),
+    );
+    expect(createCorrectionRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^correction-request\/tenant_1\/donation_1\/amount_correction\/confirmation-[0-9a-f]{32}$/,
+        ),
+      }),
+    );
+    const firstKey = createCorrectionRequest.mock.calls[0]?.[0]?.idempotencyKey;
+    const secondKey =
+      createCorrectionRequest.mock.calls[1]?.[0]?.idempotencyKey;
+    expect(secondKey).not.toBe(firstKey);
   });
 
   it("derives context-specific idempotency for pending correction requests without confirmation tokens", async () => {

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -45,7 +45,7 @@ describe("contribution operations action executor", () => {
       sourceSurface: "donor_crm_record",
       contributionId: "donation_1",
       actionType: "resend_receipt",
-      payload: { stagedGiftId: "staged_1" },
+      payload: { stagedGiftId: " staged_1 " },
       dependencies: {
         sendReceipt,
         appendAuditEvent,
@@ -93,7 +93,7 @@ describe("contribution operations action executor", () => {
       contributionId: "donation_1",
       actionType: "approve_staged_gift",
       reason: "Reviewed staging failure",
-      payload: { stagedGiftId: "staged_1" },
+      payload: { stagedGiftId: " staged_1 " },
       dependencies: {
         approveStagedGift,
         appendAuditEvent,
@@ -172,7 +172,7 @@ describe("contribution operations action executor", () => {
       reason: "Merged duplicate donor",
       confirmationToken: "confirm",
       expectedRevision: "rev_relink",
-      payload: { donorId: "donor_new" },
+      payload: { donorId: " donor_new " },
       approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
       dependencies: {
         createCorrectionRecord,
@@ -194,11 +194,13 @@ describe("contribution operations action executor", () => {
     expect(createCorrectionRecord).toHaveBeenCalledWith(
       expect.objectContaining({
         correctionType: "donor_relink",
+        afterSummary: { donorId: "donor_new" },
         reason: "Merged duplicate donor",
       }),
     );
     expect(appendAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({
+        afterSummary: { donorId: "donor_new" },
         correctionId: "correction_1",
         reason: "Merged duplicate donor",
       }),
@@ -639,6 +641,7 @@ describe("contribution operations action executor", () => {
       status: "failed",
       errorCode: "card_error",
       errorMessage: "Refund failed",
+      raw: { cardholderName: "Sensitive Name" },
     });
     const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
     const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
@@ -677,6 +680,14 @@ describe("contribution operations action executor", () => {
         }),
       }),
     );
+    const correctionProviderOutcome =
+      createCorrectionRecord.mock.calls[0]?.[0]?.providerOutcome;
+    const auditProviderOutcome =
+      appendAuditEvent.mock.calls[0]?.[0]?.providerOutcome;
+
+    expect(correctionProviderOutcome).not.toHaveProperty("raw");
+    expect(auditProviderOutcome).not.toHaveProperty("raw");
+    expect(result.providerOutcome).not.toHaveProperty("raw");
     expect(refundContribution).toHaveBeenCalledWith(
       expect.objectContaining({
         confirmationToken: "confirm",
@@ -783,6 +794,7 @@ describe("contribution operations action executor", () => {
       provider: "stripe",
       status: "queued_for_replay",
       referenceId: "evt_123",
+      raw: { customerEmail: "donor@example.com" },
     });
     const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
     const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
@@ -829,6 +841,11 @@ describe("contribution operations action executor", () => {
         }),
       }),
     );
+    const correctionProviderOutcome =
+      createCorrectionRecord.mock.calls[0]?.[0]?.providerOutcome;
+
+    expect(correctionProviderOutcome).not.toHaveProperty("raw");
+    expect(result.providerOutcome).not.toHaveProperty("raw");
     expect(result.providerOutcome?.referenceId).toBe("evt_123");
   });
 
@@ -1020,9 +1037,9 @@ describe("contribution operations action executor", () => {
       contributionId: "donation_1",
       actionType: "retry_staged_gift",
       payload: {
-        stagedGiftId: "staged_1",
+        stagedGiftId: " staged_1 ",
         scope: "designation",
-        allocationId: "alloc_2",
+        allocationId: " alloc_2 ",
       },
       dependencies: {
         retryDesignationPost,
@@ -1067,7 +1084,7 @@ describe("contribution operations action executor", () => {
       actionType: "retry_staged_gift",
       reason: "Retry parent gift post",
       payload: {
-        stagedGiftId: "staged_1",
+        stagedGiftId: " staged_1 ",
         scope: "parent",
       },
       dependencies: {

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -16,6 +16,7 @@ describe("contribution operations action executor", () => {
         tenantId: "tenant_1",
         actorProfileId: "profile_1",
         actorPermissions: ["finance:manage_contributions"],
+        actorCapabilities: ["contributions.run_refunds"],
         sourceSurface: "contribution_hub",
         contributionId: "donation_1",
         actionType: "refund",
@@ -134,6 +135,7 @@ describe("contribution operations action executor", () => {
       actionType: "donor_relink",
       reason: "Merged duplicate donor",
       confirmationToken: "confirm",
+      expectedRevision: "rev_relink",
       payload: { donorId: "donor_new" },
       approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
       dependencies: {
@@ -148,6 +150,9 @@ describe("contribution operations action executor", () => {
       tenantId: "tenant_1",
       contributionId: "donation_1",
       donorId: "donor_new",
+      expectedRevision: "rev_relink",
+      idempotencyKey:
+        "contribution-action/tenant_1/donation_1/donor_relink/confirm",
     });
     expect(createCorrectionRecord).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -277,10 +282,11 @@ describe("contribution operations action executor", () => {
       tenantId: "tenant_1",
       actorProfileId: "approver_1",
       actorPermissions: [],
-      actorCapabilities: ["contributions.apply_corrections"],
+      actorCapabilities: ["contributions.approve_corrections"],
       sourceSurface: "contribution_hub",
       contributionId: "donation_1",
       actionType: "amount_correction",
+      reason: "Caller supplied override",
       confirmationToken: "confirm",
       approvedRequestId: "request_1",
       payload: { amount: 9999 },
@@ -299,7 +305,7 @@ describe("contribution operations action executor", () => {
       actionType: "amount_correction",
       approvedRequestId: "request_1",
       actorProfileId: "approver_1",
-      actorCapabilities: ["contributions.apply_corrections"],
+      actorCapabilities: ["contributions.approve_corrections"],
       expectedRevision: null,
       requestedPayload: { amount: 9999 },
     });
@@ -311,13 +317,40 @@ describe("contribution operations action executor", () => {
     );
   });
 
-  it("requires approved request validation before bypassing request creation", async () => {
+  it("requires the approval capability before applying an approved request", async () => {
+    const validateApprovedCorrectionRequest = vi.fn();
+
     await expect(
       executeContributionAction({
         tenantId: "tenant_1",
         actorProfileId: "approver_1",
         actorPermissions: [],
         actorCapabilities: ["contributions.apply_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "amount_correction",
+        confirmationToken: "confirm",
+        approvedRequestId: "request_1",
+        payload: { amount: 1200 },
+        dependencies: {
+          validateApprovedCorrectionRequest,
+          applyCorrection: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/approve_corrections/);
+
+    expect(validateApprovedCorrectionRequest).not.toHaveBeenCalled();
+  });
+
+  it("requires approved request validation before bypassing request creation", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "approver_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.approve_corrections"],
         sourceSurface: "contribution_hub",
         contributionId: "donation_1",
         actionType: "amount_correction",
@@ -350,6 +383,7 @@ describe("contribution operations action executor", () => {
       tenantId: "tenant_1",
       actorProfileId: "profile_1",
       actorPermissions: ["finance:manage_contributions"],
+      actorCapabilities: ["contributions.run_refunds"],
       sourceSurface: "contribution_hub",
       contributionId: "donation_1",
       actionType: "refund",
@@ -394,6 +428,7 @@ describe("contribution operations action executor", () => {
         tenantId: "tenant_1",
         actorProfileId: "profile_1",
         actorPermissions: ["finance:manage_contributions"],
+        actorCapabilities: ["contributions.run_refunds"],
         sourceSurface: "contribution_hub",
         contributionId: "donation_1",
         actionType: "refund",
@@ -429,6 +464,7 @@ describe("contribution operations action executor", () => {
       tenantId: "tenant_1",
       actorProfileId: "profile_1",
       actorPermissions: ["finance:manage_contributions"],
+      actorCapabilities: ["contributions.use_provider_actions"],
       sourceSurface: "contribution_hub",
       contributionId: "donation_1",
       actionType: "stripe_replay",
@@ -562,6 +598,50 @@ describe("contribution operations action executor", () => {
         },
       }),
     ).rejects.toThrow(/run_refunds/);
+  });
+
+  it("does not let the legacy permission bypass direct provider capabilities", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: ["finance:manage_contributions"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "refund",
+        reason: "Duplicate payment",
+        confirmationToken: "confirm",
+        payload: { amount: 500 },
+        approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+        dependencies: {
+          refundContribution: vi.fn(),
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/run_refunds/);
+
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: ["finance:manage_contributions"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "stripe_replay",
+        reason: "Recover missing webhook",
+        confirmationToken: "confirm",
+        payload: { stripeEventId: "evt_123" },
+        approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+        dependencies: {
+          replayStripeEvent: vi.fn(),
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/use_provider_actions/);
   });
 
   it("requires the CRM retry capability for staged gift retries", async () => {

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -1,0 +1,495 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { executeContributionAction } from "../../../../../packages/api/src/admin/contribution-operations/actions";
+import { resolveCorrectionApprovalPolicy } from "../../../../../packages/api/src/admin/contribution-operations/approval-policy";
+
+const APPROVAL_SUPPRESSED_POLICY = resolveCorrectionApprovalPolicy({
+  ownership_mode: "no_approval_required",
+  suppressed_gates: [],
+  stronger_approval_categories: [],
+});
+
+describe("contribution operations action executor", () => {
+  it("rejects high-risk actions without reason and confirmation", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: ["finance:manage_contributions"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "refund",
+        payload: { amount: 1000 },
+        dependencies: {},
+      }),
+    ).rejects.toThrow("reason");
+  });
+
+  it("executes receipt resend through the shared contract and writes audit", async () => {
+    const sendReceipt = vi.fn().mockResolvedValue({
+      status: "sent",
+      sendLogId: "send_1",
+    });
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+      tenantId: "tenant_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "resend_receipt",
+      payload: { stagedGiftId: "staged_1" },
+      dependencies: {
+        sendReceipt,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(sendReceipt).toHaveBeenCalledWith({
+      tenantId: "tenant_1",
+      stagedGiftId: "staged_1",
+    });
+    expect(appendAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        contributionId: "donation_1",
+        actionType: "resend_receipt",
+        sourceSurface: "donor_crm_record",
+      }),
+    );
+    expect(result.auditEventId).toBe("audit_1");
+    expect(result.canonicalContribution.id).toBe("donation_1");
+    expect(result.providerOutcome).toEqual({
+      provider: "resend",
+      status: "sent",
+      referenceId: "send_1",
+    });
+  });
+
+  it("creates correction and audit records for donor relinking", async () => {
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const relinkDonor = vi.fn().mockResolvedValue({
+      before: { donorId: "donor_old" },
+      after: { donorId: "donor_new" },
+    });
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+      donor: { id: "donor_new" },
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: ["finance:manage_contributions"],
+      sourceSurface: "contribution_hub",
+      contributionId: "donation_1",
+      actionType: "donor_relink",
+      reason: "Merged duplicate donor",
+      confirmationToken: "confirm",
+      payload: { donorId: "donor_new" },
+      dependencies: {
+        createCorrectionRecord,
+        appendAuditEvent,
+        relinkDonor,
+        loadContributionDetail,
+      },
+    });
+
+    expect(relinkDonor).toHaveBeenCalledWith({
+      tenantId: "tenant_1",
+      contributionId: "donation_1",
+      donorId: "donor_new",
+    });
+    expect(createCorrectionRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correctionType: "donor_relink",
+        reason: "Merged duplicate donor",
+      }),
+    );
+    expect(appendAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correctionId: "correction_1",
+        reason: "Merged duplicate donor",
+      }),
+    );
+    expect(result.correctionId).toBe("correction_1");
+    expect(result.auditEventId).toBe("audit_1");
+  });
+
+  it("applies amount corrections before writing correction and audit records", async () => {
+    const applyCorrection = vi.fn().mockResolvedValue({
+      before: { amount: 1000 },
+      after: { amount: 1200 },
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+      amount: { value: 1200 },
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: ["finance:manage_contributions"],
+      sourceSurface: "contribution_hub",
+      contributionId: "donation_1",
+      actionType: "amount_correction",
+      reason: "Corrected imported check amount",
+      confirmationToken: "confirm",
+      payload: { amount: 1200 },
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+      dependencies: {
+        applyCorrection,
+        createCorrectionRecord,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(applyCorrection).toHaveBeenCalledWith({
+      actionType: "amount_correction",
+      contributionId: "donation_1",
+      payload: { amount: 1200 },
+      tenantId: "tenant_1",
+      reason: "Corrected imported check amount",
+      actorProfileId: "profile_1",
+      sourceSurface: "contribution_hub",
+      expectedRevision: null,
+      idempotencyKey:
+        "correction/tenant_1/donation_1/amount_correction/confirm",
+    });
+    expect(createCorrectionRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beforeSummary: { amount: 1000 },
+        afterSummary: { amount: 1200 },
+        correctionType: "amount_correction",
+        status: "applied",
+      }),
+    );
+  });
+
+  it("records failed provider outcomes for refund attempts", async () => {
+    const refundContribution = vi.fn().mockResolvedValue({
+      provider: "stripe",
+      status: "failed",
+      errorCode: "card_error",
+      errorMessage: "Refund failed",
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: ["finance:manage_contributions"],
+      sourceSurface: "contribution_hub",
+      contributionId: "donation_1",
+      actionType: "refund",
+      reason: "Duplicate payment",
+      confirmationToken: "confirm",
+      payload: { amount: 500 },
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+      dependencies: {
+        refundContribution,
+        createCorrectionRecord,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(createCorrectionRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        providerOutcome: expect.objectContaining({
+          provider: "stripe",
+          status: "failed",
+        }),
+      }),
+    );
+    expect(refundContribution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        confirmationToken: "confirm",
+      }),
+    );
+    expect(result.providerOutcome?.status).toBe("failed");
+  });
+
+  it("routes Stripe replay through a dedicated provider adapter and audit trail", async () => {
+    const replayStripeEvent = vi.fn().mockResolvedValue({
+      provider: "stripe",
+      status: "queued_for_replay",
+      referenceId: "evt_123",
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: ["finance:manage_contributions"],
+      sourceSurface: "contribution_hub",
+      contributionId: "donation_1",
+      actionType: "stripe_replay",
+      reason: "Recover missing webhook",
+      confirmationToken: "confirm",
+      payload: { stripeEventId: "evt_123" },
+      dependencies: {
+        replayStripeEvent,
+        createCorrectionRecord,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(replayStripeEvent).toHaveBeenCalledWith({
+      contributionId: "donation_1",
+      payload: { stripeEventId: "evt_123" },
+      tenantId: "tenant_1",
+    });
+    expect(createCorrectionRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correctionType: "stripe_replay",
+        providerOutcome: expect.objectContaining({
+          referenceId: "evt_123",
+          status: "queued_for_replay",
+        }),
+      }),
+    );
+    expect(result.providerOutcome?.referenceId).toBe("evt_123");
+  });
+
+  it("routes refunds through correction requests under default approval policy", async () => {
+    const refundContribution = vi.fn();
+    const createCorrectionRequest = vi.fn().mockResolvedValue("request_9");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "refund",
+      reason: "Donor requested a refund",
+      confirmationToken: "confirm",
+      payload: { amount: 500 },
+      approvalPolicy: resolveCorrectionApprovalPolicy(null),
+      dependencies: {
+        refundContribution,
+        createCorrectionRequest,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(refundContribution).not.toHaveBeenCalled();
+    expect(createCorrectionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ actionType: "refund" }),
+    );
+    expect(result.approvalStatus).toBe("pending_approval");
+    expect(result.correctionRequestId).toBe("request_9");
+  });
+
+  it("requires the run_refunds capability for direct refunds when approval is suppressed", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.request_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "refund",
+        reason: "Duplicate payment",
+        confirmationToken: "confirm",
+        payload: { amount: 500 },
+        approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+        dependencies: {
+          refundContribution: vi.fn(),
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/run_refunds/);
+  });
+
+  it("retries a single designation child record without reposting unrelated lines", async () => {
+    const retryDesignationPost = vi.fn().mockResolvedValue(undefined);
+    const retryStagedGift = vi.fn();
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "retry_staged_gift",
+      payload: {
+        stagedGiftId: "staged_1",
+        scope: "designation",
+        allocationId: "alloc_2",
+      },
+      dependencies: {
+        retryDesignationPost,
+        retryStagedGift,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(retryDesignationPost).toHaveBeenCalledWith(
+      expect.objectContaining({ allocationId: "alloc_2" }),
+    );
+    expect(retryStagedGift).not.toHaveBeenCalled();
+    expect(appendAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        downstreamEffects: expect.objectContaining({
+          retryScope: "designation",
+          allocationId: "alloc_2",
+        }),
+      }),
+    );
+  });
+
+  it("surfaces the adapter limitation when child record retries are unsupported", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        sourceSurface: "donor_crm_record",
+        contributionId: "donation_1",
+        actionType: "retry_staged_gift",
+        payload: {
+          stagedGiftId: "staged_1",
+          scope: "designation",
+          allocationId: "alloc_2",
+        },
+        dependencies: {
+          retryStagedGift: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/does not support posting designation child records/i);
+  });
+
+  it("creates a correction request instead of applying high-risk corrections under default policy", async () => {
+    const applyCorrection = vi.fn();
+    const createCorrectionRequest = vi.fn().mockResolvedValue("request_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: ["finance:manage_contributions"],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "amount_correction",
+      reason: "Donor reported the wrong amount",
+      confirmationToken: "confirm",
+      payload: { amount: 1500 },
+      approvalPolicy: resolveCorrectionApprovalPolicy(null),
+      dependencies: {
+        applyCorrection,
+        createCorrectionRequest,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(applyCorrection).not.toHaveBeenCalled();
+    expect(createCorrectionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant_1",
+        contributionId: "donation_1",
+        actionType: "amount_correction",
+        payload: { amount: 1500 },
+        reason: "Donor reported the wrong amount",
+        requestedByProfileId: "profile_1",
+        sourceSurface: "donor_crm_record",
+      }),
+    );
+    expect(result.correctionRequestId).toBe("request_1");
+    expect(result.approvalStatus).toBe("pending_approval");
+    expect(result.correctionId).toBeFalsy();
+  });
+
+  it("requires the request capability to open a correction request", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.view_detail"],
+        sourceSurface: "donor_crm_record",
+        contributionId: "donation_1",
+        actionType: "allocation_correction",
+        reason: "Split between two funds",
+        payload: { fundId: "fund_2" },
+        approvalPolicy: resolveCorrectionApprovalPolicy({
+          ownership_mode: "separation_of_duties",
+          suppressed_gates: [],
+          stronger_approval_categories: ["allocation_correction"],
+        }),
+        dependencies: {
+          createCorrectionRequest: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/request_corrections/);
+  });
+
+  it("requires the apply capability for direct high-risk corrections when approval is suppressed", async () => {
+    await expect(
+      executeContributionAction({
+        tenantId: "tenant_1",
+        actorProfileId: "profile_1",
+        actorPermissions: [],
+        actorCapabilities: ["contributions.request_corrections"],
+        sourceSurface: "contribution_hub",
+        contributionId: "donation_1",
+        actionType: "amount_correction",
+        reason: "fix",
+        confirmationToken: "confirm",
+        payload: { amount: 100 },
+        approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+        dependencies: {
+          applyCorrection: vi.fn(),
+          createCorrectionRecord: vi.fn(),
+          appendAuditEvent: vi.fn(),
+          loadContributionDetail: vi.fn(),
+        },
+      }),
+    ).rejects.toThrow(/apply_corrections|finance:manage_contributions/);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -55,6 +55,7 @@ describe("contribution operations action executor", () => {
 
     expect(sendReceipt).toHaveBeenCalledWith({
       tenantId: "tenant_1",
+      contributionId: "donation_1",
       stagedGiftId: "staged_1",
     });
     expect(appendAuditEvent).toHaveBeenCalledWith(
@@ -73,6 +74,41 @@ describe("contribution operations action executor", () => {
       status: "sent",
       referenceId: "send_1",
     });
+  });
+
+  it("passes contribution identity to staged gift approval adapters", async () => {
+    const approveStagedGift = vi.fn().mockResolvedValue(undefined);
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+      tenantId: "tenant_1",
+    });
+
+    const result = await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.apply_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "approve_staged_gift",
+      reason: "Reviewed staging failure",
+      payload: { stagedGiftId: "staged_1" },
+      dependencies: {
+        approveStagedGift,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(approveStagedGift).toHaveBeenCalledWith({
+      tenantId: "tenant_1",
+      contributionId: "donation_1",
+      stagedGiftId: "staged_1",
+      actorProfileId: "profile_1",
+      note: "Reviewed staging failure",
+    });
+    expect(result.auditEventId).toBe("audit_1");
   });
 
   it("requires the receipt management capability for receipt resends", async () => {
@@ -303,8 +339,12 @@ describe("contribution operations action executor", () => {
     });
     await executeContributionAction({
       ...baseInput,
+      actorProfileId: "profile_2",
       confirmationToken: "confirm",
+      expectedRevision: "rev_retry",
       payload: { amount: 1200 },
+      reason: "Retry after ambiguous provider response",
+      sourceSurface: "api",
     });
     await executeContributionAction({
       ...baseInput,
@@ -712,8 +752,12 @@ describe("contribution operations action executor", () => {
     });
     await executeContributionAction({
       ...baseInput,
+      actorProfileId: "profile_2",
       confirmationToken: "confirm",
+      expectedRevision: "rev_retry",
       payload: { amount: 500 },
+      reason: "Retry after ambiguous provider response",
+      sourceSurface: "api",
     });
     await executeContributionAction({
       ...baseInput,
@@ -729,6 +773,9 @@ describe("contribution operations action executor", () => {
     );
     expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
     expect(idempotencyKeys[2]).not.toBe(idempotencyKeys[0]);
+    expect(
+      refundContribution.mock.calls.map(([call]) => call.confirmationToken),
+    ).toEqual(["confirm", "confirm", "confirm"]);
   });
 
   it("routes Stripe replay through a dedicated provider adapter and audit trail", async () => {
@@ -986,7 +1033,11 @@ describe("contribution operations action executor", () => {
     });
 
     expect(retryDesignationPost).toHaveBeenCalledWith(
-      expect.objectContaining({ allocationId: "alloc_2" }),
+      expect.objectContaining({
+        allocationId: "alloc_2",
+        contributionId: "donation_1",
+        stagedGiftId: "staged_1",
+      }),
     );
     expect(retryStagedGift).not.toHaveBeenCalled();
     expect(appendAuditEvent).toHaveBeenCalledWith(
@@ -997,6 +1048,42 @@ describe("contribution operations action executor", () => {
         }),
       }),
     );
+  });
+
+  it("passes contribution identity to parent staged gift retry adapters", async () => {
+    const retryStagedGift = vi.fn().mockResolvedValue(undefined);
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.retry_crm_post"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "retry_staged_gift",
+      reason: "Retry parent gift post",
+      payload: {
+        stagedGiftId: "staged_1",
+        scope: "parent",
+      },
+      dependencies: {
+        retryStagedGift,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(retryStagedGift).toHaveBeenCalledWith({
+      tenantId: "tenant_1",
+      contributionId: "donation_1",
+      stagedGiftId: "staged_1",
+      actorProfileId: "profile_1",
+      note: "Retry parent gift post",
+    });
   });
 
   it("surfaces the adapter limitation when child record retries are unsupported", async () => {

--- a/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
@@ -95,6 +95,42 @@ describe("contribution operations permissions", () => {
     ).not.toThrow();
   });
 
+  it("allows donor-care staff to request inline correction actions", () => {
+    const donorCare = authContext({
+      memberships: [
+        {
+          tenantId: "tenant_1",
+          role: "staff",
+          staffRole: "development",
+          isActive: true,
+        },
+      ],
+    });
+
+    expect(() =>
+      assertContributionActionPermission(donorCare, "amount_correction"),
+    ).not.toThrow();
+    expect(() =>
+      assertContributionActionPermission(donorCare, "fund_correction"),
+    ).not.toThrow();
+    expect(() =>
+      assertContributionActionPermission(donorCare, "resend_receipt"),
+    ).toThrow("contributions.manage_receipts");
+    expect(() =>
+      assertContributionActionPermission(donorCare, "donor_relink"),
+    ).toThrow("contributions.apply_corrections");
+  });
+
+  it("still blocks correction request actions without tenant staff membership", () => {
+    const nonMember = authContext({ role: "staff", profileRole: "staff" });
+
+    expect(() =>
+      assertContributionActionPermission(nonMember, "amount_correction"),
+    ).toThrow(
+      "contributions.apply_corrections or contributions.request_corrections",
+    );
+  });
+
   it("resolves granular capabilities backing staff-friendly roles", () => {
     const donorCare = resolveContributionCapabilities(
       authContext({

--- a/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertContributionActionPermission,
+  hasContributionPermission,
+  resolveContributionCapabilities,
+} from "../../../../../packages/api/src/admin/contribution-operations/permissions";
+
+import type { AuthenticatedContext } from "@asym/auth/context";
+
+function authContext(
+  overrides: Partial<AuthenticatedContext>,
+): AuthenticatedContext {
+  return {
+    userId: "user_1",
+    email: "finance@example.com",
+    tenantId: "tenant_1",
+    role: "staff",
+    profileRole: "staff",
+    memberships: [],
+    profileId: "profile_1",
+    isAuthenticated: true,
+    ...overrides,
+  };
+}
+
+describe("contribution operations permissions", () => {
+  it("allows finance staff to perform high-risk contribution actions", () => {
+    const auth = authContext({
+      memberships: [
+        {
+          tenantId: "tenant_1",
+          role: "staff",
+          staffRole: "finance",
+          isActive: true,
+        },
+      ],
+    });
+
+    expect(
+      hasContributionPermission(auth, "finance:manage_contributions"),
+    ).toBe(true);
+    expect(() =>
+      assertContributionActionPermission(auth, "refund"),
+    ).not.toThrow();
+  });
+
+  it("allows admins to perform high-risk contribution actions", () => {
+    const auth = authContext({ role: "admin", profileRole: "admin" });
+
+    expect(() =>
+      assertContributionActionPermission(auth, "donor_relink"),
+    ).not.toThrow();
+  });
+
+  it("blocks non-finance staff from high-risk contribution actions", () => {
+    const auth = authContext({
+      memberships: [
+        {
+          tenantId: "tenant_1",
+          role: "staff",
+          staffRole: "development",
+          isActive: true,
+        },
+      ],
+    });
+
+    expect(
+      hasContributionPermission(auth, "finance:manage_contributions"),
+    ).toBe(false);
+    expect(() => assertContributionActionPermission(auth, "refund")).toThrow(
+      "finance:manage_contributions",
+    );
+  });
+
+  it("allows low-risk contribution actions for staff roles", () => {
+    const auth = authContext({ role: "staff", profileRole: "staff" });
+
+    expect(() =>
+      assertContributionActionPermission(auth, "resend_receipt"),
+    ).not.toThrow();
+  });
+
+  it("resolves granular capabilities backing staff-friendly roles", () => {
+    const donorCare = resolveContributionCapabilities(
+      authContext({ role: "staff", profileRole: "staff" }),
+    );
+    expect(donorCare).toContain("contributions.view_detail");
+    expect(donorCare).toContain("contributions.request_corrections");
+    expect(donorCare).not.toContain("contributions.apply_corrections");
+    expect(donorCare).not.toContain("contributions.approve_corrections");
+
+    const financeStaff = resolveContributionCapabilities(
+      authContext({
+        memberships: [
+          {
+            tenantId: "tenant_1",
+            role: "staff",
+            staffRole: "finance",
+            isActive: true,
+          },
+        ],
+      }),
+    );
+    expect(financeStaff).toContain("contributions.apply_corrections");
+    expect(financeStaff).toContain("contributions.manage_receipts");
+    expect(financeStaff).not.toContain("contributions.approve_corrections");
+
+    const approver = resolveContributionCapabilities(
+      authContext({ role: "admin", profileRole: "admin" }),
+    );
+    expect(approver).toContain("contributions.approve_corrections");
+    expect(approver).toContain("contributions.run_refunds");
+    expect(approver).not.toContain("contributions.manage_settings");
+
+    const superAdmin = resolveContributionCapabilities(
+      authContext({ role: "super_admin", profileRole: "super_admin" }),
+    );
+    expect(superAdmin).toContain("contributions.manage_settings");
+    expect(superAdmin).toContain("crm.gift_history.manage_view_defaults");
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
@@ -7,6 +7,20 @@ import {
 } from "../../../../../packages/api/src/admin/contribution-operations/permissions";
 
 import type { AuthenticatedContext } from "@asym/auth/context";
+import type { ContributionActionType } from "../../../../../packages/api/src/admin/contribution-operations/types";
+
+const APPROVAL_REQUEST_ACTION_TYPES = [
+  "refund",
+  "stripe_replay",
+  "donor_relink",
+  "amount_correction",
+  "designation_correction",
+  "fund_correction",
+  "allocation_correction",
+  "receipt_correction",
+  "statement_correction",
+  "payment_state_correction",
+] satisfies ContributionActionType[];
 
 function authContext(
   overrides: Partial<AuthenticatedContext>,
@@ -95,7 +109,7 @@ describe("contribution operations permissions", () => {
     ).not.toThrow();
   });
 
-  it("allows donor-care staff to request inline correction actions only in request mode", () => {
+  it("allows donor-care staff to request approval-gated actions only in request mode", () => {
     const donorCare = authContext({
       memberships: [
         {
@@ -107,25 +121,25 @@ describe("contribution operations permissions", () => {
       ],
     });
 
-    expect(() =>
-      assertContributionActionPermission(donorCare, "amount_correction"),
-    ).toThrow("contributions.apply_corrections");
-    expect(() =>
-      assertContributionActionPermission(donorCare, "amount_correction", {
-        mode: "request",
-      }),
-    ).not.toThrow();
-    expect(() =>
-      assertContributionActionPermission(donorCare, "fund_correction", {
-        mode: "request",
-      }),
-    ).not.toThrow();
+    for (const actionType of APPROVAL_REQUEST_ACTION_TYPES) {
+      expect(() =>
+        assertContributionActionPermission(donorCare, actionType),
+      ).toThrow();
+      expect(() =>
+        assertContributionActionPermission(donorCare, actionType, {
+          mode: "request",
+        }),
+      ).not.toThrow();
+    }
+
     expect(() =>
       assertContributionActionPermission(donorCare, "resend_receipt"),
     ).toThrow("contributions.manage_receipts");
     expect(() =>
-      assertContributionActionPermission(donorCare, "donor_relink"),
-    ).toThrow("contributions.apply_corrections");
+      assertContributionActionPermission(donorCare, "resend_receipt", {
+        mode: "request",
+      }),
+    ).toThrow("contributions.manage_receipts");
   });
 
   it("still blocks correction request actions without tenant staff membership", () => {

--- a/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
@@ -25,7 +25,7 @@ function authContext(
 }
 
 describe("contribution operations permissions", () => {
-  it("allows finance staff to perform high-risk contribution actions", () => {
+  it("allows finance staff to perform direct correction actions", () => {
     const auth = authContext({
       memberships: [
         {
@@ -41,7 +41,7 @@ describe("contribution operations permissions", () => {
       hasContributionPermission(auth, "finance:manage_contributions"),
     ).toBe(true);
     expect(() =>
-      assertContributionActionPermission(auth, "refund"),
+      assertContributionActionPermission(auth, "amount_correction"),
     ).not.toThrow();
   });
 
@@ -69,15 +69,29 @@ describe("contribution operations permissions", () => {
       hasContributionPermission(auth, "finance:manage_contributions"),
     ).toBe(false);
     expect(() => assertContributionActionPermission(auth, "refund")).toThrow(
-      "finance:manage_contributions",
+      "contributions.run_refunds",
     );
   });
 
-  it("allows low-risk contribution actions for staff roles", () => {
-    const auth = authContext({ role: "staff", profileRole: "staff" });
+  it("requires granular capability for low-risk contribution actions", () => {
+    const nonMember = authContext({ role: "staff", profileRole: "staff" });
+    const financeStaff = authContext({
+      memberships: [
+        {
+          tenantId: "tenant_1",
+          role: "staff",
+          staffRole: "finance",
+          isActive: true,
+        },
+      ],
+    });
 
     expect(() =>
-      assertContributionActionPermission(auth, "resend_receipt"),
+      assertContributionActionPermission(nonMember, "resend_receipt"),
+    ).toThrow("contributions.manage_receipts");
+
+    expect(() =>
+      assertContributionActionPermission(financeStaff, "resend_receipt"),
     ).not.toThrow();
   });
 

--- a/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
@@ -83,7 +83,18 @@ describe("contribution operations permissions", () => {
 
   it("resolves granular capabilities backing staff-friendly roles", () => {
     const donorCare = resolveContributionCapabilities(
-      authContext({ role: "staff", profileRole: "staff" }),
+      authContext({
+        role: "staff",
+        profileRole: "staff",
+        memberships: [
+          {
+            tenantId: "tenant_1",
+            role: "staff",
+            staffRole: "development",
+            isActive: true,
+          },
+        ],
+      }),
     );
     expect(donorCare).toContain("contributions.view_detail");
     expect(donorCare).toContain("contributions.request_corrections");
@@ -118,5 +129,13 @@ describe("contribution operations permissions", () => {
     );
     expect(superAdmin).toContain("contributions.manage_settings");
     expect(superAdmin).toContain("crm.gift_history.manage_view_defaults");
+  });
+
+  it("does not grant contribution capabilities without tenant membership", () => {
+    const capabilities = resolveContributionCapabilities(
+      authContext({ role: "staff", profileRole: "staff", memberships: [] }),
+    );
+
+    expect(capabilities).toEqual([]);
   });
 });

--- a/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
@@ -138,4 +138,38 @@ describe("contribution operations permissions", () => {
 
     expect(capabilities).toEqual([]);
   });
+
+  it("does not grant contribution capabilities to non-staff memberships", () => {
+    const donorCapabilities = resolveContributionCapabilities(
+      authContext({
+        role: "donor",
+        profileRole: "donor",
+        memberships: [
+          {
+            tenantId: "tenant_1",
+            role: "donor",
+            staffRole: null,
+            isActive: true,
+          },
+        ],
+      }),
+    );
+    const missionaryCapabilities = resolveContributionCapabilities(
+      authContext({
+        role: "missionary",
+        profileRole: "missionary",
+        memberships: [
+          {
+            tenantId: "tenant_1",
+            role: "missionary",
+            staffRole: null,
+            isActive: true,
+          },
+        ],
+      }),
+    );
+
+    expect(donorCapabilities).toEqual([]);
+    expect(missionaryCapabilities).toEqual([]);
+  });
 });

--- a/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-permissions.test.ts
@@ -95,7 +95,7 @@ describe("contribution operations permissions", () => {
     ).not.toThrow();
   });
 
-  it("allows donor-care staff to request inline correction actions", () => {
+  it("allows donor-care staff to request inline correction actions only in request mode", () => {
     const donorCare = authContext({
       memberships: [
         {
@@ -109,9 +109,16 @@ describe("contribution operations permissions", () => {
 
     expect(() =>
       assertContributionActionPermission(donorCare, "amount_correction"),
+    ).toThrow("contributions.apply_corrections");
+    expect(() =>
+      assertContributionActionPermission(donorCare, "amount_correction", {
+        mode: "request",
+      }),
     ).not.toThrow();
     expect(() =>
-      assertContributionActionPermission(donorCare, "fund_correction"),
+      assertContributionActionPermission(donorCare, "fund_correction", {
+        mode: "request",
+      }),
     ).not.toThrow();
     expect(() =>
       assertContributionActionPermission(donorCare, "resend_receipt"),
@@ -125,7 +132,9 @@ describe("contribution operations permissions", () => {
     const nonMember = authContext({ role: "staff", profileRole: "staff" });
 
     expect(() =>
-      assertContributionActionPermission(nonMember, "amount_correction"),
+      assertContributionActionPermission(nonMember, "amount_correction", {
+        mode: "request",
+      }),
     ).toThrow(
       "contributions.apply_corrections or contributions.request_corrections",
     );


### PR DESCRIPTION
## Summary

- Add the pure contribution action executor for receipt resend, staged-gift approval/retry, donor relink, refund, Stripe replay, and correction request/apply orchestration through injected dependencies.
- Add contribution permission/capability helpers and CRM inline action projection utilities.
- Export the new pure APIs from `@asym/api/admin/contribution-operations` while deliberately deferring DB-backed operations, routes, correction request persistence, notifications, and batches to later migration-backed slices.

## Verification

- `bun run test:unit -- tests/unit/packages/api/admin/contribution-operations-actions.test.ts tests/unit/packages/api/admin/contribution-operations-permissions.test.ts tests/unit/packages/api/admin/contribution-inline-actions.test.ts`
- `bun run test:unit -- tests/unit/packages/api/admin/contribution-*.test.ts`
- `bunx turbo run typecheck --filter=@asym/api`
- `bunx turbo run lint --filter=@asym/api`
- `bunx prettier --check packages/api/src/admin/contribution-operations/actions.ts packages/api/src/admin/contribution-operations/permissions.ts packages/api/src/admin/contribution-operations/inline-actions.ts packages/api/src/admin/contribution-operations/index.ts tests/unit/packages/api/admin/contribution-operations-actions.test.ts tests/unit/packages/api/admin/contribution-operations-permissions.test.ts tests/unit/packages/api/admin/contribution-inline-actions.test.ts`
- Pre-push guard reran full `bun run ci:preflight` before publishing this branch.

Refs #251.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the pure contribution action executor for six operation types (receipt resend, staged-gift approval/retry, donor relink, refund, Stripe replay, and generic corrections), along with capability-based permission helpers and CRM inline action projection utilities, all wired through injected dependencies with no direct DB access.

- `executeContributionAction` handles the full approval-policy branching (pending request vs. direct apply), idempotency key derivation, provider outcome sanitisation, correction record creation, audit appending, and notification dispatch.
- `resolveContributionCapabilities` / `assertContributionActionPermission` replace the legacy coarse `finance:manage_contributions` permission with granular per-action capabilities gated on role and tenant staff membership.
- `buildInlineContributionActions` projects the same shared availability derivation into CRM row-level inline menus, gating entries on the approval policy and viewer capabilities.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The executor contains one confirmed behavioural defect in the correction branch; prior review rounds identified multiple additional auth/idempotency gaps that remain open.

The unconditional reason guard at line 1097 blocks medium-risk corrections for tenants that have not enabled required reasons, contradicting the organisation-level policy that governs this. Beyond this PR's own logic, the previous review rounds flagged open issues — approval-bypass paths for donor relink and Stripe replay, unvalidated approvedRequestId, idempotency gaps on refunds and replays, and legacy-permission over-breadth — that this PR has not yet resolved. Those items collectively affect the safety of the high-value mutation paths (refund, relink, replay) and should be addressed before the executor is wired to live routes.

packages/api/src/admin/contribution-operations/actions.ts — the correction reason guard and the still-open items from prior review rounds on that file.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-operations/actions.ts | New contribution action executor: handles resend, staged-gift approval/retry, donor relink, refund, Stripe replay, and generic corrections. Has a correctness defect where medium-risk corrections unconditionally require a reason even when the policy allows omitting it. |
| packages/api/src/admin/contribution-operations/permissions.ts | New permission/capability helpers: resolves contribution capabilities from auth context and asserts per-action permissions. Final fallback returns [] for non-staff users — clean. |
| packages/api/src/admin/contribution-operations/inline-actions.ts | New CRM inline action projection: correctly gates stripe_replay and correction entries on approval policy and viewer capabilities; intentionally hides amount/fund corrections from inline menu when approval is suppressed. |
| packages/api/src/admin/contribution-operations/types.ts | Adds contributionId to workflow dependency inputs, idempotency/revision fields to refund/relink/replay adapters, and validateApprovedCorrectionRequest dependency — well-scoped additions. |
| tests/unit/packages/api/admin/contribution-operations-actions.test.ts | Comprehensive executor tests covering permission gating, approval-policy branching, idempotency key generation, and adapter contract; no test exercises medium-risk corrections without a reason under an optional-reason policy. |
| tests/unit/packages/api/admin/contribution-operations-permissions.test.ts | Covers capability resolution for all role/membership combinations and per-action permission assertions including request vs. direct modes. |
| tests/unit/packages/api/admin/contribution-inline-actions.test.ts | Good inline action coverage: de-duplication of replay/correction entries, approval-policy visibility gating, capability filtering, and next-best action selection. |
| packages/api/src/admin/contribution-operations/index.ts | Exports the new pure executor, inline actions, and permissions helpers from the package index. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executeContributionAction] --> B{approvedRequestId?}
    B -->|yes| C[assertApprovedRequestCapabilities]
    B -->|no| D{legacyPermission or directCapability or requestCorrections?}
    C --> E[applyApprovedCorrectionRequest]
    D --> E
    E --> F[normalizeActionInput]
    F --> G{actionType switch}
    G -->|resend_receipt| H[sendReceipt dep → audit]
    G -->|approve/retry_staged_gift crm_repost| I[workflow dep → audit]
    G -->|metadata_update| J[throw 501]
    G -->|donor_relink| K{requiresApproval?}
    G -->|refund| L{requiresApproval?}
    G -->|stripe_replay| M{requiresApproval?}
    G -->|correction actions default| N{requiresApproval?}
    K -->|yes| O[createPendingCorrectionRequest]
    K -->|no| P[relinkDonor → correction → audit → notify]
    L -->|yes| O
    L -->|no| Q[refundContribution → correction → audit → notify]
    M -->|yes| O
    M -->|no| R[replayStripeEvent → correction → audit → notify]
    N -->|yes| O
    N -->|no| S[applyCorrection → correction → audit → notify]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[executeContributionAction] --> B{approvedRequestId?}
    B -->|yes| C[assertApprovedRequestCapabilities]
    B -->|no| D{legacyPermission or directCapability or requestCorrections?}
    C --> E[applyApprovedCorrectionRequest]
    D --> E
    E --> F[normalizeActionInput]
    F --> G{actionType switch}
    G -->|resend_receipt| H[sendReceipt dep → audit]
    G -->|approve/retry_staged_gift crm_repost| I[workflow dep → audit]
    G -->|metadata_update| J[throw 501]
    G -->|donor_relink| K{requiresApproval?}
    G -->|refund| L{requiresApproval?}
    G -->|stripe_replay| M{requiresApproval?}
    G -->|correction actions default| N{requiresApproval?}
    K -->|yes| O[createPendingCorrectionRequest]
    K -->|no| P[relinkDonor → correction → audit → notify]
    L -->|yes| O
    L -->|no| Q[refundContribution → correction → audit → notify]
    M -->|yes| O
    M -->|no| R[replayStripeEvent → correction → audit → notify]
    N -->|yes| O
    N -->|no| S[applyCorrection → correction → audit → notify]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Public contribution-operations barrel cannot be imported at runtime**

   - **Bug**
     - The PR adds re-exports for the inline action utilities in `packages/api/src/admin/contribution-operations/index.ts`, but importing the public module fails before those exports are usable. The after harness records `publicImportResult` as `{ ok: false, error: "Cannot find module './actions' from '/home/user/repo/packages/api/src/admin/contribution-operations/index.ts'" }`, and the required public export summary remains `undefined` for `buildInlineContributionActions`, `INLINE_ACTION_CAPABILITY`, `isInlineContributionActionType`, and `pickNextBestInlineContributionAction`. Direct source import of `inline-actions` works, but consumers using the intended public barrel cannot access the new API.
   - **Cause**
     - The public barrel imports/exports `./actions` from `index.ts`, but no `packages/api/src/admin/contribution-operations/actions.ts` file exists in this checkout, causing module evaluation to fail before the new inline action re-exports are exposed.
   - **Fix**
     - Restore or add the missing `actions` module, or remove/fix the stale `export { executeContributionAction } from "./actions";` barrel entry so `packages/api/src/admin/contribution-operations` can be imported successfully and expose the inline utility re-exports.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Refund provider action accepts missing caller idempotency key**

   - **Bug**
     - The focused contract scenario `refund_missing_idempotency` omitted `idempotencyKey` but supplied a confirmation token. Head executed the refund successfully and passed a synthesized key (`contribution-action/tenant_1/contrib_1/refund/confirm`) to `refundContribution`. The requested contract says provider-backed operations must enforce required idempotency inputs and pass the caller idempotencyKey to provider dependencies, so this allows a refund to proceed without the explicit idempotency key the API contract requires.
   - **Cause**
     - `providerIdempotencyKey` in `packages/api/src/admin/contribution-operations/actions.ts` falls back to deriving an idempotency key from `confirmationToken` when `input.idempotencyKey` is absent, and the refund path at lines 726-734 uses that helper before calling the provider dependency.
   - **Fix**
     - Require `input.idempotencyKey?.trim()` for provider-backed actions such as refund, donor_relink, and stripe_replay instead of deriving one from confirmationToken; return ApiHttpError 400 with the existing idempotency-key-required message when it is missing, then pass the explicit caller key through to dependencies.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stripe replay is gated as a correction request instead of executing via the provider-action dependency**

   - **Bug**
     - The pure executor rejects a direct `stripe_replay` call from an actor with `contributions.use_provider_actions`, returning 403 `Forbidden: requires contributions.request_corrections`, and never invokes the injected `replayStripeEvent` dependency. This contradicts the PR contract that Stripe replay is orchestrated through injected dependencies and returns the provider outcome.
   - **Cause**
     - `isCorrectionAction` includes `stripe_replay` at `packages/api/src/admin/contribution-operations/actions.ts` line 350. That makes `requiresCorrectionApproval` treat Stripe replay as an approval-gated correction under the default policy before the `case "stripe_replay"` block can use `assertCanExecuteDirectly(input, DIRECT_ACTION_CAPABILITY.stripe_replay)` and call `replayStripeEvent`.
   - **Fix**
     - Remove `stripe_replay` from the correction-action approval classification or special-case it so direct provider-action capability `contributions.use_provider_actions` reaches the Stripe replay branch and calls the injected `replayStripeEvent` dependency. If Stripe replay intentionally requires approval, update the claimed API contract and tests accordingly.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fcontribution-operations%2Factions.ts%3A1097-1102%0A**Medium-risk%20corrections%20ignore%20%60policy.requiresReason%60**%0A%0AThis%20unconditional%20guard%20throws%20a%20400%20for%20every%20%60isCorrectionAction%60%20type%20when%20%60reason%60%20is%20absent%2C%20but%20%60assertReasonAndConfirmation%60%20%28called%20earlier%20in%20the%20main%20executor%29%20already%20enforces%20the%20policy-derived%20%60requiresReason%60%20flag.%20For%20medium-risk%20actions%20%28%60allocation_correction%60%2C%20%60receipt_correction%60%2C%20%60statement_correction%60%29%2C%20%60policy.requiresReason%60%20is%20%60false%60%20when%20the%20organization%20has%20not%20set%20%60defaultReasonMode%20%3D%20%22required%22%60%2C%20so%20%60assertReasonAndConfirmation%60%20correctly%20passes%20%E2%80%94%20but%20this%20redundant%20check%20then%20rejects%20the%20same%20request%20with%20a%20400.%20Any%20tenant%20where%20correction%20reasons%20are%20optional%20will%20find%20these%20three%20medium-risk%20correction%20types%20permanently%20unexecutable%20without%20a%20reason%2C%20contradicting%20the%20policy.%20Replace%20this%20check%20with%20%60if%20%28policy.requiresReason%20%26%26%20!input.reason%3F.trim%28%29%29%60%2C%20and%20also%20pass%20the%20policy%20into%20%E2%80%94%20or%20remove%20the%20duplicate%20guard%20from%20%E2%80%94%20%60correctionInput%60.%0A%0A&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (15): Last reviewed commit: ["fix(api): refine contribution action rev..."](https://github.com/asymmetric-al/core/commit/732ee8f9cd3498045e58bdb570d6240dab00c3d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38882174)</sub>

<!-- /greptile_comment -->