### PR TITLE
feat(api): add stripe replay action dependencies

### DIFF
--- a/packages/api/src/admin/contribution-operations/actions.ts
+++ b/packages/api/src/admin/contribution-operations/actions.ts
@@ -623,6 +623,8 @@ async function createPendingCorrectionRequest<TContribution>(
 ): Promise<ContributionActionResult<TContribution>> {
   assertCanRequestCorrection(input);
 
+  const payload = await resolvePendingCorrectionPayload(input);
+  const requestInput = { ...input, payload };
   const createCorrectionRequest = requireDependency(
     input.dependencies,
     "createCorrectionRequest",
@@ -631,12 +633,12 @@ async function createPendingCorrectionRequest<TContribution>(
     tenantId: input.tenantId,
     contributionId: input.contributionId,
     actionType: input.actionType,
-    payload: input.payload ?? {},
+    payload,
     reason: input.reason ?? "",
     requestedByProfileId: input.actorProfileId,
     sourceSurface: input.sourceSurface,
     expectedRevision: input.expectedRevision ?? null,
-    idempotencyKey: correctionRequestIdempotencyKey(input, extra),
+    idempotencyKey: correctionRequestIdempotencyKey(requestInput, extra),
     ...extra,
   });
   const auditEventId = await appendAuditEvent(
@@ -656,6 +658,43 @@ async function createPendingCorrectionRequest<TContribution>(
     approvalStatus: "pending_approval",
     taskIds: [],
   };
+}
+
+async function resolvePendingCorrectionPayload(
+  input: ExecuteContributionActionInput,
+): Promise<Record<string, unknown>> {
+  const payload = input.payload ?? {};
+  if (input.actionType !== "stripe_replay") {
+    return payload;
+  }
+
+  const payloadEventId =
+    typeof payload.stripeEventId === "string" &&
+    payload.stripeEventId.trim().length > 0
+      ? payload.stripeEventId.trim()
+      : null;
+  if (payloadEventId) {
+    return { ...payload, stripeEventId: payloadEventId };
+  }
+
+  const resolveReplayStripeEventId = requireDependency(
+    input.dependencies,
+    "resolveReplayStripeEventId",
+  );
+  const stripeEventId = await resolveReplayStripeEventId({
+    tenantId: input.tenantId,
+    contributionId: input.contributionId,
+    payload,
+  });
+
+  if (!stripeEventId) {
+    throw new ApiHttpError(
+      404,
+      "No stored provider event to replay for this gift.",
+    );
+  }
+
+  return { ...payload, stripeEventId };
 }
 
 function providerIdempotencyKey(input: ExecuteContributionActionInput): string {

--- a/packages/api/src/admin/contribution-operations/dependencies.ts
+++ b/packages/api/src/admin/contribution-operations/dependencies.ts
@@ -1,0 +1,169 @@
+import { serverEnv } from "@asym/env";
+
+import { ensureCorrectionApprovalWorkflow } from "./approval-notifications";
+import { createContributionCorrectionRequestInSupabase } from "./correction-requests";
+import { sendContributionCorrectionNotificationFromSupabase } from "./notifications/store";
+import {
+  applyContributionCorrection,
+  replayStripeEventThroughContributionOperations,
+} from "./operations";
+import {
+  appendContributionOperationAuditEvent,
+  createContributionCorrectionRecord,
+  loadContributionDetailFromSupabase,
+} from "./store";
+import { resolveCrmSyncRuntimeConfig } from "../../crm/sync/config";
+import { sendStagedGiftReceipt } from "../../giving/receipts";
+import {
+  queueStagedGiftPostingToTwenty,
+  retryStagedGiftDesignationPostingToTwenty,
+  retryStagedGiftPostingToTwenty,
+} from "../../giving/staged-gifts";
+import { ApiHttpError } from "../../shared/http-errors";
+import { resolveLatestStripeEventIdForDonation } from "../../stripe/replay";
+
+import type { ContributionActionDependencies } from "./types";
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+export function createContributionActionDependencies(
+  supabaseAdmin: AdminSupabaseClient,
+): ContributionActionDependencies {
+  return {
+    sendReceipt: ({ stagedGiftId, tenantId }) =>
+      sendStagedGiftReceipt({ supabaseAdmin, stagedGiftId, tenantId }),
+    approveStagedGift: ({ actorProfileId, note, stagedGiftId, tenantId }) =>
+      queueStagedGiftPostingToTwenty({
+        supabaseAdmin,
+        actorProfileId,
+        note,
+        stagedGiftId,
+        tenantId,
+        crmConfig: resolveCrmSyncRuntimeConfig(serverEnv),
+      }),
+    retryStagedGift: ({ actorProfileId, note, stagedGiftId, tenantId }) =>
+      retryStagedGiftPostingToTwenty({
+        supabaseAdmin,
+        actorProfileId,
+        note,
+        stagedGiftId,
+        tenantId,
+        crmConfig: resolveCrmSyncRuntimeConfig(serverEnv),
+      }),
+    retryDesignationPost: ({
+      actorProfileId,
+      allocationId,
+      contributionId,
+      note,
+      stagedGiftId,
+      tenantId,
+    }) =>
+      retryStagedGiftDesignationPostingToTwenty({
+        supabaseAdmin,
+        actorProfileId,
+        allocationId,
+        contributionId,
+        note,
+        stagedGiftId,
+        tenantId,
+        crmConfig: resolveCrmSyncRuntimeConfig(serverEnv),
+      }),
+    applyCorrection: (correctionInput) =>
+      applyContributionCorrection({ supabaseAdmin, ...correctionInput }),
+    resolveReplayStripeEventId: async ({
+      payload,
+      tenantId,
+      contributionId,
+    }) => {
+      const payloadEventId =
+        typeof payload.stripeEventId === "string" &&
+        payload.stripeEventId.trim().length > 0
+          ? payload.stripeEventId.trim()
+          : null;
+      return (
+        payloadEventId ??
+        (await resolveLatestStripeEventIdForDonation({
+          supabaseAdmin,
+          tenantId,
+          donationId: contributionId,
+        }))
+      );
+    },
+    createCorrectionRequest: async (request) => {
+      const requestId = await createContributionCorrectionRequestInSupabase({
+        supabaseAdmin,
+        request,
+      });
+      await ensureCorrectionApprovalWorkflow({
+        supabaseAdmin,
+        tenantId: request.tenantId,
+        requestId,
+      });
+      return requestId;
+    },
+    replayStripeEvent: async ({ payload, tenantId, contributionId }) => {
+      const payloadEventId =
+        typeof payload.stripeEventId === "string" &&
+        payload.stripeEventId.trim().length > 0
+          ? payload.stripeEventId.trim()
+          : null;
+      const stripeEventId =
+        payloadEventId ??
+        (await resolveLatestStripeEventIdForDonation({
+          supabaseAdmin,
+          tenantId,
+          donationId: contributionId,
+        }));
+
+      if (!stripeEventId) {
+        throw new ApiHttpError(
+          404,
+          "No stored provider event to replay for this gift.",
+        );
+      }
+
+      const rawEvent = await replayStripeEventThroughContributionOperations({
+        contributionId,
+        supabaseAdmin,
+        tenantId,
+        stripeEventId,
+      });
+
+      return {
+        provider: "stripe" as const,
+        status: "queued_for_replay",
+        referenceId: rawEvent.stripeEventId,
+      };
+    },
+    appendAuditEvent: (event) =>
+      appendContributionOperationAuditEvent({ supabaseAdmin, event }),
+    createCorrectionRecord: (correction) =>
+      createContributionCorrectionRecord({ supabaseAdmin, correction }),
+    sendCorrectionNotification: async (notificationInput) => {
+      const detail = await loadContributionDetailFromSupabase({
+        supabaseAdmin,
+        tenantId: notificationInput.tenantId,
+        contributionId: notificationInput.contributionId,
+      });
+
+      return sendContributionCorrectionNotificationFromSupabase({
+        supabaseAdmin,
+        tenantId: notificationInput.tenantId,
+        actionType: notificationInput.actionType,
+        contributionId: notificationInput.contributionId,
+        correctionId: notificationInput.correctionId,
+        auditEventId: notificationInput.auditEventId,
+        actorProfileId: notificationInput.actorProfileId,
+        providerOutcome: notificationInput.providerOutcome,
+        detail,
+        beforeSummary: notificationInput.beforeSummary ?? null,
+        afterSummary: notificationInput.afterSummary ?? null,
+      });
+    },
+    loadContributionDetail: ({ contributionId, tenantId }) =>
+      loadContributionDetailFromSupabase({
+        supabaseAdmin,
+        tenantId,
+        contributionId,
+      }),
+  };
+}

--- a/packages/api/src/admin/contribution-operations/operations.ts
+++ b/packages/api/src/admin/contribution-operations/operations.ts
@@ -8,6 +8,10 @@ import {
 } from "./receipt-delivery";
 import { sendStagedGiftReceipt } from "../../giving/receipts";
 import { ApiHttpError } from "../../shared/http-errors";
+import {
+  loadStripeRawEventForReplay,
+  markStripeRawEventForReplay,
+} from "../../stripe/replay";
 import { mapContributionAdjustmentRow } from "../contribution-shared/effective-values";
 
 import type { ContributionDetail } from "./detail-read-model";
@@ -283,6 +287,14 @@ async function loadContributionOperationDetail(input: {
     allocationMissionaries: [],
     crmLinks: [],
   });
+}
+
+export async function loadContributionDetailFromSupabase(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  contributionId: string;
+}): Promise<ContributionDetail> {
+  return loadContributionOperationDetail(input);
 }
 
 function isUuid(value: string): boolean {
@@ -807,4 +819,23 @@ export async function applyContributionCorrection(input: {
     idempotentReplay: false,
     receiptOutcome,
   };
+}
+
+export async function replayStripeEventThroughContributionOperations(input: {
+  contributionId: string;
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  stripeEventId: string;
+}) {
+  const rawEvent = await loadStripeRawEventForReplay({
+    supabaseAdmin: input.supabaseAdmin,
+    donationId: input.contributionId,
+    stripeEventId: input.stripeEventId,
+    tenantId: input.tenantId,
+  });
+  await markStripeRawEventForReplay({
+    supabaseAdmin: input.supabaseAdmin,
+    rawEventId: rawEvent.id,
+  });
+  return rawEvent;
 }

--- a/packages/api/src/admin/contribution-operations/store.ts
+++ b/packages/api/src/admin/contribution-operations/store.ts
@@ -1,0 +1,87 @@
+import { loadContributionDetailFromSupabase } from "./operations";
+
+import type {
+  ContributionCorrectionRecordInput,
+  ContributionOperationAuditEventInput,
+} from "./types";
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+type SupabaseAdmin = AdminSupabaseClient;
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export { loadContributionDetailFromSupabase };
+
+export async function appendContributionOperationAuditEvent(input: {
+  supabaseAdmin: SupabaseAdmin;
+  event: ContributionOperationAuditEventInput;
+}): Promise<string> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_operation_audit_events")
+    .insert({
+      tenant_id: input.event.tenantId,
+      actor_profile_id: input.event.actorProfileId,
+      donation_id: input.event.contributionId,
+      staged_gift_id: input.event.stagedGiftId ?? null,
+      donor_id: input.event.donorId ?? null,
+      correction_id: input.event.correctionId ?? null,
+      operation: input.event.actionType,
+      resource_type: "donation",
+      resource_id: input.event.contributionId,
+      source_surface: input.event.sourceSurface,
+      reason: input.event.reason ?? null,
+      before_snapshot: input.event.beforeSummary ?? {},
+      after_snapshot: input.event.afterSummary ?? {},
+      provider_outcome: input.event.providerOutcome ?? {},
+      downstream_effects: input.event.downstreamEffects ?? {},
+    })
+    .select("id")
+    .single();
+
+  if (error || !isRecord(data)) {
+    throw new Error(
+      error?.message ?? "Failed to write contribution audit event.",
+    );
+  }
+
+  return asString(data.id) ?? "";
+}
+
+export async function createContributionCorrectionRecord(input: {
+  supabaseAdmin: SupabaseAdmin;
+  correction: ContributionCorrectionRecordInput;
+}): Promise<string> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_corrections")
+    .insert({
+      tenant_id: input.correction.tenantId,
+      donation_id: input.correction.contributionId,
+      staged_gift_id: input.correction.stagedGiftId ?? null,
+      correction_type: input.correction.correctionType,
+      status: input.correction.status ?? "applied",
+      reason: input.correction.reason,
+      source_surface: input.correction.sourceSurface,
+      actor_profile_id: input.correction.actorProfileId,
+      before_summary: input.correction.beforeSummary ?? {},
+      after_summary: input.correction.afterSummary ?? {},
+      provider_outcome: input.correction.providerOutcome ?? {},
+      applied_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (error || !isRecord(data)) {
+    throw new Error(
+      error?.message ?? "Failed to write contribution correction.",
+    );
+  }
+
+  return asString(data.id) ?? "";
+}

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -183,6 +183,11 @@ export interface ContributionActionDependencies<TContribution = unknown> {
     expectedRevision?: string | null;
     idempotencyKey: string;
   }) => Promise<ContributionProviderOutcome>;
+  resolveReplayStripeEventId?: (input: {
+    tenantId: string;
+    contributionId: string;
+    payload: Record<string, unknown>;
+  }) => Promise<string | null>;
   sendCorrectionNotification?: (input: {
     tenantId: string;
     actionType: ContributionActionType;

--- a/packages/api/src/giving/staged-gifts.ts
+++ b/packages/api/src/giving/staged-gifts.ts
@@ -92,6 +92,11 @@ export interface StagedGiftPostingInput extends StagedGiftActionInput {
   crmConfig: CrmSyncRuntimeConfig;
 }
 
+export interface StagedGiftDesignationPostingInput extends StagedGiftPostingInput {
+  allocationId: string;
+  contributionId: string;
+}
+
 export interface ReconciliationFinding {
   id: string;
   reason: string;
@@ -524,6 +529,33 @@ export async function retryStagedGiftPostingToTwenty(
   }
 
   return queueStagedGiftPostingToTwenty(input);
+}
+
+export async function retryStagedGiftDesignationPostingToTwenty(
+  input: StagedGiftDesignationPostingInput,
+): Promise<never> {
+  const gift = await loadStagedGiftById(input);
+  if (gift.donationId !== input.contributionId) {
+    throw new ApiHttpError(404, "Staged gift not found for contribution.");
+  }
+
+  const allocation = await input.supabaseAdmin
+    .from("staged_gift_allocations")
+    .select("id")
+    .eq("tenant_id", input.tenantId)
+    .eq("staged_gift_id", input.stagedGiftId)
+    .eq("id", input.allocationId)
+    .maybeSingle();
+  requireNoError(allocation.error, "Failed to read staged gift allocation.");
+
+  if (!isJsonRecord(allocation.data)) {
+    throw new ApiHttpError(404, "Designation allocation not found.");
+  }
+
+  throw new ApiHttpError(
+    501,
+    "The connected CRM adapter does not support posting designation child records yet. Retry the parent gift record instead, or resolve the line in the CRM directly.",
+  );
 }
 
 async function insertReconciliationRun(input: {

--- a/packages/api/src/stripe/replay.ts
+++ b/packages/api/src/stripe/replay.ts
@@ -9,6 +9,8 @@ type SupabaseAdminClient = NonNullable<
 
 type JsonRecord = Record<string, unknown>;
 
+const STRIPE_CONTRIBUTION_REPLAY_EVENT_TYPE = "payment_intent.succeeded";
+
 function isJsonRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -44,15 +46,22 @@ function toStoredStripeRawEvent(row: JsonRecord): StoredStripeRawEvent {
 
 export async function loadStripeRawEventForReplay(input: {
   supabaseAdmin: SupabaseAdminClient;
+  donationId?: string;
   stripeEventId: string;
   tenantId: string;
 }): Promise<StoredStripeRawEvent> {
-  const { data, error } = await input.supabaseAdmin
+  const query = input.supabaseAdmin
     .from("stripe_raw_events")
     .select("*")
     .eq("stripe_event_id", input.stripeEventId)
     .eq("tenant_id", input.tenantId)
-    .maybeSingle();
+    .eq("event_type", STRIPE_CONTRIBUTION_REPLAY_EVENT_TYPE);
+
+  if (input.donationId) {
+    query.eq("donation_id", input.donationId);
+  }
+
+  const { data, error } = await query.maybeSingle();
 
   if (error) {
     throw new Error(error.message);
@@ -64,6 +73,33 @@ export async function loadStripeRawEventForReplay(input: {
   return toStoredStripeRawEvent(data);
 }
 
+/**
+ * Resolve the newest stored provider event id for a contribution. Inline
+ * contribution replay actions use this so the client does not need to carry a
+ * trusted Stripe event id.
+ */
+export async function resolveLatestStripeEventIdForDonation(input: {
+  supabaseAdmin: SupabaseAdminClient;
+  tenantId: string;
+  donationId: string;
+}): Promise<string | null> {
+  const { data, error } = await input.supabaseAdmin
+    .from("stripe_raw_events")
+    .select("stripe_event_id")
+    .eq("tenant_id", input.tenantId)
+    .eq("donation_id", input.donationId)
+    .eq("event_type", STRIPE_CONTRIBUTION_REPLAY_EVENT_TYPE)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return isJsonRecord(data) ? asString(data.stripe_event_id) : null;
+}
+
 export async function markStripeRawEventForReplay(input: {
   supabaseAdmin: SupabaseAdminClient;
   rawEventId: string;
@@ -72,9 +108,17 @@ export async function markStripeRawEventForReplay(input: {
     .from("stripe_raw_events")
     .update({
       processing_status: "received",
+      process_attempts: 0,
       next_attempt_at: new Date().toISOString(),
       lock_id: null,
       locked_at: null,
+      processed_at: null,
+      failed_at: null,
+      dead_letter_at: null,
+      last_error_code: null,
+      last_error_message: null,
+      retryable: null,
+      processing_outcome: {},
       updated_at: new Date().toISOString(),
     })
     .eq("id", input.rawEventId);

--- a/tests/unit/packages/api/admin/contribution-action-dependencies.test.ts
+++ b/tests/unit/packages/api/admin/contribution-action-dependencies.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { createContributionActionDependencies } from "../../../../../packages/api/src/admin/contribution-operations/dependencies";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+const TENANT_ID = "tenant-1";
+const DONATION_ID = "donation-1";
+
+type Row = Record<string, unknown>;
+
+class TableBuilder {
+  private filters: Record<string, unknown> = {};
+
+  constructor(private readonly rows: Row[]) {}
+
+  select() {
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    this.filters[column] = value;
+    return this;
+  }
+
+  private match(): Row[] {
+    return this.rows.filter((row) =>
+      Object.entries(this.filters).every(([key, value]) => row[key] === value),
+    );
+  }
+
+  maybeSingle() {
+    return Promise.resolve({ data: this.match()[0] ?? null, error: null });
+  }
+
+  single() {
+    const data = this.match()[0] ?? null;
+    return Promise.resolve({
+      data,
+      error: data ? null : { message: "not found" },
+    });
+  }
+}
+
+function createStub(): AdminSupabaseClient {
+  return {
+    from(table: string) {
+      if (table === "staged_gifts") {
+        return new TableBuilder([
+          {
+            id: "staged-1",
+            tenant_id: TENANT_ID,
+            donation_id: DONATION_ID,
+            status: "posted",
+            crm_post_status: "failed",
+            receipt_status: "sent",
+          },
+        ]);
+      }
+      if (table === "staged_gift_allocations") {
+        return new TableBuilder([
+          {
+            id: "allocation-1",
+            tenant_id: TENANT_ID,
+            staged_gift_id: "staged-1",
+          },
+        ]);
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  } as unknown as AdminSupabaseClient;
+}
+
+describe("contribution action dependency factory", () => {
+  it("wires designation-scoped CRM retry to the production adapter boundary", async () => {
+    const deps = createContributionActionDependencies(createStub());
+
+    await expect(
+      deps.retryDesignationPost!({
+        tenantId: TENANT_ID,
+        contributionId: DONATION_ID,
+        stagedGiftId: "staged-1",
+        allocationId: "allocation-1",
+        actorProfileId: "profile-1",
+        note: "Retry failed designation line",
+      }),
+    ).rejects.toMatchObject({
+      status: 501,
+      message: expect.stringMatching(/does not support posting designation/i),
+    });
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-actions.test.ts
@@ -950,6 +950,47 @@ describe("contribution operations action executor", () => {
     expect(result.providerOutcome?.referenceId).toBe("evt_123");
   });
 
+  it("allows Stripe replay dependencies to derive the provider event id server-side", async () => {
+    const replayStripeEvent = vi.fn().mockResolvedValue({
+      provider: "stripe",
+      status: "queued_for_replay",
+      referenceId: "evt_latest",
+    });
+    const createCorrectionRecord = vi.fn().mockResolvedValue("correction_1");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.use_provider_actions"],
+      sourceSurface: "contribution_hub",
+      contributionId: "donation_1",
+      actionType: "stripe_replay",
+      reason: "Recover missing webhook",
+      confirmationToken: "confirm",
+      payload: {},
+      approvalPolicy: APPROVAL_SUPPRESSED_POLICY,
+      dependencies: {
+        replayStripeEvent,
+        createCorrectionRecord,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(replayStripeEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contributionId: "donation_1",
+        payload: {},
+        tenantId: "tenant_1",
+      }),
+    );
+  });
+
   it("routes Stripe replay through correction requests under default approval policy", async () => {
     const replayStripeEvent = vi.fn();
     const createCorrectionRequest = vi.fn().mockResolvedValue("request_8");
@@ -990,6 +1031,50 @@ describe("contribution operations action executor", () => {
     );
     expect(result.approvalStatus).toBe("pending_approval");
     expect(result.correctionRequestId).toBe("request_8");
+  });
+
+  it("freezes derived Stripe replay event ids when opening approval requests", async () => {
+    const replayStripeEvent = vi.fn();
+    const resolveReplayStripeEventId = vi.fn().mockResolvedValue("evt_frozen");
+    const createCorrectionRequest = vi.fn().mockResolvedValue("request_8");
+    const appendAuditEvent = vi.fn().mockResolvedValue("audit_1");
+    const loadContributionDetail = vi.fn().mockResolvedValue({
+      id: "donation_1",
+    });
+
+    await executeContributionAction({
+      tenantId: "tenant_1",
+      actorProfileId: "profile_1",
+      actorPermissions: [],
+      actorCapabilities: ["contributions.request_corrections"],
+      sourceSurface: "donor_crm_record",
+      contributionId: "donation_1",
+      actionType: "stripe_replay",
+      reason: "Recover missing webhook",
+      confirmationToken: "confirm",
+      payload: {},
+      approvalPolicy: resolveCorrectionApprovalPolicy(null),
+      dependencies: {
+        replayStripeEvent,
+        resolveReplayStripeEventId,
+        createCorrectionRequest,
+        appendAuditEvent,
+        loadContributionDetail,
+      },
+    });
+
+    expect(replayStripeEvent).not.toHaveBeenCalled();
+    expect(resolveReplayStripeEventId).toHaveBeenCalledWith({
+      tenantId: "tenant_1",
+      contributionId: "donation_1",
+      payload: {},
+    });
+    expect(createCorrectionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "stripe_replay",
+        payload: { stripeEventId: "evt_frozen" },
+      }),
+    );
   });
 
   it("routes refunds through correction requests under default approval policy", async () => {

--- a/tests/unit/packages/api/admin/contribution-stripe-replay-dependency.test.ts
+++ b/tests/unit/packages/api/admin/contribution-stripe-replay-dependency.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "vitest";
+
+import { createContributionActionDependencies } from "../../../../../packages/api/src/admin/contribution-operations/dependencies";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+const TENANT_ID = "tenant-1";
+const DONATION_ID = "donation-1";
+
+interface RawEvent {
+  id: string;
+  stripe_event_id: string;
+  tenant_id: string;
+  donation_id: string;
+  created_at: string;
+  correlation_id: string;
+  event_type: string;
+  processing_status: string;
+  raw_payload: Record<string, unknown>;
+}
+
+function rawEvent(overrides: Partial<RawEvent>): RawEvent {
+  return {
+    id: "raw-1",
+    stripe_event_id: "evt_1",
+    tenant_id: TENANT_ID,
+    donation_id: DONATION_ID,
+    created_at: "2026-05-01T00:00:00.000Z",
+    correlation_id: "corr-1",
+    event_type: "payment_intent.succeeded",
+    processing_status: "processed",
+    raw_payload: {},
+    ...overrides,
+  };
+}
+
+class RawEventsBuilder {
+  private filters: Record<string, unknown> = {};
+  private ordered = false;
+  private limited = false;
+
+  constructor(
+    private readonly rows: RawEvent[],
+    private readonly updates: Record<string, unknown>[],
+  ) {}
+
+  select() {
+    return this;
+  }
+
+  update(patch: Record<string, unknown>) {
+    this.updates.push(patch);
+    return this;
+  }
+
+  eq(column: string, value: unknown) {
+    this.filters[column] = value;
+    return this;
+  }
+
+  order() {
+    this.ordered = true;
+    return this;
+  }
+
+  limit() {
+    this.limited = true;
+    return this;
+  }
+
+  private match(): RawEvent[] {
+    let result = this.rows.filter((row) =>
+      Object.entries(this.filters).every(
+        ([key, value]) => (row as Record<string, unknown>)[key] === value,
+      ),
+    );
+    if (this.ordered) {
+      result = [...result].sort((left, right) =>
+        left.created_at < right.created_at ? 1 : -1,
+      );
+    }
+    if (this.limited) {
+      result = result.slice(0, 1);
+    }
+    return result;
+  }
+
+  maybeSingle() {
+    return Promise.resolve({ data: this.match()[0] ?? null, error: null });
+  }
+
+  then<TResult>(
+    onfulfilled: (value: { data: unknown; error: null }) => TResult,
+  ) {
+    return Promise.resolve(onfulfilled({ data: this.match(), error: null }));
+  }
+}
+
+function createStub(
+  rows: RawEvent[],
+  updates: Record<string, unknown>[] = [],
+): AdminSupabaseClient {
+  return {
+    from(table: string) {
+      if (table === "stripe_raw_events") {
+        return new RawEventsBuilder(rows, updates);
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  } as unknown as AdminSupabaseClient;
+}
+
+describe("contribution replayStripeEvent dependency", () => {
+  it("derives the latest stored provider event id when no event id is supplied", async () => {
+    const deps = createContributionActionDependencies(
+      createStub([
+        rawEvent({
+          id: "raw-old",
+          stripe_event_id: "evt_old",
+          created_at: "2026-05-01T00:00:00.000Z",
+        }),
+        rawEvent({
+          id: "raw-new",
+          stripe_event_id: "evt_new",
+          created_at: "2026-05-09T00:00:00.000Z",
+        }),
+      ]),
+    );
+
+    const outcome = await deps.replayStripeEvent!({
+      tenantId: TENANT_ID,
+      contributionId: DONATION_ID,
+      payload: {},
+      expectedRevision: null,
+      idempotencyKey: "replay-key",
+    });
+
+    expect(outcome).toMatchObject({
+      provider: "stripe",
+      status: "queued_for_replay",
+      referenceId: "evt_new",
+    });
+  });
+
+  it("resets retry and dead-letter metadata when queueing a replay", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const deps = createContributionActionDependencies(
+      createStub(
+        [
+          rawEvent({
+            id: "raw-dead",
+            stripe_event_id: "evt_dead",
+            created_at: "2026-05-09T00:00:00.000Z",
+            processing_status: "dead_letter",
+          }),
+        ],
+        updates,
+      ),
+    );
+
+    await deps.replayStripeEvent!({
+      tenantId: TENANT_ID,
+      contributionId: DONATION_ID,
+      payload: {},
+      expectedRevision: null,
+      idempotencyKey: "replay-key",
+    });
+
+    expect(updates[0]).toMatchObject({
+      processing_status: "received",
+      process_attempts: 0,
+      failed_at: null,
+      dead_letter_at: null,
+      last_error_code: null,
+      last_error_message: null,
+      retryable: null,
+      processing_outcome: {},
+    });
+  });
+
+  it("skips newer non-payment events when deriving a replay event id", async () => {
+    const deps = createContributionActionDependencies(
+      createStub([
+        rawEvent({
+          id: "raw-payment",
+          stripe_event_id: "evt_payment",
+          created_at: "2026-05-01T00:00:00.000Z",
+          event_type: "payment_intent.succeeded",
+        }),
+        rawEvent({
+          id: "raw-refund",
+          stripe_event_id: "evt_refund",
+          created_at: "2026-05-09T00:00:00.000Z",
+          event_type: "charge.refunded",
+        }),
+      ]),
+    );
+
+    const outcome = await deps.replayStripeEvent!({
+      tenantId: TENANT_ID,
+      contributionId: DONATION_ID,
+      payload: {},
+      expectedRevision: null,
+      idempotencyKey: "replay-key",
+    });
+
+    expect(outcome.referenceId).toBe("evt_payment");
+  });
+
+  it("returns a clear error when no stored event exists", async () => {
+    const deps = createContributionActionDependencies(createStub([]));
+
+    await expect(
+      deps.replayStripeEvent!({
+        tenantId: TENANT_ID,
+        contributionId: DONATION_ID,
+        payload: {},
+        expectedRevision: null,
+        idempotencyKey: "replay-key",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringMatching(/no stored provider event/i),
+    });
+  });
+
+  it("honors an explicitly supplied event id for batch replay callers", async () => {
+    const deps = createContributionActionDependencies(
+      createStub([
+        rawEvent({
+          id: "raw-old",
+          stripe_event_id: "evt_old",
+          created_at: "2026-05-01T00:00:00.000Z",
+        }),
+        rawEvent({
+          id: "raw-new",
+          stripe_event_id: "evt_new",
+          created_at: "2026-05-09T00:00:00.000Z",
+        }),
+      ]),
+    );
+
+    const outcome = await deps.replayStripeEvent!({
+      tenantId: TENANT_ID,
+      contributionId: DONATION_ID,
+      payload: { stripeEventId: " evt_old " },
+      expectedRevision: null,
+      idempotencyKey: "replay-key",
+    });
+
+    expect(outcome.referenceId).toBe("evt_old");
+  });
+
+  it("rejects an explicitly supplied event id from another contribution", async () => {
+    const deps = createContributionActionDependencies(
+      createStub([
+        rawEvent({
+          id: "raw-other",
+          stripe_event_id: "evt_other",
+          donation_id: "donation-2",
+        }),
+      ]),
+    );
+
+    await expect(
+      deps.replayStripeEvent!({
+        tenantId: TENANT_ID,
+        contributionId: DONATION_ID,
+        payload: { stripeEventId: "evt_other" },
+        expectedRevision: null,
+        idempotencyKey: "replay-key",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringMatching(/stripe raw event not found/i),
+    });
+  });
+
+  it("rejects explicitly supplied non-payment events for the same contribution", async () => {
+    const deps = createContributionActionDependencies(
+      createStub([
+        rawEvent({
+          id: "raw-refund",
+          stripe_event_id: "evt_refund",
+          event_type: "charge.refunded",
+        }),
+      ]),
+    );
+
+    await expect(
+      deps.replayStripeEvent!({
+        tenantId: TENANT_ID,
+        contributionId: DONATION_ID,
+        payload: { stripeEventId: "evt_refund" },
+        expectedRevision: null,
+        idempotencyKey: "replay-key",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringMatching(/stripe raw event not found/i),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add contribution action dependency wiring for Stripe webhook replay without trusting client-supplied event ids
- resolve the newest stored Stripe event id server-side for inline replay actions
- persist contribution operation audit/correction records through a small store adapter
- allow stripe_replay action payloads to omit stripeEventId so dependencies can derive it

## Tests
- node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/contribution-operations-actions.test.ts tests/unit/packages/api/admin/contribution-stripe-replay-dependency.test.ts
- node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/contribution-operations-actions.test.ts tests/unit/packages/api/admin/contribution-stripe-replay-dependency.test.ts tests/unit/packages/api/admin/contribution-correction-requests.test.ts tests/unit/packages/api/admin/contribution-approval-notifications.test.ts tests/unit/packages/api/admin/contribution-notification-store.test.ts tests/unit/packages/api/admin/contribution-adjustment-operations.test.ts tests/unit/packages/api/admin/contribution-receipt-delivery.test.ts
- bunx turbo run typecheck --filter=@asym/api
- bunx turbo run lint --filter=@asym/api
- bun run format:check
- bun run ci:preflight

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the production dependency factory for Stripe webhook replay actions, addressing several issues raised in prior reviews: server-side event-ID resolution (no longer trusting client-supplied IDs), event-type filtering (only `payment_intent.succeeded`), retry-state reset for dead-lettered events, and freezing the resolved event ID into pending correction requests at creation time rather than at approval time.

- **`dependencies.ts`** (new): production `createContributionActionDependencies` factory, including `retryDesignationPost`, `replayStripeEvent` (with inline event-ID resolution and cross-contribution guard via `donationId`), and `resolveReplayStripeEventId` for approval-path freezing.
- **`replay.ts`**: adds `STRIPE_CONTRIBUTION_REPLAY_EVENT_TYPE` guard, optional `donationId` binding in `loadStripeRawEventForReplay`, `resolveLatestStripeEventIdForDonation`, and a full retry-state reset (`process_attempts`, `failed_at`, `dead_letter_at`, etc.) in `markStripeRawEventForReplay`.
- **`actions.ts`**: `resolvePendingCorrectionPayload` freezes the derived Stripe event ID into the correction request payload at creation time, preventing the TOCTOU window between request creation and approval.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all five concerns raised in prior review rounds are now addressed and the new test suite covers the corrected behaviour.

Every previous blocking concern is resolved: the Stripe event-type filter (payment_intent.succeeded) is applied in both the inline resolver and the load path; the cross-contribution donationId guard is wired through loadStripeRawEventForReplay; the retry/dead-letter state fields are reset atomically; the approval-path now freezes the resolved event ID at request-creation time; and retryDesignationPost is wired in the production factory. No new correctness, data-integrity, or security issues were introduced by the changes.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api/src/stripe/replay.ts | Adds event-type guard (payment_intent.succeeded only), optional donationId binding in loadStripeRawEventForReplay, server-side latest-event resolver, and full retry-state reset in markStripeRawEventForReplay. Addresses all prior review concerns. |
| packages/api/src/admin/contribution-operations/dependencies.ts | New production dependency factory; wires retryDesignationPost, replayStripeEvent (with inline event-ID resolution and cross-contribution donationId guard), resolveReplayStripeEventId, and all store adapters. |
| packages/api/src/admin/contribution-operations/actions.ts | Adds resolvePendingCorrectionPayload to freeze the derived Stripe event ID into pending correction requests at creation time; idempotency key is correctly re-computed using the resolved payload. |
| packages/api/src/admin/contribution-operations/store.ts | New store adapter; provides typed inserts for audit events and correction records with defensive error handling. Re-exports loadContributionDetailFromSupabase. |
| packages/api/src/giving/staged-gifts.ts | Adds StagedGiftDesignationPostingInput interface and retryStagedGiftDesignationPostingToTwenty which validates gift/allocation ownership then surfaces a 501 indicating the CRM adapter boundary. |
| packages/api/src/admin/contribution-operations/operations.ts | Exports loadContributionDetailFromSupabase and adds replayStripeEventThroughContributionOperations which loads and marks a Stripe event for replay with cross-contribution guard. |
| tests/unit/packages/api/admin/contribution-stripe-replay-dependency.test.ts | New test suite; covers event-ID derivation, retry-state reset, non-payment event filtering, empty-event error, explicit-ID honoring, cross-contribution rejection, and non-payment explicit-ID rejection. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant Actions as actions.ts executeContributionAction
    participant Deps as dependencies.ts replayStripeEvent
    participant Replay as stripe/replay.ts
    participant DB as Supabase DB

    alt Inline replay (approval suppressed)
        Caller->>Actions: "stripe_replay, payload={}"
        Actions->>Deps: "replayStripeEvent({contributionId, payload})"
        Deps->>Replay: resolveLatestStripeEventIdForDonation(tenantId, donationId)
        Replay->>DB: "SELECT stripe_event_id WHERE event_type=payment_intent.succeeded ORDER BY created_at DESC LIMIT 1"
        DB-->>Replay: evt_latest
        Deps->>Replay: loadStripeRawEventForReplay(stripeEventId, donationId)
        Replay->>DB: "SELECT WHERE stripe_event_id=? AND donation_id=? AND event_type=?"
        DB-->>Replay: raw event row
        Deps->>Replay: markStripeRawEventForReplay(rawEventId)
        Replay->>DB: "UPDATE status=received, attempts=0, reset failure fields"
        DB-->>Replay: ok
        Deps-->>Actions: "provider=stripe, status=queued_for_replay, referenceId=evt_latest"
        Actions->>DB: INSERT correction_record + audit_event
    else Approval-gated replay
        Caller->>Actions: "stripe_replay, payload={}, requiresApproval=true"
        Actions->>Actions: resolvePendingCorrectionPayload(input)
        Actions->>Deps: "resolveReplayStripeEventId({contributionId, payload})"
        Deps->>Replay: resolveLatestStripeEventIdForDonation(...)
        Replay->>DB: SELECT stripe_event_id ...
        DB-->>Replay: evt_frozen
        Actions->>DB: "INSERT correction_request payload={stripeEventId: evt_frozen}"
        Note over Actions,DB: event ID frozen at request time, approver applies evt_frozen even if newer events arrive later
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant Actions as actions.ts executeContributionAction
    participant Deps as dependencies.ts replayStripeEvent
    participant Replay as stripe/replay.ts
    participant DB as Supabase DB

    alt Inline replay (approval suppressed)
        Caller->>Actions: "stripe_replay, payload={}"
        Actions->>Deps: "replayStripeEvent({contributionId, payload})"
        Deps->>Replay: resolveLatestStripeEventIdForDonation(tenantId, donationId)
        Replay->>DB: "SELECT stripe_event_id WHERE event_type=payment_intent.succeeded ORDER BY created_at DESC LIMIT 1"
        DB-->>Replay: evt_latest
        Deps->>Replay: loadStripeRawEventForReplay(stripeEventId, donationId)
        Replay->>DB: "SELECT WHERE stripe_event_id=? AND donation_id=? AND event_type=?"
        DB-->>Replay: raw event row
        Deps->>Replay: markStripeRawEventForReplay(rawEventId)
        Replay->>DB: "UPDATE status=received, attempts=0, reset failure fields"
        DB-->>Replay: ok
        Deps-->>Actions: "provider=stripe, status=queued_for_replay, referenceId=evt_latest"
        Actions->>DB: INSERT correction_record + audit_event
    else Approval-gated replay
        Caller->>Actions: "stripe_replay, payload={}, requiresApproval=true"
        Actions->>Actions: resolvePendingCorrectionPayload(input)
        Actions->>Deps: "resolveReplayStripeEventId({contributionId, payload})"
        Deps->>Replay: resolveLatestStripeEventIdForDonation(...)
        Replay->>DB: SELECT stripe_event_id ...
        DB-->>Replay: evt_frozen
        Actions->>DB: "INSERT correction_request payload={stripeEventId: evt_frozen}"
        Note over Actions,DB: event ID frozen at request time, approver applies evt_frozen even if newer events arrive later
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/api/src/stripe/replay.ts`, line 97-105 ([link](https://github.com/asymmetric-al/core/blob/3202b68f0ad2ec07fba9c94241ff7dabad9bfe60/packages/api/src/stripe/replay.ts#L97-L105)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reset replay state**

   `markStripeRawEventForReplay` moves an event back to `received`, but it leaves `process_attempts` and prior failure/dead-letter fields intact. The claim RPC increments `process_attempts`, and failure handling dead-letters once the attempt count reaches the threshold, so replaying an exhausted event can immediately dead-letter again after one failure. Please reset the retry/dead-letter metadata as part of the explicit replay transition, or use a replay-specific RPC that does this atomically.

   **Context Used:** Use the repo’s source-of-truth guidance when prese... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Repro: focused replay marker harness](https://app.greptile.com/trex/artifacts/c2c55fb9-0fe0-47d8-b1f4-9793015ff9ec)**
   
   - Contains supporting evidence from the run (text/typescript; charset=utf-8).
   
   **[Repro: harness output showing before state, update payload, and retained metadata](https://app.greptile.com/trex/artifacts/c9932c46-ed2f-44d0-9f29-7432e90be083)**
   
   - Keeps the command output available without making the summary code-heavy.
   
   **[Repro: generated Vitest harness attempted before runner startup failure](https://app.greptile.com/trex/artifacts/a3b0cd54-dcdf-4f6a-a6d7-38aa852b7b6f)**
   
   - Contains supporting evidence from the run (text/typescript; charset=utf-8).
   
   **[Repro: Vitest runner startup failure log](https://app.greptile.com/trex/artifacts/eee141b7-d15f-4e20-bc6f-cf065f83ff5c)**
   
   - Keeps the command output available without making the summary code-heavy.
   
   <a href="https://app.greptile.com/trex/runs/11796124/artifacts?artifact=c2c55fb9-0fe0-47d8-b1f4-9793015ff9ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapi%2Fsrc%2Fstripe%2Freplay.ts%0ALine%3A%2097-105%0A%0AComment%3A%0A**Reset%20replay%20state**%0A%0A%60markStripeRawEventForReplay%60%20moves%20an%20event%20back%20to%20%60received%60%2C%20but%20it%20leaves%20%60process_attempts%60%20and%20prior%20failure%2Fdead-letter%20fields%20intact.%20The%20claim%20RPC%20increments%20%60process_attempts%60%2C%20and%20failure%20handling%20dead-letters%20once%20the%20attempt%20count%20reaches%20the%20threshold%2C%20so%20replaying%20an%20exhausted%20event%20can%20immediately%20dead-letter%20again%20after%20one%20failure.%20Please%20reset%20the%20retry%2Fdead-letter%20metadata%20as%20part%20of%20the%20explicit%20replay%20transition%2C%20or%20use%20a%20replay-specific%20RPC%20that%20does%20this%20atomically.%0A%0A**Context%20Used%3A**%20Use%20the%20repo%E2%80%99s%20source-of-truth%20guidance%20when%20prese...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/api/src/admin/contribution-operations/actions.ts`, line 1035-1053 ([link](https://github.com/asymmetric-al/core/blob/3202b68f0ad2ec07fba9c94241ff7dabad9bfe60/packages/api/src/admin/contribution-operations/actions.ts#L1035-L1053)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Freeze approved event**

   Approval-gated `stripe_replay` requests can now store an empty payload, and this apply path resolves the latest Stripe event only when the approver applies the request. If another Stripe event arrives for the same donation between request creation and approval, the approved action can replay a different event than the one the requester intended. Please resolve and persist the server-side `stripeEventId` when creating the correction request, or require an already-resolved id for approval-gated replay actions.

   **Context Used:** Use the repo’s source-of-truth guidance when prese... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Repro: focused approval apply harness](https://app.greptile.com/trex/artifacts/27513f1e-6c43-490c-bc23-a6271f967322)**
   
   - Contains supporting evidence from the run (text/typescript; charset=utf-8).
   
   **[Repro: harness execution output showing E2 replayed after approval](https://app.greptile.com/trex/artifacts/85e63d9e-19b7-47e3-aa5e-72cc160f9abc)**
   
   - Keeps the command output available without making the summary code-heavy.
   
   **[Repro: generated Vitest flow test attempted for the same approval scenario](https://app.greptile.com/trex/artifacts/4f66dc77-7fe0-4e39-a99e-9330455bf656)**
   
   - Contains supporting evidence from the run (text/typescript; charset=utf-8).
   
   **[Repro: Vitest attempt output showing runner startup blocker in this environment](https://app.greptile.com/trex/artifacts/14d6f764-02e2-4e02-9115-81ac491b5591)**
   
   - Keeps the command output available without making the summary code-heavy.
   
   <a href="https://app.greptile.com/trex/runs/11796124/artifacts?artifact=27513f1e-6c43-490c-bc23-a6271f967322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapi%2Fsrc%2Fadmin%2Fcontribution-operations%2Factions.ts%0ALine%3A%201035-1053%0A%0AComment%3A%0A**Freeze%20approved%20event**%0A%0AApproval-gated%20%60stripe_replay%60%20requests%20can%20now%20store%20an%20empty%20payload%2C%20and%20this%20apply%20path%20resolves%20the%20latest%20Stripe%20event%20only%20when%20the%20approver%20applies%20the%20request.%20If%20another%20Stripe%20event%20arrives%20for%20the%20same%20donation%20between%20request%20creation%20and%20approval%2C%20the%20approved%20action%20can%20replay%20a%20different%20event%20than%20the%20one%20the%20requester%20intended.%20Please%20resolve%20and%20persist%20the%20server-side%20%60stripeEventId%60%20when%20creating%20the%20correction%20request%2C%20or%20require%20an%20already-resolved%20id%20for%20approval-gated%20replay%20actions.%0A%0A**Context%20Used%3A**%20Use%20the%20repo%E2%80%99s%20source-of-truth%20guidance%20when%20prese...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["feat(api): add stripe replay action depe..."](https://github.com/asymmetric-al/core/commit/8eaeebd9e3baf3c4e48d89063cf921fa7ac30ef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38917892)</sub>

<!-- /greptile_comment -->