### PR TITLE
feat(api): add contribution correction requests

### DIFF
--- a/packages/api/src/admin/contribution-operations/correction-requests.ts
+++ b/packages/api/src/admin/contribution-operations/correction-requests.ts
@@ -1,0 +1,493 @@
+import { executeContributionAction } from "./actions";
+import {
+  assertCanDecideCorrectionRequest,
+  resolveCorrectionApprovalPolicy,
+  type CorrectionApprovalPolicy,
+  type CorrectionApprovalPolicyRow,
+} from "./approval-policy";
+import {
+  parseReceiptDeliverySelection,
+  resolveConfirmedReceiptDelivery,
+  type ReceiptDeliverySelection,
+} from "./receipt-delivery";
+import { ApiHttpError } from "../../shared/http-errors";
+
+import type {
+  ContributionActionDependencies,
+  ContributionActionResult,
+  ContributionOperationAuditEventInput,
+  ContributionActionType,
+  ContributionSourceSurface,
+} from "./types";
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+type SupabaseAdmin = AdminSupabaseClient;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export type CorrectionRequestStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "superseded";
+
+export interface ContributionCorrectionRequest {
+  id: string;
+  tenantId: string;
+  donationId: string;
+  actionType: ContributionActionType;
+  payload: Record<string, unknown>;
+  reason: string;
+  requestedByProfileId: string | null;
+  sourceSurface: ContributionSourceSurface;
+  status: CorrectionRequestStatus;
+  expectedRevision: string | null;
+  receiptDeliveryProposal: Record<string, unknown>;
+  decidedByProfileId: string | null;
+  decidedAt: string | null;
+  decisionReason: string | null;
+  appliedAdjustmentId: string | null;
+  approvalTaskId: string | null;
+  followUpTaskId: string | null;
+  createdAt: string;
+}
+
+function mapCorrectionRequestRow(
+  row: JsonRecord,
+): ContributionCorrectionRequest {
+  return {
+    id: asString(row.id) ?? "",
+    tenantId: asString(row.tenant_id) ?? "",
+    donationId: asString(row.donation_id) ?? "",
+    actionType: (asString(row.action_type) ??
+      "amount_correction") as ContributionActionType,
+    payload: isRecord(row.payload) ? row.payload : {},
+    reason: asString(row.reason) ?? "",
+    requestedByProfileId: asString(row.requested_by_profile_id),
+    sourceSurface: (asString(row.source_surface) ??
+      "api") as ContributionSourceSurface,
+    status: (asString(row.status) ?? "pending") as CorrectionRequestStatus,
+    expectedRevision: asString(row.expected_revision),
+    receiptDeliveryProposal: isRecord(row.receipt_delivery_proposal)
+      ? row.receipt_delivery_proposal
+      : {},
+    decidedByProfileId: asString(row.decided_by_profile_id),
+    decidedAt: asString(row.decided_at),
+    decisionReason: asString(row.decision_reason),
+    appliedAdjustmentId: asString(row.applied_adjustment_id),
+    approvalTaskId: asString(row.approval_task_id),
+    followUpTaskId: asString(row.follow_up_task_id),
+    createdAt: asString(row.created_at) ?? new Date(0).toISOString(),
+  };
+}
+
+export async function createContributionCorrectionRequestInSupabase(input: {
+  supabaseAdmin: SupabaseAdmin;
+  request: {
+    tenantId: string;
+    contributionId: string;
+    actionType: ContributionActionType;
+    payload: Record<string, unknown>;
+    reason: string;
+    requestedByProfileId: string | null;
+    sourceSurface: ContributionSourceSurface;
+    expectedRevision?: string | null;
+    idempotencyKey?: string | null;
+    receiptDeliveryProposal?: Record<string, unknown> | null;
+  };
+}): Promise<string> {
+  const insertResult = await input.supabaseAdmin
+    .from("contribution_correction_requests")
+    .insert({
+      tenant_id: input.request.tenantId,
+      donation_id: input.request.contributionId,
+      action_type: input.request.actionType,
+      payload: input.request.payload,
+      reason: input.request.reason,
+      requested_by_profile_id: input.request.requestedByProfileId,
+      source_surface: input.request.sourceSurface,
+      status: "pending",
+      expected_revision: input.request.expectedRevision ?? null,
+      idempotency_key: input.request.idempotencyKey ?? null,
+      receipt_delivery_proposal: input.request.receiptDeliveryProposal ?? {},
+    })
+    .select("id")
+    .single();
+
+  if (insertResult.error) {
+    const isDuplicateKey =
+      insertResult.error.code === "23505" &&
+      Boolean(input.request.idempotencyKey);
+    if (!isDuplicateKey) {
+      throw new Error(insertResult.error.message);
+    }
+
+    const existing = await input.supabaseAdmin
+      .from("contribution_correction_requests")
+      .select("id")
+      .eq("tenant_id", input.request.tenantId)
+      .eq("idempotency_key", input.request.idempotencyKey!)
+      .maybeSingle();
+
+    if (existing.error || !isRecord(existing.data)) {
+      throw new Error(
+        existing.error?.message ??
+          "Correction request already exists but could not be loaded.",
+      );
+    }
+    return asString(existing.data.id) ?? "";
+  }
+
+  return asString((insertResult.data as JsonRecord | null)?.id) ?? "";
+}
+
+export async function loadContributionCorrectionRequest(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  requestId: string;
+}): Promise<ContributionCorrectionRequest> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_correction_requests")
+    .select("*")
+    .eq("tenant_id", input.tenantId)
+    .eq("id", input.requestId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+  if (!isRecord(data)) {
+    throw new ApiHttpError(404, "Correction request not found.");
+  }
+
+  return mapCorrectionRequestRow(data);
+}
+
+export async function loadCorrectionApprovalPolicy(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+}): Promise<CorrectionApprovalPolicy> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_approval_policies")
+    .select(
+      "ownership_mode, suppressed_gates, stronger_approval_categories, reminder_hours, escalation_hours",
+    )
+    .eq("tenant_id", input.tenantId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return resolveCorrectionApprovalPolicy(
+    (data as CorrectionApprovalPolicyRow | null) ?? null,
+  );
+}
+
+async function recordDecision(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  requestId: string;
+  status: "approved" | "rejected";
+  deciderProfileId: string | null;
+  decisionReason: string | null;
+  appliedAdjustmentId?: string | null;
+  followUpTaskId?: string | null;
+}): Promise<boolean> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_correction_requests")
+    .update({
+      status: input.status,
+      decided_by_profile_id: input.deciderProfileId,
+      decided_at: new Date().toISOString(),
+      decision_reason: input.decisionReason,
+      applied_adjustment_id: input.appliedAdjustmentId ?? null,
+      follow_up_task_id: input.followUpTaskId ?? null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", input.tenantId)
+    .eq("id", input.requestId)
+    .eq("status", "pending")
+    .select("id");
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return Array.isArray(data) && data.length > 0;
+}
+
+async function appendDecisionAuditEvent(input: {
+  dependencies: ContributionActionDependencies;
+  event: ContributionOperationAuditEventInput;
+}): Promise<string> {
+  const appendAuditEvent = input.dependencies.appendAuditEvent;
+  if (!appendAuditEvent) {
+    throw new ApiHttpError(
+      501,
+      "Contribution operation dependency missing: appendAuditEvent",
+    );
+  }
+
+  return appendAuditEvent(input.event);
+}
+
+export interface DecideCorrectionRequestInput {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  requestId: string;
+  decision: "approve" | "reject";
+  reason?: string | null;
+  deciderProfileId: string | null;
+  deciderCapabilities: string[];
+  dependencies: ContributionActionDependencies;
+  policy?: CorrectionApprovalPolicy;
+  /**
+   * Approver's updated receipt delivery choice (ADR-CD-030). When omitted,
+   * the requester's proposal stands; when provided, it overrides and the
+   * change is audited.
+   */
+  receiptDelivery?: ReceiptDeliverySelection | null;
+  /** Optional hook creating requester follow-up work on rejection (#262). */
+  createFollowUpTask?: (input: {
+    tenantId: string;
+    request: ContributionCorrectionRequest;
+    decisionReason: string;
+  }) => Promise<string | null>;
+  /** Optional outcome follow-through for future task closure/notifications. */
+  recordOutcome?: (input: {
+    supabaseAdmin: SupabaseAdmin;
+    tenantId: string;
+    request: ContributionCorrectionRequest;
+    decision: "approved" | "rejected";
+    decisionReason: string | null;
+  }) => Promise<void>;
+}
+
+export interface DecideCorrectionRequestOutcome {
+  request: ContributionCorrectionRequest;
+  result?: ContributionActionResult;
+  idempotentReplay?: boolean;
+}
+
+/**
+ * Approves or rejects a pending correction request (ADR-CD-027).
+ *
+ * Approval applies the correction through the shared contribution operation
+ * contract; rejection requires a reason and may create requester follow-up
+ * work. Outcomes are audited with actor, timestamp, decision, and reason,
+ * and repeated decisions never duplicate adjustments.
+ */
+export async function decideContributionCorrectionRequest(
+  input: DecideCorrectionRequestInput,
+): Promise<DecideCorrectionRequestOutcome> {
+  const request = await loadContributionCorrectionRequest(input);
+
+  if (request.status !== "pending") {
+    const sameOutcome =
+      (request.status === "approved" && input.decision === "approve") ||
+      (request.status === "rejected" && input.decision === "reject");
+    if (sameOutcome) {
+      return { request, idempotentReplay: true };
+    }
+    throw new ApiHttpError(
+      409,
+      `This correction request was already ${request.status}.`,
+    );
+  }
+
+  const policy =
+    input.policy ??
+    (await loadCorrectionApprovalPolicy({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+    }));
+
+  assertCanDecideCorrectionRequest({
+    policy,
+    request: { requestedByProfileId: request.requestedByProfileId },
+    deciderProfileId: input.deciderProfileId,
+    deciderCapabilities: input.deciderCapabilities,
+  });
+
+  if (input.decision === "reject") {
+    const decisionReason = input.reason?.trim();
+    if (!decisionReason) {
+      throw new ApiHttpError(
+        400,
+        "A rejection reason is required so the requester knows what to fix.",
+      );
+    }
+
+    const followUpTaskId = input.createFollowUpTask
+      ? await input.createFollowUpTask({
+          tenantId: input.tenantId,
+          request,
+          decisionReason,
+        })
+      : null;
+
+    const updated = await recordDecision({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      requestId: input.requestId,
+      status: "rejected",
+      deciderProfileId: input.deciderProfileId,
+      decisionReason,
+      followUpTaskId,
+    });
+    if (!updated) {
+      throw new ApiHttpError(
+        409,
+        "This correction request was decided concurrently. Reload to see the outcome.",
+      );
+    }
+
+    await appendDecisionAuditEvent({
+      dependencies: input.dependencies,
+      event: {
+        tenantId: input.tenantId,
+        actorProfileId: input.deciderProfileId,
+        contributionId: request.donationId,
+        actionType: request.actionType,
+        sourceSurface: request.sourceSurface,
+        reason: decisionReason,
+        downstreamEffects: {
+          correctionRequestId: request.id,
+          decision: "rejected",
+          followUpTaskId,
+        },
+      },
+    });
+
+    const decidedRequest = await loadContributionCorrectionRequest(input);
+
+    if (input.recordOutcome) {
+      await input.recordOutcome({
+        supabaseAdmin: input.supabaseAdmin,
+        tenantId: input.tenantId,
+        request: decidedRequest,
+        decision: "rejected",
+        decisionReason,
+      });
+    }
+
+    return {
+      request: decidedRequest,
+    };
+  }
+
+  const receiptDelivery = resolveConfirmedReceiptDelivery({
+    proposal: parseReceiptDeliverySelection(request.receiptDeliveryProposal),
+    approverSelection: input.receiptDelivery ?? null,
+  });
+  const applicationPayload = {
+    ...request.payload,
+    ...(receiptDelivery.confirmed
+      ? {
+          receiptDelivery: receiptDelivery.confirmed,
+          requestedReceiptDelivery: receiptDelivery.requested,
+        }
+      : {}),
+  };
+
+  const result = await executeContributionAction({
+    tenantId: input.tenantId,
+    actorProfileId: input.deciderProfileId,
+    actorPermissions: [],
+    actorCapabilities: input.deciderCapabilities,
+    approvalPolicy: policy,
+    approvedRequestId: request.id,
+    sourceSurface: request.sourceSurface,
+    contributionId: request.donationId,
+    actionType: request.actionType,
+    reason: request.reason,
+    confirmationToken: `correction-request/${request.id}`,
+    expectedRevision: request.expectedRevision,
+    idempotencyKey: `correction-request-apply/${input.tenantId}/${request.id}`,
+    payload: applicationPayload,
+    dependencies: {
+      ...input.dependencies,
+      validateApprovedCorrectionRequest: async (approvedRequest) => {
+        const matchesRequest =
+          approvedRequest.tenantId === input.tenantId &&
+          approvedRequest.contributionId === request.donationId &&
+          approvedRequest.actionType === request.actionType &&
+          approvedRequest.approvedRequestId === request.id;
+
+        if (!matchesRequest) {
+          throw new ApiHttpError(
+            409,
+            "Approved correction request does not match this contribution action.",
+          );
+        }
+
+        return {
+          payload: applicationPayload,
+          reason: request.reason,
+        };
+      },
+    },
+  });
+
+  const updated = await recordDecision({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    requestId: input.requestId,
+    status: "approved",
+    deciderProfileId: input.deciderProfileId,
+    decisionReason: input.reason?.trim() || null,
+    appliedAdjustmentId: result.adjustmentId ?? null,
+  });
+  if (!updated) {
+    throw new ApiHttpError(
+      409,
+      "This correction request was decided concurrently. Reload to see the outcome.",
+    );
+  }
+
+  await appendDecisionAuditEvent({
+    dependencies: input.dependencies,
+    event: {
+      tenantId: input.tenantId,
+      actorProfileId: input.deciderProfileId,
+      contributionId: request.donationId,
+      actionType: request.actionType,
+      sourceSurface: request.sourceSurface,
+      reason: input.reason?.trim() || request.reason,
+      downstreamEffects: {
+        correctionRequestId: request.id,
+        decision: "approved",
+        adjustmentId: result.adjustmentId ?? null,
+        receiptDeliveryRequested: receiptDelivery.requested,
+        receiptDeliveryConfirmed: receiptDelivery.confirmed,
+        receiptDeliveryChangedByApprover: receiptDelivery.changedByApprover,
+      },
+    },
+  });
+
+  const decidedRequest = await loadContributionCorrectionRequest(input);
+
+  if (input.recordOutcome) {
+    await input.recordOutcome({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      request: decidedRequest,
+      decision: "approved",
+      decisionReason: input.reason?.trim() || null,
+    });
+  }
+
+  return {
+    request: decidedRequest,
+    result,
+  };
+}

--- a/packages/api/src/admin/contribution-operations/index.ts
+++ b/packages/api/src/admin/contribution-operations/index.ts
@@ -18,6 +18,14 @@ export {
   type CrmPostFailedScope,
   type CrmPostLinkInput,
 } from "./crm-post-state";
+export {
+  createContributionCorrectionRequestInSupabase,
+  decideContributionCorrectionRequest,
+  loadContributionCorrectionRequest,
+  loadCorrectionApprovalPolicy,
+  type ContributionCorrectionRequest,
+  type CorrectionRequestStatus,
+} from "./correction-requests";
 export { buildContributionDetail } from "./detail-read-model";
 export {
   buildInlineContributionActions,

--- a/packages/database/types/database.ts
+++ b/packages/database/types/database.ts
@@ -405,6 +405,44 @@ export interface ContributionAdjustment {
   created_at: string;
 }
 
+export interface ContributionApprovalPolicy {
+  tenant_id: string;
+  ownership_mode:
+    | "no_approval_required"
+    | "one_approver"
+    | "separation_of_duties";
+  suppressed_gates: string[];
+  stronger_approval_categories: string[];
+  reminder_hours: number;
+  escalation_hours: number | null;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ContributionCorrectionRequest {
+  id: string;
+  tenant_id: string;
+  donation_id: string;
+  action_type: string;
+  payload: Record<string, unknown>;
+  reason: string;
+  requested_by_profile_id: string | null;
+  source_surface: ContributionOperationSourceSurface;
+  status: "pending" | "approved" | "rejected" | "superseded";
+  expected_revision: string | null;
+  idempotency_key: string | null;
+  receipt_delivery_proposal: Record<string, unknown>;
+  decided_by_profile_id: string | null;
+  decided_at: string | null;
+  decision_reason: string | null;
+  applied_adjustment_id: string | null;
+  approval_task_id: string | null;
+  follow_up_task_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export type ContributionNotificationMode =
   | "auto_notify"
   | "always_ask"

--- a/packages/database/types/index.ts
+++ b/packages/database/types/index.ts
@@ -80,7 +80,9 @@ export type {
 } from "./crm-reports";
 export type {
   ContributionAdjustment,
+  ContributionApprovalPolicy,
   ContributionCorrection,
+  ContributionCorrectionRequest,
   ContributionCorrectionType,
   ContributionCorrectionStatus,
   ContributionNotificationDecision,

--- a/packages/email/contribution-correction-tags.ts
+++ b/packages/email/contribution-correction-tags.ts
@@ -1,0 +1,255 @@
+import type { MergeTagCategory } from "./merge-tags";
+
+export type ContributionCorrectionTemplateFamily =
+  | "refund_notification"
+  | "amount_correction_notification"
+  | "designation_correction_notification"
+  | "receipt_correction_notification"
+  | "statement_correction_notification"
+  | "payment_state_correction_notification"
+  | "donor_relinking_notification";
+
+export type ContributionCorrectionTemplateVariant =
+  | "refund_started"
+  | "refund_completed"
+  | "refund_failed"
+  | "partial_refund_completed"
+  | "full_refund_completed"
+  | "amount_corrected"
+  | "designation_changed"
+  | "receipt_corrected"
+  | "statement_corrected"
+  | "payment_state_corrected"
+  | "donor_relinked";
+
+export const CONTRIBUTION_CORRECTION_MERGE_TAG_CATEGORY: MergeTagCategory = {
+  label: "Contribution Correction",
+  tags: [
+    {
+      key: "gift_date",
+      label: "Gift Date",
+      category: "contribution_correction",
+      type: "date",
+      sample: "May 1, 2026",
+    },
+    {
+      key: "correction_reason",
+      label: "Correction Reason",
+      category: "contribution_correction",
+      type: "string",
+      sample: "Duplicate transaction corrected by finance.",
+    },
+    {
+      key: "original_amount",
+      label: "Original Amount",
+      category: "contribution_correction",
+      type: "currency",
+      sample: "$100.00",
+    },
+    {
+      key: "corrected_amount",
+      label: "Corrected Amount",
+      category: "contribution_correction",
+      type: "currency",
+      sample: "$75.00",
+    },
+    {
+      key: "refund_amount",
+      label: "Refund Amount",
+      category: "contribution_correction",
+      type: "currency",
+      sample: "$25.00",
+    },
+    {
+      key: "previous_designation_name",
+      label: "Previous Designation",
+      category: "contribution_correction",
+      type: "string",
+      sample: "General Fund",
+    },
+    {
+      key: "corrected_designation_name",
+      label: "Corrected Designation",
+      category: "contribution_correction",
+      type: "string",
+      sample: "Clean Water Initiative",
+    },
+    {
+      key: "receipt_link",
+      label: "Receipt Link",
+      category: "contribution_correction",
+      type: "url",
+      sample: "https://givehope.org/donor-dashboard/history",
+    },
+    {
+      key: "statement_link",
+      label: "Statement Link",
+      category: "contribution_correction",
+      type: "url",
+      sample: "https://givehope.org/donor-dashboard/history",
+    },
+    {
+      key: "payment_state",
+      label: "Payment State",
+      category: "contribution_correction",
+      type: "string",
+      sample: "Refunded",
+    },
+    {
+      key: "donor_portal_link",
+      label: "Donor Portal Link",
+      category: "contribution_correction",
+      type: "url",
+      sample: "https://givehope.org/donor-dashboard/history",
+    },
+    {
+      key: "support_contact_link",
+      label: "Support Contact Link",
+      category: "contribution_correction",
+      type: "url",
+      sample: "mailto:finance@givehope.org",
+    },
+    {
+      key: "operation_reference",
+      label: "Operation Reference",
+      category: "contribution_correction",
+      type: "string",
+      sample: "CO-2026-0001",
+    },
+    {
+      key: "personal_note",
+      label: "Personal Note",
+      category: "contribution_correction",
+      type: "string",
+      sample: "Thank you for your patience while we corrected this.",
+    },
+  ],
+};
+
+export const CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES = {
+  refund_notification: {
+    variants: {
+      refund_started: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "donation_amount",
+          "refund_amount",
+          "donor_portal_link",
+        ],
+      },
+      refund_completed: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "donation_amount",
+          "refund_amount",
+          "donor_portal_link",
+        ],
+      },
+      refund_failed: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "donation_amount",
+          "refund_amount",
+          "support_contact_link",
+        ],
+      },
+      partial_refund_completed: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "donation_amount",
+          "refund_amount",
+          "donor_portal_link",
+        ],
+      },
+      full_refund_completed: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "donation_amount",
+          "refund_amount",
+          "donor_portal_link",
+        ],
+      },
+    },
+  },
+  amount_correction_notification: {
+    variants: {
+      amount_corrected: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "original_amount",
+          "corrected_amount",
+          "donor_portal_link",
+        ],
+      },
+    },
+  },
+  designation_correction_notification: {
+    variants: {
+      designation_changed: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "previous_designation_name",
+          "corrected_designation_name",
+          "donor_portal_link",
+        ],
+      },
+    },
+  },
+  receipt_correction_notification: {
+    variants: {
+      receipt_corrected: {
+        requiredTags: ["full_name", "gift_date", "receipt_link"],
+      },
+    },
+  },
+  statement_correction_notification: {
+    variants: {
+      statement_corrected: {
+        requiredTags: ["full_name", "statement_link"],
+      },
+    },
+  },
+  payment_state_correction_notification: {
+    variants: {
+      payment_state_corrected: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "payment_state",
+          "donor_portal_link",
+        ],
+      },
+    },
+  },
+  donor_relinking_notification: {
+    variants: {
+      donor_relinked: {
+        requiredTags: [
+          "full_name",
+          "gift_date",
+          "operation_reference",
+          "support_contact_link",
+        ],
+      },
+    },
+  },
+} as const;
+
+export function getContributionCorrectionRequiredTags(input: {
+  family: ContributionCorrectionTemplateFamily;
+  variant: ContributionCorrectionTemplateVariant;
+}): string[] {
+  const family = CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES[input.family];
+  const variant = (
+    family.variants as Record<string, { requiredTags: readonly string[] }>
+  )[input.variant];
+
+  return [...(variant?.requiredTags ?? [])];
+}

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -56,6 +56,14 @@ export {
 } from "./merge-tags";
 
 export {
+  CONTRIBUTION_CORRECTION_MERGE_TAG_CATEGORY,
+  CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES,
+  getContributionCorrectionRequiredTags,
+  type ContributionCorrectionTemplateFamily,
+  type ContributionCorrectionTemplateVariant,
+} from "./contribution-correction-tags";
+
+export {
   parseMergeTags,
   renderMergeTags,
   renderTemplateForRecipient,

--- a/packages/email/merge-tags.ts
+++ b/packages/email/merge-tags.ts
@@ -1,3 +1,5 @@
+import { CONTRIBUTION_CORRECTION_MERGE_TAG_CATEGORY } from "./contribution-correction-tags";
+
 export type MergeTagValueType =
   | "string"
   | "currency"
@@ -151,6 +153,7 @@ export const DEFAULT_MERGE_TAG_REGISTRY: MergeTagRegistry = {
       },
     ],
   },
+  contribution_correction: CONTRIBUTION_CORRECTION_MERGE_TAG_CATEGORY,
   missionary: {
     label: "Missionary",
     tags: [

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -11,6 +11,7 @@
     "./types": "./types.ts",
     "./email-studio-types": "./email-studio-types.ts",
     "./email-builder-types": "./email-builder-types.ts",
+    "./contribution-correction-tags": "./contribution-correction-tags.ts",
     "./merge-tags": "./merge-tags.ts",
     "./merge-tag-render": "./merge-tag-render.ts",
     "./legacy/unlayer-types": "./legacy/unlayer-types.ts"

--- a/supabase/migrations/20260611120000_contribution_correction_requests.sql
+++ b/supabase/migrations/20260611120000_contribution_correction_requests.sql
@@ -1,0 +1,74 @@
+-- High-risk correction requests and tenant approval policy
+-- (ADR-CD-005 / ADR-CD-025 / ADR-CD-027).
+
+CREATE TABLE IF NOT EXISTS public.contribution_approval_policies (
+    tenant_id UUID PRIMARY KEY REFERENCES public.tenants(id) ON DELETE CASCADE,
+    ownership_mode TEXT NOT NULL DEFAULT 'separation_of_duties'
+        CHECK (
+            ownership_mode IN (
+                'no_approval_required',
+                'one_approver',
+                'separation_of_duties'
+            )
+        ),
+    suppressed_gates TEXT[] NOT NULL DEFAULT '{}'::text[],
+    stronger_approval_categories TEXT[] NOT NULL DEFAULT '{}'::text[],
+    reminder_hours INTEGER NOT NULL DEFAULT 24 CHECK (reminder_hours > 0),
+    escalation_hours INTEGER CHECK (escalation_hours > 0),
+    updated_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.contribution_correction_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    donation_id UUID NOT NULL REFERENCES public.donations(id) ON DELETE CASCADE,
+    action_type TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    reason TEXT NOT NULL,
+    requested_by_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    source_surface TEXT NOT NULL
+        CHECK (
+            source_surface IN (
+                'contribution_hub',
+                'donor_crm_record',
+                'automation',
+                'bulk_action',
+                'api'
+            )
+        ),
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'approved', 'rejected', 'superseded')),
+    expected_revision TEXT,
+    idempotency_key TEXT,
+    receipt_delivery_proposal JSONB NOT NULL DEFAULT '{}'::jsonb,
+    decided_by_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    decided_at TIMESTAMPTZ,
+    decision_reason TEXT,
+    applied_adjustment_id UUID REFERENCES public.contribution_adjustments(id) ON DELETE SET NULL,
+    approval_task_id UUID,
+    follow_up_task_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contribution_correction_requests_idempotency
+    ON public.contribution_correction_requests (tenant_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_contribution_correction_requests_tenant_donation
+    ON public.contribution_correction_requests (tenant_id, donation_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_correction_requests_pending
+    ON public.contribution_correction_requests (tenant_id, status, created_at)
+    WHERE status = 'pending';
+
+ALTER TABLE public.contribution_approval_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_correction_requests ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.contribution_approval_policies FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_correction_requests FROM anon, authenticated;
+
+GRANT ALL ON TABLE public.contribution_approval_policies TO service_role;
+GRANT ALL ON TABLE public.contribution_correction_requests TO service_role;

--- a/tests/unit/packages/api/admin/contribution-correction-requests.test.ts
+++ b/tests/unit/packages/api/admin/contribution-correction-requests.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createContributionCorrectionRequestInSupabase,
+  decideContributionCorrectionRequest,
+} from "../../../../../packages/api/src/admin/contribution-operations/correction-requests";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+const TENANT_ID = "tenant-1";
+const REQUEST_ID = "request-1";
+
+interface RequestRow extends Record<string, unknown> {
+  id: string;
+  tenant_id: string;
+  donation_id: string;
+  action_type: string;
+  payload: Record<string, unknown>;
+  reason: string;
+  requested_by_profile_id: string | null;
+  source_surface: string;
+  status: string;
+}
+
+interface StubState {
+  request: RequestRow;
+  auditInserts: Array<Record<string, unknown>>;
+  insertedRequests?: Array<Record<string, unknown>>;
+}
+
+function pendingRequest(): RequestRow {
+  return {
+    id: REQUEST_ID,
+    tenant_id: TENANT_ID,
+    donation_id: "donation-1",
+    action_type: "amount_correction",
+    payload: { amount: 20_000 },
+    reason: "Donor reported the wrong amount",
+    requested_by_profile_id: "requester-1",
+    source_surface: "donor_crm_record",
+    status: "pending",
+    expected_revision: null,
+    receipt_delivery_proposal: {},
+    decided_by_profile_id: null,
+    decided_at: null,
+    decision_reason: null,
+    applied_adjustment_id: null,
+    approval_task_id: null,
+    follow_up_task_id: null,
+    created_at: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+class QueryBuilder {
+  private operation: "select" | "insert" | "update" = "select";
+  private insertPayload: Record<string, unknown> | null = null;
+  private updatePayload: Record<string, unknown> | null = null;
+  private idempotencyKeyFilter: string | null = null;
+  private statusFilter: string | null = null;
+
+  constructor(
+    private readonly table: string,
+    private readonly state: StubState,
+  ) {}
+
+  select() {
+    return this;
+  }
+
+  insert(payload: Record<string, unknown>) {
+    this.operation = "insert";
+    this.insertPayload = payload;
+    if (this.table === "contribution_operation_audit_events") {
+      this.state.auditInserts.push(payload);
+    }
+    return this;
+  }
+
+  update(payload: Record<string, unknown>) {
+    this.operation = "update";
+    this.updatePayload = payload;
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    if (column === "status" && typeof value === "string") {
+      this.statusFilter = value;
+    }
+    if (column === "idempotency_key" && typeof value === "string") {
+      this.idempotencyKeyFilter = value;
+    }
+    return this;
+  }
+
+  order() {
+    return this;
+  }
+
+  limit() {
+    return this;
+  }
+
+  single() {
+    return this;
+  }
+
+  maybeSingle() {
+    return this;
+  }
+
+  private resolve(): {
+    data: unknown;
+    error: { code?: string; message: string } | null;
+  } {
+    if (this.table === "contribution_correction_requests") {
+      if (this.operation === "insert" && this.insertPayload) {
+        const insertedRequests = (this.state.insertedRequests ??= []);
+        const idempotencyKey = this.insertPayload.idempotency_key;
+        const duplicate =
+          typeof idempotencyKey === "string" &&
+          insertedRequests.some(
+            (request) => request.idempotency_key === idempotencyKey,
+          );
+
+        if (duplicate) {
+          return {
+            data: null,
+            error: {
+              code: "23505",
+              message: "duplicate correction request idempotency key",
+            },
+          };
+        }
+
+        const row = {
+          id: `request-${insertedRequests.length + 1}`,
+          created_at: "2026-06-01T00:00:00.000Z",
+          updated_at: "2026-06-01T00:00:00.000Z",
+          ...this.insertPayload,
+        };
+        insertedRequests.push(row);
+        return { data: { id: row.id }, error: null };
+      }
+
+      if (this.operation === "update") {
+        if (
+          this.statusFilter &&
+          this.state.request.status !== this.statusFilter
+        ) {
+          return { data: [], error: null };
+        }
+        Object.assign(this.state.request, this.updatePayload);
+        return { data: [{ id: this.state.request.id }], error: null };
+      }
+      if (this.idempotencyKeyFilter) {
+        const existing = (this.state.insertedRequests ?? []).find(
+          (request) => request.idempotency_key === this.idempotencyKeyFilter,
+        );
+        return { data: existing ?? null, error: null };
+      }
+      return { data: { ...this.state.request }, error: null };
+    }
+    if (this.table === "contribution_approval_policies") {
+      return { data: null, error: null };
+    }
+    if (this.table === "contribution_operation_audit_events") {
+      return {
+        data: { id: `audit-${this.state.auditInserts.length}` },
+        error: null,
+      };
+    }
+    return { data: null, error: null };
+  }
+
+  then<TResult>(
+    onfulfilled: (value: {
+      data: unknown;
+      error: { code?: string; message: string } | null;
+    }) => TResult,
+  ): Promise<TResult> {
+    return Promise.resolve(this.resolve()).then(onfulfilled);
+  }
+}
+
+function createStub(state: StubState): AdminSupabaseClient {
+  return {
+    from(table: string) {
+      return new QueryBuilder(table, state);
+    },
+  } as unknown as AdminSupabaseClient;
+}
+
+function approverDependencies(state?: StubState) {
+  return {
+    applyCorrection: vi.fn().mockResolvedValue({
+      before: { amount: 25_000 },
+      after: { amount: 20_000 },
+      status: "applied" as const,
+      adjustmentId: "adj-1",
+      idempotentReplay: false,
+    }),
+    createCorrectionRecord: vi.fn().mockResolvedValue("correction-1"),
+    appendAuditEvent: vi.fn().mockImplementation(async (event) => {
+      state?.auditInserts.push(event);
+      return `audit-${state?.auditInserts.length ?? 1}`;
+    }),
+    loadContributionDetail: vi.fn().mockResolvedValue({ id: "donation-1" }),
+  };
+}
+
+describe("createContributionCorrectionRequestInSupabase", () => {
+  it("persists a pending request and returns the existing request on idempotent retry", async () => {
+    const state: StubState = {
+      request: pendingRequest(),
+      auditInserts: [],
+      insertedRequests: [],
+    };
+    const supabaseAdmin = createStub(state);
+    const request = {
+      tenantId: TENANT_ID,
+      contributionId: "donation-1",
+      actionType: "amount_correction" as const,
+      payload: { amount: 20_000 },
+      reason: "Donor reported the wrong amount",
+      requestedByProfileId: "requester-1",
+      sourceSurface: "donor_crm_record" as const,
+      expectedRevision: "rev-1",
+      idempotencyKey: "request-key-1",
+      receiptDeliveryProposal: { choice: "defer" },
+    };
+
+    const firstId = await createContributionCorrectionRequestInSupabase({
+      supabaseAdmin,
+      request,
+    });
+    const secondId = await createContributionCorrectionRequestInSupabase({
+      supabaseAdmin,
+      request,
+    });
+
+    expect(firstId).toBe("request-1");
+    expect(secondId).toBe(firstId);
+    expect(state.insertedRequests).toHaveLength(1);
+    expect(state.insertedRequests![0]).toMatchObject({
+      tenant_id: TENANT_ID,
+      donation_id: "donation-1",
+      status: "pending",
+      expected_revision: "rev-1",
+      receipt_delivery_proposal: { choice: "defer" },
+    });
+  });
+});
+
+describe("decideContributionCorrectionRequest", () => {
+  it("blocks the requester from approving their own request under separation of duties", async () => {
+    const state: StubState = { request: pendingRequest(), auditInserts: [] };
+
+    await expect(
+      decideContributionCorrectionRequest({
+        supabaseAdmin: createStub(state),
+        tenantId: TENANT_ID,
+        requestId: REQUEST_ID,
+        decision: "approve",
+        deciderProfileId: "requester-1",
+        deciderCapabilities: ["contributions.approve_corrections"],
+        dependencies: approverDependencies(state),
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+
+    expect(state.request.status).toBe("pending");
+  });
+
+  it("applies approved corrections through the shared contract and records the outcome", async () => {
+    const state: StubState = { request: pendingRequest(), auditInserts: [] };
+    const dependencies = approverDependencies(state);
+    const recordOutcome = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await decideContributionCorrectionRequest({
+      supabaseAdmin: createStub(state),
+      tenantId: TENANT_ID,
+      requestId: REQUEST_ID,
+      decision: "approve",
+      deciderProfileId: "approver-1",
+      deciderCapabilities: [
+        "contributions.approve_corrections",
+        "contributions.apply_corrections",
+      ],
+      dependencies,
+      recordOutcome,
+    });
+
+    // The approval task closes and the requester is notified (ADR-CD-027).
+    expect(recordOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: "approved",
+        request: expect.objectContaining({
+          id: REQUEST_ID,
+          status: "approved",
+        }),
+      }),
+    );
+
+    expect(dependencies.applyCorrection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: TENANT_ID,
+        contributionId: "donation-1",
+        actionType: "amount_correction",
+        payload: { amount: 20_000 },
+        reason: "Donor reported the wrong amount",
+        idempotencyKey: `correction-request-apply/${TENANT_ID}/${REQUEST_ID}`,
+      }),
+    );
+
+    expect(state.request.status).toBe("approved");
+    expect(state.request.decided_by_profile_id).toBe("approver-1");
+    expect(state.request.applied_adjustment_id).toBe("adj-1");
+    expect(outcome.result?.adjustmentId).toBe("adj-1");
+    expect(
+      state.auditInserts.some(
+        (event) =>
+          (event.downstreamEffects as Record<string, unknown> | undefined)
+            ?.decision === "approved",
+      ),
+    ).toBe(true);
+  });
+
+  it("passes requester and approver receipt delivery choices into the approved correction payload", async () => {
+    const state: StubState = { request: pendingRequest(), auditInserts: [] };
+    state.request.receipt_delivery_proposal = {
+      choice: "defer",
+      deferReason: "Requester asked finance to wait",
+    };
+    const dependencies = approverDependencies(state);
+
+    await decideContributionCorrectionRequest({
+      supabaseAdmin: createStub(state),
+      tenantId: TENANT_ID,
+      requestId: REQUEST_ID,
+      decision: "approve",
+      reason: "Finance reviewed the receipt plan",
+      receiptDelivery: { choice: "pdf" },
+      deciderProfileId: "approver-1",
+      deciderCapabilities: [
+        "contributions.approve_corrections",
+        "contributions.apply_corrections",
+      ],
+      dependencies,
+    });
+
+    expect(dependencies.applyCorrection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedRevision: null,
+        payload: {
+          amount: 20_000,
+          receiptDelivery: { choice: "pdf" },
+          requestedReceiptDelivery: {
+            choice: "defer",
+            deferReason: "Requester asked finance to wait",
+          },
+        },
+      }),
+    );
+    expect(
+      state.auditInserts.some(
+        (event) =>
+          (event.downstreamEffects as Record<string, unknown> | undefined)
+            ?.receiptDeliveryChangedByApprover === true,
+      ),
+    ).toBe(true);
+  });
+
+  it("requires a rejection reason and records requester follow-up work", async () => {
+    const state: StubState = { request: pendingRequest(), auditInserts: [] };
+
+    await expect(
+      decideContributionCorrectionRequest({
+        supabaseAdmin: createStub(state),
+        tenantId: TENANT_ID,
+        requestId: REQUEST_ID,
+        decision: "reject",
+        reason: "  ",
+        deciderProfileId: "approver-1",
+        deciderCapabilities: ["contributions.approve_corrections"],
+        dependencies: approverDependencies(state),
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+
+    const createFollowUpTask = vi.fn().mockResolvedValue("task-1");
+    const recordOutcome = vi.fn().mockResolvedValue(undefined);
+    const outcome = await decideContributionCorrectionRequest({
+      supabaseAdmin: createStub(state),
+      tenantId: TENANT_ID,
+      requestId: REQUEST_ID,
+      decision: "reject",
+      reason: "Amount does not match the bank deposit",
+      deciderProfileId: "approver-1",
+      deciderCapabilities: ["contributions.approve_corrections"],
+      dependencies: approverDependencies(state),
+      createFollowUpTask,
+      recordOutcome,
+    });
+
+    expect(createFollowUpTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: TENANT_ID,
+        decisionReason: "Amount does not match the bank deposit",
+      }),
+    );
+    expect(state.request.status).toBe("rejected");
+    expect(state.request.decision_reason).toBe(
+      "Amount does not match the bank deposit",
+    );
+    expect(state.request.follow_up_task_id).toBe("task-1");
+    expect(outcome.request.status).toBe("rejected");
+    expect(recordOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: "rejected",
+        request: expect.objectContaining({
+          id: REQUEST_ID,
+          status: "rejected",
+        }),
+      }),
+    );
+  });
+
+  it("returns the recorded outcome for repeated decisions instead of duplicating work", async () => {
+    const state: StubState = { request: pendingRequest(), auditInserts: [] };
+    state.request.status = "approved";
+    const dependencies = approverDependencies(state);
+
+    const outcome = await decideContributionCorrectionRequest({
+      supabaseAdmin: createStub(state),
+      tenantId: TENANT_ID,
+      requestId: REQUEST_ID,
+      decision: "approve",
+      deciderProfileId: "approver-1",
+      deciderCapabilities: ["contributions.approve_corrections"],
+      dependencies,
+    });
+
+    expect(outcome.idempotentReplay).toBe(true);
+    expect(dependencies.applyCorrection).not.toHaveBeenCalled();
+    expect(state.auditInserts).toHaveLength(0);
+
+    await expect(
+      decideContributionCorrectionRequest({
+        supabaseAdmin: createStub(state),
+        tenantId: TENANT_ID,
+        requestId: REQUEST_ID,
+        decision: "reject",
+        reason: "changed my mind",
+        deciderProfileId: "approver-1",
+        deciderCapabilities: ["contributions.approve_corrections"],
+        dependencies,
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+});

--- a/tests/unit/packages/email/contribution-correction-tags.test.ts
+++ b/tests/unit/packages/email/contribution-correction-tags.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES,
+  getContributionCorrectionRequiredTags,
+} from "../../../../packages/email/contribution-correction-tags";
+import {
+  getMergeTagDefinition,
+  getMergeTagDefinitions,
+} from "../../../../packages/email/merge-tags";
+
+describe("@asym/email contribution correction tags", () => {
+  it("adds donor correction tags to the shared Email Studio registry", () => {
+    const keys = getMergeTagDefinitions().map((tag) => tag.key);
+
+    expect(keys).toContain("correction_reason");
+    expect(keys).toContain("corrected_amount");
+    expect(keys).toContain("refund_amount");
+    expect(keys).toContain("donor_portal_link");
+    expect(getMergeTagDefinition("support_contact_link")).toEqual(
+      expect.objectContaining({ type: "url" }),
+    );
+  });
+
+  it("defines required tags per correction family and variant", () => {
+    expect(
+      getContributionCorrectionRequiredTags({
+        family: "refund_notification",
+        variant: "refund_completed",
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        "full_name",
+        "gift_date",
+        "donation_amount",
+        "refund_amount",
+        "donor_portal_link",
+      ]),
+    );
+
+    expect(
+      CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES
+        .designation_correction_notification.variants.designation_changed
+        .requiredTags,
+    ).toContain("corrected_designation_name");
+  });
+});

--- a/tests/unit/supabase/contribution-correction-requests-migration.test.ts
+++ b/tests/unit/supabase/contribution-correction-requests-migration.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL(
+    "../../../supabase/migrations/20260611120000_contribution_correction_requests.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("contribution correction request migration", () => {
+  it("creates approval policy and correction request tables with safe access", () => {
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.contribution_approval_policies",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.contribution_correction_requests",
+    );
+    expect(migrationSql).toContain(
+      "donation_id UUID NOT NULL REFERENCES public.donations(id) ON DELETE CASCADE",
+    );
+    expect(migrationSql).toContain(
+      "applied_adjustment_id UUID REFERENCES public.contribution_adjustments(id) ON DELETE SET NULL",
+    );
+    expect(migrationSql).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_contribution_correction_requests_idempotency",
+    );
+    expect(migrationSql).toContain("WHERE idempotency_key IS NOT NULL");
+    expect(migrationSql).toContain(
+      "ALTER TABLE public.contribution_approval_policies ENABLE ROW LEVEL SECURITY",
+    );
+    expect(migrationSql).toContain(
+      "ALTER TABLE public.contribution_correction_requests ENABLE ROW LEVEL SECURITY",
+    );
+    expect(migrationSql).toContain(
+      "REVOKE ALL ON TABLE public.contribution_correction_requests FROM anon, authenticated",
+    );
+    expect(migrationSql).toContain(
+      "GRANT ALL ON TABLE public.contribution_correction_requests TO service_role",
+    );
+  });
+
+  it("keeps pending request lookup indexed for approver queues", () => {
+    expect(migrationSql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_contribution_correction_requests_pending",
+    );
+    expect(migrationSql).toContain(
+      "ON public.contribution_correction_requests (tenant_id, status, created_at)",
+    );
+    expect(migrationSql).toContain("WHERE status = 'pending'");
+  });
+});


### PR DESCRIPTION
## Summary
- add approval policy and contribution correction request schema with idempotent request creation
- add correction request decision contracts for approve/reject, approval ownership enforcement, receipt-delivery confirmation, and decision audit hooks
- add contribution correction merge tags and required-tag families for future donor notifications

## Deferred
- route wiring, notification dispatch, approval SLA/tasks, batches, CRM table preferences, UI, provider refund/replay adapters, and docs stay in later slices

## Verification
- `bun run test:unit -- tests/unit/packages/api/admin/contribution-correction-requests.test.ts tests/unit/packages/email/contribution-correction-tags.test.ts tests/unit/supabase/contribution-correction-requests-migration.test.ts`
- `bun run test:unit -- tests/unit/packages/api/admin/contribution-*.test.ts tests/unit/packages/email/contribution-correction-tags.test.ts tests/unit/supabase/contribution-*.test.ts`
- `bunx turbo run typecheck --filter=@asym/api`
- `bunx turbo run typecheck --filter=@asym/database`
- `bunx turbo run typecheck --filter=@asym/email`
- `bunx turbo run lint --filter=@asym/api`
- `bunx turbo run lint --filter=@asym/database`
- `bunx turbo run lint --filter=@asym/email`
- `bunx prettier --write ... && bunx prettier --check ... && git diff --check`
- `bun run ci:preflight`
- pre-push `bun run ci:preflight`

Refs #251

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the contribution correction request workflow: a new `contribution_correction_requests` table (with a companion `contribution_approval_policies` table), approval/rejection decision logic with ownership enforcement, idempotent request creation, and email merge-tag definitions for future donor notifications.

- **Core decision flow** (`correction-requests.ts`): implements approve/reject with an optimistic lock (`WHERE status = 'pending'`), separation-of-duties enforcement, receipt-delivery override auditing, and idempotent replay for already-decided requests.
- **Migration** (`20260611120000`): creates both tables with RLS enabled and `service_role`-only grants, matching the existing convention for internal correction tables; adds idempotency, pending-queue, and tenant/donation indexes.
- **Email** (`contribution-correction-tags.ts`): registers merge-tag categories and per-variant required-tag specs for seven correction template families; exported from `@asym/email`.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge if the orphaned-task race condition in the rejection path is addressed; the rest of the change is well-structured and matches repo conventions.

The rejection path calls createFollowUpTask — an external, non-transactional side effect — before the WHERE status='pending' optimistic-lock update. A concurrent approval or double-submit causes a 409 but leaves the task created with no DB record to link it to the correction request. This is a real correctness defect on the rejection code path that needs to be fixed before this ships to production.

packages/api/src/admin/contribution-operations/correction-requests.ts — specifically the ordering of createFollowUpTask vs recordDecision in the rejection branch (lines 330–352).
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-operations/correction-requests.ts | Core decision logic for approving/rejecting correction requests; the reject path has a race condition where createFollowUpTask fires before the optimistic-lock DB update, leaving an orphaned external task on concurrent collision. |
| supabase/migrations/20260611120000_contribution_correction_requests.sql | Creates two new tables with RLS/grants matching repo conventions; idempotency index, indexes for pending-queue and tenant/donation lookups are present; action_type column is unconstrained TEXT unlike the sibling correction_type column. |
| packages/database/types/database.ts | Adds TypeScript interfaces for ContributionApprovalPolicy and ContributionCorrectionRequest, matching the migration schema. |
| packages/email/contribution-correction-tags.ts | Defines merge-tag categories, template families, and required-tag specs for correction notification emails; getContributionCorrectionRequiredTags silently returns [] for invalid family/variant pairings. |
| tests/unit/packages/api/admin/contribution-correction-requests.test.ts | Good coverage of happy path approve/reject, separation-of-duties enforcement, idempotent replay, and receipt delivery override; no test covers the concurrent-rejection orphaned-task scenario. |
| packages/api/src/admin/contribution-operations/index.ts | Straightforward barrel export additions for the new correction-request functions and types. |
| packages/email/merge-tags.ts | Adds contribution_correction category to the shared Email Studio registry by importing the new constant. |
| tests/unit/supabase/contribution-correction-requests-migration.test.ts | Snapshot-style test confirming key SQL snippets in the migration file; covers RLS, grants, indexes, and FK structure. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant F as decideContributionCorrectionRequest
    participant DB as Supabase (DB)
    participant EA as External / Hooks

    C->>F: decide(requestId, "reject", reason)
    F->>DB: loadContributionCorrectionRequest
    DB-->>F: "request {status:"pending"}"
    F->>DB: loadCorrectionApprovalPolicy (if no policy provided)
    DB-->>F: policy
    F->>F: assertCanDecideCorrectionRequest
    F->>EA: createFollowUpTask (optional, external side-effect)
    EA-->>F: followUpTaskId
    F->>DB: "recordDecision WHERE status='pending'"
    alt Concurrent decision already landed
        DB-->>F: [] (0 rows updated)
        F-->>C: 409 ApiHttpError (followUpTask already created — orphaned)
    else Happy path
        DB-->>F: "[{id}] (1 row updated)"
        F->>EA: appendDecisionAuditEvent
        F->>DB: loadContributionCorrectionRequest (re-load decided)
        F->>EA: recordOutcome (optional)
        F-->>C: "{request}"
    end

    note over C,EA: Approve path runs executeContributionAction BEFORE recordDecision<br/>Idempotency key on executeContributionAction prevents double-apply on retry
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant F as decideContributionCorrectionRequest
    participant DB as Supabase (DB)
    participant EA as External / Hooks

    C->>F: decide(requestId, "reject", reason)
    F->>DB: loadContributionCorrectionRequest
    DB-->>F: "request {status:"pending"}"
    F->>DB: loadCorrectionApprovalPolicy (if no policy provided)
    DB-->>F: policy
    F->>F: assertCanDecideCorrectionRequest
    F->>EA: createFollowUpTask (optional, external side-effect)
    EA-->>F: followUpTaskId
    F->>DB: "recordDecision WHERE status='pending'"
    alt Concurrent decision already landed
        DB-->>F: [] (0 rows updated)
        F-->>C: 409 ApiHttpError (followUpTask already created — orphaned)
    else Happy path
        DB-->>F: "[{id}] (1 row updated)"
        F->>EA: appendDecisionAuditEvent
        F->>DB: loadContributionCorrectionRequest (re-load decided)
        F->>EA: recordOutcome (optional)
        F-->>C: "{request}"
    end

    note over C,EA: Approve path runs executeContributionAction BEFORE recordDecision<br/>Idempotency key on executeContributionAction prevents double-apply on retry
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `supabase/migrations/20260611120000_contribution_correction_requests.sql`, line 924 ([link](https://github.com/asymmetric-al/core/blob/a005c98b99b01f0e0cc6802b8ba53421dd7b6468/supabase/migrations/20260611120000_contribution_correction_requests.sql#L924)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`action_type` column has no CHECK constraint**

   The sibling `contribution_corrections` table (migration `20260526132000`) constrains `correction_type` to an explicit list of valid values. `action_type` here is unconstrained (`TEXT NOT NULL`), so any string can be persisted. TypeScript types only protect the code path through `createContributionCorrectionRequestInSupabase`; direct DB inserts or future callers that bypass the API layer could write invalid action types that would then propagate silently into correction execution. Consider adding a `CHECK (action_type IN (...))` matching `ContributionActionType`.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20supabase%2Fmigrations%2F20260611120000_contribution_correction_requests.sql%0ALine%3A%20924%0A%0AComment%3A%0A**%60action_type%60%20column%20has%20no%20CHECK%20constraint**%0A%0AThe%20sibling%20%60contribution_corrections%60%20table%20%28migration%20%6020260526132000%60%29%20constrains%20%60correction_type%60%20to%20an%20explicit%20list%20of%20valid%20values.%20%60action_type%60%20here%20is%20unconstrained%20%28%60TEXT%20NOT%20NULL%60%29%2C%20so%20any%20string%20can%20be%20persisted.%20TypeScript%20types%20only%20protect%20the%20code%20path%20through%20%60createContributionCorrectionRequestInSupabase%60%3B%20direct%20DB%20inserts%20or%20future%20callers%20that%20bypass%20the%20API%20layer%20could%20write%20invalid%20action%20types%20that%20would%20then%20propagate%20silently%20into%20correction%20execution.%20Consider%20adding%20a%20%60CHECK%20%28action_type%20IN%20%28...%29%29%60%20matching%20%60ContributionActionType%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=393&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fcontribution-operations%2Fcorrection-requests.ts%3A330-352%0A**Follow-up%20task%20created%20before%20the%20optimistic%20lock%20is%20checked**%0A%0A%60createFollowUpTask%60%20is%20an%20external%20side%20effect%20%28creates%20a%20task%20in%20a%20downstream%20system%29%20that%20runs%20before%20%60recordDecision%60%20filters%20on%20%60WHERE%20status%20%3D%20'pending'%60.%20If%20a%20concurrent%20decision%20%28race%20between%20two%20approvers%2C%20or%20a%20double-submit%29%20already%20transitioned%20the%20request%20to%20%60approved%60%2F%60rejected%60%2C%20%60recordDecision%60%20returns%20%60false%60%20and%20a%20409%20is%20thrown%20%E2%80%94%20but%20the%20follow-up%20task%20has%20already%20been%20created%20in%20the%20external%20system%20and%20%60followUpTaskId%60%20is%20never%20written%20to%20any%20row.%20The%20orphaned%20task%20will%20show%20up%20in%20the%20requester's%20work%20queue%20with%20no%20linked%20correction%20request%20context.%0A%0AThe%20fix%20is%20to%20move%20%60createFollowUpTask%60%20to%20after%20%60recordDecision%60%20succeeds%2C%20passing%20%60null%60%20as%20%60followUpTaskId%60%20initially%20and%20then%20doing%20a%20second%20update%20once%20the%20task%20is%20created%20%28or%20treating%20%60followUpTaskId%60%20as%20an%20async%20post-decision%20enrichment%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Asupabase%2Fmigrations%2F20260611120000_contribution_correction_requests.sql%3A924%0A**%60action_type%60%20column%20has%20no%20CHECK%20constraint**%0A%0AThe%20sibling%20%60contribution_corrections%60%20table%20%28migration%20%6020260526132000%60%29%20constrains%20%60correction_type%60%20to%20an%20explicit%20list%20of%20valid%20values.%20%60action_type%60%20here%20is%20unconstrained%20%28%60TEXT%20NOT%20NULL%60%29%2C%20so%20any%20string%20can%20be%20persisted.%20TypeScript%20types%20only%20protect%20the%20code%20path%20through%20%60createContributionCorrectionRequestInSupabase%60%3B%20direct%20DB%20inserts%20or%20future%20callers%20that%20bypass%20the%20API%20layer%20could%20write%20invalid%20action%20types%20that%20would%20then%20propagate%20silently%20into%20correction%20execution.%20Consider%20adding%20a%20%60CHECK%20%28action_type%20IN%20%28...%29%29%60%20matching%20%60ContributionActionType%60.%0A%0A&pr=393&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(api): add contribution correction r..."](https://github.com/asymmetric-al/core/commit/a005c98b99b01f0e0cc6802b8ba53421dd7b6468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38894596)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->