### PR TITLE
feat(api): add contribution correction notifications

### DIFF
--- a/packages/api/src/admin/contribution-operations/index.ts
+++ b/packages/api/src/admin/contribution-operations/index.ts
@@ -48,6 +48,32 @@ export {
   pickNextBestInlineContributionAction,
   type BuildInlineContributionActionsInput,
 } from "./inline-actions";
+export {
+  getContributionNotificationPolicy,
+  isContributionNotificationSuppressionReasonRequired,
+  type ContributionNotificationDecision,
+  type ContributionNotificationMode,
+} from "./notifications/policy";
+export {
+  sendContributionCorrectionNotification,
+  type ContributionCorrectionNotificationEvent,
+  type ContributionCorrectionNotificationInput,
+  type ContributionCorrectionNotificationLogResult,
+  type ContributionCorrectionNotificationSettings,
+  type ContributionCorrectionNotificationTaskInput,
+  type ContributionCorrectionNotificationTemplate,
+} from "./notifications/send";
+export {
+  logContributionNotificationEvent,
+  sendContributionCorrectionNotificationFromSupabase,
+} from "./notifications/store";
+export {
+  isContributionCorrectionTemplateFamily,
+  isContributionCorrectionTemplateVariantForFamily,
+  resolveContributionCorrectionTemplateVariant,
+  validateContributionCorrectionTemplate,
+  type ContributionCorrectionTemplateVariantRef,
+} from "./notifications/templates";
 export { applyContributionCorrection } from "./operations";
 export {
   assertAllowedPaymentStateCorrectionStatus,

--- a/packages/api/src/admin/contribution-operations/notifications/policy.ts
+++ b/packages/api/src/admin/contribution-operations/notifications/policy.ts
@@ -1,0 +1,70 @@
+import type { ContributionActionType } from "../types";
+
+export type ContributionNotificationMode =
+  | "auto_notify"
+  | "always_ask"
+  | "staff_chooses";
+
+export type ContributionNotificationDecision =
+  | "sent"
+  | "suppressed"
+  | "blocked"
+  | "failed"
+  | "not_required";
+
+const DEFAULT_MODE_BY_ACTION: Partial<
+  Record<ContributionActionType, ContributionNotificationMode>
+> = {
+  refund: "auto_notify",
+  amount_correction: "auto_notify",
+  receipt_correction: "auto_notify",
+  statement_correction: "auto_notify",
+  designation_correction: "always_ask",
+  fund_correction: "always_ask",
+  allocation_correction: "always_ask",
+  payment_state_correction: "always_ask",
+  donor_relink: "staff_chooses",
+};
+
+const SUPPRESSION_REASON_REQUIRED_ACTIONS = new Set<ContributionActionType>([
+  "refund",
+  "amount_correction",
+  "receipt_correction",
+  "statement_correction",
+  "payment_state_correction",
+]);
+
+export function getContributionNotificationPolicy(input: {
+  actionType: ContributionActionType;
+  tenantModeOverride?: ContributionNotificationMode | null;
+  suppressionReasonRequiredOverride?: boolean | null;
+}) {
+  const defaultSuppressionReasonRequired =
+    SUPPRESSION_REASON_REQUIRED_ACTIONS.has(input.actionType);
+
+  return {
+    actionType: input.actionType,
+    mode:
+      input.tenantModeOverride ??
+      DEFAULT_MODE_BY_ACTION[input.actionType] ??
+      "staff_chooses",
+    suppressionReasonRequired:
+      input.suppressionReasonRequiredOverride ??
+      defaultSuppressionReasonRequired,
+  };
+}
+
+export function isContributionNotificationSuppressionReasonRequired(input: {
+  actionType: ContributionActionType;
+  decision: ContributionNotificationDecision;
+  suppressionReasonRequiredOverride?: boolean | null;
+}) {
+  return (
+    input.decision === "suppressed" &&
+    getContributionNotificationPolicy({
+      actionType: input.actionType,
+      suppressionReasonRequiredOverride:
+        input.suppressionReasonRequiredOverride,
+    }).suppressionReasonRequired
+  );
+}

--- a/packages/api/src/admin/contribution-operations/notifications/send.ts
+++ b/packages/api/src/admin/contribution-operations/notifications/send.ts
@@ -1,0 +1,599 @@
+import { sendEmail } from "@asym/email";
+import {
+  renderMergeTags,
+  renderTemplateForRecipient,
+} from "@asym/email/merge-tag-render";
+
+import {
+  getContributionNotificationPolicy,
+  type ContributionNotificationDecision,
+  type ContributionNotificationMode,
+} from "./policy";
+import { validateContributionCorrectionTemplate } from "./templates";
+
+import type { ContributionActionType } from "../types";
+import type { SendEmailOptions } from "@asym/email";
+import type {
+  ContributionCorrectionTemplateFamily,
+  ContributionCorrectionTemplateVariant,
+} from "@asym/email/contribution-correction-tags";
+
+export interface ContributionCorrectionNotificationTemplate {
+  id: string;
+  versionId: string;
+  version: number;
+  family: ContributionCorrectionTemplateFamily;
+  variant: ContributionCorrectionTemplateVariant;
+  active: boolean;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export interface ContributionCorrectionNotificationSettings {
+  apiKey: string;
+  fromEmail: string;
+  fromName: string;
+  replyToEmail?: string | null;
+  taskAssignmentMode?: "actor_only" | "queue_only" | "actor_and_queue";
+}
+
+export interface ContributionCorrectionNotificationInput {
+  tenantId: string;
+  actionType: ContributionActionType;
+  tenantModeOverride?: ContributionNotificationMode | null;
+  suppressionReasonRequiredOverride?: boolean | null;
+  taskAssignmentMode?: "actor_only" | "queue_only" | "actor_and_queue";
+  contributionId?: string | null;
+  correctionId: string | null;
+  operationAuditEventId: string;
+  actorProfileId: string | null;
+  recipient: {
+    donorId: string | null;
+    email: string;
+    name: string;
+  };
+  mergeValues: Record<string, unknown>;
+  personalNote?: string | null;
+  suppressionReason?: string | null;
+  decisionOverride?: ContributionNotificationDecision | null;
+  template: ContributionCorrectionNotificationTemplate | null;
+  settings: ContributionCorrectionNotificationSettings | null;
+  dependencies?: {
+    sendEmail?: typeof sendEmail;
+    logNotificationEvent?: (
+      event: ContributionCorrectionNotificationEvent,
+    ) => Promise<ContributionCorrectionNotificationLogResult>;
+    recordNotificationTaskIds?: (
+      input: ContributionCorrectionNotificationTaskLinkInput,
+    ) => Promise<void>;
+    createFollowUpTask?: (
+      input: ContributionCorrectionNotificationTaskInput,
+    ) => Promise<string[]>;
+  };
+}
+
+export interface ContributionCorrectionNotificationEvent {
+  tenantId: string;
+  idempotencyKey: string;
+  operationAuditEventId: string;
+  correctionId: string | null;
+  actionType: ContributionActionType;
+  decision: ContributionNotificationDecision;
+  templateId?: string | null;
+  templateVersionId?: string | null;
+  templateFamily?: string | null;
+  templateVariant?: string | null;
+  templateVersion?: number | null;
+  recipientDonorId: string | null;
+  recipientEmail: string;
+  policySnapshot?: Record<string, unknown>;
+  suppressionReason?: string | null;
+  personalNotePresent: boolean;
+  providerStatus?: string | null;
+  providerMessageId?: string | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  taskIds?: string[];
+}
+
+export interface ContributionCorrectionNotificationLogResult {
+  eventId: string;
+  taskIds?: string[];
+}
+
+export interface ContributionCorrectionNotificationTaskInput {
+  tenantId: string;
+  actorProfileId: string | null;
+  notificationEventId: string | null;
+  operationAuditEventId: string;
+  correctionId: string | null;
+  contributionId?: string | null;
+  actionType: ContributionActionType;
+  recipientDonorId: string | null;
+  assignmentMode: "actor_only" | "queue_only" | "actor_and_queue";
+  reason: string;
+}
+
+export interface ContributionCorrectionNotificationTaskLinkInput {
+  notificationEventId: string;
+  taskIds: string[];
+}
+
+function buildProviderIdempotencyKey(input: {
+  tenantId: string;
+  operationAuditEventId: string;
+  donorId: string;
+  family: string;
+  variant: string;
+}) {
+  return [
+    "correction-notification",
+    input.tenantId,
+    input.operationAuditEventId,
+    input.donorId,
+    input.family,
+    input.variant,
+  ].join("/");
+}
+
+function buildDecisionIdempotencyKey(input: {
+  tenantId: string;
+  operationAuditEventId: string;
+  donorId: string;
+  actionType: ContributionActionType;
+  decision: ContributionNotificationDecision;
+  reason?: string;
+}) {
+  return [
+    "correction-notification",
+    input.tenantId,
+    input.operationAuditEventId,
+    input.donorId,
+    input.actionType,
+    input.decision,
+    input.reason ?? "default",
+  ].join("/");
+}
+
+function normalizeTaskIds(taskIds: string[] | null | undefined): string[] {
+  return Array.isArray(taskIds)
+    ? taskIds.filter((taskId) => taskId.trim().length > 0)
+    : [];
+}
+
+function errorMessageFromUnknown(error: unknown, fallback: string) {
+  return error instanceof Error && error.message.trim().length > 0
+    ? error.message
+    : fallback;
+}
+
+async function logEvent(
+  input: ContributionCorrectionNotificationInput,
+  event: Omit<ContributionCorrectionNotificationEvent, "tenantId">,
+): Promise<ContributionCorrectionNotificationLogResult | null> {
+  const result = await input.dependencies?.logNotificationEvent?.({
+    tenantId: input.tenantId,
+    ...event,
+  });
+
+  return result
+    ? {
+        eventId: result.eventId,
+        taskIds: normalizeTaskIds(result.taskIds),
+      }
+    : null;
+}
+
+async function createTaskIntent(
+  input: ContributionCorrectionNotificationInput,
+  reason: string,
+  notificationEventId: string | null,
+): Promise<string[]> {
+  const assignmentMode =
+    input.taskAssignmentMode ??
+    input.settings?.taskAssignmentMode ??
+    "actor_and_queue";
+
+  return (
+    (await input.dependencies?.createFollowUpTask?.({
+      tenantId: input.tenantId,
+      actorProfileId: input.actorProfileId,
+      notificationEventId,
+      operationAuditEventId: input.operationAuditEventId,
+      correctionId: input.correctionId,
+      contributionId: input.contributionId,
+      actionType: input.actionType,
+      recipientDonorId: input.recipient.donorId,
+      assignmentMode,
+      reason,
+    })) ?? []
+  );
+}
+
+async function createOrReuseTaskIntent(input: {
+  notificationInput: ContributionCorrectionNotificationInput;
+  logResult: ContributionCorrectionNotificationLogResult | null;
+  reason: string;
+}) {
+  const existingTaskIds = normalizeTaskIds(input.logResult?.taskIds);
+  if (existingTaskIds.length > 0) {
+    return existingTaskIds;
+  }
+
+  const taskIds = await createTaskIntent(
+    input.notificationInput,
+    input.reason,
+    input.logResult?.eventId ?? null,
+  );
+
+  if (input.logResult?.eventId && taskIds.length > 0) {
+    await input.notificationInput.dependencies?.recordNotificationTaskIds?.({
+      notificationEventId: input.logResult.eventId,
+      taskIds,
+    });
+  }
+
+  return taskIds;
+}
+
+async function blockNotification(
+  input: ContributionCorrectionNotificationInput,
+  message: string,
+  errorCode: string,
+) {
+  const policy = getContributionNotificationPolicy({
+    actionType: input.actionType,
+    tenantModeOverride: input.tenantModeOverride,
+    suppressionReasonRequiredOverride: input.suppressionReasonRequiredOverride,
+  });
+  const policySnapshot = {
+    mode: policy.mode,
+    suppressionReasonRequired: policy.suppressionReasonRequired,
+  };
+  const logResult = await logEvent(input, {
+    idempotencyKey: buildDecisionIdempotencyKey({
+      tenantId: input.tenantId,
+      operationAuditEventId: input.operationAuditEventId,
+      donorId: input.recipient.donorId ?? "unknown-donor",
+      actionType: input.actionType,
+      decision: "blocked",
+      reason: errorCode,
+    }),
+    operationAuditEventId: input.operationAuditEventId,
+    correctionId: input.correctionId,
+    actionType: input.actionType,
+    decision: "blocked",
+    policySnapshot,
+    recipientDonorId: input.recipient.donorId,
+    recipientEmail: input.recipient.email,
+    personalNotePresent: Boolean(input.personalNote?.trim()),
+    errorCode,
+    errorMessage: message,
+    taskIds: [],
+  });
+  const taskIds = await createOrReuseTaskIntent({
+    notificationInput: input,
+    logResult,
+    reason: message,
+  });
+
+  return {
+    decision: "blocked" as const,
+    taskIds,
+    error: {
+      code: errorCode,
+      message,
+    },
+  };
+}
+
+export async function sendContributionCorrectionNotification(
+  input: ContributionCorrectionNotificationInput,
+) {
+  const policy = getContributionNotificationPolicy({
+    actionType: input.actionType,
+    tenantModeOverride: input.tenantModeOverride,
+    suppressionReasonRequiredOverride: input.suppressionReasonRequiredOverride,
+  });
+  const policySnapshot = {
+    mode: policy.mode,
+    suppressionReasonRequired: policy.suppressionReasonRequired,
+  };
+
+  if (input.decisionOverride === "suppressed") {
+    if (policy.suppressionReasonRequired && !input.suppressionReason?.trim()) {
+      throw new Error("A suppression reason is required.");
+    }
+
+    await logEvent(input, {
+      idempotencyKey: buildDecisionIdempotencyKey({
+        tenantId: input.tenantId,
+        operationAuditEventId: input.operationAuditEventId,
+        donorId: input.recipient.donorId ?? "unknown-donor",
+        actionType: input.actionType,
+        decision: "suppressed",
+      }),
+      operationAuditEventId: input.operationAuditEventId,
+      correctionId: input.correctionId,
+      actionType: input.actionType,
+      decision: "suppressed",
+      policySnapshot,
+      recipientDonorId: input.recipient.donorId,
+      recipientEmail: input.recipient.email,
+      suppressionReason: input.suppressionReason ?? null,
+      personalNotePresent: Boolean(input.personalNote?.trim()),
+    });
+
+    return { decision: "suppressed" as const, taskIds: [] };
+  }
+
+  if (
+    (policy.mode === "staff_chooses" || policy.mode === "always_ask") &&
+    !input.decisionOverride
+  ) {
+    await logEvent(input, {
+      idempotencyKey: buildDecisionIdempotencyKey({
+        tenantId: input.tenantId,
+        operationAuditEventId: input.operationAuditEventId,
+        donorId: input.recipient.donorId ?? "unknown-donor",
+        actionType: input.actionType,
+        decision: "not_required",
+      }),
+      operationAuditEventId: input.operationAuditEventId,
+      correctionId: input.correctionId,
+      actionType: input.actionType,
+      decision: "not_required",
+      policySnapshot,
+      recipientDonorId: input.recipient.donorId,
+      recipientEmail: input.recipient.email,
+      personalNotePresent: Boolean(input.personalNote?.trim()),
+    });
+
+    return { decision: "not_required" as const, taskIds: [] };
+  }
+
+  if (!input.recipient.email.trim()) {
+    return blockNotification(
+      input,
+      "Missing donor email address for contribution correction notification.",
+      "missing_recipient_email",
+    );
+  }
+
+  if (!input.template) {
+    return blockNotification(
+      input,
+      "Missing active contribution correction template.",
+      "missing_template",
+    );
+  }
+
+  if (!input.settings) {
+    return blockNotification(
+      input,
+      "Tenant email sending is not connected for contribution correction notifications.",
+      "missing_email_settings",
+    );
+  }
+
+  if (!input.template.active) {
+    return blockNotification(
+      input,
+      "Contribution correction template is inactive.",
+      "inactive_template",
+    );
+  }
+
+  const validation = validateContributionCorrectionTemplate({
+    family: input.template.family,
+    variant: input.template.variant,
+    html: input.template.html,
+    text: input.template.text,
+    active: true,
+  });
+
+  if (!validation.valid) {
+    return blockNotification(
+      input,
+      validation.errors.join("; "),
+      "invalid_template",
+    );
+  }
+
+  const mergeValues = {
+    ...input.mergeValues,
+    personal_note: input.personalNote?.trim() ?? "",
+  };
+  const rendered = (() => {
+    try {
+      return renderTemplateForRecipient(
+        {
+          html: input.template.html,
+          text: input.template.text,
+        },
+        mergeValues,
+        {},
+        {
+          messageType: "transactional",
+        },
+      );
+    } catch (error) {
+      return new Error(
+        errorMessageFromUnknown(
+          error,
+          "Failed to render contribution correction notification.",
+        ),
+      );
+    }
+  })();
+
+  if (rendered instanceof Error) {
+    return blockNotification(
+      input,
+      errorMessageFromUnknown(
+        rendered,
+        "Failed to render contribution correction notification.",
+      ),
+      "render_failed",
+    );
+  }
+
+  const renderedSubject = (() => {
+    try {
+      return renderMergeTags(input.template.subject, mergeValues, {
+        messageType: "transactional",
+        escapeHtml: false,
+      });
+    } catch (error) {
+      return new Error(
+        errorMessageFromUnknown(
+          error,
+          "Failed to render contribution correction notification subject.",
+        ),
+      );
+    }
+  })();
+
+  if (renderedSubject instanceof Error) {
+    return blockNotification(
+      input,
+      errorMessageFromUnknown(
+        renderedSubject,
+        "Failed to render contribution correction notification subject.",
+      ),
+      "render_failed",
+    );
+  }
+
+  const settings = input.settings;
+  const sender = input.dependencies?.sendEmail ?? sendEmail;
+  const idempotencyKey = buildProviderIdempotencyKey({
+    tenantId: input.tenantId,
+    operationAuditEventId: input.operationAuditEventId,
+    donorId: input.recipient.donorId ?? "unknown-donor",
+    family: input.template.family,
+    variant: input.template.variant,
+  });
+  const sendOptions = {
+    to: {
+      email: input.recipient.email,
+      name: input.recipient.name,
+    },
+    from: {
+      email: settings.fromEmail,
+      name: settings.fromName,
+    },
+    replyTo: settings.replyToEmail
+      ? { email: settings.replyToEmail }
+      : undefined,
+    subject: renderedSubject,
+    html: rendered.html,
+    text: rendered.text,
+    idempotencyKey,
+    customArgs: {
+      source: "contribution_correction_notification",
+      correctionId: input.correctionId ?? "none",
+      operationAuditEventId: input.operationAuditEventId,
+      templateId: input.template.id,
+      templateVersionId: input.template.versionId,
+    },
+  } satisfies SendEmailOptions;
+
+  const providerResult = await (async () => {
+    try {
+      return {
+        kind: "provider_result" as const,
+        result: await sender(settings.apiKey, sendOptions),
+      };
+    } catch (error) {
+      const errorMessage = errorMessageFromUnknown(
+        error,
+        "Contribution correction email failed.",
+      );
+      const logResult = await logEvent(input, {
+        idempotencyKey,
+        operationAuditEventId: input.operationAuditEventId,
+        correctionId: input.correctionId,
+        actionType: input.actionType,
+        decision: "failed",
+        templateId: input.template?.id ?? null,
+        templateVersionId: input.template?.versionId ?? null,
+        templateFamily: input.template?.family ?? null,
+        templateVariant: input.template?.variant ?? null,
+        templateVersion: input.template?.version ?? null,
+        recipientDonorId: input.recipient.donorId,
+        recipientEmail: input.recipient.email,
+        policySnapshot,
+        personalNotePresent: Boolean(input.personalNote?.trim()),
+        providerStatus: "failed",
+        providerMessageId: null,
+        errorCode: "provider_exception",
+        errorMessage,
+        taskIds: [],
+      });
+      const taskIds = await createOrReuseTaskIntent({
+        notificationInput: input,
+        logResult,
+        reason: errorMessage,
+      });
+
+      return {
+        kind: "provider_exception" as const,
+        messageId: undefined as string | undefined,
+        taskIds,
+      };
+    }
+  })();
+
+  if (providerResult.kind === "provider_exception") {
+    return {
+      decision: "failed" as const,
+      taskIds: providerResult.taskIds,
+      messageId: providerResult.messageId,
+      templateVersionId: input.template.versionId,
+    };
+  }
+
+  const sendResult = providerResult.result;
+  const decision: ContributionNotificationDecision = sendResult.success
+    ? "sent"
+    : "failed";
+  const error = sendResult.errors?.[0] ?? null;
+  const logResult = await logEvent(input, {
+    idempotencyKey,
+    operationAuditEventId: input.operationAuditEventId,
+    correctionId: input.correctionId,
+    actionType: input.actionType,
+    decision,
+    templateId: input.template.id,
+    templateVersionId: input.template.versionId,
+    templateFamily: input.template.family,
+    templateVariant: input.template.variant,
+    templateVersion: input.template.version,
+    recipientDonorId: input.recipient.donorId,
+    recipientEmail: input.recipient.email,
+    policySnapshot,
+    personalNotePresent: Boolean(input.personalNote?.trim()),
+    providerStatus: decision,
+    providerMessageId: sendResult.messageId ?? null,
+    errorCode: error?.code ?? null,
+    errorMessage: error?.message ?? null,
+    taskIds: [],
+  });
+  const taskIds =
+    decision === "failed"
+      ? await createOrReuseTaskIntent({
+          notificationInput: input,
+          logResult,
+          reason: error?.message ?? "Contribution correction email failed.",
+        })
+      : [];
+
+  return {
+    decision,
+    taskIds,
+    messageId: sendResult.messageId,
+    templateVersionId: input.template.versionId,
+  };
+}

--- a/packages/api/src/admin/contribution-operations/notifications/store.ts
+++ b/packages/api/src/admin/contribution-operations/notifications/store.ts
@@ -1,0 +1,516 @@
+import { DEFAULT_SITE_URL } from "@asym/config/site-shared";
+import { serverEnv } from "@asym/env";
+
+import { sendContributionCorrectionNotification } from "./send";
+import { resolveContributionCorrectionTemplateVariant } from "./templates";
+import { decryptResendApiKey } from "../../../email/crypto";
+import { readTenantEmailSettings } from "../../../email/settings-store";
+import {
+  listEmailTemplateVersions,
+  readEmailTemplate,
+} from "../../../email/template-store";
+import { createMissionControlTaskInSupabase } from "../../mission-control-tasks/store";
+
+import type { MissionControlLinkedRecord } from "../../mission-control-tasks/types";
+import type { ContributionDetail } from "../detail-read-model";
+import type {
+  ContributionActionType,
+  ContributionProviderOutcome,
+} from "../types";
+import type { ContributionNotificationMode } from "./policy";
+import type {
+  ContributionCorrectionNotificationEvent,
+  ContributionCorrectionNotificationLogResult,
+  ContributionCorrectionNotificationTaskInput,
+} from "./send";
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+type SupabaseAdmin = AdminSupabaseClient;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function isContributionNotificationMode(
+  value: unknown,
+): value is ContributionNotificationMode {
+  return (
+    value === "auto_notify" ||
+    value === "always_ask" ||
+    value === "staff_chooses"
+  );
+}
+
+function isTaskAssignmentMode(
+  value: unknown,
+): value is "actor_only" | "queue_only" | "actor_and_queue" {
+  return (
+    value === "actor_only" ||
+    value === "queue_only" ||
+    value === "actor_and_queue"
+  );
+}
+
+function isUniqueViolation(error: { code?: string } | null | undefined) {
+  return error?.code === "23505";
+}
+
+function getRefundKind(detail: ContributionDetail) {
+  if (detail.refund.status === "partial_refund") {
+    return "partial" as const;
+  }
+  if (detail.refund.status === "refunded") {
+    return "full" as const;
+  }
+  return null;
+}
+
+function formatMoney(cents: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    currency,
+    style: "currency",
+  }).format(cents / 100);
+}
+
+function summaryAmountCents(
+  summary: Record<string, unknown> | null | undefined,
+  key: string,
+  fallback: number,
+) {
+  const value = summary?.[key];
+  return typeof value === "number" ? value : fallback;
+}
+
+function summaryString(
+  summary: Record<string, unknown> | null | undefined,
+  key: string,
+  fallback: string | null | undefined,
+) {
+  const value = summary?.[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : (fallback ?? "");
+}
+
+function stripTrailingSlash(value: string) {
+  return value.replace(/\/$/, "");
+}
+
+function resolveDonorOrigin() {
+  return stripTrailingSlash(
+    serverEnv.NEXT_PUBLIC_DONOR_URL ||
+      serverEnv.DONOR_APP_URL ||
+      serverEnv.NEXT_PUBLIC_SITE_URL ||
+      serverEnv.NEXT_PUBLIC_APP_URL ||
+      DEFAULT_SITE_URL,
+  );
+}
+
+function buildDonorUrl(path: string) {
+  return new URL(path, `${resolveDonorOrigin()}/`).toString();
+}
+
+export function buildContributionCorrectionNotificationMergeValues(input: {
+  detail: ContributionDetail;
+  beforeSummary?: Record<string, unknown> | null;
+  afterSummary?: Record<string, unknown> | null;
+  orgName?: string | null;
+  supportContactEmail?: string | null;
+}) {
+  const currency = input.detail.amount.currency;
+  const currentAmount = input.detail.amount.value;
+  const originalCents = summaryAmountCents(
+    input.beforeSummary,
+    "amount",
+    currentAmount,
+  );
+  const correctedCents = summaryAmountCents(
+    input.afterSummary,
+    "amount",
+    currentAmount,
+  );
+  const refundCents =
+    typeof input.afterSummary?.refundAmount === "number"
+      ? input.afterSummary.refundAmount
+      : input.detail.refund.amount;
+  const orgName = input.orgName?.trim() || "Your ministry";
+  const supportEmail = input.supportContactEmail?.trim();
+  const supportContactLink = supportEmail ? `mailto:${supportEmail}` : null;
+  const fallbackDesignationName =
+    input.detail.shared.designationSummary.fundName;
+  const donorHistoryUrl = buildDonorUrl("/donor-dashboard/history");
+
+  return {
+    full_name: input.detail.donor?.name ?? "Donor",
+    email: input.detail.donor?.email ?? "",
+    org_name: orgName,
+    gift_date: new Date(input.detail.gift.date).toLocaleDateString("en-US", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }),
+    donation_amount: formatMoney(correctedCents, currency),
+    original_amount: formatMoney(originalCents, currency),
+    corrected_amount: formatMoney(correctedCents, currency),
+    refund_amount: formatMoney(refundCents, currency),
+    previous_designation_name: summaryString(
+      input.beforeSummary,
+      "designationName",
+      fallbackDesignationName,
+    ),
+    corrected_designation_name: summaryString(
+      input.afterSummary,
+      "designationName",
+      fallbackDesignationName,
+    ),
+    receipt_link: donorHistoryUrl,
+    statement_link: donorHistoryUrl,
+    payment_state: input.detail.donorVisible.status,
+    donor_portal_link: donorHistoryUrl,
+    support_contact_link: supportContactLink,
+    operation_reference: input.detail.id,
+  };
+}
+
+async function readActiveTemplateBinding(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  family: string;
+  variant: string;
+}) {
+  const { data, error } = await input.supabaseAdmin
+    .from("email_template_system_bindings")
+    .select("template_id, family_key, variant_key, is_active")
+    .eq("tenant_id", input.tenantId)
+    .eq("family_key", input.family)
+    .eq("variant_key", input.variant)
+    .eq("is_active", true)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return isRecord(data) ? data : null;
+}
+
+export async function readContributionNotificationSettings(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  actionType: ContributionActionType;
+}): Promise<{
+  mode: ContributionNotificationMode | null;
+  suppressionReasonRequired: boolean | null;
+  taskAssignmentMode: "actor_only" | "queue_only" | "actor_and_queue" | null;
+}> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_notification_settings")
+    .select("mode, suppression_reason_required, task_assignment_mode")
+    .eq("tenant_id", input.tenantId)
+    .eq("action_type", input.actionType)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!isRecord(data)) {
+    return {
+      mode: null,
+      suppressionReasonRequired: null,
+      taskAssignmentMode: null,
+    };
+  }
+
+  return {
+    mode: isContributionNotificationMode(data.mode) ? data.mode : null,
+    suppressionReasonRequired:
+      typeof data.suppression_reason_required === "boolean"
+        ? data.suppression_reason_required
+        : null,
+    taskAssignmentMode: isTaskAssignmentMode(data.task_assignment_mode)
+      ? data.task_assignment_mode
+      : null,
+  };
+}
+
+export async function logContributionNotificationEvent(input: {
+  supabaseAdmin: SupabaseAdmin;
+  event: ContributionCorrectionNotificationEvent;
+}): Promise<ContributionCorrectionNotificationLogResult> {
+  const payload = {
+    tenant_id: input.event.tenantId,
+    idempotency_key: input.event.idempotencyKey,
+    operation_audit_event_id: input.event.operationAuditEventId,
+    correction_id: input.event.correctionId,
+    action_type: input.event.actionType,
+    template_id: input.event.templateId ?? null,
+    template_version_id: input.event.templateVersionId ?? null,
+    template_family: input.event.templateFamily ?? null,
+    template_variant: input.event.templateVariant ?? null,
+    template_version: input.event.templateVersion ?? null,
+    decision: input.event.decision,
+    policy_snapshot: input.event.policySnapshot ?? {},
+    suppression_reason: input.event.suppressionReason ?? null,
+    personal_note_present: input.event.personalNotePresent,
+    recipient_donor_id: input.event.recipientDonorId,
+    recipient_email: input.event.recipientEmail,
+    provider_status: input.event.providerStatus ?? null,
+    provider_message_id: input.event.providerMessageId ?? null,
+    error_code: input.event.errorCode ?? null,
+    error_message: input.event.errorMessage ?? null,
+    task_ids: input.event.taskIds ?? [],
+    sent_at: input.event.decision === "sent" ? new Date().toISOString() : null,
+  };
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_notification_events")
+    .insert(payload)
+    .select("id, task_ids")
+    .single();
+
+  if (error) {
+    if (isUniqueViolation(error)) {
+      const existing = await input.supabaseAdmin
+        .from("contribution_notification_events")
+        .select("id, task_ids")
+        .eq("tenant_id", input.event.tenantId)
+        .eq("idempotency_key", input.event.idempotencyKey)
+        .maybeSingle();
+
+      if (existing.error || !isRecord(existing.data)) {
+        throw new Error(
+          existing.error?.message ??
+            "Failed to load existing contribution notification event.",
+        );
+      }
+
+      return {
+        eventId: asString(existing.data.id) ?? "",
+        taskIds: asStringArray(existing.data.task_ids),
+      };
+    }
+
+    throw new Error(error.message);
+  }
+
+  return {
+    eventId: asString((data as JsonRecord | null)?.id) ?? "",
+    taskIds: asStringArray((data as JsonRecord | null)?.task_ids),
+  };
+}
+
+async function findExistingNotificationTaskIds(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  notificationEventId: string | null;
+}): Promise<string[]> {
+  if (!input.notificationEventId) {
+    return [];
+  }
+
+  const { data, error } = await input.supabaseAdmin
+    .from("mission_control_task_links")
+    .select("task_id")
+    .eq("tenant_id", input.tenantId)
+    .eq("record_type", "notification_event")
+    .eq("record_id", input.notificationEventId)
+    .limit(10);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return ((data ?? []) as JsonRecord[])
+    .map((row) => asString(row.task_id))
+    .filter((taskId): taskId is string => Boolean(taskId));
+}
+
+function buildNotificationTaskLinks(
+  taskInput: ContributionCorrectionNotificationTaskInput,
+): MissionControlLinkedRecord[] {
+  const records: MissionControlLinkedRecord[] = [];
+
+  if (taskInput.contributionId) {
+    records.push({
+      type: "contribution",
+      id: taskInput.contributionId,
+    });
+  }
+
+  if (taskInput.recipientDonorId) {
+    records.push({
+      type: "donor",
+      id: taskInput.recipientDonorId,
+    });
+  }
+
+  records.push({
+    type: "audit_event",
+    id: taskInput.operationAuditEventId,
+  });
+
+  if (taskInput.notificationEventId) {
+    records.push({
+      type: "notification_event",
+      id: taskInput.notificationEventId,
+    });
+  }
+
+  return records;
+}
+
+export async function sendContributionCorrectionNotificationFromSupabase(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  actionType: ContributionActionType;
+  contributionId: string;
+  correctionId: string | null;
+  auditEventId: string;
+  actorProfileId: string | null;
+  providerOutcome?: ContributionProviderOutcome | null;
+  detail: ContributionDetail;
+  beforeSummary?: Record<string, unknown> | null;
+  afterSummary?: Record<string, unknown> | null;
+}) {
+  const notificationSettings = await readContributionNotificationSettings({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    actionType: input.actionType,
+  });
+  const variant = resolveContributionCorrectionTemplateVariant({
+    actionType: input.actionType,
+    outcome: {
+      status: input.providerOutcome?.status,
+      refundKind: getRefundKind(input.detail),
+    },
+  });
+  const binding = variant
+    ? await readActiveTemplateBinding({
+        supabaseAdmin: input.supabaseAdmin,
+        tenantId: input.tenantId,
+        family: variant.family,
+        variant: variant.variant,
+      })
+    : null;
+  const templateId = asString(binding?.template_id);
+  const template = templateId
+    ? await readEmailTemplate(input.tenantId, templateId)
+    : null;
+  const versions = templateId
+    ? await listEmailTemplateVersions(input.tenantId, templateId)
+    : [];
+  const version = versions.find((row) => row.version === template?.version);
+  const settings = await readTenantEmailSettings(input.tenantId);
+  const encryptedApiKey = settings?.resend_api_key_encrypted ?? null;
+  const defaultFromEmail = settings?.default_from_email ?? null;
+  const defaultFromName = settings?.default_from_name ?? null;
+  const sendingSettings =
+    settings?.is_connected &&
+    encryptedApiKey &&
+    defaultFromEmail &&
+    defaultFromName
+      ? {
+          apiKey: decryptResendApiKey(encryptedApiKey),
+          fromEmail: defaultFromEmail,
+          fromName: defaultFromName,
+          replyToEmail: settings.reply_to_email,
+          taskAssignmentMode:
+            notificationSettings.taskAssignmentMode ?? undefined,
+        }
+      : null;
+  const donor = input.detail.donor;
+
+  return sendContributionCorrectionNotification({
+    tenantId: input.tenantId,
+    actionType: input.actionType,
+    tenantModeOverride: notificationSettings.mode,
+    suppressionReasonRequiredOverride:
+      notificationSettings.suppressionReasonRequired,
+    taskAssignmentMode: notificationSettings.taskAssignmentMode ?? undefined,
+    contributionId: input.contributionId,
+    correctionId: input.correctionId,
+    operationAuditEventId: input.auditEventId,
+    actorProfileId: input.actorProfileId,
+    recipient: {
+      donorId: donor?.id ?? null,
+      email: donor?.email ?? "",
+      name: donor?.name ?? "Donor",
+    },
+    mergeValues: buildContributionCorrectionNotificationMergeValues({
+      detail: input.detail,
+      beforeSummary: input.beforeSummary,
+      afterSummary: input.afterSummary,
+      orgName: defaultFromName,
+      supportContactEmail: settings?.reply_to_email?.trim() || defaultFromEmail,
+    }),
+    template:
+      template && version && variant
+        ? {
+            id: template.id,
+            versionId: version.id,
+            version: version.version,
+            family: variant.family,
+            variant: variant.variant,
+            active: template.is_active,
+            subject: template.default_subject ?? "Contribution update",
+            html: template.html_content ?? "",
+            text: template.text_content ?? "",
+          }
+        : null,
+    settings: sendingSettings,
+    dependencies: {
+      logNotificationEvent: (event) =>
+        logContributionNotificationEvent({
+          supabaseAdmin: input.supabaseAdmin,
+          event,
+        }),
+      recordNotificationTaskIds: async ({ notificationEventId, taskIds }) => {
+        const { error } = await input.supabaseAdmin
+          .from("contribution_notification_events")
+          .update({ task_ids: taskIds })
+          .eq("tenant_id", input.tenantId)
+          .eq("id", notificationEventId);
+
+        if (error) {
+          throw new Error(error.message);
+        }
+      },
+      createFollowUpTask: async (taskInput) => {
+        const existingTaskIds = await findExistingNotificationTaskIds({
+          supabaseAdmin: input.supabaseAdmin,
+          tenantId: input.tenantId,
+          notificationEventId: taskInput.notificationEventId,
+        });
+
+        if (existingTaskIds.length > 0) {
+          return existingTaskIds;
+        }
+
+        const result = await createMissionControlTaskInSupabase({
+          supabaseAdmin: input.supabaseAdmin,
+          tenantId: input.tenantId,
+          title: "Resolve blocked donor correction notification",
+          description: taskInput.reason,
+          issueType: "donor_notification_failed",
+          actorProfileId: taskInput.actorProfileId,
+          assignmentMode: taskInput.assignmentMode,
+          linkedRecords: buildNotificationTaskLinks(taskInput),
+        });
+
+        return [result.taskId];
+      },
+    },
+  });
+}

--- a/packages/api/src/admin/contribution-operations/notifications/templates.ts
+++ b/packages/api/src/admin/contribution-operations/notifications/templates.ts
@@ -1,0 +1,80 @@
+import type { ContributionActionType } from "../types";
+import type {
+  ContributionCorrectionTemplateFamily,
+  ContributionCorrectionTemplateVariant,
+} from "@asym/email/contribution-correction-tags";
+
+export {
+  isContributionCorrectionTemplateFamily,
+  isContributionCorrectionTemplateVariantForFamily,
+  validateContributionCorrectionTemplate,
+} from "../../../email/contribution-correction-template-validation";
+
+export interface ContributionCorrectionTemplateVariantRef {
+  family: ContributionCorrectionTemplateFamily;
+  variant: ContributionCorrectionTemplateVariant;
+}
+
+export function resolveContributionCorrectionTemplateVariant(input: {
+  actionType: ContributionActionType;
+  outcome?: {
+    status?: string | null;
+    refundKind?: "partial" | "full" | null;
+  };
+}): ContributionCorrectionTemplateVariantRef | null {
+  if (input.actionType === "refund") {
+    if (input.outcome?.status === "failed") {
+      return { family: "refund_notification", variant: "refund_failed" };
+    }
+    if (input.outcome?.refundKind === "partial") {
+      return {
+        family: "refund_notification",
+        variant: "partial_refund_completed",
+      };
+    }
+    if (input.outcome?.refundKind === "full") {
+      return {
+        family: "refund_notification",
+        variant: "full_refund_completed",
+      };
+    }
+    return { family: "refund_notification", variant: "refund_completed" };
+  }
+
+  switch (input.actionType) {
+    case "amount_correction":
+      return {
+        family: "amount_correction_notification",
+        variant: "amount_corrected",
+      };
+    case "designation_correction":
+    case "fund_correction":
+    case "allocation_correction":
+      return {
+        family: "designation_correction_notification",
+        variant: "designation_changed",
+      };
+    case "receipt_correction":
+      return {
+        family: "receipt_correction_notification",
+        variant: "receipt_corrected",
+      };
+    case "statement_correction":
+      return {
+        family: "statement_correction_notification",
+        variant: "statement_corrected",
+      };
+    case "payment_state_correction":
+      return {
+        family: "payment_state_correction_notification",
+        variant: "payment_state_corrected",
+      };
+    case "donor_relink":
+      return {
+        family: "donor_relinking_notification",
+        variant: "donor_relinked",
+      };
+    default:
+      return null;
+  }
+}

--- a/packages/api/src/admin/contribution-operations/operations.ts
+++ b/packages/api/src/admin/contribution-operations/operations.ts
@@ -20,6 +20,7 @@ import type {
   ContributionActionType,
   ContributionSourceSurface,
 } from "./types";
+import type { DesignationFundInput } from "../contribution-shared/designation-set";
 import type {
   ContributionAdjustmentEffectiveValues,
   ContributionAdjustmentRecord,
@@ -108,6 +109,62 @@ async function loadContributionAdjustments(input: {
   return ((data ?? []) as JsonRecord[]).map(mapContributionAdjustmentRow);
 }
 
+function collectAdjustmentFundIds(input: {
+  donationFundId: string | null;
+  adjustments: ContributionAdjustmentRecord[];
+}) {
+  const fundIds = new Set<string>();
+  const addFundId = (value: unknown) => {
+    if (typeof value === "string" && value.trim().length > 0) {
+      fundIds.add(value);
+    }
+  };
+
+  addFundId(input.donationFundId);
+
+  for (const adjustment of input.adjustments) {
+    addFundId(adjustment.effectiveValues.fundId);
+
+    for (const line of adjustment.effectiveValues.designationLines ?? []) {
+      addFundId(line.fundId);
+    }
+  }
+
+  return [...fundIds];
+}
+
+async function loadDesignationFunds(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  fundIds: string[];
+}): Promise<DesignationFundInput[]> {
+  const queryableIds = input.fundIds.filter(isUuid);
+
+  if (queryableIds.length === 0) {
+    return [];
+  }
+
+  const { data, error } = await input.supabaseAdmin
+    .from("funds")
+    .select("id, name, missionary_id, goal_amount, start_date, end_date")
+    .eq("tenant_id", input.tenantId)
+    .in("id", queryableIds);
+
+  assertNoError(error, "Failed to load contribution fund metadata.");
+
+  return ((data ?? []) as JsonRecord[]).map((row) => ({
+    id: asString(row.id) ?? "",
+    name: asString(row.name),
+    missionary_id: asString(row.missionary_id),
+    goal_amount:
+      typeof row.goal_amount === "number" && Number.isFinite(row.goal_amount)
+        ? row.goal_amount
+        : null,
+    start_date: asString(row.start_date),
+    end_date: asString(row.end_date),
+  }));
+}
+
 async function loadContributionOperationDetail(input: {
   supabaseAdmin: SupabaseAdmin;
   tenantId: string;
@@ -171,6 +228,21 @@ async function loadContributionOperationDetail(input: {
         twentyRecordId: asString(stagedGiftResult.data.twenty_record_id),
       }
     : null;
+  const allocationFunds = await loadDesignationFunds({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    fundIds: collectAdjustmentFundIds({
+      donationFundId: donation.fundId,
+      adjustments,
+    }),
+  });
+  const primaryFund =
+    donation.fundId !== null
+      ? (allocationFunds.find((fund) => fund.id === donation.fundId) ?? {
+          id: donation.fundId,
+          name: null,
+        })
+      : null;
 
   return buildContributionDetail({
     donation,
@@ -185,7 +257,7 @@ async function loadContributionOperationDetail(input: {
           organization: null,
         }
       : null,
-    fund: donation.fundId ? { id: donation.fundId, name: null } : null,
+    fund: primaryFund,
     missionary: donation.missionaryId
       ? { id: donation.missionaryId, name: null }
       : null,
@@ -207,7 +279,7 @@ async function loadContributionOperationDetail(input: {
     correctionRequests: [],
     adjustments,
     allocations: [],
-    allocationFunds: [],
+    allocationFunds,
     allocationMissionaries: [],
     crmLinks: [],
   });
@@ -432,6 +504,7 @@ function summarizeEffectiveDetail(detail: ContributionDetail) {
     amount: detail.effective.amountCents,
     donorId: detail.donor?.id ?? null,
     fundId: detail.effective.fundId,
+    designationName: detail.shared.designationSummary.fundName,
     missionaryId: detail.effective.missionaryId,
     status: detail.effective.paymentStatus,
   };

--- a/packages/api/src/email/contribution-correction-template-validation.ts
+++ b/packages/api/src/email/contribution-correction-template-validation.ts
@@ -1,0 +1,98 @@
+import {
+  CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES,
+  getContributionCorrectionRequiredTags,
+  type ContributionCorrectionTemplateFamily,
+  type ContributionCorrectionTemplateVariant,
+} from "@asym/email/contribution-correction-tags";
+import {
+  parseMergeTags,
+  validateMergeTags,
+} from "@asym/email/merge-tag-render";
+
+export function getContributionCorrectionTemplateBinding(
+  metadata: Record<string, unknown> | null | undefined,
+): {
+  family: string;
+  variant: string;
+} | null {
+  const value = metadata?.contributionCorrection;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const family =
+    "family" in value && typeof value.family === "string" ? value.family : null;
+  const variant =
+    "variant" in value && typeof value.variant === "string"
+      ? value.variant
+      : null;
+
+  return family && variant ? { family, variant } : null;
+}
+
+export function validateContributionCorrectionTemplate(input: {
+  family: ContributionCorrectionTemplateFamily;
+  variant: string;
+  html: string;
+  text: string;
+  active: boolean;
+}) {
+  if (
+    !isContributionCorrectionTemplateVariantForFamily({
+      family: input.family,
+      variant: input.variant,
+    })
+  ) {
+    return {
+      valid: false,
+      errors: ["Unknown contribution correction template variant."],
+      missingRequiredTags: [],
+      requiredTags: [],
+      usedTags: parseMergeTags(`${input.html}\n${input.text}`),
+    };
+  }
+
+  const variant = input.variant as ContributionCorrectionTemplateVariant;
+  const requiredTags = getContributionCorrectionRequiredTags({
+    family: input.family,
+    variant,
+  });
+  const usedTags = parseMergeTags(`${input.html}\n${input.text}`);
+  const mergeTagValidation = validateMergeTags(`${input.html}\n${input.text}`, {
+    messageType: "transactional",
+  });
+  const missingRequiredTags = requiredTags.filter(
+    (tag) => !usedTags.includes(tag),
+  );
+  const errors = [
+    ...mergeTagValidation.errors,
+    ...(input.active
+      ? missingRequiredTags.map((tag) => `Missing required merge tag: ${tag}`)
+      : []),
+  ];
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    missingRequiredTags,
+    requiredTags,
+    usedTags,
+  };
+}
+
+export function isContributionCorrectionTemplateFamily(
+  value: string,
+): value is ContributionCorrectionTemplateFamily {
+  return value in CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES;
+}
+
+export function isContributionCorrectionTemplateVariantForFamily(input: {
+  family: ContributionCorrectionTemplateFamily;
+  variant: string;
+}): input is {
+  family: ContributionCorrectionTemplateFamily;
+  variant: ContributionCorrectionTemplateVariant;
+} {
+  const family = CONTRIBUTION_CORRECTION_TEMPLATE_FAMILIES[input.family];
+  return input.variant in family.variants;
+}

--- a/packages/api/src/email/template-store.ts
+++ b/packages/api/src/email/template-store.ts
@@ -1,5 +1,11 @@
 import { getAdminClient } from "@asym/database/supabase/admin";
+import { getContributionCorrectionRequiredTags } from "@asym/email/contribution-correction-tags";
 
+import {
+  getContributionCorrectionTemplateBinding,
+  isContributionCorrectionTemplateFamily,
+  isContributionCorrectionTemplateVariantForFamily,
+} from "./contribution-correction-template-validation";
 import { ApiHttpError } from "../shared/http-errors";
 
 import type { EmailBuilderKind } from "@asym/email/email-builder-types";
@@ -7,6 +13,7 @@ import type { EmailTemplateCategory } from "@asym/email/types";
 
 const EMAIL_TEMPLATES_TABLE = "email_templates";
 const EMAIL_TEMPLATE_VERSIONS_TABLE = "email_template_versions";
+const EMAIL_TEMPLATE_SYSTEM_BINDINGS_TABLE = "email_template_system_bindings";
 
 const TEMPLATE_COLUMNS = [
   "id",
@@ -153,6 +160,7 @@ function isStorageMissing(error: { code?: string; message?: string }): boolean {
   const message = error.message?.toLowerCase() ?? "";
   return (
     (message.includes(EMAIL_TEMPLATES_TABLE) ||
+      message.includes(EMAIL_TEMPLATE_SYSTEM_BINDINGS_TABLE) ||
       message.includes(EMAIL_TEMPLATE_VERSIONS_TABLE)) &&
     (error.code === "PGRST205" ||
       error.code === "42P01" ||
@@ -160,6 +168,90 @@ function isStorageMissing(error: { code?: string; message?: string }): boolean {
       message.includes("could not find the table") ||
       message.includes("does not exist"))
   );
+}
+
+function getValidContributionCorrectionBinding(
+  metadata: Record<string, unknown>,
+) {
+  const binding = getContributionCorrectionTemplateBinding(metadata);
+
+  if (!binding || !isContributionCorrectionTemplateFamily(binding.family)) {
+    return null;
+  }
+
+  const variantRef = {
+    family: binding.family,
+    variant: binding.variant,
+  };
+
+  return isContributionCorrectionTemplateVariantForFamily(variantRef)
+    ? variantRef
+    : null;
+}
+
+async function deactivateContributionCorrectionTemplateBindings(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  templateId: string;
+}) {
+  const { error } = await input.supabaseAdmin
+    .from(EMAIL_TEMPLATE_SYSTEM_BINDINGS_TABLE)
+    .update({
+      is_active: false,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", input.tenantId)
+    .eq("template_id", input.templateId);
+
+  if (error) throwSupabaseError(error);
+}
+
+async function syncContributionCorrectionTemplateBinding(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  template: EmailTemplateRow;
+  previousTemplate?: EmailTemplateRow | null;
+}) {
+  const binding = getValidContributionCorrectionBinding(
+    input.template.editor_metadata,
+  );
+  const previousBinding = input.previousTemplate
+    ? getValidContributionCorrectionBinding(
+        input.previousTemplate.editor_metadata,
+      )
+    : null;
+
+  if (!binding && !previousBinding) {
+    return;
+  }
+
+  await deactivateContributionCorrectionTemplateBindings({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.template.tenant_id,
+    templateId: input.template.id,
+  });
+
+  if (!input.template.is_active || !binding) {
+    return;
+  }
+
+  const { error } = await input.supabaseAdmin
+    .from(EMAIL_TEMPLATE_SYSTEM_BINDINGS_TABLE)
+    .upsert(
+      {
+        tenant_id: input.template.tenant_id,
+        template_id: input.template.id,
+        family_key: binding.family,
+        variant_key: binding.variant,
+        required_merge_tags: getContributionCorrectionRequiredTags(binding),
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      },
+      {
+        onConflict: "tenant_id,family_key,variant_key",
+      },
+    );
+
+  if (error) throwSupabaseError(error);
 }
 
 function normalizeStorageError(error: {
@@ -336,6 +428,10 @@ export async function createEmailTemplate(input: {
     template,
     input.profileId,
   );
+  await syncContributionCorrectionTemplateBinding({
+    supabaseAdmin,
+    template,
+  });
   return { template, version };
 }
 
@@ -365,6 +461,11 @@ export async function updateEmailTemplate(input: {
     template,
     input.profileId,
   );
+  await syncContributionCorrectionTemplateBinding({
+    supabaseAdmin,
+    template,
+    previousTemplate: current,
+  });
   return { template, version };
 }
 
@@ -380,6 +481,11 @@ export async function deleteEmailTemplate(
     .eq("id", templateId);
 
   if (error) throwSupabaseError(error);
+  await deactivateContributionCorrectionTemplateBindings({
+    supabaseAdmin,
+    tenantId,
+    templateId,
+  });
 }
 
 export async function duplicateEmailTemplate(input: {
@@ -482,5 +588,10 @@ export async function restoreEmailTemplateVersion(input: {
     template,
     input.profileId,
   );
+  await syncContributionCorrectionTemplateBinding({
+    supabaseAdmin,
+    template,
+    previousTemplate: current,
+  });
   return { template, version };
 }

--- a/packages/api/src/email/templates.ts
+++ b/packages/api/src/email/templates.ts
@@ -8,6 +8,11 @@ import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import {
+  getContributionCorrectionTemplateBinding,
+  isContributionCorrectionTemplateFamily,
+  validateContributionCorrectionTemplate,
+} from "./contribution-correction-template-validation";
+import {
   createEmailTemplate,
   deleteEmailTemplate,
   duplicateEmailTemplate,
@@ -17,6 +22,7 @@ import {
   requireEmailTemplate,
   restoreEmailTemplateVersion,
   updateEmailTemplate,
+  type EmailTemplateRow,
 } from "./template-store";
 import {
   ApiHttpError,
@@ -54,6 +60,8 @@ function validateTemplateMergeTags(input: {
   textContent?: string | null;
   defaultSubject?: string | null;
   defaultPreheader?: string | null;
+  editorMetadata?: Record<string, unknown>;
+  isActive?: boolean;
 }) {
   const validation = validateMergeTags(
     [
@@ -63,6 +71,81 @@ function validateTemplateMergeTags(input: {
       input.defaultPreheader ?? "",
     ].join("\n"),
   );
+
+  if (!validation.valid) {
+    throw new ApiHttpError(400, validation.errors.join("; "));
+  }
+
+  validateEmailTemplateForActivation(input);
+}
+
+function patchNeedsEffectiveValidation(
+  patch: z.infer<typeof templatePatchSchema>,
+) {
+  return (
+    patch.htmlContent !== undefined ||
+    patch.textContent !== undefined ||
+    patch.editorMetadata !== undefined ||
+    patch.isActive !== undefined
+  );
+}
+
+function buildEffectiveTemplateValidationInput(
+  patch: z.infer<typeof templatePatchSchema>,
+  current: EmailTemplateRow,
+) {
+  return {
+    htmlContent:
+      patch.htmlContent !== undefined
+        ? patch.htmlContent
+        : current.html_content,
+    textContent:
+      patch.textContent !== undefined
+        ? patch.textContent
+        : current.text_content,
+    defaultSubject:
+      patch.defaultSubject !== undefined
+        ? patch.defaultSubject
+        : current.default_subject,
+    defaultPreheader:
+      patch.defaultPreheader !== undefined
+        ? patch.defaultPreheader
+        : current.default_preheader,
+    editorMetadata:
+      patch.editorMetadata !== undefined
+        ? patch.editorMetadata
+        : current.editor_metadata,
+    isActive: patch.isActive !== undefined ? patch.isActive : current.is_active,
+  };
+}
+
+export function validateEmailTemplateForActivation(input: {
+  htmlContent?: string | null;
+  textContent?: string | null;
+  editorMetadata?: Record<string, unknown>;
+  isActive?: boolean;
+}) {
+  const binding = getContributionCorrectionTemplateBinding(
+    input.editorMetadata,
+  );
+  if (!binding) {
+    return;
+  }
+
+  if (!isContributionCorrectionTemplateFamily(binding.family)) {
+    throw new ApiHttpError(
+      400,
+      "Unknown contribution correction template family.",
+    );
+  }
+
+  const validation = validateContributionCorrectionTemplate({
+    family: binding.family,
+    variant: binding.variant,
+    html: input.htmlContent ?? "",
+    text: input.textContent ?? "",
+    active: input.isActive !== false,
+  });
 
   if (!validation.valid) {
     throw new ApiHttpError(400, validation.errors.join("; "));
@@ -140,6 +223,18 @@ export async function PATCH_TEMPLATE(
     const body = templatePatchSchema.parse(await ensureJsonBody(request));
 
     validateTemplateMergeTags(body);
+
+    if (patchNeedsEffectiveValidation(body)) {
+      const current = await readEmailTemplate(ctx.tenantId, templateId);
+
+      if (!current) {
+        throw new ApiHttpError(404, "Email template not found");
+      }
+
+      validateTemplateMergeTags(
+        buildEffectiveTemplateValidationInput(body, current),
+      );
+    }
 
     const result = await updateEmailTemplate({
       tenantId: ctx.tenantId,

--- a/packages/database/types/database.ts
+++ b/packages/database/types/database.ts
@@ -516,6 +516,7 @@ export interface ContributionNotificationSetting {
 export interface ContributionNotificationEvent {
   id: string;
   tenant_id: string;
+  idempotency_key: string;
   operation_audit_event_id: string | null;
   correction_id: string | null;
   action_type: string;

--- a/supabase/migrations/20260611151000_contribution_correction_notifications.sql
+++ b/supabase/migrations/20260611151000_contribution_correction_notifications.sql
@@ -1,0 +1,242 @@
+-- Email Studio donor correction notification support for contribution operations.
+
+CREATE TABLE IF NOT EXISTS public.email_template_system_bindings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    template_id UUID NOT NULL REFERENCES public.email_templates(id) ON DELETE CASCADE,
+    family_key TEXT NOT NULL,
+    variant_key TEXT NOT NULL,
+    required_merge_tags TEXT[] NOT NULL DEFAULT '{}'::text[],
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, family_key, variant_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.contribution_notification_settings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    action_type TEXT NOT NULL,
+    mode TEXT NOT NULL DEFAULT 'staff_chooses'
+        CHECK (mode IN ('auto_notify', 'always_ask', 'staff_chooses')),
+    suppression_reason_required BOOLEAN NOT NULL DEFAULT FALSE,
+    task_assignment_mode TEXT NOT NULL DEFAULT 'actor_and_queue'
+        CHECK (task_assignment_mode IN ('actor_only', 'queue_only', 'actor_and_queue')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    UNIQUE (tenant_id, action_type)
+);
+
+CREATE TABLE IF NOT EXISTS public.contribution_notification_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    idempotency_key TEXT NOT NULL,
+    operation_audit_event_id UUID REFERENCES public.contribution_operation_audit_events(id) ON DELETE SET NULL,
+    correction_id UUID REFERENCES public.contribution_corrections(id) ON DELETE SET NULL,
+    action_type TEXT NOT NULL,
+    template_id UUID REFERENCES public.email_templates(id) ON DELETE SET NULL,
+    template_version_id UUID REFERENCES public.email_template_versions(id) ON DELETE SET NULL,
+    template_family TEXT,
+    template_variant TEXT,
+    template_version INTEGER,
+    decision TEXT NOT NULL
+        CHECK (decision IN ('sent', 'suppressed', 'blocked', 'failed', 'not_required')),
+    policy_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    suppression_reason TEXT,
+    personal_note_present BOOLEAN NOT NULL DEFAULT FALSE,
+    recipient_donor_id UUID REFERENCES public.donors(id) ON DELETE SET NULL,
+    recipient_email TEXT,
+    email_send_log_id UUID REFERENCES public.email_send_logs(id) ON DELETE SET NULL,
+    provider_status TEXT,
+    provider_message_id TEXT,
+    error_code TEXT,
+    error_message TEXT,
+    task_ids UUID[] NOT NULL DEFAULT '{}'::uuid[],
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    sent_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_template_system_bindings_tenant_family
+    ON public.email_template_system_bindings (tenant_id, family_key, variant_key);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_notification_settings_tenant_action
+    ON public.contribution_notification_settings (tenant_id, action_type);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_notification_events_tenant_audit
+    ON public.contribution_notification_events (tenant_id, operation_audit_event_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_notification_events_recipient
+    ON public.contribution_notification_events (tenant_id, recipient_donor_id, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contribution_notification_events_idempotency
+    ON public.contribution_notification_events (tenant_id, idempotency_key);
+
+CREATE OR REPLACE FUNCTION public.enforce_contribution_notification_tenant_refs()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO public
+AS $function$
+DECLARE
+    row_data JSONB;
+    row_tenant_id UUID;
+    ref_id UUID;
+    ref_tenant_id UUID;
+BEGIN
+    row_data := to_jsonb(NEW);
+    row_tenant_id := (row_data ->> 'tenant_id')::uuid;
+
+    IF row_tenant_id IS NULL THEN
+        RAISE EXCEPTION 'contribution notification tenant is required'
+            USING ERRCODE = '23502';
+    END IF;
+
+    IF
+        row_data ? 'updated_by'
+        AND (row_data ->> 'updated_by') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'updated_by')::uuid;
+        SELECT p.tenant_id
+        INTO ref_tenant_id
+        FROM public.profiles AS p
+        WHERE p.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution notification updater profile tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF
+        row_data ? 'template_id'
+        AND (row_data ->> 'template_id') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'template_id')::uuid;
+        SELECT et.tenant_id
+        INTO ref_tenant_id
+        FROM public.email_templates AS et
+        WHERE et.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution notification template tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF
+        row_data ? 'operation_audit_event_id'
+        AND (row_data ->> 'operation_audit_event_id') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'operation_audit_event_id')::uuid;
+        SELECT ae.tenant_id
+        INTO ref_tenant_id
+        FROM public.contribution_operation_audit_events AS ae
+        WHERE ae.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution notification audit event tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF
+        row_data ? 'correction_id'
+        AND (row_data ->> 'correction_id') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'correction_id')::uuid;
+        SELECT cc.tenant_id
+        INTO ref_tenant_id
+        FROM public.contribution_corrections AS cc
+        WHERE cc.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution notification correction tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF
+        row_data ? 'template_version_id'
+        AND (row_data ->> 'template_version_id') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'template_version_id')::uuid;
+        SELECT etv.tenant_id
+        INTO ref_tenant_id
+        FROM public.email_template_versions AS etv
+        WHERE etv.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution notification template version tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    IF
+        row_data ? 'recipient_donor_id'
+        AND (row_data ->> 'recipient_donor_id') IS NOT NULL
+    THEN
+        ref_id := (row_data ->> 'recipient_donor_id')::uuid;
+        SELECT d.tenant_id
+        INTO ref_tenant_id
+        FROM public.donors AS d
+        WHERE d.id = ref_id;
+
+        IF FOUND AND ref_tenant_id IS DISTINCT FROM row_tenant_id THEN
+            RAISE EXCEPTION 'contribution notification donor tenant mismatch'
+                USING ERRCODE = '23514';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS enforce_email_template_system_bindings_tenant_refs
+    ON public.email_template_system_bindings;
+
+CREATE TRIGGER enforce_email_template_system_bindings_tenant_refs
+    BEFORE INSERT OR UPDATE OF
+        tenant_id,
+        template_id
+    ON public.email_template_system_bindings
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_contribution_notification_tenant_refs();
+
+DROP TRIGGER IF EXISTS enforce_contribution_notification_settings_tenant_refs
+    ON public.contribution_notification_settings;
+
+CREATE TRIGGER enforce_contribution_notification_settings_tenant_refs
+    BEFORE INSERT OR UPDATE OF
+        tenant_id,
+        updated_by
+    ON public.contribution_notification_settings
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_contribution_notification_tenant_refs();
+
+DROP TRIGGER IF EXISTS enforce_contribution_notification_events_tenant_refs
+    ON public.contribution_notification_events;
+
+CREATE TRIGGER enforce_contribution_notification_events_tenant_refs
+    BEFORE INSERT OR UPDATE OF
+        tenant_id,
+        operation_audit_event_id,
+        correction_id,
+        template_id,
+        template_version_id,
+        recipient_donor_id
+    ON public.contribution_notification_events
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_contribution_notification_tenant_refs();
+
+ALTER TABLE public.email_template_system_bindings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_notification_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_notification_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.email_template_system_bindings FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_notification_settings FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_notification_events FROM anon, authenticated;
+
+GRANT ALL ON TABLE public.email_template_system_bindings TO service_role;
+GRANT ALL ON TABLE public.contribution_notification_settings TO service_role;
+GRANT ALL ON TABLE public.contribution_notification_events TO service_role;

--- a/tests/unit/packages/api/admin/contribution-adjustment-operations.test.ts
+++ b/tests/unit/packages/api/admin/contribution-adjustment-operations.test.ts
@@ -32,7 +32,7 @@ interface StubState {
   donor?: Record<string, unknown> | null;
   policy?: Record<string, unknown> | null;
   snapshots?: Array<Record<string, unknown>>;
-  funds?: string[];
+  funds?: Array<string | { id: string; name?: string | null }>;
   missionaries?: string[];
 }
 
@@ -100,8 +100,22 @@ class QueryBuilder {
     if (this.table === "funds") {
       const valid = this.state.funds ?? [];
       const rows = this.inValues
-        .filter((id) => valid.includes(id as string))
-        .map((id) => ({ id }));
+        .map((id) => {
+          const fund = valid.find((item) =>
+            typeof item === "string" ? item === id : item.id === id,
+          );
+
+          if (!fund) {
+            return null;
+          }
+
+          return typeof fund === "string"
+            ? { id: fund, name: null }
+            : { id: fund.id, name: fund.name ?? null };
+        })
+        .filter((row): row is { id: string; name: string | null } =>
+          Boolean(row),
+        );
       return { data: rows, error: null };
     }
     if (this.table === "missionaries") {
@@ -400,7 +414,7 @@ describe("applyContributionCorrection", () => {
     const state: StubState = {
       adjustments: [],
       insertCount: 0,
-      funds: [FUND_VALID],
+      funds: [{ id: FUND_VALID, name: "Clean Water Initiative" }],
     };
 
     const result = await applyContributionCorrection({
@@ -415,6 +429,18 @@ describe("applyContributionCorrection", () => {
       adjustment_type: "fund_correction",
       effective_values: { fundId: FUND_VALID },
     });
+    expect(result.before).toEqual(
+      expect.objectContaining({
+        fundId: null,
+        designationName: "General Fund",
+      }),
+    );
+    expect(result.after).toEqual(
+      expect.objectContaining({
+        fundId: FUND_VALID,
+        designationName: "Clean Water Initiative",
+      }),
+    );
     expect(result.status).toBe("applied");
   });
 

--- a/tests/unit/packages/api/admin/contribution-notification-policy.test.ts
+++ b/tests/unit/packages/api/admin/contribution-notification-policy.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getContributionNotificationPolicy,
+  isContributionNotificationSuppressionReasonRequired,
+} from "../../../../../packages/api/src/admin/contribution-operations/notifications/policy";
+import {
+  resolveContributionCorrectionTemplateVariant,
+  validateContributionCorrectionTemplate,
+} from "../../../../../packages/api/src/admin/contribution-operations/notifications/templates";
+
+describe("contribution correction notification policy", () => {
+  it.each([
+    ["refund", "auto_notify"],
+    ["amount_correction", "auto_notify"],
+    ["receipt_correction", "auto_notify"],
+    ["statement_correction", "auto_notify"],
+    ["designation_correction", "always_ask"],
+    ["payment_state_correction", "always_ask"],
+    ["donor_relink", "staff_chooses"],
+  ] as const)("defaults %s to %s", (actionType, expectedMode) => {
+    expect(getContributionNotificationPolicy({ actionType }).mode).toBe(
+      expectedMode,
+    );
+  });
+
+  it("requires suppression reasons for money and official document changes", () => {
+    expect(
+      isContributionNotificationSuppressionReasonRequired({
+        actionType: "refund",
+        decision: "suppressed",
+      }),
+    ).toBe(true);
+    expect(
+      isContributionNotificationSuppressionReasonRequired({
+        actionType: "donor_relink",
+        decision: "suppressed",
+      }),
+    ).toBe(false);
+  });
+
+  it("selects variants from the actual action outcome", () => {
+    expect(
+      resolveContributionCorrectionTemplateVariant({
+        actionType: "refund",
+        outcome: { status: "succeeded", refundKind: "partial" },
+      }),
+    ).toEqual({
+      family: "refund_notification",
+      variant: "partial_refund_completed",
+    });
+
+    expect(
+      resolveContributionCorrectionTemplateVariant({
+        actionType: "refund",
+        outcome: { status: "failed" },
+      }),
+    ).toEqual({
+      family: "refund_notification",
+      variant: "refund_failed",
+    });
+  });
+
+  it("does not resolve templates for non-notification action types", () => {
+    expect(
+      resolveContributionCorrectionTemplateVariant({
+        actionType: "crm_repost",
+      }),
+    ).toBeNull();
+  });
+
+  it("blocks active templates missing required correction tags", () => {
+    const result = validateContributionCorrectionTemplate({
+      family: "receipt_correction_notification",
+      variant: "receipt_corrected",
+      html: "<p>Hello {{full_name}}</p>",
+      text: "Hello {{full_name}}",
+      active: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.missingRequiredTags).toContain("receipt_link");
+  });
+
+  it("allows drafts to save with missing required correction tags", () => {
+    const result = validateContributionCorrectionTemplate({
+      family: "receipt_correction_notification",
+      variant: "receipt_corrected",
+      html: "<p>Hello {{full_name}}</p>",
+      text: "Hello {{full_name}}",
+      active: false,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.missingRequiredTags).toContain("receipt_link");
+  });
+
+  it("rejects variants that do not belong to the selected family", () => {
+    const result = validateContributionCorrectionTemplate({
+      family: "receipt_correction_notification",
+      variant: "refund_completed",
+      html: "<p>{{full_name}} {{gift_date}} {{receipt_link}}</p>",
+      text: "{{full_name}} {{gift_date}} {{receipt_link}}",
+      active: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Unknown contribution correction template variant.",
+    );
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-notification-send.test.ts
+++ b/tests/unit/packages/api/admin/contribution-notification-send.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { sendContributionCorrectionNotification } from "../../../../../packages/api/src/admin/contribution-operations/notifications/send";
+
+const baseInput = {
+  tenantId: "tenant_1",
+  actionType: "refund" as const,
+  correctionId: "correction_1",
+  operationAuditEventId: "audit_1",
+  actorProfileId: "actor_1",
+  recipient: {
+    donorId: "donor_1",
+    email: "donor@example.com",
+    name: "Donor One",
+  },
+  mergeValues: {
+    full_name: "Donor One",
+    org_name: "Give Hope",
+    gift_date: "May 1, 2026",
+    donation_amount: "$100.00",
+    refund_amount: "$100.00",
+    donor_portal_link: "https://example.com/history",
+    support_contact_link: "https://example.com/support",
+  },
+  personalNote: "Thank you for your patience.",
+};
+
+describe("sendContributionCorrectionNotification", () => {
+  it("sends active correction templates through Resend and logs the decision", async () => {
+    const sendEmail = vi.fn().mockResolvedValue({
+      success: true,
+      messageId: "msg_1",
+      correlationId: "corr_1",
+      retryCount: 0,
+    });
+    const logNotificationEvent = vi
+      .fn()
+      .mockResolvedValue({ eventId: "event_1" });
+
+    const result = await sendContributionCorrectionNotification({
+      ...baseInput,
+      template: {
+        id: "template_1",
+        versionId: "version_1",
+        version: 3,
+        family: "refund_notification",
+        variant: "refund_completed",
+        active: true,
+        subject: "Your refund for {{donation_amount}}",
+        html: "<p>{{full_name}} {{gift_date}} {{donation_amount}} {{refund_amount}} {{donor_portal_link}} {{personal_note}}</p>",
+        text: "{{full_name}} {{gift_date}} {{donation_amount}} {{refund_amount}} {{donor_portal_link}} {{personal_note}}",
+      },
+      settings: {
+        apiKey: "re_test",
+        fromEmail: "finance@example.com",
+        fromName: "Finance Team",
+      },
+      dependencies: {
+        sendEmail,
+        logNotificationEvent,
+      },
+    });
+
+    expect(result.decision).toBe("sent");
+    expect(sendEmail).toHaveBeenCalledWith(
+      "re_test",
+      expect.objectContaining({
+        idempotencyKey:
+          "correction-notification/tenant_1/audit_1/donor_1/refund_notification/refund_completed",
+        subject: "Your refund for $100.00",
+        html: expect.stringContaining("Thank you for your patience."),
+      }),
+    );
+    expect(logNotificationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: "sent",
+        idempotencyKey:
+          "correction-notification/tenant_1/audit_1/donor_1/refund_notification/refund_completed",
+        templateFamily: "refund_notification",
+        templateVariant: "refund_completed",
+      }),
+    );
+  });
+
+  it("blocks invalid templates, audits the failure, and creates follow-up task intent", async () => {
+    const sendEmail = vi.fn();
+    const logNotificationEvent = vi
+      .fn()
+      .mockResolvedValue({ eventId: "event_1" });
+    const createFollowUpTask = vi.fn().mockResolvedValue(["task_1", "task_2"]);
+    const recordNotificationTaskIds = vi.fn();
+
+    const result = await sendContributionCorrectionNotification({
+      ...baseInput,
+      template: {
+        id: "template_1",
+        versionId: "version_1",
+        version: 3,
+        family: "refund_notification",
+        variant: "refund_completed",
+        active: true,
+        subject: "Refund update",
+        html: "<p>{{full_name}}</p>",
+        text: "{{full_name}}",
+      },
+      settings: {
+        apiKey: "re_test",
+        fromEmail: "finance@example.com",
+        fromName: "Finance Team",
+      },
+      dependencies: {
+        sendEmail,
+        logNotificationEvent,
+        createFollowUpTask,
+        recordNotificationTaskIds,
+      },
+    });
+
+    expect(result.decision).toBe("blocked");
+    expect(result.taskIds).toEqual(["task_1", "task_2"]);
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(logNotificationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: "blocked",
+        errorCode: "invalid_template",
+      }),
+    );
+    expect(createFollowUpTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentMode: "actor_and_queue",
+        notificationEventId: "event_1",
+        reason: expect.stringContaining("Missing required merge tag"),
+      }),
+    );
+    expect(recordNotificationTaskIds).toHaveBeenCalledWith({
+      notificationEventId: "event_1",
+      taskIds: ["task_1", "task_2"],
+    });
+  });
+
+  it("reuses task ids from an existing notification event instead of creating duplicate tasks", async () => {
+    const logNotificationEvent = vi
+      .fn()
+      .mockResolvedValue({ eventId: "event_1", taskIds: ["task_existing"] });
+    const createFollowUpTask = vi.fn();
+
+    const result = await sendContributionCorrectionNotification({
+      ...baseInput,
+      template: null,
+      settings: {
+        apiKey: "re_test",
+        fromEmail: "finance@example.com",
+        fromName: "Finance Team",
+      },
+      dependencies: {
+        logNotificationEvent,
+        createFollowUpTask,
+      },
+    });
+
+    expect(result.decision).toBe("blocked");
+    expect(result.taskIds).toEqual(["task_existing"]);
+    expect(createFollowUpTask).not.toHaveBeenCalled();
+  });
+
+  it("blocks missing tenant email settings with a specific task reason", async () => {
+    const logNotificationEvent = vi
+      .fn()
+      .mockResolvedValue({ eventId: "event_1" });
+    const createFollowUpTask = vi.fn().mockResolvedValue(["task_1"]);
+
+    const result = await sendContributionCorrectionNotification({
+      ...baseInput,
+      template: {
+        id: "template_1",
+        versionId: "version_1",
+        version: 3,
+        family: "refund_notification",
+        variant: "refund_completed",
+        active: true,
+        subject: "Refund update",
+        html: "<p>{{full_name}} {{gift_date}} {{donation_amount}} {{refund_amount}} {{donor_portal_link}}</p>",
+        text: "{{full_name}} {{gift_date}} {{donation_amount}} {{refund_amount}} {{donor_portal_link}}",
+      },
+      settings: null,
+      dependencies: {
+        logNotificationEvent,
+        createFollowUpTask,
+      },
+    });
+
+    expect(result.decision).toBe("blocked");
+    expect(logNotificationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: "blocked",
+        errorCode: "missing_email_settings",
+      }),
+    );
+    expect(createFollowUpTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: expect.stringContaining("email sending is not connected"),
+      }),
+    );
+  });
+
+  it("audits provider exceptions and creates a follow-up task", async () => {
+    const sendEmail = vi.fn().mockRejectedValue(new Error("resend timeout"));
+    const logNotificationEvent = vi
+      .fn()
+      .mockResolvedValue({ eventId: "event_1" });
+    const createFollowUpTask = vi.fn().mockResolvedValue(["task_1"]);
+
+    const result = await sendContributionCorrectionNotification({
+      ...baseInput,
+      template: {
+        id: "template_1",
+        versionId: "version_1",
+        version: 3,
+        family: "refund_notification",
+        variant: "refund_completed",
+        active: true,
+        subject: "Refund update",
+        html: "<p>{{full_name}} {{gift_date}} {{donation_amount}} {{refund_amount}} {{donor_portal_link}}</p>",
+        text: "{{full_name}} {{gift_date}} {{donation_amount}} {{refund_amount}} {{donor_portal_link}}",
+      },
+      settings: {
+        apiKey: "re_test",
+        fromEmail: "finance@example.com",
+        fromName: "Finance Team",
+      },
+      dependencies: {
+        sendEmail,
+        logNotificationEvent,
+        createFollowUpTask,
+      },
+    });
+
+    expect(result.decision).toBe("failed");
+    expect(result.taskIds).toEqual(["task_1"]);
+    expect(logNotificationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: "failed",
+        errorCode: "provider_exception",
+        errorMessage: "resend timeout",
+      }),
+    );
+  });
+
+  it("requires a reason when suppressing money-change notifications", async () => {
+    await expect(
+      sendContributionCorrectionNotification({
+        ...baseInput,
+        decisionOverride: "suppressed",
+        suppressionReason: null,
+        template: null,
+        settings: null,
+        dependencies: {},
+      }),
+    ).rejects.toThrow("suppression reason");
+  });
+
+  it("does not auto-send always-ask notifications without a staff decision", async () => {
+    const sendEmail = vi.fn();
+    const logNotificationEvent = vi
+      .fn()
+      .mockResolvedValue({ eventId: "event_1" });
+
+    const result = await sendContributionCorrectionNotification({
+      ...baseInput,
+      actionType: "designation_correction",
+      mergeValues: {
+        ...baseInput.mergeValues,
+        previous_designation_name: "General Fund",
+        corrected_designation_name: "Clean Water Initiative",
+      },
+      template: {
+        id: "template_1",
+        versionId: "version_1",
+        version: 3,
+        family: "designation_correction_notification",
+        variant: "designation_changed",
+        active: true,
+        subject: "Designation updated",
+        html: "<p>{{full_name}} {{gift_date}} {{previous_designation_name}} {{corrected_designation_name}} {{donor_portal_link}}</p>",
+        text: "{{full_name}} {{gift_date}} {{previous_designation_name}} {{corrected_designation_name}} {{donor_portal_link}}",
+      },
+      settings: {
+        apiKey: "re_test",
+        fromEmail: "finance@example.com",
+        fromName: "Finance Team",
+      },
+      dependencies: {
+        sendEmail,
+        logNotificationEvent,
+      },
+    });
+
+    expect(result).toEqual({ decision: "not_required", taskIds: [] });
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(logNotificationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: "not_required",
+        policySnapshot: expect.objectContaining({ mode: "always_ask" }),
+      }),
+    );
+  });
+
+  it("honors tenant policy overrides when deciding suppression requirements", async () => {
+    await expect(
+      sendContributionCorrectionNotification({
+        ...baseInput,
+        decisionOverride: "suppressed",
+        suppressionReasonRequiredOverride: false,
+        suppressionReason: null,
+        template: null,
+        settings: null,
+        dependencies: {
+          logNotificationEvent: vi
+            .fn()
+            .mockResolvedValue({ eventId: "event_1" }),
+        },
+      }),
+    ).resolves.toEqual({ decision: "suppressed", taskIds: [] });
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-notification-store.test.ts
+++ b/tests/unit/packages/api/admin/contribution-notification-store.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildContributionCorrectionNotificationMergeValues,
+  logContributionNotificationEvent,
+  readContributionNotificationSettings,
+} from "../../../../../packages/api/src/admin/contribution-operations/notifications/store";
+
+class NotificationEventQuery {
+  private payload: Record<string, unknown> | null = null;
+  private filters = new Map<string, unknown>();
+
+  constructor(
+    private readonly options: {
+      duplicate?: boolean;
+      inserted?: Record<string, unknown>[];
+      existing?: Record<string, unknown> | null;
+    },
+  ) {}
+
+  insert(payload: Record<string, unknown>) {
+    this.payload = payload;
+    return this;
+  }
+
+  select() {
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    this.filters.set(column, value);
+    return this;
+  }
+
+  async single() {
+    if (this.options.duplicate) {
+      return {
+        data: null,
+        error: { code: "23505", message: "duplicate key" },
+      };
+    }
+
+    if (this.payload) {
+      this.options.inserted?.push(this.payload);
+    }
+
+    return {
+      data: { id: "event_1", task_ids: this.payload?.task_ids ?? [] },
+      error: null,
+    };
+  }
+
+  async maybeSingle() {
+    expect(this.filters.get("tenant_id")).toBe("tenant_1");
+    expect(this.filters.get("idempotency_key")).toBe(
+      "correction-notification/tenant_1/audit_1/donor_1/refund_notification/refund_completed",
+    );
+
+    return {
+      data: this.options.existing ?? null,
+      error: null,
+    };
+  }
+}
+
+function createSupabaseStub(options: {
+  duplicate?: boolean;
+  inserted?: Record<string, unknown>[];
+  existing?: Record<string, unknown> | null;
+}) {
+  return {
+    from(table: string) {
+      expect(table).toBe("contribution_notification_events");
+      return new NotificationEventQuery(options);
+    },
+  };
+}
+
+class NotificationSettingsQuery {
+  private filters = new Map<string, unknown>();
+
+  constructor(private readonly row: Record<string, unknown> | null) {}
+
+  select() {
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    this.filters.set(column, value);
+    return this;
+  }
+
+  async maybeSingle() {
+    expect(this.filters.get("tenant_id")).toBe("tenant_1");
+    expect(this.filters.get("action_type")).toBe("designation_correction");
+
+    return {
+      data: this.row,
+      error: null,
+    };
+  }
+}
+
+function createSettingsSupabaseStub(row: Record<string, unknown> | null) {
+  return {
+    from(table: string) {
+      expect(table).toBe("contribution_notification_settings");
+      return new NotificationSettingsQuery(row);
+    },
+  };
+}
+
+const baseEvent = {
+  tenantId: "tenant_1",
+  idempotencyKey:
+    "correction-notification/tenant_1/audit_1/donor_1/refund_notification/refund_completed",
+  operationAuditEventId: "audit_1",
+  correctionId: "correction_1",
+  actionType: "refund" as const,
+  decision: "sent" as const,
+  templateId: "template_1",
+  templateVersionId: "version_1",
+  templateFamily: "refund_notification",
+  templateVariant: "refund_completed",
+  templateVersion: 3,
+  recipientDonorId: "donor_1",
+  recipientEmail: "donor@example.com",
+  policySnapshot: {
+    mode: "auto_notify",
+    suppressionReasonRequired: true,
+  },
+  personalNotePresent: false,
+  providerStatus: "sent",
+  providerMessageId: "msg_1",
+  taskIds: [],
+};
+
+describe("logContributionNotificationEvent", () => {
+  it("persists idempotency keys and policy snapshots", async () => {
+    const inserted: Record<string, unknown>[] = [];
+
+    const result = await logContributionNotificationEvent({
+      supabaseAdmin: createSupabaseStub({ inserted }) as never,
+      event: baseEvent,
+    });
+
+    expect(result).toEqual({ eventId: "event_1", taskIds: [] });
+    expect(inserted[0]).toEqual(
+      expect.objectContaining({
+        tenant_id: "tenant_1",
+        idempotency_key: baseEvent.idempotencyKey,
+        policy_snapshot: baseEvent.policySnapshot,
+        decision: "sent",
+        sent_at: expect.any(String),
+      }),
+    );
+  });
+
+  it("returns existing task ids when idempotent logging is replayed", async () => {
+    const result = await logContributionNotificationEvent({
+      supabaseAdmin: createSupabaseStub({
+        duplicate: true,
+        existing: { id: "event_existing", task_ids: ["task_existing"] },
+      }) as never,
+      event: baseEvent,
+    });
+
+    expect(result).toEqual({
+      eventId: "event_existing",
+      taskIds: ["task_existing"],
+    });
+  });
+});
+
+describe("readContributionNotificationSettings", () => {
+  it("returns tenant policy overrides from contribution_notification_settings", async () => {
+    const result = await readContributionNotificationSettings({
+      supabaseAdmin: createSettingsSupabaseStub({
+        mode: "auto_notify",
+        suppression_reason_required: true,
+        task_assignment_mode: "queue_only",
+      }) as never,
+      tenantId: "tenant_1",
+      actionType: "designation_correction",
+    });
+
+    expect(result).toEqual({
+      mode: "auto_notify",
+      suppressionReasonRequired: true,
+      taskAssignmentMode: "queue_only",
+    });
+  });
+
+  it("falls back to defaults when no tenant policy row exists", async () => {
+    const result = await readContributionNotificationSettings({
+      supabaseAdmin: createSettingsSupabaseStub(null) as never,
+      tenantId: "tenant_1",
+      actionType: "designation_correction",
+    });
+
+    expect(result).toEqual({
+      mode: null,
+      suppressionReasonRequired: null,
+      taskAssignmentMode: null,
+    });
+  });
+});
+
+describe("buildContributionCorrectionNotificationMergeValues", () => {
+  it("uses before and after summaries for designation names", () => {
+    const values = buildContributionCorrectionNotificationMergeValues({
+      detail: {
+        id: "contribution_1",
+        amount: { value: 12000, currency: "USD" },
+        donor: { id: "donor_1", name: "Donor One", email: "donor@example.com" },
+        donorVisible: { status: "Corrected" },
+        gift: { date: "2026-05-01T00:00:00.000Z" },
+        refund: { amount: 0, status: "none" },
+        shared: { designationSummary: { fundName: "Fallback Fund" } },
+      } as never,
+      beforeSummary: { amount: 10000, designationName: "General Fund" },
+      afterSummary: {
+        amount: 12000,
+        designationName: "Clean Water Initiative",
+      },
+      orgName: "Give Hope",
+      supportContactEmail: "finance@givehope.test",
+    });
+
+    expect(values).toEqual(
+      expect.objectContaining({
+        previous_designation_name: "General Fund",
+        corrected_designation_name: "Clean Water Initiative",
+        support_contact_link: "mailto:finance@givehope.test",
+      }),
+    );
+  });
+
+  it("does not invent placeholder support links", () => {
+    const values = buildContributionCorrectionNotificationMergeValues({
+      detail: {
+        id: "contribution_1",
+        amount: { value: 12000, currency: "USD" },
+        donor: null,
+        donorVisible: { status: "Corrected" },
+        gift: { date: "2026-05-01T00:00:00.000Z" },
+        refund: { amount: 0, status: "none" },
+        shared: { designationSummary: { fundName: "Fallback Fund" } },
+      } as never,
+    });
+
+    expect(values.support_contact_link).toBeNull();
+    expect(values.donor_portal_link).toMatch(/^https?:\/\//);
+    expect(new URL(values.donor_portal_link as string).pathname).toBe(
+      "/donor-dashboard/history",
+    );
+    expect(values.receipt_link).toBe(values.donor_portal_link);
+    expect(values.statement_link).toBe(values.donor_portal_link);
+  });
+});

--- a/tests/unit/packages/api/email/template-activation-validation.test.ts
+++ b/tests/unit/packages/api/email/template-activation-validation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiHttpError } from "../../../../../packages/api/src/shared/http-errors";
+import { validateEmailTemplateForActivation } from "../../../../../packages/api/src/email/templates";
+
+describe("email template activation validation", () => {
+  it("blocks active contribution correction templates missing required tags", () => {
+    expect(() =>
+      validateEmailTemplateForActivation({
+        htmlContent: "<p>Hello {{full_name}}</p>",
+        textContent: "Hello {{full_name}}",
+        isActive: true,
+        editorMetadata: {
+          contributionCorrection: {
+            family: "refund_notification",
+            variant: "refund_completed",
+          },
+        },
+      }),
+    ).toThrow(ApiHttpError);
+  });
+
+  it("allows contribution correction drafts with missing required tags", () => {
+    expect(() =>
+      validateEmailTemplateForActivation({
+        htmlContent: "<p>Hello {{full_name}}</p>",
+        textContent: "Hello {{full_name}}",
+        isActive: false,
+        editorMetadata: {
+          contributionCorrection: {
+            family: "refund_notification",
+            variant: "refund_completed",
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("blocks active contribution correction templates with unknown variants", () => {
+    expect(() =>
+      validateEmailTemplateForActivation({
+        htmlContent: "<p>{{full_name}} {{gift_date}} {{receipt_link}}</p>",
+        textContent: "{{full_name}} {{gift_date}} {{receipt_link}}",
+        isActive: true,
+        editorMetadata: {
+          contributionCorrection: {
+            family: "receipt_correction_notification",
+            variant: "refund_completed",
+          },
+        },
+      }),
+    ).toThrow(ApiHttpError);
+  });
+});

--- a/tests/unit/packages/api/email/template-store.test.ts
+++ b/tests/unit/packages/api/email/template-store.test.ts
@@ -56,6 +56,12 @@ class FakeQuery {
     return this;
   }
 
+  upsert(payload: unknown) {
+    this.action = "upsert";
+    this.payload = payload;
+    return this;
+  }
+
   select(columns: string) {
     this.selected = columns;
     return this;
@@ -275,6 +281,75 @@ describe("email template store", () => {
         version: 2,
         html_content: "<p>Updated</p>",
         text_content: "Updated",
+      }),
+    });
+  });
+
+  it("upserts contribution correction system bindings when activating templates", async () => {
+    const correctionMetadata = {
+      contributionCorrection: {
+        family: "refund_notification",
+        variant: "refund_completed",
+      },
+    };
+    const currentTemplate = templateRow({
+      is_active: false,
+      version: 1,
+      editor_metadata: correctionMetadata,
+    });
+    const updatedTemplate = templateRow({
+      is_active: true,
+      version: 2,
+      editor_metadata: correctionMetadata,
+    });
+    const insertedVersion = versionRow({
+      id: "version_2",
+      version: 2,
+      editor_metadata: correctionMetadata,
+    });
+    const { client, records } = createFakeSupabase([
+      { data: currentTemplate },
+      { data: updatedTemplate },
+      { data: insertedVersion },
+      { data: null },
+      { data: null },
+    ]);
+    getAdminClientMock.mockReturnValue({ client });
+
+    await updateEmailTemplate({
+      tenantId: "tenant_1",
+      profileId: "profile_1",
+      templateId: "template_1",
+      patch: {
+        isActive: true,
+      },
+    });
+
+    expect(records[3]).toMatchObject({
+      table: "email_template_system_bindings",
+      action: "update",
+      payload: expect.objectContaining({
+        is_active: false,
+      }),
+      filters: [
+        ["tenant_id", "tenant_1"],
+        ["template_id", "template_1"],
+      ],
+    });
+    expect(records[4]).toMatchObject({
+      table: "email_template_system_bindings",
+      action: "upsert",
+      payload: expect.objectContaining({
+        tenant_id: "tenant_1",
+        template_id: "template_1",
+        family_key: "refund_notification",
+        variant_key: "refund_completed",
+        required_merge_tags: expect.arrayContaining([
+          "full_name",
+          "refund_amount",
+          "donor_portal_link",
+        ]),
+        is_active: true,
       }),
     });
   });

--- a/tests/unit/packages/api/email/templates.test.ts
+++ b/tests/unit/packages/api/email/templates.test.ts
@@ -198,6 +198,15 @@ describe("api/email/templates", () => {
   });
 
   it("patches templates and creates a new version through the store", async () => {
+    readEmailTemplateMock.mockResolvedValueOnce({
+      id: "template_1",
+      html_content: null,
+      text_content: null,
+      default_subject: null,
+      default_preheader: null,
+      editor_metadata: {},
+      is_active: true,
+    });
     updateEmailTemplateMock.mockResolvedValueOnce({
       template: {
         id: "template_1",
@@ -228,6 +237,33 @@ describe("api/email/templates", () => {
       templateId: "template_1",
       patch: expect.objectContaining({ name: "Updated" }),
     });
+  });
+
+  it("validates effective contribution correction template state before activation patches", async () => {
+    readEmailTemplateMock.mockResolvedValueOnce({
+      id: "template_1",
+      html_content: "<p>Hello {{full_name}}</p>",
+      text_content: "Hello {{full_name}}",
+      default_subject: "Refund update",
+      default_preheader: null,
+      editor_metadata: {
+        contributionCorrection: {
+          family: "refund_notification",
+          variant: "refund_completed",
+        },
+      },
+      is_active: false,
+    });
+
+    const response = await PATCH_TEMPLATE(
+      createJsonRequest({ isActive: true }, "PATCH"),
+      templateContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Missing required merge tag");
+    expect(updateEmailTemplateMock).not.toHaveBeenCalled();
   });
 
   it("deletes templates through the tenant-scoped store", async () => {

--- a/tests/unit/supabase/contribution-correction-notifications-migration.test.ts
+++ b/tests/unit/supabase/contribution-correction-notifications-migration.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL(
+    "../../../supabase/migrations/20260611151000_contribution_correction_notifications.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("contribution correction notifications migration", () => {
+  it("creates Email Studio bindings, notification settings, and notification events", () => {
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.email_template_system_bindings",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.contribution_notification_settings",
+    );
+    expect(migrationSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.contribution_notification_events",
+    );
+    expect(migrationSql).toContain(
+      "UNIQUE (tenant_id, family_key, variant_key)",
+    );
+    expect(migrationSql).toContain("idempotency_key TEXT NOT NULL");
+    expect(migrationSql).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_contribution_notification_events_idempotency",
+    );
+  });
+
+  it("locks notification tables to service role access", () => {
+    for (const table of [
+      "email_template_system_bindings",
+      "contribution_notification_settings",
+      "contribution_notification_events",
+    ]) {
+      expect(migrationSql).toContain(
+        `ALTER TABLE public.${table} ENABLE ROW LEVEL SECURITY`,
+      );
+      expect(migrationSql).toContain(
+        `REVOKE ALL ON TABLE public.${table} FROM anon, authenticated`,
+      );
+      expect(migrationSql).toContain(
+        `GRANT ALL ON TABLE public.${table} TO service_role`,
+      );
+    }
+  });
+
+  it("enforces tenant ownership for notification references", () => {
+    for (const triggerName of [
+      "enforce_email_template_system_bindings_tenant_refs",
+      "enforce_contribution_notification_settings_tenant_refs",
+      "enforce_contribution_notification_events_tenant_refs",
+    ]) {
+      expect(migrationSql).toContain(`CREATE TRIGGER ${triggerName}`);
+    }
+
+    for (const referencedTable of [
+      "public.profiles",
+      "public.email_templates",
+      "public.email_template_versions",
+      "public.contribution_operation_audit_events",
+      "public.contribution_corrections",
+      "public.donors",
+    ]) {
+      expect(migrationSql).toContain(`FROM ${referencedTable}`);
+    }
+
+    for (const mismatchMessage of [
+      "contribution notification updater profile tenant mismatch",
+      "contribution notification template tenant mismatch",
+      "contribution notification template version tenant mismatch",
+      "contribution notification audit event tenant mismatch",
+      "contribution notification correction tenant mismatch",
+      "contribution notification donor tenant mismatch",
+    ]) {
+      expect(migrationSql).toContain(mismatchMessage);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add contribution correction notification policy, template selection, send, and persistence support
- validate Email Studio contribution-correction template metadata before activation
- add notification persistence tables with RLS/service-role posture, tenant-reference triggers, and deterministic idempotency keys
- cover policy, send, store, template activation, and migration behavior with focused tests

## Verification
- `node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/contribution-notification-policy.test.ts tests/unit/packages/api/admin/contribution-notification-send.test.ts tests/unit/packages/api/admin/contribution-notification-store.test.ts tests/unit/packages/api/email/template-activation-validation.test.ts tests/unit/supabase/contribution-correction-notifications-migration.test.ts`
- `node scripts/run-with-ci-env.mjs -- bun test $(rg --files tests/unit | rg '(/contribution-|mission-control-tasks|email/template-activation).*\.test\.ts$')`
- `git diff --check`
- `bun run format:check && bun run lint && bun run typecheck`
- `bun run ci:preflight`

## Deferred
- route/UI wiring, batches, CRM table preferences, and docs/OpenSpec remain in later #251 split slices.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the contribution-correction notification foundation: a policy engine, multi-step send orchestrator, Supabase-backed persistence layer, template binding management, and pre-activation template validation — all covered by focused unit and migration tests.

- **Notification pipeline**: `policy.ts` → `send.ts` → `store.ts` correctly handles suppression, staff-confirmation guards, template/settings validation, email rendering, provider send, idempotent event logging, and follow-up task creation. The previously flagged issues (designation name before/after confusion, `example.com` reply-to placeholder) are correctly resolved in this version.
- **Migration**: Three new tables (`email_template_system_bindings`, `contribution_notification_settings`, `contribution_notification_events`) with RLS enabled, all grants scoped to `service_role`, a deterministic idempotency unique index, and a `SECURITY DEFINER` trigger that enforces cross-tenant FK integrity across every nullable reference column.
- **Template binding sync**: `syncContributionCorrectionTemplateBinding` correctly maintains the one-active-binding-per-slot invariant via upsert-on-conflict and targeted deactivation on deactivation/deletion/restore.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no data-integrity, auth, or correctness regressions found in the changed code.

The migration is additive and backward-compatible, all three new tables are locked to service_role with RLS enabled, and the notification pipeline has idempotent event logging that correctly handles race conditions and partial failures. The two open comments are interface-hardening suggestions that do not affect current correctness.

send.ts — the decisionOverride type wideness is worth narrowing before this interface acquires more callers.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-operations/notifications/policy.ts | New file defining notification policy logic — clean, focused, and correctly handles default modes, overrides, and suppression-reason enforcement. |
| packages/api/src/admin/contribution-operations/notifications/send.ts | Core send orchestration: handles suppression, policy guards, template validation, email rendering, provider send, and event logging. The decisionOverride field accepts the full ContributionNotificationDecision union but only "suppressed" is given special handling — other values fall through to the send path silently. |
| packages/api/src/admin/contribution-operations/notifications/store.ts | Supabase-backed persistence layer: correctly reads settings, resolves template bindings, builds merge values (including fixed before/after designation names), logs events with idempotency, and creates follow-up tasks. Fetches all template versions to find the current one — wasteful but functionally correct. |
| packages/api/src/admin/contribution-operations/notifications/templates.ts | Template family/variant resolution and re-export of validation helpers — correct mapping of action types to template families and variants including refund outcome branching. |
| supabase/migrations/20260611151000_contribution_correction_notifications.sql | Adds three new tables with RLS enabled, all grants scoped to service_role only, unique idempotency index, and a shared SECURITY DEFINER trigger correctly enforcing cross-tenant referential integrity for every nullable FK column. |
| packages/api/src/email/template-store.ts | Extended to sync contribution-correction system bindings on create/update/delete/restore — upsert on conflict correctly handles the single-binding-per-slot invariant and deactivation correctly targets only the current template's rows. |
| packages/api/src/email/contribution-correction-template-validation.ts | New validation module for contribution-correction template metadata and required merge tags — correctly validates family/variant registry and suppresses required-tag errors for inactive templates. |
| packages/api/src/email/templates.ts | Template route handlers extended with contribution-correction activation validation; effective-state validation for PATCH is correctly computed from merged patch + current template fields. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as applyContributionCorrection
    participant Store as sendFromSupabase (store.ts)
    participant DB as Supabase DB
    participant Send as sendContributionCorrectionNotification (send.ts)
    participant Provider as Email Provider (Resend)
    participant Log as logContributionNotificationEvent

    Caller->>Store: correctionId, actionType, detail, before/afterSummary
    Store->>DB: readContributionNotificationSettings
    Store->>DB: readActiveTemplateBinding
    Store->>DB: readEmailTemplate + listEmailTemplateVersions
    Store->>DB: readTenantEmailSettings
    Store->>Send: buildMergeValues + template + settings + deps

    alt decisionOverride suppressed
        Send->>Log: "decision=suppressed"
        Send-->>Store: decision suppressed
    else always_ask / staff_chooses no override
        Send->>Log: "decision=not_required"
        Send-->>Store: decision not_required
    else auto_notify or override
        Send->>Send: validateTemplate, renderMergeTags
        Send->>Provider: sendEmail
        alt success
            Provider-->>Send: messageId
            Send->>Log: "decision=sent"
            Send-->>Store: decision sent
        else provider error
            Provider--xSend: exception
            Send->>Log: "decision=failed"
            Send->>DB: createMissionControlTask
            Send-->>Store: decision failed
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as applyContributionCorrection
    participant Store as sendFromSupabase (store.ts)
    participant DB as Supabase DB
    participant Send as sendContributionCorrectionNotification (send.ts)
    participant Provider as Email Provider (Resend)
    participant Log as logContributionNotificationEvent

    Caller->>Store: correctionId, actionType, detail, before/afterSummary
    Store->>DB: readContributionNotificationSettings
    Store->>DB: readActiveTemplateBinding
    Store->>DB: readEmailTemplate + listEmailTemplateVersions
    Store->>DB: readTenantEmailSettings
    Store->>Send: buildMergeValues + template + settings + deps

    alt decisionOverride suppressed
        Send->>Log: "decision=suppressed"
        Send-->>Store: decision suppressed
    else always_ask / staff_chooses no override
        Send->>Log: "decision=not_required"
        Send-->>Store: decision not_required
    else auto_notify or override
        Send->>Send: validateTemplate, renderMergeTags
        Send->>Provider: sendEmail
        alt success
            Provider-->>Send: messageId
            Send->>Log: "decision=sent"
            Send-->>Store: decision sent
        else provider error
            Provider--xSend: exception
            Send->>Log: "decision=failed"
            Send->>DB: createMissionControlTask
            Send-->>Store: decision failed
        end
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(api): add contribution correction n..."](https://github.com/asymmetric-al/core/commit/0c132c6ca9e6bcb9c5d79622affd6978c18893ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38912533)</sub>

<!-- /greptile_comment -->