### PR TITLE
feat(api): add contribution adjustment operations

### DIFF
--- a/packages/api/src/admin/contribution-operations/index.ts
+++ b/packages/api/src/admin/contribution-operations/index.ts
@@ -26,6 +26,12 @@ export {
   pickNextBestInlineContributionAction,
   type BuildInlineContributionActionsInput,
 } from "./inline-actions";
+export { applyContributionCorrection } from "./operations";
+export {
+  assertAllowedPaymentStateCorrectionStatus,
+  isAllowedPaymentStateCorrectionStatus,
+  type PaymentStateCorrectionStatus,
+} from "./payment-status-allowlist";
 export {
   assertContributionActionPermission,
   assertContributionPermission,

--- a/packages/api/src/admin/contribution-operations/operations.ts
+++ b/packages/api/src/admin/contribution-operations/operations.ts
@@ -1,0 +1,737 @@
+import { buildContributionDetail } from "./detail-read-model";
+import { assertAllowedPaymentStateCorrectionStatus } from "./payment-status-allowlist";
+import {
+  computeReceiptAffectedFields,
+  parseReceiptDeliverySelection,
+  resolveTenantReceiptDeliveryPolicy,
+  validateReceiptDeliverySelection,
+} from "./receipt-delivery";
+import { sendStagedGiftReceipt } from "../../giving/receipts";
+import { ApiHttpError } from "../../shared/http-errors";
+import { mapContributionAdjustmentRow } from "../contribution-shared/effective-values";
+
+import type { ContributionDetail } from "./detail-read-model";
+import type {
+  ReceiptDeliveryOutcome,
+  ReceiptDeliverySelection,
+  TenantReceiptDeliveryPolicyRow,
+} from "./receipt-delivery";
+import type {
+  ContributionActionType,
+  ContributionSourceSurface,
+} from "./types";
+import type {
+  ContributionAdjustmentEffectiveValues,
+  ContributionAdjustmentRecord,
+} from "../contribution-shared/effective-values";
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+type SupabaseAdmin = AdminSupabaseClient;
+type JsonRecord = Record<string, unknown>;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function assertNoError(
+  error: { message?: string } | null,
+  fallback: string,
+): void {
+  if (error) {
+    throw new Error(error.message ?? fallback);
+  }
+}
+
+function normalizeDonation(row: JsonRecord) {
+  return {
+    id: asString(row.id) ?? "",
+    tenantId: asString(row.tenant_id) ?? "",
+    donorId: asString(row.donor_id),
+    missionaryId: asString(row.missionary_id),
+    fundId: asString(row.fund_id),
+    amount: asNumber(row.amount),
+    currency: asString(row.currency) ?? "usd",
+    status: asString(row.status),
+    donationType: asString(row.donation_type),
+    paymentMethod: asString(row.payment_method),
+    isRecurring: row.is_recurring === true,
+    recurringInterval: asString(row.recurring_interval),
+    notes: asString(row.notes),
+    stripePaymentIntentId: asString(row.stripe_payment_intent_id),
+    stripeChargeId: asString(row.stripe_charge_id),
+    giftDate:
+      asString(row.gift_date) ??
+      asString(row.created_at) ??
+      new Date(0).toISOString(),
+    campaignId: asString(row.campaign_id),
+    pledgeId: asString(row.pledge_id),
+    processedAt: asString(row.processed_at),
+    completedAt: asString(row.completed_at),
+    failedAt: asString(row.failed_at),
+    errorCode: asString(row.error_code),
+    errorMessage: asString(row.error_message),
+    refundedAt: asString(row.refunded_at),
+    refundAmount: asNumber(row.refund_amount),
+    source: asString(row.source),
+    createdAt: asString(row.created_at) ?? new Date(0).toISOString(),
+    updatedAt: asString(row.updated_at) ?? new Date(0).toISOString(),
+  };
+}
+
+async function loadContributionAdjustments(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  contributionId: string;
+}): Promise<ContributionAdjustmentRecord[]> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_adjustments")
+    .select(
+      "id, adjustment_type, status, effective_values, reason, actor_profile_id, source_surface, created_at",
+    )
+    .eq("tenant_id", input.tenantId)
+    .eq("donation_id", input.contributionId)
+    .order("created_at", { ascending: true });
+
+  assertNoError(error, "Failed to load contribution adjustments.");
+
+  return ((data ?? []) as JsonRecord[]).map(mapContributionAdjustmentRow);
+}
+
+async function loadContributionOperationDetail(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  contributionId: string;
+}): Promise<ContributionDetail> {
+  const donationResult = await input.supabaseAdmin
+    .from("donations")
+    .select(
+      "id, tenant_id, donor_id, missionary_id, fund_id, amount, currency, status, donation_type, payment_method, is_recurring, recurring_interval, notes, stripe_payment_intent_id, gift_date, campaign_id, pledge_id, processed_at, completed_at, failed_at, error_code, error_message, stripe_charge_id, refunded_at, refund_amount, source, created_at, updated_at",
+    )
+    .eq("tenant_id", input.tenantId)
+    .eq("id", input.contributionId)
+    .single();
+
+  if (donationResult.error || !isRecord(donationResult.data)) {
+    throw new ApiHttpError(404, "Contribution not found.");
+  }
+
+  const donation = normalizeDonation(donationResult.data);
+  const [adjustments, stagedGiftResult, auditResult, correctionResult] =
+    await Promise.all([
+      loadContributionAdjustments(input),
+      input.supabaseAdmin
+        .from("staged_gifts")
+        .select(
+          "id, donation_id, status, review_reason, receipt_status, crm_post_status, twenty_record_id",
+        )
+        .eq("tenant_id", input.tenantId)
+        .eq("donation_id", input.contributionId)
+        .maybeSingle(),
+      input.supabaseAdmin
+        .from("contribution_operation_audit_events")
+        .select("id, operation, source_surface, reason, created_at")
+        .eq("tenant_id", input.tenantId)
+        .eq("donation_id", input.contributionId)
+        .order("created_at", { ascending: false })
+        .limit(50),
+      input.supabaseAdmin
+        .from("contribution_corrections")
+        .select("id, correction_type, status")
+        .eq("tenant_id", input.tenantId)
+        .eq("donation_id", input.contributionId)
+        .order("created_at", { ascending: false })
+        .limit(50),
+    ]);
+
+  assertNoError(stagedGiftResult.error, "Failed to load staged gift.");
+  assertNoError(auditResult.error, "Failed to load contribution audit.");
+  assertNoError(
+    correctionResult.error,
+    "Failed to load contribution corrections.",
+  );
+
+  const stagedGift = isRecord(stagedGiftResult.data)
+    ? {
+        id: asString(stagedGiftResult.data.id) ?? "",
+        status: asString(stagedGiftResult.data.status),
+        receiptStatus: asString(stagedGiftResult.data.receipt_status),
+        crmPostStatus: asString(stagedGiftResult.data.crm_post_status),
+        reviewReason: asString(stagedGiftResult.data.review_reason),
+        twentyRecordId: asString(stagedGiftResult.data.twenty_record_id),
+      }
+    : null;
+
+  return buildContributionDetail({
+    donation,
+    donor: donation.donorId
+      ? {
+          id: donation.donorId,
+          profileId: null,
+          name: null,
+          email: null,
+          phone: null,
+          location: null,
+          organization: null,
+        }
+      : null,
+    fund: donation.fundId ? { id: donation.fundId, name: null } : null,
+    missionary: donation.missionaryId
+      ? { id: donation.missionaryId, name: null }
+      : null,
+    stagedGift,
+    auditEvents: ((auditResult.data ?? []) as JsonRecord[]).map((event) => ({
+      id: asString(event.id) ?? "",
+      actionType: asString(event.operation) ?? "unknown",
+      sourceSurface: asString(event.source_surface) ?? "api",
+      reason: asString(event.reason),
+      createdAt: asString(event.created_at) ?? new Date(0).toISOString(),
+    })),
+    corrections: ((correctionResult.data ?? []) as JsonRecord[]).map(
+      (correction) => ({
+        id: asString(correction.id) ?? "",
+        correctionType: asString(correction.correction_type) ?? "unknown",
+        status: asString(correction.status) ?? "pending",
+      }),
+    ),
+    correctionRequests: [],
+    adjustments,
+    allocations: [],
+    allocationFunds: [],
+    allocationMissionaries: [],
+    crmLinks: [],
+  });
+}
+
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+function collectCorrectionReferenceIds(
+  effectiveValues: ContributionAdjustmentEffectiveValues,
+): {
+  fundIds: string[];
+  missionaryIds: string[];
+} {
+  const fundIds = new Set<string>();
+  const missionaryIds = new Set<string>();
+  const addFund = (value: unknown) => {
+    if (typeof value === "string" && value.length > 0) {
+      fundIds.add(value);
+    }
+  };
+  const addMissionary = (value: unknown) => {
+    if (typeof value === "string" && value.length > 0) {
+      missionaryIds.add(value);
+    }
+  };
+
+  addFund(effectiveValues.fundId);
+  addMissionary(effectiveValues.missionaryId);
+
+  const lines = effectiveValues.designationLines;
+  if (Array.isArray(lines)) {
+    for (const line of lines) {
+      addFund(line.fundId);
+      addMissionary(line.missionaryId);
+    }
+  }
+
+  return { fundIds: [...fundIds], missionaryIds: [...missionaryIds] };
+}
+
+async function findMissingReferenceIds(input: {
+  supabaseAdmin: SupabaseAdmin;
+  table: "funds" | "missionaries";
+  tenantId: string;
+  ids: string[];
+}): Promise<string[]> {
+  const queryableIds = input.ids.filter(isUuid);
+  const { data, error } =
+    queryableIds.length > 0
+      ? await input.supabaseAdmin
+          .from(input.table)
+          .select("id")
+          .eq("tenant_id", input.tenantId)
+          .in("id", queryableIds)
+      : { data: [], error: null };
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const found = new Set(
+    ((data ?? []) as Array<{ id: string }>).map((row) => row.id),
+  );
+  return input.ids.filter((id) => !found.has(id));
+}
+
+async function assertCorrectionReferencesExist(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  effectiveValues: ContributionAdjustmentEffectiveValues;
+}): Promise<void> {
+  const { fundIds, missionaryIds } = collectCorrectionReferenceIds(
+    input.effectiveValues,
+  );
+
+  if (fundIds.length > 0) {
+    const missing = await findMissingReferenceIds({
+      supabaseAdmin: input.supabaseAdmin,
+      table: "funds",
+      tenantId: input.tenantId,
+      ids: fundIds,
+    });
+    if (missing.length > 0) {
+      throw new ApiHttpError(
+        400,
+        `Unknown fund for this organization: ${missing.join(", ")}.`,
+      );
+    }
+  }
+
+  if (missionaryIds.length > 0) {
+    const missing = await findMissingReferenceIds({
+      supabaseAdmin: input.supabaseAdmin,
+      table: "missionaries",
+      tenantId: input.tenantId,
+      ids: missionaryIds,
+    });
+    if (missing.length > 0) {
+      throw new ApiHttpError(
+        400,
+        `Unknown missionary for this organization: ${missing.join(", ")}.`,
+      );
+    }
+  }
+}
+
+function requireReferenceIdOrNull(
+  value: unknown,
+  field: string,
+): string | null {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  throw new ApiHttpError(
+    400,
+    `${field} must be a non-empty id string or null.`,
+  );
+}
+
+function optionalReferenceIdOrNull(
+  value: unknown,
+  field: string,
+): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  return requireReferenceIdOrNull(value, field);
+}
+
+function correctionEffectiveValues(
+  actionType: ContributionActionType,
+  payload: Record<string, unknown>,
+): ContributionAdjustmentEffectiveValues {
+  if (actionType === "amount_correction") {
+    const amount = payload.amount;
+    if (
+      typeof amount !== "number" ||
+      !Number.isSafeInteger(amount) ||
+      amount < 0
+    ) {
+      throw new ApiHttpError(
+        400,
+        "amount must be a non-negative safe integer.",
+      );
+    }
+    return { amountCents: amount };
+  }
+
+  if (
+    actionType === "designation_correction" ||
+    actionType === "fund_correction"
+  ) {
+    return { fundId: requireReferenceIdOrNull(payload.fundId, "fundId") };
+  }
+
+  if (actionType === "allocation_correction") {
+    const designationLines = payload.designationLines;
+    if (Array.isArray(designationLines)) {
+      const lines = designationLines.map((line, index) => {
+        if (!isRecord(line)) {
+          throw new ApiHttpError(400, "designationLines must be objects.");
+        }
+        const amountCents = line.amountCents;
+        if (
+          typeof amountCents !== "number" ||
+          !Number.isSafeInteger(amountCents) ||
+          amountCents < 0
+        ) {
+          throw new ApiHttpError(
+            400,
+            "Each designation line needs a non-negative amountCents safe integer.",
+          );
+        }
+        return {
+          id:
+            typeof line.id === "string" && line.id.trim()
+              ? line.id.trim()
+              : `line-${index + 1}`,
+          amountCents,
+          fundId: optionalReferenceIdOrNull(line.fundId, "fundId"),
+          missionaryId: optionalReferenceIdOrNull(
+            line.missionaryId,
+            "missionaryId",
+          ),
+          memo: typeof line.memo === "string" ? line.memo : null,
+        };
+      });
+      return { designationLines: lines };
+    }
+
+    return {
+      fundId: optionalReferenceIdOrNull(payload.fundId, "fundId"),
+      missionaryId: optionalReferenceIdOrNull(
+        payload.missionaryId,
+        "missionaryId",
+      ),
+    };
+  }
+
+  if (actionType === "payment_state_correction") {
+    const status = payload.status;
+    if (typeof status !== "string" || status.trim().length === 0) {
+      throw new ApiHttpError(400, "status is required.");
+    }
+    const normalizedStatus = status.trim();
+    assertAllowedPaymentStateCorrectionStatus(normalizedStatus);
+    return { paymentStatus: normalizedStatus };
+  }
+
+  throw new ApiHttpError(
+    501,
+    `${actionType} requires a dedicated operation adapter before it can be applied.`,
+  );
+}
+
+function summarizeEffectiveDetail(detail: ContributionDetail) {
+  return {
+    amount: detail.effective.amountCents,
+    donorId: detail.donor?.id ?? null,
+    fundId: detail.effective.fundId,
+    missionaryId: detail.effective.missionaryId,
+    status: detail.effective.paymentStatus,
+  };
+}
+
+async function loadReceiptDeliveryContext(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  donorId: string | null;
+}) {
+  const [policyResult, donorResult] = await Promise.all([
+    input.supabaseAdmin
+      .from("contribution_receipt_delivery_policies")
+      .select(
+        "default_choice, allow_defer, defer_reason_required, require_delivery_action, email_capability, pdf_capability",
+      )
+      .eq("tenant_id", input.tenantId)
+      .maybeSingle(),
+    input.donorId
+      ? input.supabaseAdmin
+          .from("donors")
+          .select("email, do_not_email")
+          .eq("tenant_id", input.tenantId)
+          .eq("id", input.donorId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+  ]);
+
+  assertNoError(policyResult.error, "Failed to load receipt delivery policy.");
+  assertNoError(donorResult.error, "Failed to load donor receipt context.");
+
+  const donorRow = donorResult.data as {
+    email?: string | null;
+    do_not_email?: boolean | null;
+  } | null;
+
+  return {
+    policy: resolveTenantReceiptDeliveryPolicy(
+      (policyResult.data as TenantReceiptDeliveryPolicyRow | null) ?? null,
+    ),
+    donor: {
+      email: donorRow?.email ?? null,
+      doNotEmail: donorRow?.do_not_email === true,
+    },
+  };
+}
+
+async function insertReceiptSnapshot(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  contributionId: string;
+  adjustmentId: string | null;
+  kind: "email" | "pdf";
+  content: Record<string, unknown>;
+}): Promise<string | null> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_receipt_snapshots")
+    .insert({
+      tenant_id: input.tenantId,
+      donation_id: input.contributionId,
+      adjustment_id: input.adjustmentId,
+      kind: input.kind,
+      content: input.content,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const id = (data as Record<string, unknown> | null)?.id;
+  return typeof id === "string" ? id : null;
+}
+
+async function runReceiptDelivery(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  contributionId: string;
+  adjustmentId: string | null;
+  stagedGiftId: string | null;
+  selection: ReceiptDeliverySelection;
+  affectedFields: string[];
+  requested: ReceiptDeliverySelection | null;
+  snapshotContent: Record<string, unknown>;
+}): Promise<ReceiptDeliveryOutcome> {
+  const base = {
+    affectedFields: input.affectedFields,
+    requested: input.requested,
+    confirmed: input.selection,
+  };
+
+  if (input.selection.choice === "defer") {
+    return {
+      ...base,
+      status: "deferred",
+      reason: input.selection.deferReason ?? null,
+      snapshotId: null,
+    };
+  }
+
+  if (input.selection.choice === "pdf") {
+    const snapshotId = await insertReceiptSnapshot({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      contributionId: input.contributionId,
+      adjustmentId: input.adjustmentId,
+      kind: "pdf",
+      content: input.snapshotContent,
+    });
+    return { ...base, status: "pdf_generated", reason: null, snapshotId };
+  }
+
+  if (!input.stagedGiftId) {
+    return {
+      ...base,
+      status: "blocked",
+      reason:
+        "This gift has no staged gift workflow record, so an updated receipt email cannot be sent.",
+      snapshotId: null,
+    };
+  }
+
+  await sendStagedGiftReceipt({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    stagedGiftId: input.stagedGiftId,
+  });
+  const snapshotId = await insertReceiptSnapshot({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    contributionId: input.contributionId,
+    adjustmentId: input.adjustmentId,
+    kind: "email",
+    content: input.snapshotContent,
+  });
+  return { ...base, status: "emailed", reason: null, snapshotId };
+}
+
+export async function applyContributionCorrection(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  contributionId: string;
+  actionType: ContributionActionType;
+  payload: Record<string, unknown>;
+  reason: string;
+  actorProfileId: string | null;
+  sourceSurface: ContributionSourceSurface;
+  actorCapabilities?: string[];
+  expectedRevision?: string | null;
+  idempotencyKey?: string | null;
+}) {
+  const before = await loadContributionOperationDetail(input);
+
+  if (input.expectedRevision && input.expectedRevision !== before.revision) {
+    throw new ApiHttpError(
+      409,
+      "This gift changed since you loaded it. Reload the latest detail, review the changes, and submit the correction again.",
+    );
+  }
+
+  const effectiveValues = correctionEffectiveValues(
+    input.actionType,
+    input.payload,
+  );
+
+  await assertCorrectionReferencesExist({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    effectiveValues,
+  });
+
+  const affectedFields = computeReceiptAffectedFields(effectiveValues);
+  const receiptAffected =
+    before.shared.receiptStatus === "sent" && affectedFields.length > 0;
+  const deliverySelection = parseReceiptDeliverySelection(
+    input.payload.receiptDelivery,
+  );
+  const requestedDelivery = parseReceiptDeliverySelection(
+    input.payload.requestedReceiptDelivery,
+  );
+
+  let receiptContext: Awaited<
+    ReturnType<typeof loadReceiptDeliveryContext>
+  > | null = null;
+  if (receiptAffected) {
+    receiptContext = await loadReceiptDeliveryContext({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      donorId: before.donor?.id ?? null,
+    });
+
+    if (!deliverySelection && receiptContext.policy.requireDeliveryAction) {
+      throw new ApiHttpError(
+        400,
+        `This correction changes receipt fields (${affectedFields.join(", ")}) and your organization requires choosing an updated receipt action (email or PDF) before completing it.`,
+      );
+    }
+
+    if (deliverySelection) {
+      validateReceiptDeliverySelection({
+        policy: receiptContext.policy,
+        donor: receiptContext.donor,
+        actorCapabilities: input.actorCapabilities ?? [],
+        selection: deliverySelection,
+      });
+    }
+  }
+
+  const insertResult = await input.supabaseAdmin
+    .from("contribution_adjustments")
+    .insert({
+      tenant_id: input.tenantId,
+      donation_id: input.contributionId,
+      adjustment_type: input.actionType,
+      status: "applied",
+      effective_values: effectiveValues,
+      reason: input.reason,
+      actor_profile_id: input.actorProfileId,
+      source_surface: input.sourceSurface,
+      base_revision: before.revision,
+      idempotency_key: input.idempotencyKey ?? null,
+    })
+    .select("id")
+    .single();
+
+  if (insertResult.error) {
+    const isDuplicateKey =
+      insertResult.error.code === "23505" && Boolean(input.idempotencyKey);
+    if (!isDuplicateKey) {
+      throw new Error(insertResult.error.message);
+    }
+
+    const existingResult = await input.supabaseAdmin
+      .from("contribution_adjustments")
+      .select("id")
+      .eq("tenant_id", input.tenantId)
+      .eq("idempotency_key", input.idempotencyKey!)
+      .maybeSingle();
+
+    if (existingResult.error || !existingResult.data) {
+      throw new Error(
+        existingResult.error?.message ??
+          "Adjustment already exists but could not be loaded for replay.",
+      );
+    }
+
+    return {
+      before: summarizeEffectiveDetail(before),
+      after: summarizeEffectiveDetail(before),
+      status: "applied" as const,
+      adjustmentId: String(
+        (existingResult.data as Record<string, unknown>).id ?? "",
+      ),
+      idempotentReplay: true,
+      receiptOutcome: null,
+    };
+  }
+
+  const adjustmentId = String(
+    ((insertResult.data ?? {}) as Record<string, unknown>).id ?? "",
+  );
+  const after = await loadContributionOperationDetail(input);
+
+  let receiptOutcome: ReceiptDeliveryOutcome | null = null;
+  if (receiptAffected) {
+    if (deliverySelection) {
+      receiptOutcome = await runReceiptDelivery({
+        supabaseAdmin: input.supabaseAdmin,
+        tenantId: input.tenantId,
+        contributionId: input.contributionId,
+        adjustmentId,
+        stagedGiftId: before.stagedGift?.id ?? null,
+        selection: deliverySelection,
+        affectedFields,
+        requested: requestedDelivery ?? deliverySelection,
+        snapshotContent: {
+          effective: after.effective,
+          designationLines: after.designations.lines,
+        },
+      });
+    } else {
+      receiptOutcome = {
+        status: "deferred",
+        reason:
+          "No updated receipt action was selected; the receipt remains as originally sent.",
+        snapshotId: null,
+        affectedFields,
+        requested: requestedDelivery,
+        confirmed: null,
+      };
+    }
+  }
+
+  return {
+    before: summarizeEffectiveDetail(before),
+    after: summarizeEffectiveDetail(after),
+    status: "applied" as const,
+    adjustmentId,
+    idempotentReplay: false,
+    receiptOutcome,
+  };
+}

--- a/packages/api/src/admin/contribution-operations/payment-status-allowlist.ts
+++ b/packages/api/src/admin/contribution-operations/payment-status-allowlist.ts
@@ -1,0 +1,33 @@
+import { SETTLED_DONATION_STATUSES } from "../../reads/settled-donation-statuses";
+import { ApiHttpError } from "../../shared/http-errors";
+
+const PAYMENT_STATE_CORRECTION_STATUSES = [
+  "pending",
+  "processing",
+  "completed",
+  "failed",
+  "refunded",
+  ...SETTLED_DONATION_STATUSES,
+] as const;
+
+export type PaymentStateCorrectionStatus =
+  (typeof PAYMENT_STATE_CORRECTION_STATUSES)[number];
+
+const paymentStateCorrectionStatusSet = new Set<string>(
+  PAYMENT_STATE_CORRECTION_STATUSES,
+);
+
+export function isAllowedPaymentStateCorrectionStatus(
+  status: string,
+): status is PaymentStateCorrectionStatus {
+  return paymentStateCorrectionStatusSet.has(status);
+}
+
+export function assertAllowedPaymentStateCorrectionStatus(status: string) {
+  if (!isAllowedPaymentStateCorrectionStatus(status)) {
+    throw new ApiHttpError(
+      400,
+      `status must be one of: ${PAYMENT_STATE_CORRECTION_STATUSES.join(", ")}.`,
+    );
+  }
+}

--- a/packages/database/types/database.ts
+++ b/packages/database/types/database.ts
@@ -389,6 +389,22 @@ export interface ContributionOperationAuditEvent {
   created_at: string;
 }
 
+export interface ContributionAdjustment {
+  id: string;
+  tenant_id: string;
+  donation_id: string;
+  correction_id: string | null;
+  adjustment_type: string;
+  status: "applied" | "reversed";
+  effective_values: Record<string, unknown>;
+  reason: string;
+  actor_profile_id: string | null;
+  source_surface: ContributionOperationSourceSurface;
+  base_revision: string | null;
+  idempotency_key: string | null;
+  created_at: string;
+}
+
 export type ContributionNotificationMode =
   | "auto_notify"
   | "always_ask"

--- a/packages/database/types/index.ts
+++ b/packages/database/types/index.ts
@@ -79,6 +79,7 @@ export type {
   CrmReportSlice,
 } from "./crm-reports";
 export type {
+  ContributionAdjustment,
   ContributionCorrection,
   ContributionCorrectionType,
   ContributionCorrectionStatus,

--- a/supabase/migrations/20260611100000_contribution_adjustments.sql
+++ b/supabase/migrations/20260611100000_contribution_adjustments.sql
@@ -1,0 +1,45 @@
+-- Contribution adjustment records (ADR-CD-004).
+-- Corrections and refunds never rewrite original donation truth. They are
+-- persisted as immutable adjustment records linked to donation.id, and the
+-- current effective gift view derives from original donation data plus every
+-- applied adjustment.
+
+CREATE TABLE IF NOT EXISTS public.contribution_adjustments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    donation_id UUID NOT NULL REFERENCES public.donations(id) ON DELETE CASCADE,
+    correction_id UUID REFERENCES public.contribution_corrections(id) ON DELETE SET NULL,
+    adjustment_type TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'applied'
+        CHECK (status IN ('applied', 'reversed')),
+    effective_values JSONB NOT NULL DEFAULT '{}'::jsonb,
+    reason TEXT NOT NULL,
+    actor_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    source_surface TEXT NOT NULL
+        CHECK (
+            source_surface IN (
+                'contribution_hub',
+                'donor_crm_record',
+                'automation',
+                'bulk_action',
+                'api'
+            )
+        ),
+    base_revision TEXT,
+    idempotency_key TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Idempotent retry: a repeated save with the same idempotency key returns the
+-- existing adjustment instead of creating a duplicate.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contribution_adjustments_idempotency
+    ON public.contribution_adjustments (tenant_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_contribution_adjustments_tenant_donation
+    ON public.contribution_adjustments (tenant_id, donation_id, created_at);
+
+ALTER TABLE public.contribution_adjustments ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.contribution_adjustments FROM anon, authenticated;
+GRANT ALL ON TABLE public.contribution_adjustments TO service_role;

--- a/supabase/migrations/20260611140000_contribution_receipt_delivery.sql
+++ b/supabase/migrations/20260611140000_contribution_receipt_delivery.sql
@@ -1,0 +1,40 @@
+-- Updated receipt delivery policy and receipt content snapshots
+-- (ADR-CD-013 / ADR-CD-029 / ADR-CD-030 / ADR-CD-031).
+
+CREATE TABLE IF NOT EXISTS public.contribution_receipt_delivery_policies (
+    tenant_id UUID PRIMARY KEY REFERENCES public.tenants(id) ON DELETE CASCADE,
+    default_choice TEXT NOT NULL DEFAULT 'email'
+        CHECK (default_choice IN ('email', 'pdf', 'defer')),
+    allow_defer BOOLEAN NOT NULL DEFAULT TRUE,
+    defer_reason_required BOOLEAN NOT NULL DEFAULT TRUE,
+    require_delivery_action BOOLEAN NOT NULL DEFAULT FALSE,
+    email_capability TEXT NOT NULL DEFAULT 'contributions.manage_receipts',
+    pdf_capability TEXT NOT NULL DEFAULT 'contributions.manage_receipts',
+    updated_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Durable receipt content snapshots: what designation lines and effective
+-- values a sent/generated receipt represented at delivery time (ADR-CD-013).
+CREATE TABLE IF NOT EXISTS public.contribution_receipt_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    donation_id UUID NOT NULL REFERENCES public.donations(id) ON DELETE CASCADE,
+    adjustment_id UUID REFERENCES public.contribution_adjustments(id) ON DELETE SET NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('email', 'pdf')),
+    content JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_receipt_snapshots_tenant_donation
+    ON public.contribution_receipt_snapshots (tenant_id, donation_id, created_at DESC);
+
+ALTER TABLE public.contribution_receipt_delivery_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_receipt_snapshots ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.contribution_receipt_delivery_policies FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_receipt_snapshots FROM anon, authenticated;
+
+GRANT ALL ON TABLE public.contribution_receipt_delivery_policies TO service_role;
+GRANT ALL ON TABLE public.contribution_receipt_snapshots TO service_role;

--- a/tests/unit/packages/api/admin/contribution-adjustment-operations.test.ts
+++ b/tests/unit/packages/api/admin/contribution-adjustment-operations.test.ts
@@ -1,0 +1,562 @@
+import { describe, expect, it } from "vitest";
+
+import { applyContributionCorrection } from "../../../../../packages/api/src/admin/contribution-operations/operations";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+const TENANT_ID = "tenant-1";
+const DONATION_ID = "donation-1";
+const FUND_VALID = "11111111-1111-4111-8111-111111111111";
+const FUND_OTHER = "22222222-2222-4222-8222-222222222222";
+
+const donationRow = {
+  id: DONATION_ID,
+  tenant_id: TENANT_ID,
+  donor_id: "donor-1",
+  missionary_id: null,
+  fund_id: null,
+  amount: 25_000,
+  currency: "usd",
+  status: "completed",
+  gift_date: "2026-05-01",
+  refund_amount: 0,
+  refunded_at: null,
+  created_at: "2026-05-01T00:00:00.000Z",
+  updated_at: "2026-05-01T00:00:00.000Z",
+};
+
+interface StubState {
+  adjustments: Array<Record<string, unknown>>;
+  insertCount: number;
+  stagedGift?: Record<string, unknown> | null;
+  donor?: Record<string, unknown> | null;
+  policy?: Record<string, unknown> | null;
+  snapshots?: Array<Record<string, unknown>>;
+  funds?: string[];
+  missionaries?: string[];
+}
+
+class QueryBuilder {
+  private operation: "select" | "insert" = "select";
+  private insertPayload: Record<string, unknown> | null = null;
+  private wantsSingle = false;
+  private inValues: unknown[] = [];
+
+  constructor(
+    private readonly table: string,
+    private readonly state: StubState,
+  ) {}
+
+  select() {
+    return this;
+  }
+
+  insert(payload: Record<string, unknown>) {
+    this.operation = "insert";
+    this.insertPayload = payload;
+    return this;
+  }
+
+  eq() {
+    return this;
+  }
+
+  in(_column: string, values: unknown[]) {
+    this.inValues = values;
+    return this;
+  }
+
+  order() {
+    return this;
+  }
+
+  limit() {
+    return this;
+  }
+
+  single() {
+    this.wantsSingle = true;
+    return this;
+  }
+
+  maybeSingle() {
+    this.wantsSingle = true;
+    return this;
+  }
+
+  private resolve(): {
+    data: unknown;
+    error: { code?: string; message: string } | null;
+  } {
+    if (this.table === "donations") {
+      return { data: donationRow, error: null };
+    }
+    if (this.table === "staged_gifts") {
+      return { data: this.state.stagedGift ?? null, error: null };
+    }
+    if (this.table === "donors") {
+      return { data: this.state.donor ?? null, error: null };
+    }
+    if (this.table === "funds") {
+      const valid = this.state.funds ?? [];
+      const rows = this.inValues
+        .filter((id) => valid.includes(id as string))
+        .map((id) => ({ id }));
+      return { data: rows, error: null };
+    }
+    if (this.table === "missionaries") {
+      const valid = this.state.missionaries ?? [];
+      const rows = this.inValues
+        .filter((id) => valid.includes(id as string))
+        .map((id) => ({ id }));
+      return { data: rows, error: null };
+    }
+    if (this.table === "contribution_operation_audit_events") {
+      return { data: [], error: null };
+    }
+    if (this.table === "contribution_corrections") {
+      return { data: [], error: null };
+    }
+    if (this.table === "contribution_receipt_delivery_policies") {
+      return { data: this.state.policy ?? null, error: null };
+    }
+    if (this.table === "contribution_receipt_snapshots") {
+      if (this.operation === "insert" && this.insertPayload) {
+        const snapshots = (this.state.snapshots ??= []);
+        const row = {
+          id: `snap-${snapshots.length + 1}`,
+          ...this.insertPayload,
+        };
+        snapshots.push(row);
+        return { data: { id: row.id }, error: null };
+      }
+      return { data: null, error: null };
+    }
+    if (this.table === "contribution_adjustments") {
+      if (this.operation === "insert") {
+        const key = this.insertPayload?.idempotency_key;
+        const duplicate =
+          typeof key === "string" &&
+          this.state.adjustments.some((row) => row.idempotency_key === key);
+        if (duplicate) {
+          return {
+            data: null,
+            error: { code: "23505", message: "duplicate idempotency key" },
+          };
+        }
+
+        this.state.insertCount += 1;
+        const row = {
+          id: `adj-${this.state.insertCount}`,
+          created_at: `2026-06-0${this.state.insertCount}T00:00:00.000Z`,
+          ...this.insertPayload,
+        };
+        this.state.adjustments.push(row);
+        return { data: { id: row.id }, error: null };
+      }
+
+      if (this.wantsSingle) {
+        return { data: this.state.adjustments[0] ?? null, error: null };
+      }
+      return { data: this.state.adjustments, error: null };
+    }
+    return { data: null, error: null };
+  }
+
+  then<TResult>(
+    onfulfilled: (value: {
+      data: unknown;
+      error: { code?: string; message: string } | null;
+    }) => TResult,
+  ): Promise<TResult> {
+    return Promise.resolve(this.resolve()).then(onfulfilled);
+  }
+}
+
+function createStub(state: StubState): AdminSupabaseClient {
+  return {
+    from(table: string) {
+      return new QueryBuilder(table, state);
+    },
+  } as unknown as AdminSupabaseClient;
+}
+
+function baseInput(state: StubState) {
+  return {
+    supabaseAdmin: createStub(state),
+    tenantId: TENANT_ID,
+    contributionId: DONATION_ID,
+    actionType: "amount_correction" as const,
+    payload: { amount: 20_000 },
+    reason: "data entry error",
+    actorProfileId: "profile-1",
+    sourceSurface: "contribution_hub" as const,
+  };
+}
+
+describe("applyContributionCorrection", () => {
+  it("writes an adjustment record and never rewrites original donation truth", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+    };
+
+    const result = await applyContributionCorrection({
+      ...baseInput(state),
+      idempotencyKey: "key-1",
+    });
+
+    expect(state.adjustments).toHaveLength(1);
+    expect(state.adjustments[0]).toMatchObject({
+      adjustment_type: "amount_correction",
+      status: "applied",
+      effective_values: { amountCents: 20_000 },
+      reason: "data entry error",
+      actor_profile_id: "profile-1",
+      source_surface: "contribution_hub",
+      idempotency_key: "key-1",
+    });
+    expect(result.before.amount).toBe(25_000);
+    expect(result.after.amount).toBe(20_000);
+    expect(result.status).toBe("applied");
+    expect(result.adjustmentId).toBe("adj-1");
+    expect(result.idempotentReplay).toBe(false);
+  });
+
+  it("rejects stale saves with a clear recovery path and writes nothing", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+    };
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        expectedRevision: "stale-revision",
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      message: expect.stringMatching(/reload the latest detail/i),
+    });
+
+    expect(state.adjustments).toHaveLength(0);
+  });
+
+  it("returns the existing adjustment on idempotent retry", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+    };
+
+    const first = await applyContributionCorrection({
+      ...baseInput(state),
+      idempotencyKey: "key-retry",
+    });
+    const second = await applyContributionCorrection({
+      ...baseInput(state),
+      idempotencyKey: "key-retry",
+    });
+
+    expect(state.adjustments).toHaveLength(1);
+    expect(first.idempotentReplay).toBe(false);
+    expect(second.idempotentReplay).toBe(true);
+    expect(second.adjustmentId).toBe(first.adjustmentId);
+  });
+
+  it("records a deferred receipt outcome for receipt-affecting corrections", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      stagedGift: {
+        id: "staged-1",
+        status: "posted",
+        review_reason: null,
+        receipt_status: "sent",
+        crm_post_status: "posted",
+        twenty_record_id: null,
+      },
+      donor: { id: "donor-1", email: "donor@example.com", do_not_email: false },
+    };
+
+    const result = await applyContributionCorrection({
+      ...baseInput(state),
+      payload: {
+        amount: 20_000,
+        receiptDelivery: {
+          choice: "defer",
+          deferReason: "Donor asked us to wait",
+        },
+      },
+      actorCapabilities: ["contributions.manage_receipts"],
+    });
+
+    expect(result.receiptOutcome).toMatchObject({
+      status: "deferred",
+      affectedFields: ["amount"],
+      confirmed: { choice: "defer" },
+    });
+  });
+
+  it("blocks updated receipt emails when the donor opted out", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      stagedGift: {
+        id: "staged-1",
+        status: "posted",
+        review_reason: null,
+        receipt_status: "sent",
+        crm_post_status: "posted",
+        twenty_record_id: null,
+      },
+      donor: { id: "donor-1", email: "donor@example.com", do_not_email: true },
+    };
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        payload: {
+          amount: 20_000,
+          receiptDelivery: { choice: "email" },
+        },
+        actorCapabilities: ["contributions.manage_receipts"],
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/opted out/i),
+    });
+
+    expect(state.adjustments).toHaveLength(0);
+  });
+
+  it("requires a receipt delivery choice when tenant policy demands it", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      stagedGift: {
+        id: "staged-1",
+        status: "posted",
+        review_reason: null,
+        receipt_status: "sent",
+        crm_post_status: "posted",
+        twenty_record_id: null,
+      },
+      donor: { id: "donor-1", email: "donor@example.com", do_not_email: false },
+      policy: {
+        default_choice: "email",
+        allow_defer: true,
+        defer_reason_required: true,
+        require_delivery_action: true,
+        email_capability: "contributions.manage_receipts",
+        pdf_capability: "contributions.manage_receipts",
+      },
+    };
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        payload: { amount: 20_000 },
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringMatching(/requires choosing an updated receipt/i),
+    });
+
+    expect(state.adjustments).toHaveLength(0);
+  });
+
+  it("generates a durable PDF snapshot when staff choose PDF delivery", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      stagedGift: {
+        id: "staged-1",
+        status: "posted",
+        review_reason: null,
+        receipt_status: "sent",
+        crm_post_status: "posted",
+        twenty_record_id: null,
+      },
+      donor: { id: "donor-1", email: null, do_not_email: false },
+    };
+
+    const result = await applyContributionCorrection({
+      ...baseInput(state),
+      payload: {
+        amount: 20_000,
+        receiptDelivery: { choice: "pdf" },
+      },
+      actorCapabilities: ["contributions.manage_receipts"],
+    });
+
+    expect(result.receiptOutcome).toMatchObject({
+      status: "pdf_generated",
+      snapshotId: "snap-1",
+    });
+    expect(state.snapshots).toHaveLength(1);
+    expect(state.snapshots![0]).toMatchObject({ kind: "pdf" });
+  });
+
+  it("applies a fund correction when the fund exists for the tenant", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      funds: [FUND_VALID],
+    };
+
+    const result = await applyContributionCorrection({
+      ...baseInput(state),
+      actionType: "fund_correction",
+      payload: { fundId: FUND_VALID },
+      reason: "Donor redirected the gift",
+    });
+
+    expect(state.adjustments).toHaveLength(1);
+    expect(state.adjustments[0]).toMatchObject({
+      adjustment_type: "fund_correction",
+      effective_values: { fundId: FUND_VALID },
+    });
+    expect(result.status).toBe("applied");
+  });
+
+  it("rejects unknown, cross-tenant, or malformed fund IDs before writing", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      funds: [FUND_VALID],
+    };
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        actionType: "fund_correction",
+        payload: { fundId: FUND_OTHER },
+        reason: "Typo'd fund id",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringMatching(/unknown fund/i),
+    });
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        actionType: "fund_correction",
+        payload: { fundId: "not-a-real-uuid" },
+        reason: "Pasted the wrong thing",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringMatching(/unknown fund/i),
+    });
+
+    expect(state.adjustments).toHaveLength(0);
+  });
+
+  it("rejects malformed reference payloads instead of clearing financial truth", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      funds: [FUND_VALID],
+    };
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        actionType: "fund_correction",
+        payload: {},
+        reason: "Malformed client payload",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringMatching(/fundId/),
+    });
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        actionType: "allocation_correction",
+        payload: {
+          designationLines: [{ amountCents: 10_000, fundId: 42 }],
+        },
+        reason: "Malformed client payload",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringMatching(/fundId/),
+    });
+
+    expect(state.adjustments).toHaveLength(0);
+  });
+
+  it("allows allocation corrections to omit optional missionary IDs", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+      funds: [FUND_VALID],
+    };
+
+    const result = await applyContributionCorrection({
+      ...baseInput(state),
+      actionType: "allocation_correction",
+      payload: { fundId: FUND_VALID },
+      reason: "Reassign the fund only",
+    });
+
+    expect(state.adjustments).toHaveLength(1);
+    expect(state.adjustments[0]).toMatchObject({
+      effective_values: { fundId: FUND_VALID, missionaryId: null },
+    });
+    expect(result.status).toBe("applied");
+  });
+
+  it("allows a fund correction that explicitly clears the designation", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+    };
+
+    const result = await applyContributionCorrection({
+      ...baseInput(state),
+      actionType: "fund_correction",
+      payload: { fundId: null },
+      reason: "Move to General Fund",
+    });
+
+    expect(state.adjustments).toHaveLength(1);
+    expect(state.adjustments[0]).toMatchObject({
+      effective_values: { fundId: null },
+    });
+    expect(result.status).toBe("applied");
+  });
+
+  it("validates payment-state corrections against the allowed status set", async () => {
+    const state: StubState = {
+      adjustments: [],
+      insertCount: 0,
+    };
+
+    await applyContributionCorrection({
+      ...baseInput(state),
+      actionType: "payment_state_correction",
+      payload: { status: " refunded " },
+      reason: "Stripe state reconciled",
+    });
+
+    expect(state.adjustments[0]).toMatchObject({
+      effective_values: { paymentStatus: "refunded" },
+    });
+
+    await expect(
+      applyContributionCorrection({
+        ...baseInput(state),
+        actionType: "payment_state_correction",
+        payload: { status: "not-a-status" },
+        reason: "Bad status",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringMatching(/status must be one of/i),
+    });
+    expect(state.adjustments).toHaveLength(1);
+  });
+});

--- a/tests/unit/supabase/contribution-adjustments-migration.test.ts
+++ b/tests/unit/supabase/contribution-adjustments-migration.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const adjustmentSql = readFileSync(
+  new URL(
+    "../../../supabase/migrations/20260611100000_contribution_adjustments.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+const receiptDeliverySql = readFileSync(
+  new URL(
+    "../../../supabase/migrations/20260611140000_contribution_receipt_delivery.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("contribution adjustment migrations", () => {
+  it("creates immutable adjustment records with idempotent retry support", () => {
+    expect(adjustmentSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.contribution_adjustments",
+    );
+    expect(adjustmentSql).toContain(
+      "donation_id UUID NOT NULL REFERENCES public.donations(id) ON DELETE CASCADE",
+    );
+    expect(adjustmentSql).toContain(
+      "correction_id UUID REFERENCES public.contribution_corrections(id) ON DELETE SET NULL",
+    );
+    expect(adjustmentSql).toContain(
+      "effective_values JSONB NOT NULL DEFAULT '{}'::jsonb",
+    );
+    expect(adjustmentSql).toContain(
+      "CHECK (status IN ('applied', 'reversed'))",
+    );
+    expect(adjustmentSql).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_contribution_adjustments_idempotency",
+    );
+    expect(adjustmentSql).toContain("WHERE idempotency_key IS NOT NULL");
+    expect(adjustmentSql).toContain(
+      "ALTER TABLE public.contribution_adjustments ENABLE ROW LEVEL SECURITY",
+    );
+    expect(adjustmentSql).toContain(
+      "GRANT ALL ON TABLE public.contribution_adjustments TO service_role",
+    );
+  });
+
+  it("creates receipt delivery policies and durable receipt snapshots", () => {
+    expect(receiptDeliverySql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.contribution_receipt_delivery_policies",
+    );
+    expect(receiptDeliverySql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.contribution_receipt_snapshots",
+    );
+    expect(receiptDeliverySql).toContain(
+      "adjustment_id UUID REFERENCES public.contribution_adjustments(id) ON DELETE SET NULL",
+    );
+    expect(receiptDeliverySql).toContain(
+      "kind TEXT NOT NULL CHECK (kind IN ('email', 'pdf'))",
+    );
+    expect(receiptDeliverySql).toContain(
+      "ALTER TABLE public.contribution_receipt_delivery_policies ENABLE ROW LEVEL SECURITY",
+    );
+    expect(receiptDeliverySql).toContain(
+      "ALTER TABLE public.contribution_receipt_snapshots ENABLE ROW LEVEL SECURITY",
+    );
+    expect(receiptDeliverySql).toContain(
+      "GRANT ALL ON TABLE public.contribution_receipt_snapshots TO service_role",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add immutable contribution adjustment and receipt-delivery schema
- add the DB-backed contribution correction adapter for adjustment writes, idempotent retry, stale-save protection, tenant-scoped reference validation, and receipt delivery outcomes
- export the adjustment adapter and payment-state allowlist for future route/dependency wiring

## Deferred
- route wiring, correction request persistence, notifications, batches, CRM table preferences, provider refund/replay adapters, and docs stay in later slices

## Verification
- `bun run test:unit -- tests/unit/packages/api/admin/contribution-adjustment-operations.test.ts tests/unit/supabase/contribution-adjustments-migration.test.ts`
- `bun run test:unit -- tests/unit/packages/api/admin/contribution-*.test.ts tests/unit/supabase/contribution-*.test.ts`
- `bunx turbo run typecheck --filter=@asym/api`
- `bunx turbo run typecheck --filter=@asym/database`
- `bunx turbo run lint --filter=@asym/api`
- `bunx turbo run lint --filter=@asym/database`
- `bunx prettier --write ... && bunx prettier --check ... && git diff --check`
- `bun run ci:preflight`

Refs #251

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an immutable contribution adjustment system: a `contribution_adjustments` table (with idempotent-retry via partial unique index and RLS restricted to `service_role`), companion `contribution_receipt_delivery_policies` and `contribution_receipt_snapshots` tables, and the `applyContributionCorrection` adapter that validates, writes, and optionally triggers receipt re-delivery after financial corrections.

- **Schema and RLS** are well-structured — `service_role`-only access, correct FK chains, and a partial unique index for idempotency.
- **`applyContributionCorrection`** has three correctness issues in its core commit-and-deliver sequence: the idempotent-replay path returns the wrong `before`/`after` diff, a receipt-delivery failure after a committed INSERT is permanently lost on retry, and the `expectedRevision` optimistic-lock check is not atomically enforced at the DB level — all detailed in inline comments.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is: the core adapter has three correctness bugs in the commit-and-deliver sequence that affect data integrity and audit reliability.

The migration schema and RLS posture are solid, and the test suite covers the primary happy and error paths well. However, the `applyContributionCorrection` function has three bugs in its critical path: the idempotent replay returns `before == after` (zero diff), making any audit display that compares the two snapshots useless; a receipt-delivery failure after a committed INSERT creates an irrecoverable state where the correction is applied but the delivery outcome is permanently lost; and the `expectedRevision` optimistic-lock check is application-level only, leaving a race window where two concurrent corrections can both be committed without either being rejected. These issues will surface on the correction routes once they are wired in the next slice.

packages/api/src/admin/contribution-operations/operations.ts — specifically the idempotent replay return block (lines 682–691), the insert-then-deliver sequence (lines 694–727), and the expectedRevision guard (lines 612–617).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-operations/operations.ts | Core adapter for contribution corrections — has three logic bugs: idempotent replay returns wrong before/after snapshots, receipt delivery failure after a committed INSERT is irrecoverable via retry, and the expectedRevision optimistic-lock check is not DB-enforced. |
| supabase/migrations/20260611100000_contribution_adjustments.sql | Creates contribution_adjustments table with correct RLS, service_role-only grants, and idempotency partial-unique index; no structural issues. |
| supabase/migrations/20260611140000_contribution_receipt_delivery.sql | Creates receipt delivery policy and snapshot tables with correct RLS posture; updated_at on the policy table has no auto-update trigger. |
| tests/unit/packages/api/admin/contribution-adjustment-operations.test.ts | Good coverage for happy paths, idempotent retry, stale-revision rejection, fund/missionary validation, and receipt policy enforcement; does not cover the receipt delivery failure-after-commit scenario. |
| packages/api/src/admin/contribution-operations/payment-status-allowlist.ts | Simple allowlist guard for payment-state corrections; correct and well-tested. |
| packages/database/types/database.ts | Adds ContributionAdjustment TypeScript interface matching the new migration schema; no issues. |
| packages/api/src/admin/contribution-operations/index.ts | Exports new adapter and allowlist helpers; no issues. |
| packages/database/types/index.ts | Re-exports ContributionAdjustment type; no issues. |
| tests/unit/supabase/contribution-adjustments-migration.test.ts | SQL text assertions verify schema correctness; straightforward and passes. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant applyContributionCorrection
    participant DB as Supabase DB
    participant Email as sendStagedGiftReceipt

    Caller->>applyContributionCorrection: call(tenantId, contributionId, actionType, payload, idempotencyKey?)
    applyContributionCorrection->>DB: SELECT donations + adjustments + staged_gifts
    DB-->>applyContributionCorrection: before snapshot + revision

    alt expectedRevision mismatch
        applyContributionCorrection-->>Caller: 409 Conflict
    end

    applyContributionCorrection->>DB: SELECT funds/missionaries (reference validation)
    DB-->>applyContributionCorrection: validation result

    applyContributionCorrection->>DB: INSERT contribution_adjustments

    alt duplicate idempotency_key 23505
        DB-->>applyContributionCorrection: error
        applyContributionCorrection->>DB: SELECT existing by idempotency_key
        applyContributionCorrection-->>Caller: "idempotentReplay=true, receiptOutcome=null, before==after"
    else insert success
        DB-->>applyContributionCorrection: adjustmentId
        applyContributionCorrection->>DB: SELECT after snapshot
        alt "receiptAffected and choice==email"
            applyContributionCorrection->>Email: sendStagedGiftReceipt
            Note over applyContributionCorrection,Email: If this throws, INSERT is already committed
            applyContributionCorrection->>DB: INSERT contribution_receipt_snapshots
        else "choice==pdf"
            applyContributionCorrection->>DB: INSERT contribution_receipt_snapshots
        end
        applyContributionCorrection-->>Caller: before, after, adjustmentId, receiptOutcome
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant applyContributionCorrection
    participant DB as Supabase DB
    participant Email as sendStagedGiftReceipt

    Caller->>applyContributionCorrection: call(tenantId, contributionId, actionType, payload, idempotencyKey?)
    applyContributionCorrection->>DB: SELECT donations + adjustments + staged_gifts
    DB-->>applyContributionCorrection: before snapshot + revision

    alt expectedRevision mismatch
        applyContributionCorrection-->>Caller: 409 Conflict
    end

    applyContributionCorrection->>DB: SELECT funds/missionaries (reference validation)
    DB-->>applyContributionCorrection: validation result

    applyContributionCorrection->>DB: INSERT contribution_adjustments

    alt duplicate idempotency_key 23505
        DB-->>applyContributionCorrection: error
        applyContributionCorrection->>DB: SELECT existing by idempotency_key
        applyContributionCorrection-->>Caller: "idempotentReplay=true, receiptOutcome=null, before==after"
    else insert success
        DB-->>applyContributionCorrection: adjustmentId
        applyContributionCorrection->>DB: SELECT after snapshot
        alt "receiptAffected and choice==email"
            applyContributionCorrection->>Email: sendStagedGiftReceipt
            Note over applyContributionCorrection,Email: If this throws, INSERT is already committed
            applyContributionCorrection->>DB: INSERT contribution_receipt_snapshots
        else "choice==pdf"
            applyContributionCorrection->>DB: INSERT contribution_receipt_snapshots
        end
        applyContributionCorrection-->>Caller: before, after, adjustmentId, receiptOutcome
    end
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fcontribution-operations%2Foperations.ts%3A682-691%0A**Idempotent%20replay%20returns%20wrong%20%60before%60%2F%60after%60%20snapshots**%0A%0AOn%20a%20replay%20path%2C%20%60before%60%20is%20loaded%20at%20the%20top%20of%20%60applyContributionCorrection%60%20*after*%20the%20first%20adjustment%20is%20already%20in%20the%20DB%2C%20so%20it%20reflects%20the%20post-adjustment%20effective%20state%20%E2%80%94%20not%20the%20pre-adjustment%20state.%20Both%20%60before%60%20and%20%60after%60%20are%20then%20set%20to%20%60summarizeEffectiveDetail%28before%29%60%2C%20meaning%20the%20returned%20diff%20is%20zero%3A%20callers%20see%20no%20change%20between%20%60before%60%20and%20%60after%60%2C%20even%20though%20the%20adjustment%20was%20applied%20on%20the%20first%20call.%20Any%20UI%20or%20downstream%20audit%20that%20compares%20the%20two%20snapshots%20to%20display%20%22what%20changed%22%20will%20show%20nothing.%20The%20fix%20is%20to%20either%20%28a%29%20reload%20%60after%60%20from%20the%20DB%20so%20at%20least%20%60after%60%20is%20accurate%20on%20replay%2C%20or%20%28b%29%20persist%20the%20pre-adjustment%20snapshot%20in%20the%20adjustment%20record%20and%20retrieve%20it%20here.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fcontribution-operations%2Foperations.ts%3A694-715%0A**Adjustment%20committed%20but%20receipt-delivery%20failure%20makes%20state%20unrecoverable%20via%20idempotent%20retry**%0A%0AThe%20%60contribution_adjustments%60%20INSERT%20at%20line%20~644%20is%20committed%20before%20%60sendStagedGiftReceipt%60%20or%20%60insertReceiptSnapshot%60%20are%20called.%20If%20either%20throws%2C%20the%20adjustment%20is%20persisted%20in%20the%20DB%20but%20the%20function%20propagates%20the%20error%20to%20the%20caller.%20When%20the%20caller%20retries%20with%20the%20same%20%60idempotencyKey%60%2C%20the%20duplicate-key%20path%20fires%20and%20returns%20%60%7B%20idempotentReplay%3A%20true%2C%20receiptOutcome%3A%20null%20%7D%60%20%E2%80%94%20the%20delivery%20outcome%20is%20silently%20dropped%20with%20no%20way%20to%20recover%20it%20through%20this%20function.%20A%20correction%20that%20succeeded%20in%20the%20DB%20can%20appear%20to%20an%20admin%20as%20a%20failure%2C%20and%20retrying%20without%20an%20idempotency%20key%20would%20write%20a%20second%2C%20duplicate%20adjustment.%20Consider%20wrapping%20the%20receipt%20delivery%20in%20a%20try%2Fcatch%20that%20stores%20a%20failed-delivery%20record%20rather%20than%20letting%20the%20exception%20propagate%20after%20the%20INSERT.%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fcontribution-operations%2Foperations.ts%3A612-617%0A**Application-level%20optimistic%20lock%20is%20not%20atomically%20enforced%20%E2%80%94%20concurrent%20corrections%20can%20both%20be%20committed**%0A%0AThe%20%60expectedRevision%60%20check%20compares%20against%20the%20in-memory%20%60before.revision%60%20at%20application%20level%2C%20but%20the%20subsequent%20INSERT%20is%20a%20separate%2C%20non-atomic%20operation.%20Two%20concurrent%20callers%20with%20the%20same%20%60expectedRevision%60%20can%20both%20pass%20this%20check%20before%20either%20writes%2C%20resulting%20in%20two%20conflicting%20adjustments%20persisted%20to%20the%20DB%20%28e.g.%2C%20one%20correcting%20amount%20to%2020%20000%2C%20another%20to%2030%20000%29.%20The%20schema%20has%20no%20%60UNIQUE%28donation_id%2C%20base_revision%29%60%20constraint%20or%20advisory%20lock%20to%20prevent%20this.%20For%20financial%20corrections%2C%20this%20race%20window%20is%20a%20data-integrity%20risk.%20A%20DB-level%20constraint%20on%20%60%28donation_id%2C%20base_revision%29%60%20%28with%20%60base_revision%20NOT%20NULL%60%20in%20that%20index%29%20or%20a%20Postgres%20advisory%20lock%20keyed%20on%20%60donation_id%60%20would%20make%20the%20guard%20atomic.%0A%0A%23%23%23%20Issue%204%20of%204%0Asupabase%2Fmigrations%2F20260611140000_contribution_receipt_delivery.sql%3A15%0A**%60updated_at%60%20has%20no%20auto-update%20trigger**%0A%0A%60contribution_receipt_delivery_policies.updated_at%60%20defaults%20to%20%60NOW%28%29%60%20at%20insert%20time%20but%20is%20never%20automatically%20updated%20on%20%60UPDATE%60.%20Without%20a%20%60BEFORE%20UPDATE%60%20trigger%20%28or%20an%20equivalent%20%60moddatetime%60%20extension%20call%29%2C%20every%20policy%20row%20will%20always%20show%20its%20creation%20timestamp%20as%20%60updated_at%60%2C%20making%20it%20impossible%20to%20tell%20when%20a%20tenant's%20receipt%20policy%20was%20last%20changed.%20Add%20a%20trigger%20analogous%20to%20those%20on%20other%20mutable%20policy%20tables%20in%20the%20schema.%0A%0A&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(api): add contribution adjustment o..."](https://github.com/asymmetric-al/core/commit/cf3c54ff415b9080dd4324e69bd94fe3831188d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38893472)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->