### PR TITLE
feat(api): add mission control task foundation

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,6 +32,7 @@
     "./admin/users": "./src/admin/users.ts",
     "./admin/contribution-shared": "./src/admin/contribution-shared/index.ts",
     "./admin/contribution-operations": "./src/admin/contribution-operations/index.ts",
+    "./admin/mission-control-tasks": "./src/admin/mission-control-tasks/index.ts",
     "./admin/contributions": "./src/admin/contributions/index.ts",
     "./admin/contributions/reconcile": "./src/admin/contributions/reconcile.ts",
     "./admin/contributions/replay": "./src/admin/contributions/replay.ts",

--- a/packages/api/src/admin/mission-control-tasks/assignment-policy.ts
+++ b/packages/api/src/admin/mission-control-tasks/assignment-policy.ts
@@ -1,0 +1,31 @@
+import type {
+  MissionControlTaskAssignment,
+  MissionControlTaskAssignmentMode,
+} from "./types";
+
+export function resolveMissionControlTaskAssignment(input: {
+  actorProfileId: string | null;
+  defaultQueueId: string;
+  mode?: MissionControlTaskAssignmentMode;
+}): MissionControlTaskAssignment {
+  const mode = input.mode ?? "actor_and_queue";
+
+  if (mode === "actor_only") {
+    return {
+      assigneeProfileId: input.actorProfileId,
+      queueId: null,
+    };
+  }
+
+  if (mode === "queue_only") {
+    return {
+      assigneeProfileId: null,
+      queueId: input.defaultQueueId,
+    };
+  }
+
+  return {
+    assigneeProfileId: input.actorProfileId,
+    queueId: input.defaultQueueId,
+  };
+}

--- a/packages/api/src/admin/mission-control-tasks/attention.ts
+++ b/packages/api/src/admin/mission-control-tasks/attention.ts
@@ -1,0 +1,43 @@
+import { getSuggestedAttentionUrgency } from "./urgency";
+
+import type {
+  MissionControlIssueType,
+  MissionControlLinkedRecord,
+  MissionControlUrgencyThresholds,
+} from "./types";
+
+export async function upsertNeedsAttentionItem(input: {
+  tenantId: string;
+  dedupeKey: string;
+  issueType: MissionControlIssueType;
+  summary: string;
+  linkedRecords: MissionControlLinkedRecord[];
+  firstSeenAt?: string;
+  thresholds?: MissionControlUrgencyThresholds;
+  dependencies: {
+    upsert: (item: {
+      tenantId: string;
+      dedupeKey: string;
+      issueType: MissionControlIssueType;
+      summary: string;
+      urgency: string;
+      linkedRecords: MissionControlLinkedRecord[];
+    }) => Promise<{
+      attentionItemId: string;
+      created: boolean;
+    }>;
+  };
+}) {
+  return input.dependencies.upsert({
+    tenantId: input.tenantId,
+    dedupeKey: input.dedupeKey,
+    issueType: input.issueType,
+    summary: input.summary,
+    urgency: getSuggestedAttentionUrgency({
+      issueType: input.issueType,
+      firstSeenAt: input.firstSeenAt ?? new Date().toISOString(),
+      thresholds: input.thresholds,
+    }),
+    linkedRecords: input.linkedRecords,
+  });
+}

--- a/packages/api/src/admin/mission-control-tasks/index.ts
+++ b/packages/api/src/admin/mission-control-tasks/index.ts
@@ -1,0 +1,26 @@
+export {
+  buildNeedsAttentionGroups,
+  mapNeedsAttentionRow,
+  type NeedsAttentionGroup,
+  type NeedsAttentionItem,
+  type NeedsAttentionRow,
+} from "./read-model";
+export { resolveMissionControlTaskAssignment } from "./assignment-policy";
+export { upsertNeedsAttentionItem } from "./attention";
+export { createMissionControlTask } from "./service";
+export {
+  createMissionControlTaskInSupabase,
+  ensureMissionControlQueue,
+  listContributionNeedsAttention,
+} from "./store";
+export { getSuggestedAttentionUrgency, recordUrgencyOverride } from "./urgency";
+
+export type {
+  MissionControlIssueType,
+  MissionControlLinkedRecord,
+  MissionControlTaskAssignment,
+  MissionControlTaskAssignmentMode,
+  MissionControlTaskStatus,
+  MissionControlUrgency,
+  MissionControlUrgencyThresholds,
+} from "./types";

--- a/packages/api/src/admin/mission-control-tasks/read-model.ts
+++ b/packages/api/src/admin/mission-control-tasks/read-model.ts
@@ -1,0 +1,127 @@
+import type { MissionControlIssueType, MissionControlUrgency } from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+export interface NeedsAttentionRow {
+  id: string;
+  task_id: string | null;
+  issue_type: string;
+  urgency: string;
+  status: string;
+  summary: string;
+  dedupe_key: string;
+  first_seen_at: string;
+  last_seen_at: string;
+  details: JsonRecord | null;
+}
+
+export interface NeedsAttentionItem {
+  id: string;
+  taskId: string | null;
+  issueType: string;
+  issueLabel: string;
+  urgency: MissionControlUrgency;
+  status: string;
+  summary: string;
+  contributionId: string | null;
+  donorId: string | null;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface NeedsAttentionGroup {
+  key: string;
+  title: string;
+  urgency: MissionControlUrgency;
+  count: number;
+  items: NeedsAttentionItem[];
+}
+
+const URGENCY_ORDER: Record<MissionControlUrgency, number> = {
+  critical: 0,
+  high: 1,
+  normal: 2,
+};
+
+const ISSUE_LABELS: Partial<Record<MissionControlIssueType, string>> = {
+  receipt_failed: "Receipt",
+  statement_failed: "Statement",
+  donor_notification_failed: "Donor notification",
+  crm_post_failed: "CRM post",
+  provider_failed: "Provider",
+  failed_refund: "Refund",
+  pending_refund: "Pending refund",
+  correction_review: "Correction review",
+  batch_completed_with_issues: "Batch issue",
+  missing_donor: "Missing donor",
+  missing_designation: "Missing designation",
+  staged_gift_review: "Staged gift review",
+  recurring_gift_issue: "Recurring gift",
+};
+
+function normalizeUrgency(value: string): MissionControlUrgency {
+  if (value === "critical" || value === "high" || value === "normal") {
+    return value;
+  }
+
+  return "normal";
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export function mapNeedsAttentionRow(
+  row: NeedsAttentionRow,
+): NeedsAttentionItem {
+  const issueType = row.issue_type;
+  const details = row.details ?? {};
+
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    issueType,
+    issueLabel: ISSUE_LABELS[issueType as MissionControlIssueType] ?? issueType,
+    urgency: normalizeUrgency(row.urgency),
+    status: row.status,
+    summary: row.summary,
+    contributionId: getString(details.contributionId),
+    donorId: getString(details.donorId),
+    firstSeenAt: row.first_seen_at,
+    lastSeenAt: row.last_seen_at,
+  };
+}
+
+export function buildNeedsAttentionGroups(
+  items: NeedsAttentionItem[],
+): NeedsAttentionGroup[] {
+  const groupByKey = new Map<string, NeedsAttentionGroup>();
+
+  for (const item of items) {
+    const key = `${item.urgency}:${item.issueType}`;
+    const existing = groupByKey.get(key);
+    if (existing) {
+      existing.items.push(item);
+      existing.count += 1;
+      continue;
+    }
+
+    groupByKey.set(key, {
+      key,
+      title: item.issueLabel,
+      urgency: item.urgency,
+      count: 1,
+      items: [item],
+    });
+  }
+
+  return [...groupByKey.values()].sort((left, right) => {
+    const urgencyDelta =
+      URGENCY_ORDER[left.urgency] - URGENCY_ORDER[right.urgency];
+    if (urgencyDelta !== 0) {
+      return urgencyDelta;
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+}

--- a/packages/api/src/admin/mission-control-tasks/service.ts
+++ b/packages/api/src/admin/mission-control-tasks/service.ts
@@ -1,0 +1,85 @@
+import { resolveMissionControlTaskAssignment } from "./assignment-policy";
+import { getSuggestedAttentionUrgency } from "./urgency";
+
+import type {
+  MissionControlIssueType,
+  MissionControlLinkedRecord,
+  MissionControlTaskAssignmentMode,
+  MissionControlUrgency,
+} from "./types";
+
+export interface CreateMissionControlTaskInput {
+  tenantId: string;
+  source: string;
+  issueType: MissionControlIssueType;
+  title: string;
+  description: string;
+  actorProfileId: string | null;
+  queueId: string;
+  assignmentMode?: MissionControlTaskAssignmentMode;
+  linkedRecords: MissionControlLinkedRecord[];
+  urgency?: MissionControlUrgency;
+  dueAt?: string | null;
+  dependencies: {
+    insertTask: (task: {
+      tenantId: string;
+      source: string;
+      issueType: MissionControlIssueType;
+      title: string;
+      description: string;
+      urgency: MissionControlUrgency;
+      assigneeProfileId: string | null;
+      queueId: string | null;
+      dueAt: string | null;
+      createdByProfileId: string | null;
+      createdByKind: "human" | "system";
+    }) => Promise<string>;
+    insertLinks: (
+      taskId: string,
+      linkedRecords: MissionControlLinkedRecord[],
+    ) => Promise<void>;
+    appendEvent: (
+      taskId: string,
+      event: Record<string, unknown>,
+    ) => Promise<void>;
+  };
+}
+
+export async function createMissionControlTask(
+  input: CreateMissionControlTaskInput,
+) {
+  const assignment = resolveMissionControlTaskAssignment({
+    actorProfileId: input.actorProfileId,
+    defaultQueueId: input.queueId,
+    mode: input.assignmentMode,
+  });
+  const urgency =
+    input.urgency ??
+    getSuggestedAttentionUrgency({
+      issueType: input.issueType,
+      firstSeenAt: new Date().toISOString(),
+    });
+  const taskId = await input.dependencies.insertTask({
+    tenantId: input.tenantId,
+    source: input.source,
+    issueType: input.issueType,
+    title: input.title,
+    description: input.description,
+    urgency,
+    assigneeProfileId: assignment.assigneeProfileId,
+    queueId: assignment.queueId,
+    dueAt: input.dueAt ?? null,
+    createdByProfileId: input.actorProfileId,
+    createdByKind: input.actorProfileId ? "human" : "system",
+  });
+
+  await input.dependencies.insertLinks(taskId, input.linkedRecords);
+  await input.dependencies.appendEvent(taskId, {
+    type: "created",
+    issueType: input.issueType,
+    urgency,
+    linkedRecordCount: input.linkedRecords.length,
+  });
+
+  return { taskId, urgency };
+}

--- a/packages/api/src/admin/mission-control-tasks/store.ts
+++ b/packages/api/src/admin/mission-control-tasks/store.ts
@@ -1,0 +1,163 @@
+import {
+  buildNeedsAttentionGroups,
+  mapNeedsAttentionRow,
+  type NeedsAttentionRow,
+} from "./read-model";
+import { createMissionControlTask } from "./service";
+
+import type {
+  MissionControlIssueType,
+  MissionControlLinkedRecord,
+  MissionControlTaskAssignmentMode,
+} from "./types";
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+type SupabaseAdmin = AdminSupabaseClient;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export async function ensureMissionControlQueue(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  key: string;
+  name: string;
+}) {
+  const { data, error } = await input.supabaseAdmin
+    .from("mission_control_queues")
+    .upsert(
+      {
+        tenant_id: input.tenantId,
+        key: input.key,
+        name: input.name,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "tenant_id,key" },
+    )
+    .select("id")
+    .single();
+
+  if (error || !isRecord(data)) {
+    throw new Error(
+      error?.message ?? "Failed to ensure Mission Control queue.",
+    );
+  }
+
+  return asString(data.id) ?? "";
+}
+
+export async function createMissionControlTaskInSupabase(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  title: string;
+  description: string;
+  issueType: MissionControlIssueType;
+  actorProfileId: string | null;
+  assignmentMode?: MissionControlTaskAssignmentMode;
+  linkedRecords: MissionControlLinkedRecord[];
+}) {
+  const queueId = await ensureMissionControlQueue({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    key: "finance_operations",
+    name: "Finance Operations",
+  });
+
+  return createMissionControlTask({
+    tenantId: input.tenantId,
+    source: "contribution_operations",
+    issueType: input.issueType,
+    title: input.title,
+    description: input.description,
+    actorProfileId: input.actorProfileId,
+    queueId,
+    assignmentMode: input.assignmentMode ?? "actor_and_queue",
+    linkedRecords: input.linkedRecords,
+    dependencies: {
+      insertTask: async (task) => {
+        const { data, error } = await input.supabaseAdmin
+          .from("mission_control_tasks")
+          .insert({
+            tenant_id: task.tenantId,
+            source_module: task.source,
+            issue_type: task.issueType,
+            title: task.title,
+            description: task.description,
+            urgency: task.urgency,
+            assignee_profile_id: task.assigneeProfileId,
+            queue_id: task.queueId,
+            due_at: task.dueAt,
+            created_by_profile_id: task.createdByProfileId,
+            created_by_kind: task.createdByKind,
+          })
+          .select("id")
+          .single();
+        if (error || !isRecord(data)) {
+          throw new Error(error?.message ?? "Failed to create task.");
+        }
+        return asString(data.id) ?? "";
+      },
+      insertLinks: async (taskId, records) => {
+        if (records.length === 0) return;
+        const { error } = await input.supabaseAdmin
+          .from("mission_control_task_links")
+          .insert(
+            records.map((record) => ({
+              tenant_id: input.tenantId,
+              task_id: taskId,
+              record_type: record.type,
+              record_id: record.id,
+              relationship: record.relationship ?? null,
+              metadata: record.metadata ?? {},
+            })),
+          );
+        if (error) throw new Error(error.message);
+      },
+      appendEvent: async (taskId, event) => {
+        const { error } = await input.supabaseAdmin
+          .from("mission_control_task_events")
+          .insert({
+            tenant_id: input.tenantId,
+            task_id: taskId,
+            actor_profile_id: input.actorProfileId,
+            event_type: String(event.type ?? "created"),
+            details: event,
+          });
+        if (error) throw new Error(error.message);
+      },
+    },
+  });
+}
+
+export async function listContributionNeedsAttention(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+}) {
+  const { data, error } = await input.supabaseAdmin
+    .from("mission_control_attention_items")
+    .select(
+      "id, task_id, issue_type, urgency, status, summary, dedupe_key, first_seen_at, last_seen_at, details",
+    )
+    .eq("tenant_id", input.tenantId)
+    .eq("status", "open")
+    .order("last_seen_at", { ascending: false })
+    .limit(100);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const items = ((data ?? []) as NeedsAttentionRow[]).map(mapNeedsAttentionRow);
+
+  return {
+    groups: buildNeedsAttentionGroups(items),
+    items,
+  };
+}

--- a/packages/api/src/admin/mission-control-tasks/types.ts
+++ b/packages/api/src/admin/mission-control-tasks/types.ts
@@ -1,0 +1,54 @@
+export type MissionControlTaskStatus =
+  | "open"
+  | "in_progress"
+  | "completed"
+  | "dismissed"
+  | "suppressed";
+
+export type MissionControlUrgency = "normal" | "high" | "critical";
+
+export type MissionControlIssueType =
+  | "receipt_failed"
+  | "statement_failed"
+  | "donor_notification_failed"
+  | "crm_post_failed"
+  | "provider_failed"
+  | "failed_refund"
+  | "pending_refund"
+  | "correction_review"
+  | "batch_completed_with_issues"
+  | "missing_donor"
+  | "missing_designation"
+  | "staged_gift_review"
+  | "recurring_gift_issue";
+
+export type MissionControlTaskAssignmentMode =
+  | "actor_only"
+  | "queue_only"
+  | "actor_and_queue";
+
+export type MissionControlLinkedRecordType =
+  | "donor"
+  | "contribution"
+  | "staged_gift"
+  | "audit_event"
+  | "notification_event"
+  | "batch"
+  | "provider_action";
+
+export interface MissionControlLinkedRecord {
+  type: MissionControlLinkedRecordType;
+  id: string;
+  relationship?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MissionControlTaskAssignment {
+  assigneeProfileId: string | null;
+  queueId: string | null;
+}
+
+export interface MissionControlUrgencyThresholds {
+  normalToHighHours?: number;
+  highToCriticalHours?: number;
+}

--- a/packages/api/src/admin/mission-control-tasks/urgency.ts
+++ b/packages/api/src/admin/mission-control-tasks/urgency.ts
@@ -1,0 +1,71 @@
+import type {
+  MissionControlIssueType,
+  MissionControlUrgency,
+  MissionControlUrgencyThresholds,
+} from "./types";
+
+const CRITICAL_ISSUES = new Set<MissionControlIssueType>([
+  "failed_refund",
+  "provider_failed",
+  "receipt_failed",
+  "statement_failed",
+  "donor_notification_failed",
+]);
+
+const HIGH_ISSUES = new Set<MissionControlIssueType>([
+  "crm_post_failed",
+  "batch_completed_with_issues",
+  "correction_review",
+  "recurring_gift_issue",
+  "missing_designation",
+]);
+
+function hoursBetween(start: string, end: Date): number {
+  const startMs = new Date(start).getTime();
+  if (!Number.isFinite(startMs)) {
+    return 0;
+  }
+
+  return Math.max(0, (end.getTime() - startMs) / (1000 * 60 * 60));
+}
+
+export function getSuggestedAttentionUrgency(input: {
+  issueType: MissionControlIssueType;
+  firstSeenAt: string;
+  now?: Date;
+  thresholds?: MissionControlUrgencyThresholds;
+}): MissionControlUrgency {
+  const now = input.now ?? new Date();
+  const ageHours = hoursBetween(input.firstSeenAt, now);
+  const normalToHigh = input.thresholds?.normalToHighHours ?? 24;
+  const highToCritical = input.thresholds?.highToCriticalHours ?? 48;
+
+  if (CRITICAL_ISSUES.has(input.issueType)) {
+    return "critical";
+  }
+
+  if (HIGH_ISSUES.has(input.issueType) || ageHours >= normalToHigh) {
+    if (ageHours >= highToCritical) {
+      return "critical";
+    }
+    return "high";
+  }
+
+  return "normal";
+}
+
+export function recordUrgencyOverride(input: {
+  actorProfileId: string;
+  previousUrgency: MissionControlUrgency;
+  newUrgency: MissionControlUrgency;
+  reason?: string | null;
+  now?: Date;
+}) {
+  return {
+    actorProfileId: input.actorProfileId,
+    previousUrgency: input.previousUrgency,
+    newUrgency: input.newUrgency,
+    reason: input.reason ?? null,
+    changedAt: (input.now ?? new Date()).toISOString(),
+  };
+}

--- a/supabase/migrations/20260526193000_mission_control_tasks.sql
+++ b/supabase/migrations/20260526193000_mission_control_tasks.sql
@@ -1,0 +1,131 @@
+-- Shared Mission Control tasks and contribution Needs Attention.
+
+CREATE TABLE IF NOT EXISTS public.mission_control_queues (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, key)
+);
+
+CREATE TABLE IF NOT EXISTS public.mission_control_tasks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'open'
+        CHECK (status IN ('open', 'in_progress', 'completed', 'dismissed', 'suppressed')),
+    urgency TEXT NOT NULL DEFAULT 'normal'
+        CHECK (urgency IN ('normal', 'high', 'critical')),
+    queue_id UUID REFERENCES public.mission_control_queues(id) ON DELETE SET NULL,
+    assignee_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    source_module TEXT NOT NULL,
+    issue_type TEXT NOT NULL,
+    created_by_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    created_by_kind TEXT NOT NULL DEFAULT 'system' CHECK (created_by_kind IN ('human', 'system')),
+    due_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    dismissed_at TIMESTAMPTZ,
+    dismissed_reason TEXT,
+    suppressed_at TIMESTAMPTZ,
+    suppressed_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.mission_control_task_links (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    task_id UUID NOT NULL REFERENCES public.mission_control_tasks(id) ON DELETE CASCADE,
+    record_type TEXT NOT NULL,
+    record_id TEXT NOT NULL,
+    relationship TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.mission_control_task_comments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    task_id UUID NOT NULL REFERENCES public.mission_control_tasks(id) ON DELETE CASCADE,
+    author_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.mission_control_task_reminders (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    task_id UUID NOT NULL REFERENCES public.mission_control_tasks(id) ON DELETE CASCADE,
+    remind_at TIMESTAMPTZ NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'sent', 'cancelled')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.mission_control_task_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    task_id UUID REFERENCES public.mission_control_tasks(id) ON DELETE CASCADE,
+    actor_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    event_type TEXT NOT NULL,
+    details JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.mission_control_attention_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    dedupe_key TEXT NOT NULL,
+    issue_type TEXT NOT NULL,
+    urgency TEXT NOT NULL DEFAULT 'normal'
+        CHECK (urgency IN ('normal', 'high', 'critical')),
+    status TEXT NOT NULL DEFAULT 'open'
+        CHECK (status IN ('open', 'resolved', 'dismissed', 'suppressed')),
+    task_id UUID REFERENCES public.mission_control_tasks(id) ON DELETE SET NULL,
+    summary TEXT NOT NULL,
+    details JSONB NOT NULL DEFAULT '{}'::jsonb,
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at TIMESTAMPTZ,
+    dismissed_at TIMESTAMPTZ,
+    suppressed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, dedupe_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mission_control_tasks_tenant_status
+    ON public.mission_control_tasks (tenant_id, status, urgency, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mission_control_task_links_task
+    ON public.mission_control_task_links (task_id);
+
+CREATE INDEX IF NOT EXISTS idx_mission_control_attention_tenant_status
+    ON public.mission_control_attention_items (tenant_id, status, urgency, last_seen_at DESC);
+
+ALTER TABLE public.mission_control_queues ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_control_tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_control_task_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_control_task_comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_control_task_reminders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_control_task_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mission_control_attention_items ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.mission_control_queues FROM anon, authenticated;
+REVOKE ALL ON TABLE public.mission_control_tasks FROM anon, authenticated;
+REVOKE ALL ON TABLE public.mission_control_task_links FROM anon, authenticated;
+REVOKE ALL ON TABLE public.mission_control_task_comments FROM anon, authenticated;
+REVOKE ALL ON TABLE public.mission_control_task_reminders FROM anon, authenticated;
+REVOKE ALL ON TABLE public.mission_control_task_events FROM anon, authenticated;
+REVOKE ALL ON TABLE public.mission_control_attention_items FROM anon, authenticated;
+
+GRANT ALL ON TABLE public.mission_control_queues TO service_role;
+GRANT ALL ON TABLE public.mission_control_tasks TO service_role;
+GRANT ALL ON TABLE public.mission_control_task_links TO service_role;
+GRANT ALL ON TABLE public.mission_control_task_comments TO service_role;
+GRANT ALL ON TABLE public.mission_control_task_reminders TO service_role;
+GRANT ALL ON TABLE public.mission_control_task_events TO service_role;
+GRANT ALL ON TABLE public.mission_control_attention_items TO service_role;

--- a/tests/unit/packages/api/admin/mission-control-tasks.test.ts
+++ b/tests/unit/packages/api/admin/mission-control-tasks.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveMissionControlTaskAssignment } from "../../../../../packages/api/src/admin/mission-control-tasks/assignment-policy";
+import { createMissionControlTask } from "../../../../../packages/api/src/admin/mission-control-tasks/service";
+import {
+  getSuggestedAttentionUrgency,
+  recordUrgencyOverride,
+} from "../../../../../packages/api/src/admin/mission-control-tasks/urgency";
+import { upsertNeedsAttentionItem } from "../../../../../packages/api/src/admin/mission-control-tasks/attention";
+import {
+  createMissionControlTaskInSupabase,
+  listContributionNeedsAttention,
+} from "../../../../../packages/api/src/admin/mission-control-tasks/store";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+interface StubState {
+  queues: Array<Record<string, unknown>>;
+  tasks: Array<Record<string, unknown>>;
+  links: Array<Record<string, unknown>>;
+  events: Array<Record<string, unknown>>;
+  attentionRows: Array<Record<string, unknown>>;
+}
+
+class QueryBuilder {
+  private operation: "select" | "insert" | "upsert" = "select";
+  private payload: unknown = null;
+  private statusFilter: string | null = null;
+
+  constructor(
+    private readonly table: string,
+    private readonly state: StubState,
+  ) {}
+
+  select() {
+    return this;
+  }
+
+  insert(payload: unknown) {
+    this.operation = "insert";
+    this.payload = payload;
+    return this;
+  }
+
+  upsert(payload: unknown) {
+    this.operation = "upsert";
+    this.payload = payload;
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    if (column === "status" && typeof value === "string") {
+      this.statusFilter = value;
+    }
+    return this;
+  }
+
+  order() {
+    return this;
+  }
+
+  limit() {
+    return this;
+  }
+
+  single() {
+    return this;
+  }
+
+  private resolve(): {
+    data: unknown;
+    error: { message: string } | null;
+  } {
+    if (this.table === "mission_control_queues") {
+      if (this.operation === "upsert") {
+        this.state.queues.push(this.payload as Record<string, unknown>);
+      }
+      return { data: { id: "queue_1" }, error: null };
+    }
+
+    if (this.table === "mission_control_tasks") {
+      if (this.operation === "insert") {
+        this.state.tasks.push(this.payload as Record<string, unknown>);
+      }
+      return { data: { id: "task_1" }, error: null };
+    }
+
+    if (this.table === "mission_control_task_links") {
+      if (this.operation === "insert") {
+        this.state.links.push(
+          ...((Array.isArray(this.payload)
+            ? this.payload
+            : [this.payload]) as Array<Record<string, unknown>>),
+        );
+      }
+      return { data: null, error: null };
+    }
+
+    if (this.table === "mission_control_task_events") {
+      if (this.operation === "insert") {
+        this.state.events.push(this.payload as Record<string, unknown>);
+      }
+      return { data: null, error: null };
+    }
+
+    if (this.table === "mission_control_attention_items") {
+      const rows = this.statusFilter
+        ? this.state.attentionRows.filter(
+            (row) => row.status === this.statusFilter,
+          )
+        : this.state.attentionRows;
+
+      return { data: rows, error: null };
+    }
+
+    return { data: null, error: null };
+  }
+
+  then<TResult>(
+    onfulfilled: (value: {
+      data: unknown;
+      error: { message: string } | null;
+    }) => TResult,
+  ): Promise<TResult> {
+    return Promise.resolve(this.resolve()).then(onfulfilled);
+  }
+}
+
+function createStub(state: StubState): AdminSupabaseClient {
+  return {
+    from(table: string) {
+      return new QueryBuilder(table, state);
+    },
+  } as unknown as AdminSupabaseClient;
+}
+
+function stubState(): StubState {
+  return {
+    queues: [],
+    tasks: [],
+    links: [],
+    events: [],
+    attentionRows: [],
+  };
+}
+
+describe("mission control task assignment", () => {
+  it("defaults contribution follow-up tasks to actor plus Finance Operations queue", () => {
+    expect(
+      resolveMissionControlTaskAssignment({
+        actorProfileId: "actor_1",
+        defaultQueueId: "finance_queue",
+        mode: "actor_and_queue",
+      }),
+    ).toEqual({
+      assigneeProfileId: "actor_1",
+      queueId: "finance_queue",
+    });
+  });
+
+  it("supports actor-only and queue-only assignment settings", () => {
+    expect(
+      resolveMissionControlTaskAssignment({
+        actorProfileId: "actor_1",
+        defaultQueueId: "finance_queue",
+        mode: "actor_only",
+      }),
+    ).toEqual({
+      assigneeProfileId: "actor_1",
+      queueId: null,
+    });
+
+    expect(
+      resolveMissionControlTaskAssignment({
+        actorProfileId: "actor_1",
+        defaultQueueId: "finance_queue",
+        mode: "queue_only",
+      }),
+    ).toEqual({
+      assigneeProfileId: null,
+      queueId: "finance_queue",
+    });
+  });
+});
+
+describe("mission control task urgency", () => {
+  it("marks donor trust and money-state risks as critical", () => {
+    expect(
+      getSuggestedAttentionUrgency({
+        issueType: "failed_refund",
+        firstSeenAt: "2026-05-26T00:00:00.000Z",
+        now: new Date("2026-05-26T01:00:00.000Z"),
+      }),
+    ).toBe("critical");
+  });
+
+  it("ages normal issues into high urgency after tenant threshold", () => {
+    expect(
+      getSuggestedAttentionUrgency({
+        issueType: "missing_designation",
+        firstSeenAt: "2026-05-25T00:00:00.000Z",
+        now: new Date("2026-05-26T01:00:00.000Z"),
+        thresholds: {
+          normalToHighHours: 24,
+          highToCriticalHours: 48,
+        },
+      }),
+    ).toBe("high");
+  });
+
+  it("records audited urgency overrides", () => {
+    expect(
+      recordUrgencyOverride({
+        actorProfileId: "actor_1",
+        previousUrgency: "normal",
+        newUrgency: "high",
+        reason: "Donor called twice.",
+        now: new Date("2026-05-26T00:00:00.000Z"),
+      }),
+    ).toEqual({
+      actorProfileId: "actor_1",
+      previousUrgency: "normal",
+      newUrgency: "high",
+      reason: "Donor called twice.",
+      changedAt: "2026-05-26T00:00:00.000Z",
+    });
+  });
+});
+
+describe("mission control task creation", () => {
+  it("creates tasks with linked contribution context and audit event", async () => {
+    const insertTask = vi.fn().mockResolvedValue("task_1");
+    const insertLinks = vi.fn().mockResolvedValue(undefined);
+    const appendEvent = vi.fn().mockResolvedValue(undefined);
+
+    const result = await createMissionControlTask({
+      tenantId: "tenant_1",
+      source: "contribution_operations",
+      issueType: "donor_notification_failed",
+      title: "Follow up donor correction email",
+      description: "Email failed after correction.",
+      actorProfileId: "actor_1",
+      queueId: "finance_queue",
+      assignmentMode: "actor_and_queue",
+      linkedRecords: [
+        { type: "donor", id: "donor_1" },
+        { type: "contribution", id: "donation_1" },
+        { type: "audit_event", id: "audit_1" },
+      ],
+      dependencies: {
+        insertTask,
+        insertLinks,
+        appendEvent,
+      },
+    });
+
+    expect(result.taskId).toBe("task_1");
+    expect(insertTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigneeProfileId: "actor_1",
+        queueId: "finance_queue",
+        urgency: "critical",
+      }),
+    );
+    expect(insertLinks).toHaveBeenCalledWith(
+      "task_1",
+      expect.arrayContaining([
+        { type: "contribution", id: "donation_1" },
+        { type: "audit_event", id: "audit_1" },
+      ]),
+    );
+  });
+
+  it("persists tasks through Supabase with a Finance Operations queue", async () => {
+    const state = stubState();
+
+    const result = await createMissionControlTaskInSupabase({
+      supabaseAdmin: createStub(state),
+      tenantId: "tenant_1",
+      title: "Resolve blocked donor correction notification",
+      description: "Template is missing required tags.",
+      issueType: "donor_notification_failed",
+      actorProfileId: "actor_1",
+      assignmentMode: "actor_and_queue",
+      linkedRecords: [
+        { type: "donor", id: "donor_1" },
+        { type: "audit_event", id: "audit_1" },
+      ],
+    });
+
+    expect(result).toEqual({ taskId: "task_1", urgency: "critical" });
+    expect(state.queues[0]).toMatchObject({
+      tenant_id: "tenant_1",
+      key: "finance_operations",
+      name: "Finance Operations",
+    });
+    expect(state.tasks[0]).toMatchObject({
+      tenant_id: "tenant_1",
+      source_module: "contribution_operations",
+      issue_type: "donor_notification_failed",
+      assignee_profile_id: "actor_1",
+      queue_id: "queue_1",
+      created_by_profile_id: "actor_1",
+      created_by_kind: "human",
+    });
+    expect(state.links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          task_id: "task_1",
+          record_type: "donor",
+          record_id: "donor_1",
+        }),
+        expect.objectContaining({
+          task_id: "task_1",
+          record_type: "audit_event",
+          record_id: "audit_1",
+        }),
+      ]),
+    );
+    expect(state.events[0]).toMatchObject({
+      task_id: "task_1",
+      actor_profile_id: "actor_1",
+      event_type: "created",
+    });
+  });
+});
+
+describe("mission control needs attention", () => {
+  it("dedupes contribution attention by tenant and source key", async () => {
+    const upsert = vi.fn().mockResolvedValue({
+      attentionItemId: "attention_1",
+      created: false,
+    });
+
+    const result = await upsertNeedsAttentionItem({
+      tenantId: "tenant_1",
+      dedupeKey: "notification:audit_1",
+      issueType: "donor_notification_failed",
+      summary: "Donor notification failed",
+      linkedRecords: [{ type: "audit_event", id: "audit_1" }],
+      dependencies: { upsert },
+    });
+
+    expect(result).toEqual({
+      attentionItemId: "attention_1",
+      created: false,
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupeKey: "notification:audit_1",
+        urgency: "critical",
+      }),
+    );
+  });
+
+  it("loads and groups open Needs Attention rows from Supabase", async () => {
+    const state = stubState();
+    state.attentionRows = [
+      {
+        id: "attention_1",
+        task_id: "task_1",
+        issue_type: "donor_notification_failed",
+        urgency: "critical",
+        status: "open",
+        summary: "Donor notification failed",
+        dedupe_key: "notification:audit_1",
+        first_seen_at: "2026-06-01T00:00:00.000Z",
+        last_seen_at: "2026-06-01T01:00:00.000Z",
+        details: { donorId: "donor_1" },
+      },
+      {
+        id: "attention_2",
+        task_id: null,
+        issue_type: "missing_designation",
+        urgency: "high",
+        status: "resolved",
+        summary: "Resolved item",
+        dedupe_key: "resolved:item",
+        first_seen_at: "2026-06-01T00:00:00.000Z",
+        last_seen_at: "2026-06-01T01:00:00.000Z",
+        details: {},
+      },
+    ];
+
+    const result = await listContributionNeedsAttention({
+      supabaseAdmin: createStub(state),
+      tenantId: "tenant_1",
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: "attention_1",
+      urgency: "critical",
+      donorId: "donor_1",
+    });
+    expect(result.groups).toEqual([
+      expect.objectContaining({
+        key: "critical:donor_notification_failed",
+        title: "Donor notification",
+        count: 1,
+      }),
+    ]);
+  });
+});

--- a/tests/unit/supabase/mission-control-tasks-migration.test.ts
+++ b/tests/unit/supabase/mission-control-tasks-migration.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL(
+    "../../../supabase/migrations/20260526193000_mission_control_tasks.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("mission control tasks migration", () => {
+  it("creates task, link, event, reminder, queue, and attention tables", () => {
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.mission_control_queues",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.mission_control_tasks",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.mission_control_task_links",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.mission_control_task_comments",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.mission_control_task_reminders",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.mission_control_task_events",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.mission_control_attention_items",
+    );
+  });
+
+  it("keeps queue and attention writes idempotent by tenant", () => {
+    expect(migrationSql).toContain("UNIQUE (tenant_id, key)");
+    expect(migrationSql).toContain("UNIQUE (tenant_id, dedupe_key)");
+  });
+
+  it("locks task tables to service role access", () => {
+    expect(migrationSql).toContain(
+      "ALTER TABLE public.mission_control_tasks ENABLE ROW LEVEL SECURITY",
+    );
+    expect(migrationSql).toContain(
+      "ALTER TABLE public.mission_control_attention_items ENABLE ROW LEVEL SECURITY",
+    );
+    expect(migrationSql).toContain(
+      "REVOKE ALL ON TABLE public.mission_control_tasks FROM anon, authenticated",
+    );
+    expect(migrationSql).toContain(
+      "REVOKE ALL ON TABLE public.mission_control_attention_items FROM anon, authenticated",
+    );
+    expect(migrationSql).toContain(
+      "GRANT ALL ON TABLE public.mission_control_tasks TO service_role",
+    );
+    expect(migrationSql).toContain(
+      "GRANT ALL ON TABLE public.mission_control_attention_items TO service_role",
+    );
+  });
+
+  it("indexes open task and attention queues for Mission Control dashboards", () => {
+    expect(migrationSql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_mission_control_tasks_tenant_status",
+    );
+    expect(migrationSql).toContain(
+      "ON public.mission_control_tasks (tenant_id, status, urgency, updated_at DESC)",
+    );
+    expect(migrationSql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_mission_control_attention_tenant_status",
+    );
+    expect(migrationSql).toContain(
+      "ON public.mission_control_attention_items (tenant_id, status, urgency, last_seen_at DESC)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Mission Control task/queue/attention schema used by contribution follow-up workflows
- add backend task assignment, urgency, creation, Needs Attention grouping, and Supabase persistence primitives
- export `@asym/api/admin/mission-control-tasks` for later approval workflow and notification slices

## Deferred
- app API route wiring, approval notification dispatch/SLA processing, automations, UI task surfaces, contribution batches, CRM table preferences, and docs stay in later slices

## Verification
- `bun run test:unit -- tests/unit/packages/api/admin/mission-control-tasks.test.ts tests/unit/supabase/mission-control-tasks-migration.test.ts`
- `bunx turbo run typecheck --filter=@asym/api`
- `bunx turbo run lint --filter=@asym/api`
- `bunx prettier --check packages/api/package.json packages/api/src/admin/mission-control-tasks/assignment-policy.ts packages/api/src/admin/mission-control-tasks/attention.ts packages/api/src/admin/mission-control-tasks/index.ts packages/api/src/admin/mission-control-tasks/read-model.ts packages/api/src/admin/mission-control-tasks/service.ts packages/api/src/admin/mission-control-tasks/store.ts packages/api/src/admin/mission-control-tasks/types.ts packages/api/src/admin/mission-control-tasks/urgency.ts tests/unit/packages/api/admin/mission-control-tasks.test.ts tests/unit/supabase/mission-control-tasks-migration.test.ts docs/ai/working-set.md`
- `git diff --check`
- `bun run ci:preflight`
- pre-push `bun run ci:preflight`

Refs #251

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Mission Control task foundation: schema (7 new tables), TypeScript primitives for task creation, urgency classification, attention-item grouping, and a `@asym/api/admin/mission-control-tasks` package export. UI wiring, approval workflows, and notification dispatch are all intentionally deferred to later slices.

- **Schema & access control**: All tables enable RLS, revoke `anon`/`authenticated` access, and grant only `service_role` — correct posture for admin-only data. Uniqueness constraints on `(tenant_id, key)` and `(tenant_id, dedupe_key)` guard idempotent upserts.
- **Application layer**: Dependency-injection pattern in `service.ts` and `attention.ts` keeps Supabase coupling at the `store.ts` boundary; `createMissionControlTask` correctly derives `createdByKind` from `actorProfileId`.
- **Concern**: `mission_control_tasks.updated_at` and `mission_control_attention_items.updated_at` have no auto-update trigger, while the task dashboard index sorts by `updated_at DESC`. Future status-change operations will need an explicit trigger or per-`UPDATE` column set to preserve the intended sort order.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The schema, RLS posture, and application layer are solid for a foundation PR; the main gap is that the dashboard index sorts by updated_at DESC but nothing in the migration ensures that column is maintained past insertion time.

The task index (updated_at DESC) will produce incorrect sort order the moment any status-change code updates a row without an explicit updated_at set or a trigger — a concrete behavioral regression that lands as soon as the deferred update slice ships. The two store-level empty-string fallbacks and the missing tenant-isolation assertion in the test are real but lower-risk gaps.

supabase/migrations/20260526193000_mission_control_tasks.sql (missing updated_at trigger), packages/api/src/admin/mission-control-tasks/store.ts (asString ?? "" fallbacks), tests/unit/packages/api/admin/mission-control-tasks.test.ts (tenant isolation gap in QueryBuilder stub)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| supabase/migrations/20260526193000_mission_control_tasks.sql | Creates 7 mission-control tables with correct RLS/REVOKE/GRANT posture; missing updated_at trigger on mission_control_tasks and mission_control_attention_items despite the task index ordering on updated_at DESC |
| packages/api/src/admin/mission-control-tasks/store.ts | Supabase persistence layer; asString(data.id) ?? "" silently produces an empty-string ID in both ensureMissionControlQueue and the insertTask closure; createMissionControlTaskInSupabase hardcodes the finance_operations queue and contribution_operations source |
| tests/unit/packages/api/admin/mission-control-tasks.test.ts | Good coverage of assignment, urgency, and event-audit paths; QueryBuilder stub ignores tenant_id eq filter, leaving cross-tenant isolation untested for listContributionNeedsAttention |
| packages/api/src/admin/mission-control-tasks/urgency.ts | Urgency classification is clear; pending_refund, missing_donor, and staged_gift_review default to normal urgency (only age-based escalation) — intentional but worth confirming |
| packages/api/src/admin/mission-control-tasks/service.ts | Clean dependency-injection pattern for task creation; correctly derives createdByKind from actorProfileId presence |
| packages/api/src/admin/mission-control-tasks/read-model.ts | Read-model mapping and grouping logic is correct; urgency normalization and sort order are well-defined |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant store as store.ts
    participant service as service.ts
    participant assign as assignment-policy.ts
    participant urgency as urgency.ts
    participant DB as Supabase (service_role)

    Caller->>store: createMissionControlTaskInSupabase(input)
    store->>DB: upsert mission_control_queues (tenant_id, key)
    DB-->>store: "{ id: queueId }"
    store->>service: createMissionControlTask(input + queueId)
    service->>assign: resolveMissionControlTaskAssignment(actorId, queueId, mode)
    assign-->>service: "{ assigneeProfileId, queueId }"
    service->>urgency: getSuggestedAttentionUrgency(issueType, firstSeenAt)
    urgency-->>service: urgency
    service->>DB: insert mission_control_tasks
    DB-->>service: "{ id: taskId }"
    service->>DB: insert mission_control_task_links[]
    service->>DB: insert mission_control_task_events (type: created)
    service-->>store: "{ taskId, urgency }"
    store-->>Caller: "{ taskId, urgency }"

    Note over Caller,DB: listContributionNeedsAttention
    Caller->>store: "listContributionNeedsAttention({ tenantId })"
    store->>DB: "select mission_control_attention_items WHERE tenant_id=? AND status=open ORDER BY last_seen_at DESC LIMIT 100"
    DB-->>store: NeedsAttentionRow[]
    store->>store: mapNeedsAttentionRow() per row
    store->>store: buildNeedsAttentionGroups(items)
    store-->>Caller: "{ groups, items }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant store as store.ts
    participant service as service.ts
    participant assign as assignment-policy.ts
    participant urgency as urgency.ts
    participant DB as Supabase (service_role)

    Caller->>store: createMissionControlTaskInSupabase(input)
    store->>DB: upsert mission_control_queues (tenant_id, key)
    DB-->>store: "{ id: queueId }"
    store->>service: createMissionControlTask(input + queueId)
    service->>assign: resolveMissionControlTaskAssignment(actorId, queueId, mode)
    assign-->>service: "{ assigneeProfileId, queueId }"
    service->>urgency: getSuggestedAttentionUrgency(issueType, firstSeenAt)
    urgency-->>service: urgency
    service->>DB: insert mission_control_tasks
    DB-->>service: "{ id: taskId }"
    service->>DB: insert mission_control_task_links[]
    service->>DB: insert mission_control_task_events (type: created)
    service-->>store: "{ taskId, urgency }"
    store-->>Caller: "{ taskId, urgency }"

    Note over Caller,DB: listContributionNeedsAttention
    Caller->>store: "listContributionNeedsAttention({ tenantId })"
    store->>DB: "select mission_control_attention_items WHERE tenant_id=? AND status=open ORDER BY last_seen_at DESC LIMIT 100"
    DB-->>store: NeedsAttentionRow[]
    store->>store: mapNeedsAttentionRow() per row
    store->>store: buildNeedsAttentionGroups(items)
    store-->>Caller: "{ groups, items }"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `supabase/migrations/20260526193000_mission_control_tasks.sql`, line 766-767 ([link](https://github.com/asymmetric-al/core/blob/4d4747532d038f7d193622b74284a7d23e5aa786/supabase/migrations/20260526193000_mission_control_tasks.sql#L766-L767)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`updated_at` column on `mission_control_tasks` has no auto-update mechanism**

   The composite index `idx_mission_control_tasks_tenant_status` uses `updated_at DESC` as its trailing column, implying dashboard queries will sort tasks by "most recently changed." However, the migration defines no `BEFORE UPDATE` trigger (e.g. a shared `set_updated_at()` function) on `mission_control_tasks` or `mission_control_attention_items`. Once the deferred status-transition operations ship, any `UPDATE` that doesn't explicitly set `updated_at` will leave the column frozen at insertion time, silently breaking the sort semantics this index was built for.

   Add a trigger before the index definition — or, if the codebase already has a shared `set_updated_at` function (check the foundation migration), apply it here. At minimum, add a comment documenting that every future UPDATE statement must set `updated_at` explicitly.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20supabase%2Fmigrations%2F20260526193000_mission_control_tasks.sql%0ALine%3A%20766-767%0A%0AComment%3A%0A**%60updated_at%60%20column%20on%20%60mission_control_tasks%60%20has%20no%20auto-update%20mechanism**%0A%0AThe%20composite%20index%20%60idx_mission_control_tasks_tenant_status%60%20uses%20%60updated_at%20DESC%60%20as%20its%20trailing%20column%2C%20implying%20dashboard%20queries%20will%20sort%20tasks%20by%20%22most%20recently%20changed.%22%20However%2C%20the%20migration%20defines%20no%20%60BEFORE%20UPDATE%60%20trigger%20%28e.g.%20a%20shared%20%60set_updated_at%28%29%60%20function%29%20on%20%60mission_control_tasks%60%20or%20%60mission_control_attention_items%60.%20Once%20the%20deferred%20status-transition%20operations%20ship%2C%20any%20%60UPDATE%60%20that%20doesn't%20explicitly%20set%20%60updated_at%60%20will%20leave%20the%20column%20frozen%20at%20insertion%20time%2C%20silently%20breaking%20the%20sort%20semantics%20this%20index%20was%20built%20for.%0A%0AAdd%20a%20trigger%20before%20the%20index%20definition%20%E2%80%94%20or%2C%20if%20the%20codebase%20already%20has%20a%20shared%20%60set_updated_at%60%20function%20%28check%20the%20foundation%20migration%29%2C%20apply%20it%20here.%20At%20minimum%2C%20add%20a%20comment%20documenting%20that%20every%20future%20UPDATE%20statement%20must%20set%20%60updated_at%60%20explicitly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=394&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `tests/unit/packages/api/admin/mission-control-tasks.test.ts`, line 854-858 ([link](https://github.com/asymmetric-al/core/blob/4d4747532d038f7d193622b74284a7d23e5aa786/tests/unit/packages/api/admin/mission-control-tasks.test.ts#L854-L858)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`QueryBuilder.eq` stub ignores `tenant_id` — tenant isolation is untested**

   The `eq` handler only stores the `status` value; the `.eq("tenant_id", ...)` call in `listContributionNeedsAttention` is silently dropped. The test at line 1188 therefore never exercises cross-tenant data isolation: if the production `.eq("tenant_id", ...)` call were accidentally removed, the test would still pass. For a multi-tenant system this is a security-critical gap. Add a second tenant's rows to `state.attentionRows` and assert they are absent from the result.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Funit%2Fpackages%2Fapi%2Fadmin%2Fmission-control-tasks.test.ts%0ALine%3A%20854-858%0A%0AComment%3A%0A**%60QueryBuilder.eq%60%20stub%20ignores%20%60tenant_id%60%20%E2%80%94%20tenant%20isolation%20is%20untested**%0A%0AThe%20%60eq%60%20handler%20only%20stores%20the%20%60status%60%20value%3B%20the%20%60.eq%28%22tenant_id%22%2C%20...%29%60%20call%20in%20%60listContributionNeedsAttention%60%20is%20silently%20dropped.%20The%20test%20at%20line%201188%20therefore%20never%20exercises%20cross-tenant%20data%20isolation%3A%20if%20the%20production%20%60.eq%28%22tenant_id%22%2C%20...%29%60%20call%20were%20accidentally%20removed%2C%20the%20test%20would%20still%20pass.%20For%20a%20multi-tenant%20system%20this%20is%20a%20security-critical%20gap.%20Add%20a%20second%20tenant's%20rows%20to%20%60state.attentionRows%60%20and%20assert%20they%20are%20absent%20from%20the%20result.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=394&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Asupabase%2Fmigrations%2F20260526193000_mission_control_tasks.sql%3A766-767%0A**%60updated_at%60%20column%20on%20%60mission_control_tasks%60%20has%20no%20auto-update%20mechanism**%0A%0AThe%20composite%20index%20%60idx_mission_control_tasks_tenant_status%60%20uses%20%60updated_at%20DESC%60%20as%20its%20trailing%20column%2C%20implying%20dashboard%20queries%20will%20sort%20tasks%20by%20%22most%20recently%20changed.%22%20However%2C%20the%20migration%20defines%20no%20%60BEFORE%20UPDATE%60%20trigger%20%28e.g.%20a%20shared%20%60set_updated_at%28%29%60%20function%29%20on%20%60mission_control_tasks%60%20or%20%60mission_control_attention_items%60.%20Once%20the%20deferred%20status-transition%20operations%20ship%2C%20any%20%60UPDATE%60%20that%20doesn't%20explicitly%20set%20%60updated_at%60%20will%20leave%20the%20column%20frozen%20at%20insertion%20time%2C%20silently%20breaking%20the%20sort%20semantics%20this%20index%20was%20built%20for.%0A%0AAdd%20a%20trigger%20before%20the%20index%20definition%20%E2%80%94%20or%2C%20if%20the%20codebase%20already%20has%20a%20shared%20%60set_updated_at%60%20function%20%28check%20the%20foundation%20migration%29%2C%20apply%20it%20here.%20At%20minimum%2C%20add%20a%20comment%20documenting%20that%20every%20future%20UPDATE%20statement%20must%20set%20%60updated_at%60%20explicitly.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fmission-control-tasks%2Fstore.ts%3A47-54%0A**Silent%20empty-string%20ID%20fallback%20in%20%60ensureMissionControlQueue%60**%0A%0A%60asString%28data.id%29%20%3F%3F%20%22%22%60%20returns%20%60%22%22%60%20when%20the%20UUID%20column%20is%20somehow%20absent.%20An%20empty%20string%20then%20flows%20into%20%60createMissionControlTask%60%20as%20%60queueId%60%2C%20reaching%20the%20%60mission_control_tasks.queue_id%60%20FK%20column%20and%20producing%20a%20cryptic%20Postgres%20%22invalid%20input%20syntax%20for%20type%20uuid%22%20error%20instead%20of%20a%20clear%20diagnostic.%20Throw%20eagerly%20so%20the%20failure%20points%20to%20the%20right%20layer.%0A%0A%60%60%60suggestion%0A%20%20if%20%28error%20%7C%7C%20!isRecord%28data%29%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20error%3F.message%20%3F%3F%20%22Failed%20to%20ensure%20Mission%20Control%20queue.%22%2C%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%0A%20%20const%20queueId%20%3D%20asString%28data.id%29%3B%0A%20%20if%20%28!queueId%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%22ensureMissionControlQueue%3A%20received%20empty%20or%20missing%20id%20from%20Supabase.%22%29%3B%0A%20%20%7D%0A%20%20return%20queueId%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fmission-control-tasks%2Fstore.ts%3A102-106%0A**Same%20silent%20empty-string%20ID%20fallback%20in%20%60insertTask%60**%0A%0AIf%20%60asString%28data.id%29%60%20returns%20null%20here%2C%20%60%22%22%60%20is%20passed%20to%20both%20%60insertLinks%60%20and%20%60appendEvent%60%20as%20%60taskId%60%2C%20causing%20FK%20violations%20that%20reference%20the%20wrong%20layer%20rather%20than%20surfacing%20the%20root%20cause.%20Apply%20the%20same%20explicit%20guard%20used%20in%20%60ensureMissionControlQueue%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20%28error%20%7C%7C%20!isRecord%28data%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20throw%20new%20Error%28error%3F.message%20%3F%3F%20%22Failed%20to%20create%20task.%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20const%20taskId%20%3D%20asString%28data.id%29%3B%0A%20%20%20%20%20%20%20%20if%20%28!taskId%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20throw%20new%20Error%28%22insertTask%3A%20received%20empty%20or%20missing%20id%20from%20Supabase.%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20taskId%3B%0A%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Atests%2Funit%2Fpackages%2Fapi%2Fadmin%2Fmission-control-tasks.test.ts%3A854-858%0A**%60QueryBuilder.eq%60%20stub%20ignores%20%60tenant_id%60%20%E2%80%94%20tenant%20isolation%20is%20untested**%0A%0AThe%20%60eq%60%20handler%20only%20stores%20the%20%60status%60%20value%3B%20the%20%60.eq%28%22tenant_id%22%2C%20...%29%60%20call%20in%20%60listContributionNeedsAttention%60%20is%20silently%20dropped.%20The%20test%20at%20line%201188%20therefore%20never%20exercises%20cross-tenant%20data%20isolation%3A%20if%20the%20production%20%60.eq%28%22tenant_id%22%2C%20...%29%60%20call%20were%20accidentally%20removed%2C%20the%20test%20would%20still%20pass.%20For%20a%20multi-tenant%20system%20this%20is%20a%20security-critical%20gap.%20Add%20a%20second%20tenant's%20rows%20to%20%60state.attentionRows%60%20and%20assert%20they%20are%20absent%20from%20the%20result.%0A%0A&pr=394&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(api): add mission control task foun..."](https://github.com/asymmetric-al/core/commit/4d4747532d038f7d193622b74284a7d23e5aa786) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38895511)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->