### PR TITLE
feat(api): add contribution operation batches

### DIFF
--- a/apps/admin/app/api/admin/contribution-batches/[batchId]/process/route.ts
+++ b/apps/admin/app/api/admin/contribution-batches/[batchId]/process/route.ts
@@ -1,0 +1,1 @@
+export { POST_PROCESS_BATCH as POST } from "@asym/api/admin/contribution-batches/route";

--- a/apps/admin/app/api/admin/contribution-batches/route.ts
+++ b/apps/admin/app/api/admin/contribution-batches/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@asym/api/admin/contribution-batches/route";

--- a/docs/guides/architecture/runtime-map.md
+++ b/docs/guides/architecture/runtime-map.md
@@ -28,6 +28,8 @@ commit when the deployment exposes a non-`unknown` commit.
 | ---------- | -------------------------------------------------------------- | ------------------------------------- | --------------------------------------------- |
 | admin      | `/api/admin/comments`                                          | Node.js (no `runtime` segment export) | Admin client                                  |
 | admin      | `/api/admin/comments/[commentId]`                              | Node.js (no `runtime` segment export) | Admin client                                  |
+| admin      | `/api/admin/contribution-batches`                              | Node.js (no `runtime` segment export) | Bulk contribution operations, admin client    |
+| admin      | `/api/admin/contribution-batches/[batchId]/process`            | Node.js (no `runtime` segment export) | Bulk contribution background processing       |
 | admin      | `/api/admin/contributions`                                     | Node.js (no `runtime` segment export) | Admin client                                  |
 | admin      | `/api/admin/contributions/reconcile`                           | Node.js (no `runtime` segment export) | Giving reconciliation, admin client           |
 | admin      | `/api/admin/contributions/replay`                              | Node.js (no `runtime` segment export) | Giving replay tooling, Stripe SDK             |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,6 +32,8 @@
     "./admin/users": "./src/admin/users.ts",
     "./admin/contribution-shared": "./src/admin/contribution-shared/index.ts",
     "./admin/contribution-operations": "./src/admin/contribution-operations/index.ts",
+    "./admin/contribution-batches": "./src/admin/contribution-batches/index.ts",
+    "./admin/contribution-batches/route": "./src/admin/contribution-batches/route.ts",
     "./admin/mission-control-tasks": "./src/admin/mission-control-tasks/index.ts",
     "./admin/contributions": "./src/admin/contributions/index.ts",
     "./admin/contributions/reconcile": "./src/admin/contributions/reconcile.ts",

--- a/packages/api/src/admin/contribution-batches/action-catalog.ts
+++ b/packages/api/src/admin/contribution-batches/action-catalog.ts
@@ -1,0 +1,52 @@
+import { getContributionActionRiskLevel } from "../contribution-operations/policy";
+
+import type { ContributionBatchRiskLevel } from "./types";
+import type { ContributionActionType } from "../contribution-operations/types";
+
+const PREVIEW_SKIPPABLE_LOW_RISK_ACTIONS = new Set<ContributionActionType>([
+  "resend_receipt",
+  "crm_repost",
+]);
+
+const BULK_RISK_OVERRIDES: Partial<
+  Record<ContributionActionType, ContributionBatchRiskLevel>
+> = {
+  // CRM reposts are provider replays, but bulk reposting is recoverable and
+  // preview-skippable in this workflow.
+  crm_repost: "low",
+  // Allocation corrections are medium-risk one at a time, but bulk allocation
+  // edits can reassign financial ownership across many contributions.
+  allocation_correction: "high",
+};
+
+export function getBulkContributionActionRiskLevel(
+  actionType: ContributionActionType,
+): ContributionBatchRiskLevel {
+  const override = BULK_RISK_OVERRIDES[actionType];
+  if (override) {
+    return override;
+  }
+
+  return getContributionActionRiskLevel(actionType) === "low" ? "low" : "high";
+}
+
+export function isBulkPreviewSkippable(
+  actionType: ContributionActionType,
+): boolean {
+  return PREVIEW_SKIPPABLE_LOW_RISK_ACTIONS.has(actionType);
+}
+
+export function getBulkContributionActionPolicy(
+  actionType: ContributionActionType,
+) {
+  const riskLevel = getBulkContributionActionRiskLevel(actionType);
+
+  return {
+    actionType,
+    riskLevel,
+    requiresConfirmation: true,
+    requiresPreview: riskLevel === "high",
+    backgroundRequired: riskLevel === "high",
+    previewSkippable: isBulkPreviewSkippable(actionType),
+  };
+}

--- a/packages/api/src/admin/contribution-batches/index.ts
+++ b/packages/api/src/admin/contribution-batches/index.ts
@@ -1,0 +1,29 @@
+export {
+  getBulkContributionActionPolicy,
+  getBulkContributionActionRiskLevel,
+  isBulkPreviewSkippable,
+} from "./action-catalog";
+export {
+  processContributionBatch,
+  processPersistedContributionBatch,
+} from "./process-batch";
+export {
+  chooseContributionBatchExecutionMode,
+  createContributionBatchPreview,
+} from "./preview";
+export {
+  buildContributionBatchCsv,
+  summarizeContributionBatchResults,
+} from "./results";
+
+export type {
+  ContributionBatchAffectedRecord,
+  ContributionBatchExecutionMode,
+  ContributionBatchItemResult,
+  ContributionBatchItemStatus,
+  ContributionBatchRecord,
+  ContributionBatchRiskLevel,
+  ContributionBatchSkippedRecord,
+  ContributionBatchStatus,
+  ProcessContributionBatchInput,
+} from "./types";

--- a/packages/api/src/admin/contribution-batches/preview.ts
+++ b/packages/api/src/admin/contribution-batches/preview.ts
@@ -1,0 +1,155 @@
+import { getBulkContributionActionPolicy } from "./action-catalog";
+
+import type {
+  ContributionBatchAffectedRecord,
+  ContributionBatchExecutionMode,
+  ContributionBatchRecord,
+  ContributionBatchSkippedRecord,
+} from "./types";
+import type { ContributionActionType } from "../contribution-operations/types";
+
+const IMMEDIATE_BATCH_LIMIT = 10;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function asPayload(value: unknown): JsonRecord {
+  return isRecord(value) ? value : {};
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasPositiveFiniteNumber(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function hasNonNegativeFiniteNumber(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function getSkipReason(
+  actionType: ContributionActionType,
+  record: ContributionBatchRecord,
+): string | null {
+  const payload = asPayload(record.payload);
+
+  if (
+    (actionType === "resend_receipt" || actionType === "crm_repost") &&
+    !record.stagedGiftId
+  ) {
+    return "Missing staged gift id.";
+  }
+
+  if (actionType === "refund" && !hasPositiveFiniteNumber(payload.amount)) {
+    return "Missing payload.amount for refund.";
+  }
+
+  if (actionType === "donor_relink" && !hasNonEmptyString(payload.donorId)) {
+    return "Missing payload.donorId for donor relink.";
+  }
+
+  if (
+    actionType === "amount_correction" &&
+    !hasNonNegativeFiniteNumber(payload.amount)
+  ) {
+    return "Missing payload.amount for amount correction.";
+  }
+
+  if (
+    actionType === "designation_correction" &&
+    !hasNonEmptyString(payload.fundId)
+  ) {
+    return "Missing payload.fundId for designation correction.";
+  }
+
+  if (actionType === "fund_correction" && !hasNonEmptyString(payload.fundId)) {
+    return "Missing payload.fundId for fund correction.";
+  }
+
+  if (actionType === "allocation_correction") {
+    if (!hasNonEmptyString(payload.fundId)) {
+      return "Missing payload.fundId for allocation correction.";
+    }
+    if (!hasNonEmptyString(payload.missionaryId)) {
+      return "Missing payload.missionaryId for allocation correction.";
+    }
+  }
+
+  if (
+    actionType === "payment_state_correction" &&
+    !hasNonEmptyString(payload.status)
+  ) {
+    return "Missing payload.status for payment state correction.";
+  }
+
+  if (
+    actionType === "stripe_replay" &&
+    !hasNonEmptyString(payload.stripeEventId)
+  ) {
+    return "Missing payload.stripeEventId for Stripe replay.";
+  }
+
+  if (
+    actionType === "receipt_correction" ||
+    actionType === "statement_correction"
+  ) {
+    return `${actionType} is not supported for bulk batch execution.`;
+  }
+
+  return null;
+}
+
+export function createContributionBatchPreview(input: {
+  actionType: ContributionActionType;
+  records: ContributionBatchRecord[];
+}) {
+  const affectedRecords: ContributionBatchAffectedRecord[] = [];
+  const skippedRecords: ContributionBatchSkippedRecord[] = [];
+
+  for (const record of input.records) {
+    const skipReason = getSkipReason(input.actionType, record);
+    if (skipReason) {
+      skippedRecords.push({
+        batchItemId: record.batchItemId,
+        contributionId: record.id,
+        reason: skipReason,
+      });
+      continue;
+    }
+
+    affectedRecords.push({
+      batchItemId: record.batchItemId,
+      contributionId: record.id,
+      stagedGiftId: record.stagedGiftId,
+      proposedAction: input.actionType,
+      payload: asPayload(record.payload),
+    });
+  }
+
+  return {
+    actionType: input.actionType,
+    affectedRecords,
+    skippedRecords,
+    totalCount: input.records.length,
+  };
+}
+
+export function chooseContributionBatchExecutionMode(input: {
+  actionType: ContributionActionType;
+  selectedCount: number;
+}): ContributionBatchExecutionMode {
+  const policy = getBulkContributionActionPolicy(input.actionType);
+  if (
+    policy.backgroundRequired ||
+    input.selectedCount > IMMEDIATE_BATCH_LIMIT
+  ) {
+    return "background";
+  }
+
+  return "immediate";
+}

--- a/packages/api/src/admin/contribution-batches/process-batch.ts
+++ b/packages/api/src/admin/contribution-batches/process-batch.ts
@@ -1,0 +1,695 @@
+import { asPayload, createContributionBatchPreview } from "./preview";
+import { summarizeContributionBatchResults } from "./results";
+
+import type {
+  ContributionBatchStatus,
+  ProcessContributionBatchInput,
+} from "./types";
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+const PERSISTED_BATCH_CHUNK_SIZE = 25;
+const RUNNING_ITEM_STALE_AFTER_MS = 5 * 60 * 1000;
+const OPEN_ITEM_STALE_AFTER_MS = 30 * 60 * 1000;
+
+type PersistedBatchItemStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "skipped"
+  | "failed";
+
+interface BatchItemSummary {
+  processed: number;
+  succeeded: number;
+  skipped: number;
+  failed: number;
+  pending: number;
+  running: number;
+  followUpTasksCreated: number;
+  staleRunningItemIds: string[];
+}
+
+export async function processContributionBatch(
+  input: ProcessContributionBatchInput,
+) {
+  const preview = createContributionBatchPreview({
+    actionType: input.actionType,
+    records: input.records,
+  });
+  const results = [];
+
+  for (const skipped of preview.skippedRecords) {
+    results.push({
+      batchItemId: skipped.batchItemId,
+      contributionId: skipped.contributionId,
+      action: input.actionType,
+      status: "skipped" as const,
+      skipReason: skipped.reason,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  for (const record of preview.affectedRecords) {
+    try {
+      const result = await input.executeContributionAction({
+        tenantId: input.tenantId,
+        actorProfileId: input.actorProfileId,
+        sourceSurface: input.sourceSurface,
+        contributionId: record.contributionId,
+        stagedGiftId: record.stagedGiftId,
+        actionType: input.actionType,
+        actorPermissions: input.actorPermissions,
+        actorCapabilities: input.actorCapabilities,
+        reason: input.reason,
+        confirmationToken: input.confirmationToken,
+        payload: asPayload(record.payload),
+      });
+      results.push({
+        batchItemId: record.batchItemId,
+        contributionId: record.contributionId,
+        action: input.actionType,
+        status: "succeeded" as const,
+        auditEventId: result.auditEventId ?? null,
+        taskId: result.taskIds?.[0] ?? null,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      let failureReason =
+        error instanceof Error ? error.message : "Contribution action failed.";
+      let taskId: string | null = null;
+
+      if (input.createFollowUpTask != null) {
+        try {
+          taskId = await input.createFollowUpTask({
+            tenantId: input.tenantId,
+            actorProfileId: input.actorProfileId,
+            contributionId: record.contributionId,
+            actionType: input.actionType,
+            reason: failureReason,
+          });
+        } catch (taskError) {
+          const taskFailureReason =
+            taskError instanceof Error
+              ? taskError.message
+              : "Follow-up task creation failed.";
+          failureReason = `${failureReason} Follow-up task creation failed: ${taskFailureReason}`;
+        }
+      }
+
+      results.push({
+        batchItemId: record.batchItemId,
+        contributionId: record.contributionId,
+        action: input.actionType,
+        status: "failed" as const,
+        failureReason,
+        taskId,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  const summary = summarizeContributionBatchResults(results);
+  const { status, ...summaryCounts } = summary;
+
+  return {
+    results,
+    summary: summaryCounts,
+    status,
+  };
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function asItemStatus(value: unknown): PersistedBatchItemStatus | null {
+  if (
+    value === "pending" ||
+    value === "running" ||
+    value === "succeeded" ||
+    value === "skipped" ||
+    value === "failed"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function toFailureReason(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Contribution batch processing failed.";
+}
+
+function isStaleRunningItem(row: JsonRecord, nowMs = Date.now()) {
+  const status = asItemStatus(row.status);
+  if (status !== "running") {
+    return false;
+  }
+
+  const updatedAt = asString(row.updated_at);
+  if (!updatedAt) {
+    return true;
+  }
+
+  const updatedAtMs = Date.parse(updatedAt);
+  if (!Number.isFinite(updatedAtMs)) {
+    return true;
+  }
+
+  return nowMs - updatedAtMs > RUNNING_ITEM_STALE_AFTER_MS;
+}
+
+function getBatchStatusFromSummary(
+  summary: Pick<
+    BatchItemSummary,
+    "failed" | "processed" | "skipped" | "succeeded"
+  >,
+): ContributionBatchStatus {
+  if (
+    summary.processed > 0 &&
+    summary.succeeded === 0 &&
+    summary.failed > 0 &&
+    summary.skipped === 0
+  ) {
+    return "failed";
+  }
+
+  return summary.failed > 0 || summary.skipped > 0
+    ? "complete_with_issues"
+    : "complete";
+}
+
+function getPublicSummary(summary: BatchItemSummary) {
+  return {
+    processed: summary.processed,
+    succeeded: summary.succeeded,
+    skipped: summary.skipped,
+    failed: summary.failed,
+    followUpTasksCreated: summary.followUpTasksCreated,
+  };
+}
+
+function hasOpenItems(summary: BatchItemSummary) {
+  return summary.pending > 0 || summary.running > 0;
+}
+
+function isBatchStale(row: JsonRecord, nowMs = Date.now()) {
+  const createdAt = asString(row.created_at);
+  if (!createdAt) {
+    return false;
+  }
+
+  const createdAtMs = Date.parse(createdAt);
+  if (!Number.isFinite(createdAtMs)) {
+    return false;
+  }
+
+  return nowMs - createdAtMs > OPEN_ITEM_STALE_AFTER_MS;
+}
+
+function assertBatchProcessOwner(input: {
+  batchRow: JsonRecord;
+  actorProfileId: string | null;
+}) {
+  const createdByProfileId = asString(input.batchRow.created_by_profile_id);
+  if (
+    createdByProfileId &&
+    (!input.actorProfileId || createdByProfileId !== input.actorProfileId)
+  ) {
+    throw new Error(
+      "Only the batch creator can process this contribution batch.",
+    );
+  }
+}
+
+async function readBatchItemSummary(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+}): Promise<BatchItemSummary> {
+  const { data, error } = await input.supabaseAdmin
+    .from("contribution_operation_batch_items")
+    .select("id, status, task_id, updated_at")
+    .eq("tenant_id", input.tenantId)
+    .eq("batch_id", input.batchId);
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const summary: BatchItemSummary = {
+    processed: 0,
+    succeeded: 0,
+    skipped: 0,
+    failed: 0,
+    pending: 0,
+    running: 0,
+    followUpTasksCreated: 0,
+    staleRunningItemIds: [],
+  };
+
+  for (const row of (data ?? []) as JsonRecord[]) {
+    const status = asItemStatus(row.status);
+    if (!status) {
+      continue;
+    }
+
+    if (status === "pending") {
+      summary.pending += 1;
+      continue;
+    }
+
+    if (status === "running") {
+      summary.running += 1;
+      const itemId = asString(row.id);
+      if (itemId && isStaleRunningItem(row)) {
+        summary.staleRunningItemIds.push(itemId);
+      }
+      continue;
+    }
+
+    summary.processed += 1;
+    if (status === "succeeded") {
+      summary.succeeded += 1;
+    }
+    if (status === "skipped") {
+      summary.skipped += 1;
+    }
+    if (status === "failed") {
+      summary.failed += 1;
+    }
+    if (asString(row.task_id)) {
+      summary.followUpTasksCreated += 1;
+    }
+  }
+
+  return summary;
+}
+
+async function markBatchItemsFailedById(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+  itemIds: string[];
+  reason: string;
+}) {
+  if (input.itemIds.length === 0) {
+    return;
+  }
+
+  const { error } = await input.supabaseAdmin
+    .from("contribution_operation_batch_items")
+    .update({
+      status: "failed",
+      error_message: input.reason,
+      processed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", input.tenantId)
+    .eq("batch_id", input.batchId)
+    .eq("status", "running")
+    .in("id", input.itemIds);
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+async function markOpenBatchItemsFailed(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+  reason: string;
+}) {
+  const { error } = await input.supabaseAdmin
+    .from("contribution_operation_batch_items")
+    .update({
+      status: "failed",
+      error_message: input.reason,
+      processed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", input.tenantId)
+    .eq("batch_id", input.batchId)
+    .in("status", ["pending", "running"]);
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+async function readSummaryAfterStaleRecovery(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+}) {
+  const summary = await readBatchItemSummary(input);
+  if (summary.staleRunningItemIds.length === 0) {
+    return summary;
+  }
+
+  await markBatchItemsFailedById({
+    ...input,
+    itemIds: summary.staleRunningItemIds,
+    reason: "Batch item processing timed out before a result was recorded.",
+  });
+
+  return readBatchItemSummary(input);
+}
+
+async function updateBatchProgress(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+  summary: BatchItemSummary;
+  finalize: boolean;
+}) {
+  const payload = {
+    status: input.finalize
+      ? getBatchStatusFromSummary(input.summary)
+      : ("running" as const),
+    processed_count: input.summary.processed,
+    succeeded_count: input.summary.succeeded,
+    skipped_count: input.summary.skipped,
+    failed_count: input.summary.failed,
+    follow_up_task_count: input.summary.followUpTasksCreated,
+    ...(input.finalize ? { finished_at: new Date().toISOString() } : {}),
+  };
+
+  const { error } = await input.supabaseAdmin
+    .from("contribution_operation_batches")
+    .update(payload)
+    .eq("tenant_id", input.tenantId)
+    .eq("id", input.batchId);
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return payload.status;
+}
+
+async function claimPendingBatchItems(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+  chunkSize: number;
+}) {
+  const { data: pendingRows, error: selectError } = await input.supabaseAdmin
+    .from("contribution_operation_batch_items")
+    .select("id, donation_id, staged_gift_id, payload")
+    .eq("tenant_id", input.tenantId)
+    .eq("batch_id", input.batchId)
+    .eq("status", "pending")
+    .order("record_index", { ascending: true })
+    .limit(input.chunkSize);
+  if (selectError) {
+    throw new Error(selectError.message);
+  }
+
+  const rows = (pendingRows ?? []) as JsonRecord[];
+  const itemIds = rows
+    .map((row) => asString(row.id))
+    .filter((id) => id != null);
+  if (itemIds.length === 0) {
+    return [];
+  }
+
+  const { data: claimedRows, error: claimError } = await input.supabaseAdmin
+    .from("contribution_operation_batch_items")
+    .update({
+      status: "running",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", input.tenantId)
+    .eq("batch_id", input.batchId)
+    .eq("status", "pending")
+    .in("id", itemIds)
+    .select("id");
+  if (claimError) {
+    throw new Error(claimError.message);
+  }
+
+  const claimedIds = new Set(
+    ((claimedRows ?? []) as JsonRecord[])
+      .map((row) => asString(row.id))
+      .filter((id) => id != null),
+  );
+
+  return rows.filter((row) => {
+    const id = asString(row.id);
+    return id != null && claimedIds.has(id);
+  });
+}
+
+/**
+ * Best-effort terminal marker for a batch whose item persistence or background
+ * processing failed before results could be recorded. Without it, a thrown
+ * error would strand the batch row in `running` forever. Never throws — it is
+ * called from error paths where the original failure must surface, not this
+ * cleanup.
+ */
+export async function markContributionBatchFailed(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+}): Promise<void> {
+  try {
+    await markOpenBatchItemsFailed({
+      ...input,
+      reason: "Batch processing failed before this item recorded a result.",
+    });
+  } catch (error) {
+    console.error("[contribution-batches] Could not mark open items failed", {
+      batchId: input.batchId,
+      error,
+    });
+  }
+
+  try {
+    const { error } = await input.supabaseAdmin
+      .from("contribution_operation_batches")
+      .update({
+        status: "failed",
+        finished_at: new Date().toISOString(),
+      })
+      .eq("tenant_id", input.tenantId)
+      .eq("id", input.batchId);
+    if (error) {
+      console.error("[contribution-batches] Could not mark batch failed", {
+        batchId: input.batchId,
+        error: error.message,
+      });
+    }
+  } catch (error) {
+    console.error("[contribution-batches] Could not mark batch failed", {
+      batchId: input.batchId,
+      error,
+    });
+  }
+}
+
+export async function processPersistedContributionBatch(input: {
+  supabaseAdmin: AdminSupabaseClient;
+  tenantId: string;
+  batchId: string;
+  actorProfileId: string | null;
+  executeContributionAction: ProcessContributionBatchInput["executeContributionAction"];
+  createFollowUpTask?: ProcessContributionBatchInput["createFollowUpTask"];
+  actorPermissions?: ProcessContributionBatchInput["actorPermissions"];
+  actorCapabilities?: ProcessContributionBatchInput["actorCapabilities"];
+  assertActionPermission?: (
+    actionType: ProcessContributionBatchInput["actionType"],
+  ) => void;
+  chunkSize?: number;
+}) {
+  const { data: batchRow, error: batchError } = await input.supabaseAdmin
+    .from("contribution_operation_batches")
+    .select(
+      "id, operation, source_surface, reason, confirmation_snapshot, status, processed_count, succeeded_count, skipped_count, failed_count, follow_up_task_count, created_by_profile_id, created_at",
+    )
+    .eq("tenant_id", input.tenantId)
+    .eq("id", input.batchId)
+    .single();
+  if (batchError || !isRecord(batchRow)) {
+    throw new Error(batchError?.message ?? "Batch not found.");
+  }
+  const actionType = String(
+    batchRow.operation,
+  ) as ProcessContributionBatchInput["actionType"];
+  input.assertActionPermission?.(actionType);
+  assertBatchProcessOwner({
+    batchRow,
+    actorProfileId: input.actorProfileId,
+  });
+
+  if (batchRow.status !== "running") {
+    return {
+      results: [],
+      status: String(batchRow.status),
+      summary: {
+        processed: Number(batchRow.processed_count ?? 0),
+        succeeded: Number(batchRow.succeeded_count ?? 0),
+        skipped: Number(batchRow.skipped_count ?? 0),
+        failed: Number(batchRow.failed_count ?? 0),
+        followUpTasksCreated: Number(batchRow.follow_up_task_count ?? 0),
+      },
+    };
+  }
+
+  if (isBatchStale(batchRow)) {
+    const summaryBeforeCleanup = await readSummaryAfterStaleRecovery({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      batchId: input.batchId,
+    });
+
+    if (hasOpenItems(summaryBeforeCleanup)) {
+      await markOpenBatchItemsFailed({
+        supabaseAdmin: input.supabaseAdmin,
+        tenantId: input.tenantId,
+        batchId: input.batchId,
+        reason:
+          "Batch processing timed out before all items recorded a result.",
+      });
+    }
+
+    const summary = await readBatchItemSummary({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      batchId: input.batchId,
+    });
+    const status = await updateBatchProgress({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      batchId: input.batchId,
+      summary,
+      finalize: true,
+    });
+
+    return {
+      results: [],
+      status,
+      summary: getPublicSummary(summary),
+    };
+  }
+
+  const rows = await claimPendingBatchItems({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    batchId: input.batchId,
+    chunkSize: input.chunkSize ?? PERSISTED_BATCH_CHUNK_SIZE,
+  });
+  const records = rows.map((row) => ({
+    batchItemId: asString(row.id) ?? undefined,
+    id: asString(row.donation_id) ?? "",
+    stagedGiftId: asString(row.staged_gift_id),
+    payload: asPayload(row.payload),
+  }));
+  if (rows.length === 0) {
+    const summary = await readSummaryAfterStaleRecovery({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      batchId: input.batchId,
+    });
+    const finalize = !hasOpenItems(summary);
+    const status = await updateBatchProgress({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      batchId: input.batchId,
+      summary,
+      finalize,
+    });
+
+    return {
+      results: [],
+      status,
+      summary: getPublicSummary(summary),
+    };
+  }
+
+  let result: Awaited<ReturnType<typeof processContributionBatch>>;
+  try {
+    result = await processContributionBatch({
+      tenantId: input.tenantId,
+      actorProfileId: input.actorProfileId,
+      actionType,
+      sourceSurface: String(batchRow.source_surface) as never,
+      reason: asString(batchRow.reason),
+      confirmationToken: isRecord(batchRow.confirmation_snapshot)
+        ? asString(batchRow.confirmation_snapshot.confirmationToken)
+        : null,
+      actorPermissions: input.actorPermissions,
+      actorCapabilities: input.actorCapabilities,
+      records,
+      executeContributionAction: input.executeContributionAction,
+      createFollowUpTask: input.createFollowUpTask,
+    });
+  } catch (error) {
+    await markBatchItemsFailedById({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      batchId: input.batchId,
+      itemIds: rows.map((row) => asString(row.id)).filter((id) => id != null),
+      reason: toFailureReason(error),
+    });
+    throw error;
+  }
+
+  for (const row of rows) {
+    const id = asString(row.id);
+    if (!id) continue;
+
+    const contributionId = asString(row.donation_id);
+    const itemResult =
+      result.results.find((candidate) => candidate.batchItemId === id) ??
+      result.results.find(
+        (candidate) =>
+          candidate.batchItemId == null &&
+          candidate.contributionId === contributionId,
+      );
+    if (!itemResult) continue;
+
+    const { error: updateError } = await input.supabaseAdmin
+      .from("contribution_operation_batch_items")
+      .update({
+        status: itemResult.status,
+        skip_reason: itemResult.skipReason ?? null,
+        error_message: itemResult.failureReason ?? null,
+        operation_audit_event_id: itemResult.auditEventId ?? null,
+        task_id: itemResult.taskId ?? null,
+        result: itemResult,
+        processed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("tenant_id", input.tenantId)
+      .eq("id", id);
+    if (updateError) {
+      throw new Error(updateError.message);
+    }
+  }
+
+  const summary = await readSummaryAfterStaleRecovery({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    batchId: input.batchId,
+  });
+  const finalize = !hasOpenItems(summary);
+  const status = await updateBatchProgress({
+    supabaseAdmin: input.supabaseAdmin,
+    tenantId: input.tenantId,
+    batchId: input.batchId,
+    summary,
+    finalize,
+  });
+
+  return {
+    ...result,
+    status,
+    summary: getPublicSummary(summary),
+  };
+}

--- a/packages/api/src/admin/contribution-batches/results.ts
+++ b/packages/api/src/admin/contribution-batches/results.ts
@@ -1,0 +1,81 @@
+import type {
+  ContributionBatchItemResult,
+  ContributionBatchStatus,
+} from "./types";
+
+function csvEscape(value: unknown): string {
+  const stringValue = value == null ? "" : String(value);
+  return /[",\n]/.test(stringValue)
+    ? `"${stringValue.replaceAll('"', '""')}"`
+    : stringValue;
+}
+
+export function summarizeContributionBatchResults(
+  results: Array<Pick<ContributionBatchItemResult, "status" | "taskId">>,
+) {
+  const processed = results.length;
+  const succeeded = results.filter(
+    (result) => result.status === "succeeded",
+  ).length;
+  const skipped = results.filter(
+    (result) => result.status === "skipped",
+  ).length;
+  const failed = results.filter((result) => result.status === "failed").length;
+  const followUpTasksCreated = results.filter((result) => result.taskId).length;
+  let status: ContributionBatchStatus = "complete";
+
+  if (failed > 0 || skipped > 0) {
+    status = "complete_with_issues";
+  }
+  if (processed > 0 && succeeded === 0 && failed > 0 && skipped === 0) {
+    status = "failed";
+  }
+
+  return {
+    status,
+    processed,
+    succeeded,
+    skipped,
+    failed,
+    followUpTasksCreated,
+  };
+}
+
+export function buildContributionBatchCsv(
+  results: ContributionBatchItemResult[],
+): string {
+  const headers = [
+    "contributionId",
+    "donorName",
+    "donorEmail",
+    "amount",
+    "currency",
+    "action",
+    "status",
+    "skipReason",
+    "failureReason",
+    "auditEventId",
+    "taskId",
+    "timestamp",
+  ];
+  const rows = results.map((result) =>
+    [
+      result.contributionId,
+      result.donorName,
+      result.donorEmail,
+      result.amount,
+      result.currency,
+      result.action,
+      result.status,
+      result.skipReason,
+      result.failureReason,
+      result.auditEventId,
+      result.taskId,
+      result.timestamp,
+    ]
+      .map(csvEscape)
+      .join(","),
+  );
+
+  return [headers.join(","), ...rows].join("\n");
+}

--- a/packages/api/src/admin/contribution-batches/route.ts
+++ b/packages/api/src/admin/contribution-batches/route.ts
@@ -1,0 +1,397 @@
+import { createHash } from "node:crypto";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getBulkContributionActionPolicy } from "./action-catalog";
+import { chooseContributionBatchExecutionMode } from "./preview";
+import {
+  markContributionBatchFailed,
+  processContributionBatch,
+  processPersistedContributionBatch,
+} from "./process-batch";
+import {
+  ApiHttpError,
+  ensureJsonBody,
+  toErrorResponse,
+} from "../../shared/http-errors";
+import {
+  withOperation,
+  type OperationRouteContext,
+} from "../../shared/with-operation";
+import { executeContributionAction } from "../contribution-operations/actions";
+import { createContributionActionDependencies } from "../contribution-operations/dependencies";
+import {
+  assertContributionActionPermission,
+  hasContributionPermission,
+  resolveContributionCapabilities,
+} from "../contribution-operations/permissions";
+import { createMissionControlTaskInSupabase } from "../mission-control-tasks/store";
+
+const batchRecordSchema = z.object({
+  id: z.string().uuid(),
+  stagedGiftId: z.string().uuid().nullable().optional(),
+  receiptStatus: z.string().nullable().optional(),
+  payload: z.record(z.string(), z.unknown()).optional().default({}),
+});
+
+const previewSnapshotSchema = z
+  .object({
+    previewId: z.string().trim().min(1),
+    totalCount: z.number().int().positive(),
+    selectionHash: z.string().trim().min(1),
+  })
+  .passthrough();
+
+export const batchRequestSchema = z
+  .object({
+    actionType: z.enum([
+      "resend_receipt",
+      "crm_repost",
+      "refund",
+      "donor_relink",
+      "amount_correction",
+      "designation_correction",
+      "fund_correction",
+      "allocation_correction",
+      "payment_state_correction",
+      "stripe_replay",
+    ]),
+    confirmationToken: z.string().min(1),
+    reason: z.string().trim().min(1).optional(),
+    previewSnapshot: previewSnapshotSchema.optional(),
+    records: z.array(batchRecordSchema).min(1).max(1000),
+  })
+  .superRefine((body, ctx) => {
+    const seenRecordIds = new Set<string>();
+
+    for (const [index, record] of body.records.entries()) {
+      if (seenRecordIds.has(record.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["records", index, "id"],
+          message: "Duplicate contribution id in batch request.",
+        });
+        continue;
+      }
+
+      seenRecordIds.add(record.id);
+    }
+  });
+
+type BatchRequestBody = z.infer<typeof batchRequestSchema>;
+
+function normalizeSelectionValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeSelectionValue(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, normalizeSelectionValue(item)]),
+    );
+  }
+
+  return value;
+}
+
+export function createContributionBatchSelectionHash(input: {
+  actionType: BatchRequestBody["actionType"];
+  records: BatchRequestBody["records"];
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        actionType: input.actionType,
+        records: input.records.map((record) => ({
+          id: record.id,
+          stagedGiftId: record.stagedGiftId ?? null,
+          payload: normalizeSelectionValue(record.payload ?? {}),
+        })),
+      }),
+    )
+    .digest("hex");
+}
+
+export function assertPreviewSnapshotMatchesBatchSelection(input: {
+  actionType: BatchRequestBody["actionType"];
+  previewSnapshot: BatchRequestBody["previewSnapshot"] | undefined;
+  records: BatchRequestBody["records"];
+}) {
+  if (!input.previewSnapshot) {
+    throw new ApiHttpError(
+      400,
+      "High-risk bulk contribution actions require a preview snapshot.",
+    );
+  }
+
+  if (input.previewSnapshot.totalCount !== input.records.length) {
+    throw new ApiHttpError(
+      400,
+      "Preview snapshot does not match the selected contribution count.",
+    );
+  }
+
+  const expectedHash = createContributionBatchSelectionHash({
+    actionType: input.actionType,
+    records: input.records,
+  });
+  if (input.previewSnapshot.selectionHash !== expectedHash) {
+    throw new ApiHttpError(
+      400,
+      "Preview snapshot does not match the selected contributions.",
+    );
+  }
+}
+
+async function getBatchIdFromRouteContext(
+  routeContext: OperationRouteContext | undefined,
+) {
+  const params = await routeContext?.params;
+  const batchId = params?.batchId;
+  if (Array.isArray(batchId)) {
+    return batchId[0] ?? null;
+  }
+
+  return typeof batchId === "string" && batchId.length > 0 ? batchId : null;
+}
+
+export const POST = withOperation(
+  async ({ auth, request, requestId, supabaseAdmin }) => {
+    try {
+      const body = batchRequestSchema.parse(await ensureJsonBody(request));
+      const executionMode = chooseContributionBatchExecutionMode({
+        actionType: body.actionType,
+        selectedCount: body.records.length,
+      });
+      const bulkPolicy = getBulkContributionActionPolicy(body.actionType);
+      assertContributionActionPermission(auth, body.actionType);
+      const actorPermissions = hasContributionPermission(
+        auth,
+        "finance:manage_contributions",
+      )
+        ? (["finance:manage_contributions"] as const)
+        : [];
+      const actorCapabilities = resolveContributionCapabilities(auth);
+
+      if (bulkPolicy.riskLevel === "high" && !body.reason) {
+        throw new ApiHttpError(
+          400,
+          "High-risk bulk contribution actions require a reason.",
+        );
+      }
+      if (bulkPolicy.riskLevel === "high") {
+        assertPreviewSnapshotMatchesBatchSelection({
+          actionType: body.actionType,
+          previewSnapshot: body.previewSnapshot,
+          records: body.records,
+        });
+      }
+
+      if (executionMode === "background") {
+        const { data, error } = await supabaseAdmin
+          .from("contribution_operation_batches")
+          .insert({
+            tenant_id: auth.tenantId,
+            operation: body.actionType,
+            risk_level: bulkPolicy.riskLevel,
+            source_surface: "bulk_action",
+            status: "running",
+            execution_mode: "background",
+            total_count: body.records.length,
+            reason: body.reason ?? null,
+            selection_snapshot: {
+              records: body.records,
+            },
+            preview_snapshot: body.previewSnapshot ?? {},
+            confirmation_snapshot: {
+              confirmationToken: body.confirmationToken,
+            },
+            created_by_profile_id: auth.profileId,
+            started_at: new Date().toISOString(),
+          })
+          .select("id")
+          .single();
+        if (error) throw new Error(error.message);
+        const batchId = (data as { id?: string } | null)?.id ?? null;
+
+        if (batchId) {
+          const { error: itemError } = await supabaseAdmin
+            .from("contribution_operation_batch_items")
+            .insert(
+              body.records.map((record, index) => ({
+                batch_id: batchId,
+                tenant_id: auth.tenantId,
+                record_index: index,
+                resource_type: "donation",
+                resource_id: record.id,
+                donation_id: record.id,
+                staged_gift_id: record.stagedGiftId ?? null,
+                payload: record.payload ?? {},
+                status: "pending",
+                result: {},
+              })),
+            );
+          if (itemError) {
+            // The batch row already exists as `running`; without this it
+            // would be stranded there forever after the item insert failed.
+            await markContributionBatchFailed({
+              supabaseAdmin,
+              tenantId: auth.tenantId,
+              batchId,
+            });
+            throw new Error(itemError.message);
+          }
+        }
+
+        return NextResponse.json({
+          batch: {
+            id: batchId,
+            status: "running",
+            executionMode,
+            summary: {
+              processed: 0,
+              succeeded: 0,
+              skipped: 0,
+              failed: 0,
+              followUpTasksCreated: 0,
+            },
+          },
+          nextAction: batchId
+            ? {
+                method: "POST",
+                href: `/api/admin/contribution-batches/${batchId}/process`,
+              }
+            : null,
+          requestId,
+        });
+      }
+
+      const contributionActionDependencies =
+        createContributionActionDependencies(supabaseAdmin);
+      const batch = await processContributionBatch({
+        tenantId: auth.tenantId,
+        actorProfileId: auth.profileId,
+        actionType: body.actionType,
+        sourceSurface: "bulk_action",
+        reason: body.reason ?? null,
+        confirmationToken: body.confirmationToken,
+        actorPermissions: [...actorPermissions],
+        actorCapabilities,
+        records: body.records.map((record) => ({
+          id: record.id,
+          receiptStatus: record.receiptStatus,
+          stagedGiftId: record.stagedGiftId ?? null,
+          payload: record.payload ?? {},
+        })),
+        executeContributionAction: (actionInput) =>
+          executeContributionAction({
+            ...actionInput,
+            actorPermissions: actionInput.actorPermissions ?? [],
+            actorCapabilities: actionInput.actorCapabilities,
+            confirmationToken: body.confirmationToken,
+            reason: body.reason ?? actionInput.reason,
+            dependencies: contributionActionDependencies,
+          }),
+        createFollowUpTask: async ({ contributionId, reason }) => {
+          const result = await createMissionControlTaskInSupabase({
+            supabaseAdmin,
+            tenantId: auth.tenantId,
+            title: "Resolve bulk contribution action failure",
+            description: reason,
+            issueType:
+              body.actionType === "resend_receipt"
+                ? "receipt_failed"
+                : "provider_failed",
+            actorProfileId: auth.profileId,
+            linkedRecords: [
+              {
+                type: "contribution",
+                id: contributionId,
+              },
+            ],
+          });
+
+          return result.taskId;
+        },
+      });
+
+      return NextResponse.json({ batch, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to process contribution batch.",
+        requestId,
+      );
+    }
+  },
+  { roles: ["staff", "admin", "super_admin"] },
+);
+
+export const POST_PROCESS_BATCH = withOperation(
+  async ({ auth, requestId, routeContext, supabaseAdmin }) => {
+    try {
+      const batchId = await getBatchIdFromRouteContext(routeContext);
+      if (!batchId) {
+        throw new ApiHttpError(400, "Missing batch id.");
+      }
+
+      const batch = await processPersistedContributionBatch({
+        supabaseAdmin,
+        tenantId: auth.tenantId,
+        batchId,
+        actorProfileId: auth.profileId,
+        actorPermissions: hasContributionPermission(
+          auth,
+          "finance:manage_contributions",
+        )
+          ? ["finance:manage_contributions"]
+          : [],
+        actorCapabilities: resolveContributionCapabilities(auth),
+        assertActionPermission: (actionType) =>
+          assertContributionActionPermission(auth, actionType),
+        executeContributionAction: (actionInput) =>
+          executeContributionAction({
+            ...actionInput,
+            actorPermissions: actionInput.actorPermissions ?? [],
+            actorCapabilities: actionInput.actorCapabilities,
+            confirmationToken: actionInput.confirmationToken,
+            reason: actionInput.reason,
+            dependencies: createContributionActionDependencies(supabaseAdmin),
+          }),
+        createFollowUpTask: async ({ contributionId, reason, actionType }) => {
+          const result = await createMissionControlTaskInSupabase({
+            supabaseAdmin,
+            tenantId: auth.tenantId,
+            title: "Resolve bulk contribution action failure",
+            description: reason,
+            issueType:
+              actionType === "resend_receipt"
+                ? "receipt_failed"
+                : "provider_failed",
+            actorProfileId: auth.profileId,
+            linkedRecords: [
+              {
+                type: "contribution",
+                id: contributionId,
+              },
+            ],
+          });
+
+          return result.taskId;
+        },
+      });
+
+      return NextResponse.json({ batch, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to process contribution batch.",
+        requestId,
+      );
+    }
+  },
+  { roles: ["staff", "admin", "super_admin"] },
+);

--- a/packages/api/src/admin/contribution-batches/types.ts
+++ b/packages/api/src/admin/contribution-batches/types.ts
@@ -1,0 +1,84 @@
+import type {
+  ContributionActionType,
+  ContributionSourceSurface,
+} from "../contribution-operations/types";
+
+export type ContributionBatchRiskLevel = "low" | "high";
+export type ContributionBatchExecutionMode = "immediate" | "background";
+export type ContributionBatchStatus =
+  | "running"
+  | "complete"
+  | "complete_with_issues"
+  | "failed"
+  | "cancelled";
+export type ContributionBatchItemStatus = "succeeded" | "skipped" | "failed";
+
+export interface ContributionBatchRecord {
+  batchItemId?: string;
+  id: string;
+  stagedGiftId: string | null;
+  receiptStatus?: string | null;
+  payload?: Record<string, unknown>;
+}
+
+export interface ContributionBatchAffectedRecord {
+  batchItemId?: string;
+  contributionId: string;
+  stagedGiftId: string | null;
+  proposedAction: ContributionActionType;
+  payload?: Record<string, unknown>;
+}
+
+export interface ContributionBatchSkippedRecord {
+  batchItemId?: string;
+  contributionId: string;
+  reason: string;
+}
+
+export interface ContributionBatchItemResult {
+  batchItemId?: string;
+  contributionId?: string;
+  donorName?: string;
+  donorEmail?: string;
+  amount?: number;
+  currency?: string;
+  action?: ContributionActionType;
+  status: ContributionBatchItemStatus;
+  skipReason?: string | null;
+  failureReason?: string | null;
+  auditEventId?: string | null;
+  taskId?: string | null;
+  timestamp?: string;
+}
+
+export interface ProcessContributionBatchInput {
+  tenantId: string;
+  actorProfileId: string | null;
+  actionType: ContributionActionType;
+  sourceSurface: ContributionSourceSurface;
+  records: ContributionBatchRecord[];
+  reason?: string | null;
+  confirmationToken?: string | null;
+  actorPermissions?: Array<"finance:manage_contributions">;
+  actorCapabilities?: string[];
+  executeContributionAction: (input: {
+    tenantId: string;
+    actorProfileId: string | null;
+    actorCapabilities?: string[];
+    sourceSurface: ContributionSourceSurface;
+    contributionId: string;
+    stagedGiftId?: string | null;
+    actionType: ContributionActionType;
+    reason?: string | null;
+    confirmationToken?: string | null;
+    actorPermissions?: Array<"finance:manage_contributions">;
+    payload: Record<string, unknown>;
+  }) => Promise<{ auditEventId?: string | null; taskIds?: string[] }>;
+  createFollowUpTask?: (input: {
+    tenantId: string;
+    actorProfileId: string | null;
+    contributionId: string;
+    actionType: ContributionActionType;
+    reason: string;
+  }) => Promise<string>;
+}

--- a/packages/api/src/shared/with-operation.ts
+++ b/packages/api/src/shared/with-operation.ts
@@ -18,12 +18,17 @@ type AdminSupabaseClient = Exclude<
   null
 >;
 
+export interface OperationRouteContext {
+  params?: Promise<Record<string, string | string[] | undefined>>;
+}
+
 export interface OperationContext {
   supabaseAdmin: AdminSupabaseClient;
   auth: AuthenticatedContext;
   audit: ReturnType<typeof createAuditLogger>;
   request: NextRequest;
   requestId: string;
+  routeContext?: OperationRouteContext;
 }
 
 export interface OperationOptions {
@@ -107,8 +112,14 @@ async function normalizeHandlerErrorResponse(
 export function withOperation(
   handler: (ctx: OperationContext) => Promise<NextResponse>,
   options?: OperationOptions,
-): (request: NextRequest) => Promise<NextResponse> {
-  return async function operationHandler(request: NextRequest) {
+): (
+  request: NextRequest,
+  routeContext?: OperationRouteContext,
+) => Promise<NextResponse> {
+  return async function operationHandler(
+    request: NextRequest,
+    routeContext?: OperationRouteContext,
+  ) {
     const requestId = crypto.randomUUID();
 
     try {
@@ -142,6 +153,7 @@ export function withOperation(
         audit,
         request,
         requestId,
+        routeContext,
       });
 
       return normalizeHandlerErrorResponse(response, requestId);

--- a/supabase/migrations/20260526202500_contribution_operation_batches.sql
+++ b/supabase/migrations/20260526202500_contribution_operation_batches.sql
@@ -1,0 +1,71 @@
+-- Bulk Contribution Actions and Batch Results.
+
+CREATE TABLE IF NOT EXISTS public.contribution_operation_batches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    operation TEXT NOT NULL,
+    risk_level TEXT NOT NULL DEFAULT 'low' CHECK (risk_level IN ('low', 'high')),
+    source_surface TEXT NOT NULL DEFAULT 'contribution_hub',
+    selection_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    preview_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    preview_skipped BOOLEAN NOT NULL DEFAULT FALSE,
+    confirmation_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    reason TEXT,
+    status TEXT NOT NULL DEFAULT 'running'
+        CHECK (status IN ('running', 'complete', 'complete_with_issues', 'failed', 'cancelled')),
+    execution_mode TEXT NOT NULL DEFAULT 'immediate'
+        CHECK (execution_mode IN ('immediate', 'background')),
+    total_count INTEGER NOT NULL DEFAULT 0,
+    processed_count INTEGER NOT NULL DEFAULT 0,
+    succeeded_count INTEGER NOT NULL DEFAULT 0,
+    skipped_count INTEGER NOT NULL DEFAULT 0,
+    failed_count INTEGER NOT NULL DEFAULT 0,
+    follow_up_task_count INTEGER NOT NULL DEFAULT 0,
+    created_by_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    activity_audit_event_id UUID REFERENCES public.contribution_operation_audit_events(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    finished_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS public.contribution_operation_batch_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES public.contribution_operation_batches(id) ON DELETE CASCADE,
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    record_index INTEGER NOT NULL DEFAULT 0,
+    resource_type TEXT NOT NULL DEFAULT 'donation',
+    resource_id UUID,
+    donation_id UUID REFERENCES public.donations(id) ON DELETE SET NULL,
+    staged_gift_id UUID REFERENCES public.staged_gifts(id) ON DELETE SET NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'running', 'succeeded', 'skipped', 'failed')),
+    skip_reason TEXT,
+    error_code TEXT,
+    error_message TEXT,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    result JSONB NOT NULL DEFAULT '{}'::jsonb,
+    operation_audit_event_id UUID REFERENCES public.contribution_operation_audit_events(id) ON DELETE SET NULL,
+    task_id UUID REFERENCES public.mission_control_tasks(id) ON DELETE SET NULL,
+    processed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_batches_tenant_status
+    ON public.contribution_operation_batches (tenant_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_batch_items_batch
+    ON public.contribution_operation_batch_items (batch_id, record_index);
+
+CREATE INDEX IF NOT EXISTS idx_contribution_batch_items_batch_status
+    ON public.contribution_operation_batch_items (tenant_id, batch_id, status, record_index);
+
+ALTER TABLE public.contribution_operation_batches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contribution_operation_batch_items ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.contribution_operation_batches FROM anon, authenticated;
+REVOKE ALL ON TABLE public.contribution_operation_batch_items FROM anon, authenticated;
+
+GRANT ALL ON TABLE public.contribution_operation_batches TO service_role;
+GRANT ALL ON TABLE public.contribution_operation_batch_items TO service_role;

--- a/tests/unit/packages/api/admin/contribution-batches.test.ts
+++ b/tests/unit/packages/api/admin/contribution-batches.test.ts
@@ -1,0 +1,1752 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getBulkContributionActionPolicy,
+  isBulkPreviewSkippable,
+} from "../../../../../packages/api/src/admin/contribution-batches/action-catalog";
+import {
+  chooseContributionBatchExecutionMode,
+  createContributionBatchPreview,
+} from "../../../../../packages/api/src/admin/contribution-batches/preview";
+import {
+  buildContributionBatchCsv,
+  summarizeContributionBatchResults,
+} from "../../../../../packages/api/src/admin/contribution-batches/results";
+import {
+  markContributionBatchFailed,
+  processContributionBatch,
+  processPersistedContributionBatch,
+} from "../../../../../packages/api/src/admin/contribution-batches/process-batch";
+
+describe("bulk contribution action catalog", () => {
+  it("allows preview skipping only for configured low-risk actions", () => {
+    expect(isBulkPreviewSkippable("resend_receipt")).toBe(true);
+    expect(isBulkPreviewSkippable("crm_repost")).toBe(true);
+    expect(isBulkPreviewSkippable("refund")).toBe(false);
+    expect(isBulkPreviewSkippable("amount_correction")).toBe(false);
+  });
+
+  it("requires preview and background execution for high-risk actions", () => {
+    expect(getBulkContributionActionPolicy("refund")).toEqual(
+      expect.objectContaining({
+        riskLevel: "high",
+        requiresConfirmation: true,
+        requiresPreview: true,
+        backgroundRequired: true,
+      }),
+    );
+    expect(getBulkContributionActionPolicy("allocation_correction")).toEqual(
+      expect.objectContaining({
+        riskLevel: "high",
+        requiresPreview: true,
+        backgroundRequired: true,
+      }),
+    );
+    expect(getBulkContributionActionPolicy("crm_repost")).toEqual(
+      expect.objectContaining({
+        riskLevel: "low",
+        requiresPreview: false,
+      }),
+    );
+  });
+});
+
+describe("bulk contribution preview and execution", () => {
+  it("runs small low-risk batches immediately and large batches in background", () => {
+    expect(
+      chooseContributionBatchExecutionMode({
+        actionType: "resend_receipt",
+        selectedCount: 10,
+      }),
+    ).toBe("immediate");
+
+    expect(
+      chooseContributionBatchExecutionMode({
+        actionType: "resend_receipt",
+        selectedCount: 11,
+      }),
+    ).toBe("background");
+
+    expect(
+      chooseContributionBatchExecutionMode({
+        actionType: "refund",
+        selectedCount: 2,
+      }),
+    ).toBe("background");
+  });
+
+  it("uses the same planner for affected and skipped records", () => {
+    const preview = createContributionBatchPreview({
+      actionType: "resend_receipt",
+      records: [
+        {
+          id: "donation_1",
+          stagedGiftId: "staged_1",
+          receiptStatus: "pending",
+        },
+        { id: "donation_2", stagedGiftId: null, receiptStatus: "pending" },
+      ],
+    });
+
+    expect(preview.affectedRecords).toEqual([
+      expect.objectContaining({ contributionId: "donation_1" }),
+    ]);
+    expect(preview.skippedRecords).toEqual([
+      {
+        contributionId: "donation_2",
+        reason: "Missing staged gift id.",
+      },
+    ]);
+    expect(preview.totalCount).toBe(2);
+  });
+
+  it("calls the shared contribution action executor for each executable item", async () => {
+    const executeContributionAction = vi
+      .fn()
+      .mockResolvedValueOnce({ auditEventId: "audit_1", taskIds: [] })
+      .mockRejectedValueOnce(new Error("Receipt failed"));
+
+    const result = await processContributionBatch({
+      tenantId: "tenant_1",
+      actorProfileId: "actor_1",
+      actionType: "resend_receipt",
+      sourceSurface: "contribution_hub",
+      records: [
+        {
+          id: "donation_1",
+          stagedGiftId: "staged_1",
+          receiptStatus: "pending",
+        },
+        {
+          id: "donation_2",
+          stagedGiftId: "staged_2",
+          receiptStatus: "pending",
+        },
+      ],
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe("complete_with_issues");
+    expect(result.summary).toEqual({
+      processed: 2,
+      succeeded: 1,
+      skipped: 0,
+      failed: 1,
+      followUpTasksCreated: 0,
+    });
+  });
+
+  it("passes per-record payload through for immediate high-risk records", async () => {
+    const executeContributionAction = vi
+      .fn()
+      .mockResolvedValue({ auditEventId: "audit_1", taskIds: [] });
+
+    const result = await processContributionBatch({
+      tenantId: "tenant_1",
+      actorProfileId: "actor_1",
+      actionType: "refund",
+      sourceSurface: "contribution_hub",
+      reason: "Bulk refund review",
+      confirmationToken: "confirm",
+      actorPermissions: ["finance:manage_contributions"],
+      actorCapabilities: ["contributions.run_refunds"],
+      records: [
+        {
+          id: "donation_1",
+          stagedGiftId: null,
+          payload: { amount: 2500 },
+        },
+      ],
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "refund",
+        contributionId: "donation_1",
+        reason: "Bulk refund review",
+        confirmationToken: "confirm",
+        actorPermissions: ["finance:manage_contributions"],
+        actorCapabilities: ["contributions.run_refunds"],
+        payload: { amount: 2500 },
+      }),
+    );
+    expect(result.status).toBe("complete");
+  });
+
+  it("skips destructive corrections when required payload is missing", async () => {
+    const executeContributionAction = vi.fn();
+
+    const result = await processContributionBatch({
+      tenantId: "tenant_1",
+      actorProfileId: "actor_1",
+      actionType: "fund_correction",
+      sourceSurface: "contribution_hub",
+      reason: "Correct designation",
+      confirmationToken: "confirm",
+      actorPermissions: ["finance:manage_contributions"],
+      records: [{ id: "donation_1", stagedGiftId: null, payload: {} }],
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).not.toHaveBeenCalled();
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        contributionId: "donation_1",
+        status: "skipped",
+        skipReason: "Missing payload.fundId for fund correction.",
+      }),
+    );
+    expect(result.summary).toEqual(
+      expect.objectContaining({ processed: 1, skipped: 1, succeeded: 0 }),
+    );
+  });
+
+  it("preserves explicit correction payload for executable records", async () => {
+    const executeContributionAction = vi
+      .fn()
+      .mockResolvedValue({ auditEventId: "audit_1", taskIds: [] });
+
+    await processContributionBatch({
+      tenantId: "tenant_1",
+      actorProfileId: "actor_1",
+      actionType: "fund_correction",
+      sourceSurface: "contribution_hub",
+      reason: "Correct designation",
+      confirmationToken: "confirm",
+      actorPermissions: ["finance:manage_contributions"],
+      records: [
+        {
+          id: "donation_1",
+          stagedGiftId: null,
+          payload: { fundId: "fund_1" },
+        },
+      ],
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionType: "fund_correction",
+        contributionId: "donation_1",
+        payload: { fundId: "fund_1" },
+      }),
+    );
+  });
+
+  it("creates follow-up tasks for important failed records", async () => {
+    const executeContributionAction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Stripe failed"));
+    const createFollowUpTask = vi.fn().mockResolvedValue("task_1");
+
+    const result = await processContributionBatch({
+      tenantId: "tenant_1",
+      actorProfileId: "actor_1",
+      actionType: "refund",
+      sourceSurface: "contribution_hub",
+      records: [
+        {
+          id: "donation_1",
+          stagedGiftId: "staged_1",
+          receiptStatus: "sent",
+          payload: { amount: 2500 },
+        },
+      ],
+      executeContributionAction,
+      createFollowUpTask,
+    });
+
+    expect(createFollowUpTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contributionId: "donation_1",
+        reason: "Stripe failed",
+      }),
+    );
+    expect(result.summary.followUpTasksCreated).toBe(1);
+    expect(result.results[0]?.taskId).toBe("task_1");
+  });
+
+  it("accepts high-risk and large background route inputs", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://127.0.0.1:54321";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+    const { batchRequestSchema, createContributionBatchSelectionHash } =
+      await import("../../../../../packages/api/src/admin/contribution-batches/route");
+    const records = [
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        stagedGiftId: null,
+        payload: { amount: 2500 },
+      },
+    ];
+
+    const parsed = batchRequestSchema.parse({
+      actionType: "refund",
+      confirmationToken: "confirm",
+      reason: "Bulk refund review",
+      previewSnapshot: {
+        previewId: "preview_1",
+        totalCount: records.length,
+        selectionHash: createContributionBatchSelectionHash({
+          actionType: "refund",
+          records,
+        }),
+      },
+      records,
+    });
+
+    expect(parsed.records[0]?.payload).toEqual({ amount: 2500 });
+  });
+
+  it("rejects duplicate contribution ids in a batch request", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://127.0.0.1:54321";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+    const { batchRequestSchema, createContributionBatchSelectionHash } =
+      await import("../../../../../packages/api/src/admin/contribution-batches/route");
+    const records = [
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        stagedGiftId: null,
+        payload: { amount: 2500 },
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        stagedGiftId: null,
+        payload: { amount: 5000 },
+      },
+    ];
+
+    expect(() =>
+      batchRequestSchema.parse({
+        actionType: "refund",
+        confirmationToken: "confirm",
+        reason: "Bulk refund review",
+        previewSnapshot: {
+          previewId: "preview_1",
+          totalCount: records.length,
+          selectionHash: createContributionBatchSelectionHash({
+            actionType: "refund",
+            records,
+          }),
+        },
+        records,
+      }),
+    ).toThrow("Duplicate contribution id in batch request.");
+  });
+
+  it("rejects mismatched high-risk preview snapshots", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://127.0.0.1:54321";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+    const {
+      assertPreviewSnapshotMatchesBatchSelection,
+      createContributionBatchSelectionHash,
+    } =
+      await import("../../../../../packages/api/src/admin/contribution-batches/route");
+    const records = [
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        stagedGiftId: null,
+        payload: { amount: 2500 },
+      },
+    ];
+
+    expect(() =>
+      assertPreviewSnapshotMatchesBatchSelection({
+        actionType: "refund",
+        previewSnapshot: {
+          previewId: "preview_1",
+          totalCount: records.length,
+          selectionHash: "wrong-hash",
+        },
+        records,
+      }),
+    ).toThrow("Preview snapshot does not match the selected contributions.");
+
+    const originalSelectionHash = createContributionBatchSelectionHash({
+      actionType: "refund",
+      records,
+    });
+    expect(() =>
+      assertPreviewSnapshotMatchesBatchSelection({
+        actionType: "refund",
+        previewSnapshot: {
+          previewId: "preview_1",
+          totalCount: records.length,
+          selectionHash: originalSelectionHash,
+        },
+        records: [
+          {
+            ...records[0]!,
+            payload: { amount: 5000 },
+          },
+        ],
+      }),
+    ).toThrow("Preview snapshot does not match the selected contributions.");
+  });
+
+  it("executes persisted batches with stored reason and confirmation", async () => {
+    const itemUpdates: Array<Record<string, unknown>> = [];
+    const batchUpdates: Array<Record<string, unknown>> = [];
+    const supabaseAdmin = {
+      from(table: string) {
+        let itemSelectMode: "claim" | "claim-update" | "summary" = "summary";
+        let activeItemUpdate: Record<string, unknown> | null = null;
+        const builder = {
+          select(columns?: string) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns?.includes("donation_id")
+            ) {
+              itemSelectMode = "claim";
+            }
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns === "id" &&
+              activeItemUpdate?.status === "running"
+            ) {
+              itemSelectMode = "claim-update";
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          order() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batch_items") {
+              itemUpdates.push(payload);
+              activeItemUpdate = payload;
+            } else {
+              batchUpdates.push(payload);
+            }
+            return builder;
+          },
+          limit() {
+            return Promise.resolve({
+              data: [
+                {
+                  id: "item_1",
+                  donation_id: "donation_1",
+                  staged_gift_id: "staged_1",
+                  payload: { amount: 2500 },
+                },
+              ],
+              error: null,
+            }) as never;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              data?: Array<Record<string, unknown>>;
+              error: null;
+            }) => TResult,
+          ): Promise<TResult> {
+            const value =
+              table === "contribution_operation_batch_items" &&
+              itemSelectMode === "summary"
+                ? {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "succeeded",
+                        task_id: "task_1",
+                        updated_at: new Date().toISOString(),
+                      },
+                    ],
+                    error: null,
+                  }
+                : table === "contribution_operation_batch_items" &&
+                    itemSelectMode === "claim-update"
+                  ? {
+                      data: [{ id: "item_1" }],
+                      error: null,
+                    }
+                  : { error: null };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+    const executeContributionAction = vi.fn().mockResolvedValue({
+      auditEventId: "audit_1",
+      taskIds: ["task_1"],
+    });
+
+    await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      actorPermissions: ["finance:manage_contributions"],
+      actorCapabilities: ["contributions.run_refunds"],
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "bulk refund",
+        confirmationToken: "confirm_1",
+        actorPermissions: ["finance:manage_contributions"],
+        actorCapabilities: ["contributions.run_refunds"],
+        sourceSurface: "bulk_action",
+        payload: { amount: 2500 },
+      }),
+    );
+    expect(itemUpdates).toContainEqual(
+      expect.objectContaining({
+        status: "succeeded",
+        operation_audit_event_id: "audit_1",
+        task_id: "task_1",
+      }),
+    );
+    expect(batchUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "complete",
+        processed_count: 1,
+        succeeded_count: 1,
+      }),
+    );
+  });
+
+  it("selects a bounded candidate set before claiming persisted batch items", async () => {
+    const pendingRows = [
+      {
+        id: "item_1",
+        donation_id: "donation_1",
+        staged_gift_id: "staged_1",
+        payload: { amount: 1000 },
+      },
+      {
+        id: "item_2",
+        donation_id: "donation_2",
+        staged_gift_id: "staged_2",
+        payload: { amount: 2000 },
+      },
+      {
+        id: "item_3",
+        donation_id: "donation_3",
+        staged_gift_id: "staged_3",
+        payload: { amount: 3000 },
+      },
+    ];
+    let requestedLimit: number | null = null;
+    let claimedIds: string[] = [];
+
+    const supabaseAdmin = {
+      from(table: string) {
+        let itemSelectMode: "claim" | "claim-update" | "summary" = "summary";
+        let activeItemUpdate: Record<string, unknown> | null = null;
+        const builder = {
+          select(columns?: string) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns?.includes("donation_id")
+            ) {
+              itemSelectMode = "claim";
+            }
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns === "id" &&
+              activeItemUpdate?.status === "running"
+            ) {
+              itemSelectMode = "claim-update";
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in(column: string, values: string[]) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              column === "id"
+            ) {
+              claimedIds = [...values];
+            }
+            return builder;
+          },
+          order() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batch_items") {
+              activeItemUpdate = payload;
+            }
+            return builder;
+          },
+          limit(limit: number) {
+            requestedLimit = limit;
+            return Promise.resolve({
+              data: pendingRows.slice(0, limit),
+              error: null,
+            }) as never;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              data?: Array<Record<string, unknown>>;
+              error: null;
+            }) => TResult,
+          ): Promise<TResult> {
+            const value =
+              table === "contribution_operation_batch_items" &&
+              itemSelectMode === "claim-update"
+                ? {
+                    data: claimedIds.map((id) => ({ id })),
+                    error: null,
+                  }
+                : table === "contribution_operation_batch_items" &&
+                    itemSelectMode === "summary"
+                  ? {
+                      data: [
+                        {
+                          id: "item_1",
+                          status: "succeeded",
+                          task_id: null,
+                          updated_at: new Date().toISOString(),
+                        },
+                        {
+                          id: "item_2",
+                          status: "succeeded",
+                          task_id: null,
+                          updated_at: new Date().toISOString(),
+                        },
+                        {
+                          id: "item_3",
+                          status: "pending",
+                          task_id: null,
+                          updated_at: new Date().toISOString(),
+                        },
+                      ],
+                      error: null,
+                    }
+                  : { error: null };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+    const executeContributionAction = vi.fn().mockResolvedValue({
+      auditEventId: "audit_1",
+      taskIds: [],
+    });
+
+    const result = await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      actorCapabilities: ["contributions.run_refunds"],
+      chunkSize: 2,
+      executeContributionAction,
+    });
+
+    expect(requestedLimit).toBe(2);
+    expect(claimedIds).toEqual(["item_1", "item_2"]);
+    expect(executeContributionAction).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe("running");
+    expect(result.summary).toEqual(
+      expect.objectContaining({
+        processed: 2,
+        succeeded: 2,
+      }),
+    );
+  });
+
+  it("updates persisted duplicate contribution rows by batch item id", async () => {
+    const itemUpdates: Array<{
+      id: string;
+      payload: Record<string, unknown>;
+    }> = [];
+    let activeItemUpdate: Record<string, unknown> | null = null;
+
+    const supabaseAdmin = {
+      from(table: string) {
+        let itemSelectMode: "claim" | "claim-update" | "summary" = "summary";
+        const builder = {
+          select(columns?: string) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns?.includes("donation_id")
+            ) {
+              itemSelectMode = "claim";
+            }
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns === "id" &&
+              activeItemUpdate?.status === "running"
+            ) {
+              itemSelectMode = "claim-update";
+            }
+            return builder;
+          },
+          eq(column: string, value: unknown) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              column === "id" &&
+              activeItemUpdate
+            ) {
+              itemUpdates.push({
+                id: String(value),
+                payload: activeItemUpdate,
+              });
+            }
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          order() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batch_items") {
+              activeItemUpdate = payload;
+            }
+            return builder;
+          },
+          limit() {
+            return Promise.resolve({
+              data: [
+                {
+                  id: "item_1",
+                  donation_id: "donation_1",
+                  staged_gift_id: "staged_1",
+                  payload: { amount: 2500 },
+                },
+                {
+                  id: "item_2",
+                  donation_id: "donation_1",
+                  staged_gift_id: "staged_2",
+                  payload: { amount: 5000 },
+                },
+              ],
+              error: null,
+            }) as never;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              data?: Array<Record<string, unknown>>;
+              error: null;
+            }) => TResult,
+          ): Promise<TResult> {
+            const value =
+              table === "contribution_operation_batch_items" &&
+              itemSelectMode === "summary"
+                ? {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "succeeded",
+                        task_id: null,
+                        updated_at: new Date().toISOString(),
+                      },
+                      {
+                        id: "item_2",
+                        status: "failed",
+                        task_id: null,
+                        updated_at: new Date().toISOString(),
+                      },
+                    ],
+                    error: null,
+                  }
+                : table === "contribution_operation_batch_items" &&
+                    itemSelectMode === "claim-update"
+                  ? {
+                      data: [{ id: "item_1" }, { id: "item_2" }],
+                      error: null,
+                    }
+                  : { error: null };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+    const executeContributionAction = vi
+      .fn()
+      .mockResolvedValueOnce({ auditEventId: "audit_1", taskIds: [] })
+      .mockRejectedValueOnce(new Error("second item failed"));
+
+    await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      actorCapabilities: ["contributions.run_refunds"],
+      executeContributionAction,
+    });
+
+    expect(itemUpdates).toEqual([
+      {
+        id: "item_1",
+        payload: expect.objectContaining({
+          status: "succeeded",
+          operation_audit_event_id: "audit_1",
+        }),
+      },
+      {
+        id: "item_2",
+        payload: expect.objectContaining({
+          status: "failed",
+          error_message: "second item failed",
+        }),
+      },
+    ]);
+  });
+
+  it("does not mark successful actions failed when result persistence fails", async () => {
+    const itemUpdates: Array<Record<string, unknown>> = [];
+    let activeItemUpdate: Record<string, unknown> | null = null;
+
+    const supabaseAdmin = {
+      from(table: string) {
+        let itemSelectMode: "claim-update" | "summary" = "summary";
+        const builder = {
+          select(columns?: string) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns === "id" &&
+              activeItemUpdate?.status === "running"
+            ) {
+              itemSelectMode = "claim-update";
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          order() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batch_items") {
+              activeItemUpdate = payload;
+              itemUpdates.push(payload);
+            }
+            return builder;
+          },
+          limit() {
+            return Promise.resolve({
+              data: [
+                {
+                  id: "item_1",
+                  donation_id: "donation_1",
+                  staged_gift_id: "staged_1",
+                  payload: { amount: 2500 },
+                },
+              ],
+              error: null,
+            }) as never;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              error: { message: string } | null;
+            }) => TResult,
+          ): Promise<TResult> {
+            const error =
+              table === "contribution_operation_batch_items" &&
+              activeItemUpdate?.status === "succeeded"
+                ? { message: "result persistence failed" }
+                : null;
+            const value =
+              table === "contribution_operation_batch_items" &&
+              itemSelectMode === "claim-update"
+                ? { data: [{ id: "item_1" }], error: null }
+                : { error };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+    const executeContributionAction = vi.fn().mockResolvedValue({
+      auditEventId: "audit_1",
+      taskIds: [],
+    });
+
+    await expect(
+      processPersistedContributionBatch({
+        supabaseAdmin: supabaseAdmin as never,
+        tenantId: "tenant_1",
+        batchId: "batch_1",
+        actorProfileId: "actor_1",
+        actorCapabilities: ["contributions.run_refunds"],
+        executeContributionAction,
+      }),
+    ).rejects.toThrow("result persistence failed");
+
+    expect(executeContributionAction).toHaveBeenCalledTimes(1);
+    expect(itemUpdates.map((update) => update.status)).toEqual([
+      "running",
+      "succeeded",
+    ]);
+  });
+
+  it("does not rerun already finished persisted batches", async () => {
+    const supabaseAdmin = {
+      from() {
+        const builder = {
+          select() {
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "contribution_hub",
+              status: "complete",
+              processed_count: 3,
+              succeeded_count: 2,
+              skipped_count: 0,
+              failed_count: 1,
+              follow_up_task_count: 1,
+            },
+            error: null,
+          }),
+        };
+        return builder;
+      },
+    };
+    const executeContributionAction = vi.fn();
+
+    const result = await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      actorPermissions: ["finance:manage_contributions"],
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).not.toHaveBeenCalled();
+    expect(result.summary).toEqual({
+      processed: 3,
+      succeeded: 2,
+      skipped: 0,
+      failed: 1,
+      followUpTasksCreated: 1,
+    });
+  });
+
+  it("requires the batch creator to process a persisted background batch", async () => {
+    const executeContributionAction = vi.fn();
+    const supabaseAdmin = {
+      from() {
+        const builder = {
+          select() {
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+              created_by_profile_id: "actor_2",
+            },
+            error: null,
+          }),
+        };
+        return builder;
+      },
+    };
+
+    await expect(
+      processPersistedContributionBatch({
+        supabaseAdmin: supabaseAdmin as never,
+        tenantId: "tenant_1",
+        batchId: "batch_1",
+        actorProfileId: "actor_1",
+        executeContributionAction,
+      }),
+    ).rejects.toThrow(
+      "Only the batch creator can process this contribution batch.",
+    );
+    expect(executeContributionAction).not.toHaveBeenCalled();
+  });
+
+  it("finalizes the batch when no pending rows are claimed", async () => {
+    const batchUpdates: Array<Record<string, unknown>> = [];
+    const supabaseAdmin = {
+      from(table: string) {
+        let itemSelectMode: "claim" | "summary" = "summary";
+        const builder = {
+          select(columns?: string) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns?.includes("donation_id")
+            ) {
+              itemSelectMode = "claim";
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          order() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "contribution_hub",
+              status: "running",
+              processed_count: 1,
+              succeeded_count: 1,
+              skipped_count: 0,
+              failed_count: 0,
+              follow_up_task_count: 0,
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batches") {
+              batchUpdates.push(payload);
+            }
+            return builder;
+          },
+          limit() {
+            return Promise.resolve({ data: [], error: null }) as never;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              data?: Array<Record<string, unknown>>;
+              error: null;
+            }) => TResult,
+          ): Promise<TResult> {
+            const value =
+              table === "contribution_operation_batch_items" &&
+              itemSelectMode === "summary"
+                ? {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "succeeded",
+                        task_id: null,
+                        updated_at: new Date().toISOString(),
+                      },
+                    ],
+                    error: null,
+                  }
+                : { error: null };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+    const executeContributionAction = vi.fn();
+
+    const result = await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      actorPermissions: ["finance:manage_contributions"],
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).not.toHaveBeenCalled();
+    expect(result.status).toBe("complete");
+    expect(result.summary.succeeded).toBe(1);
+    expect(batchUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "complete",
+        finished_at: expect.any(String),
+      }),
+    );
+  });
+
+  it("uses immediate-mode terminal status semantics for persisted finalization", async () => {
+    async function finalizeWithSummaryRows(
+      summaryRows: Array<Record<string, unknown>>,
+    ) {
+      const batchUpdates: Array<Record<string, unknown>> = [];
+      const supabaseAdmin = {
+        from(table: string) {
+          let itemSelectMode: "claim" | "summary" = "summary";
+          const builder = {
+            select(columns?: string) {
+              if (
+                table === "contribution_operation_batch_items" &&
+                columns?.includes("donation_id")
+              ) {
+                itemSelectMode = "claim";
+              }
+              return builder;
+            },
+            eq() {
+              return builder;
+            },
+            order() {
+              return builder;
+            },
+            single: async () => ({
+              data: {
+                id: "batch_1",
+                operation: "refund",
+                source_surface: "contribution_hub",
+                status: "running",
+                reason: "bulk refund",
+                confirmation_snapshot: { confirmationToken: "confirm_1" },
+              },
+              error: null,
+            }),
+            update(payload: Record<string, unknown>) {
+              if (table === "contribution_operation_batches") {
+                batchUpdates.push(payload);
+              }
+              return builder;
+            },
+            limit() {
+              return Promise.resolve({ data: [], error: null }) as never;
+            },
+            then<TResult>(
+              onfulfilled: (value: {
+                data?: Array<Record<string, unknown>>;
+                error: null;
+              }) => TResult,
+            ): Promise<TResult> {
+              const value =
+                table === "contribution_operation_batch_items" &&
+                itemSelectMode === "summary"
+                  ? { data: summaryRows, error: null }
+                  : { error: null };
+              return Promise.resolve(value).then(onfulfilled);
+            },
+          };
+
+          return builder;
+        },
+      };
+
+      const result = await processPersistedContributionBatch({
+        supabaseAdmin: supabaseAdmin as never,
+        tenantId: "tenant_1",
+        batchId: "batch_1",
+        actorProfileId: "actor_1",
+        executeContributionAction: vi.fn(),
+      });
+
+      return { batchUpdates, result };
+    }
+
+    const skipped = await finalizeWithSummaryRows([
+      {
+        id: "item_1",
+        status: "skipped",
+        task_id: null,
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+    expect(skipped.result.status).toBe("complete_with_issues");
+    expect(skipped.batchUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "complete_with_issues",
+        skipped_count: 1,
+      }),
+    );
+
+    const failed = await finalizeWithSummaryRows([
+      {
+        id: "item_1",
+        status: "failed",
+        task_id: null,
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+    expect(failed.result.status).toBe("failed");
+    expect(failed.batchUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        failed_count: 1,
+      }),
+    );
+  });
+
+  it("does not complete the batch while claimed rows are still running", async () => {
+    const batchUpdates: Array<Record<string, unknown>> = [];
+    const supabaseAdmin = {
+      from(table: string) {
+        let itemSelectMode: "claim" | "summary" = "summary";
+        const builder = {
+          select(columns?: string) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns?.includes("donation_id")
+            ) {
+              itemSelectMode = "claim";
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          order() {
+            return builder;
+          },
+          limit() {
+            return Promise.resolve({ data: [], error: null }) as never;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batches") {
+              batchUpdates.push(payload);
+            }
+            return builder;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              data?: Array<Record<string, unknown>>;
+              error: null;
+            }) => TResult,
+          ): Promise<TResult> {
+            const value =
+              table === "contribution_operation_batch_items" &&
+              itemSelectMode === "summary"
+                ? {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "running",
+                        task_id: null,
+                        updated_at: new Date().toISOString(),
+                      },
+                    ],
+                    error: null,
+                  }
+                : { error: null };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+    const executeContributionAction = vi.fn();
+
+    const result = await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).not.toHaveBeenCalled();
+    expect(result.status).toBe("running");
+    expect(batchUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "running",
+        processed_count: 0,
+      }),
+    );
+    expect(batchUpdates[0]).not.toHaveProperty("finished_at");
+  });
+
+  it("fails stale running rows before finalizing an otherwise empty claim", async () => {
+    const batchUpdates: Array<Record<string, unknown>> = [];
+    const itemUpdates: Array<Record<string, unknown>> = [];
+    let summaryReads = 0;
+    const staleUpdatedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const supabaseAdmin = {
+      from(table: string) {
+        let itemSelectMode: "claim" | "summary" = "summary";
+        let updatePayload: Record<string, unknown> | null = null;
+        const builder = {
+          select(columns?: string) {
+            if (
+              table === "contribution_operation_batch_items" &&
+              columns?.includes("donation_id")
+            ) {
+              itemSelectMode = "claim";
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          order() {
+            return builder;
+          },
+          limit() {
+            return Promise.resolve({ data: [], error: null }) as never;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            updatePayload = payload;
+            if (table === "contribution_operation_batches") {
+              batchUpdates.push(payload);
+            }
+            if (
+              table === "contribution_operation_batch_items" &&
+              payload.status === "failed"
+            ) {
+              itemUpdates.push(payload);
+            }
+            return builder;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              data?: Array<Record<string, unknown>>;
+              error: null;
+            }) => TResult,
+          ): Promise<TResult> {
+            if (
+              table !== "contribution_operation_batch_items" ||
+              itemSelectMode !== "summary" ||
+              updatePayload
+            ) {
+              return Promise.resolve({ error: null }).then(onfulfilled);
+            }
+
+            summaryReads += 1;
+            const value =
+              summaryReads === 1
+                ? {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "running",
+                        task_id: null,
+                        updated_at: staleUpdatedAt,
+                      },
+                    ],
+                    error: null,
+                  }
+                : {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "failed",
+                        task_id: null,
+                        updated_at: new Date().toISOString(),
+                      },
+                    ],
+                    error: null,
+                  };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+
+    const result = await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      executeContributionAction: vi.fn(),
+    });
+
+    expect(itemUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error_message:
+          "Batch item processing timed out before a result was recorded.",
+      }),
+    );
+    expect(result.status).toBe("failed");
+    expect(result.summary.failed).toBe(1);
+    expect(batchUpdates.at(-1)).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        finished_at: expect.any(String),
+      }),
+    );
+  });
+
+  it("fails stale open items before processing an abandoned persisted batch", async () => {
+    const batchUpdates: Array<Record<string, unknown>> = [];
+    const itemUpdates: Array<Record<string, unknown>> = [];
+    let summaryReads = 0;
+    const staleCreatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const supabaseAdmin = {
+      from(table: string) {
+        let updatePayload: Record<string, unknown> | null = null;
+        const builder = {
+          select() {
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          single: async () => ({
+            data: {
+              id: "batch_1",
+              operation: "refund",
+              source_surface: "bulk_action",
+              status: "running",
+              reason: "bulk refund",
+              confirmation_snapshot: { confirmationToken: "confirm_1" },
+              created_at: staleCreatedAt,
+            },
+            error: null,
+          }),
+          update(payload: Record<string, unknown>) {
+            updatePayload = payload;
+            if (table === "contribution_operation_batches") {
+              batchUpdates.push(payload);
+            }
+            if (table === "contribution_operation_batch_items") {
+              itemUpdates.push(payload);
+            }
+            return builder;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              data?: Array<Record<string, unknown>>;
+              error: null;
+            }) => TResult,
+          ): Promise<TResult> {
+            if (
+              table !== "contribution_operation_batch_items" ||
+              updatePayload
+            ) {
+              return Promise.resolve({ error: null }).then(onfulfilled);
+            }
+
+            summaryReads += 1;
+            const value =
+              summaryReads === 1
+                ? {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "pending",
+                        task_id: null,
+                        updated_at: new Date().toISOString(),
+                      },
+                    ],
+                    error: null,
+                  }
+                : {
+                    data: [
+                      {
+                        id: "item_1",
+                        status: "failed",
+                        task_id: null,
+                        updated_at: new Date().toISOString(),
+                      },
+                    ],
+                    error: null,
+                  };
+            return Promise.resolve(value).then(onfulfilled);
+          },
+        };
+
+        return builder;
+      },
+    };
+    const executeContributionAction = vi.fn();
+
+    const result = await processPersistedContributionBatch({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+      actorProfileId: "actor_1",
+      executeContributionAction,
+    });
+
+    expect(executeContributionAction).not.toHaveBeenCalled();
+    expect(itemUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error_message:
+          "Batch processing timed out before all items recorded a result.",
+      }),
+    );
+    expect(result.status).toBe("failed");
+    expect(batchUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        failed_count: 1,
+        finished_at: expect.any(String),
+      }),
+    );
+  });
+
+  it("marks a batch failed so persistence/processing errors never strand it as running", async () => {
+    const batchUpdates: Array<Record<string, unknown>> = [];
+    const itemUpdates: Array<Record<string, unknown>> = [];
+    const supabaseAdmin = {
+      from(table: string) {
+        const builder = {
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batches") {
+              batchUpdates.push(payload);
+            } else {
+              itemUpdates.push(payload);
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          then<TResult>(
+            onfulfilled: (value: { error: null }) => TResult,
+          ): Promise<TResult> {
+            return Promise.resolve({ error: null }).then(onfulfilled);
+          },
+        };
+        return builder;
+      },
+    };
+
+    await markContributionBatchFailed({
+      supabaseAdmin: supabaseAdmin as never,
+      tenantId: "tenant_1",
+      batchId: "batch_1",
+    });
+
+    expect(itemUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error_message:
+          "Batch processing failed before this item recorded a result.",
+      }),
+    );
+    expect(batchUpdates[0]).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        finished_at: expect.any(String),
+      }),
+    );
+  });
+
+  it("still marks the batch failed when open item cleanup fails", async () => {
+    const batchUpdates: Array<Record<string, unknown>> = [];
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const supabaseAdmin = {
+      from(table: string) {
+        const builder = {
+          update(payload: Record<string, unknown>) {
+            if (table === "contribution_operation_batches") {
+              batchUpdates.push(payload);
+            }
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          then<TResult>(
+            onfulfilled: (value: {
+              error: { message: string } | null;
+            }) => TResult,
+          ): Promise<TResult> {
+            return Promise.resolve({
+              error:
+                table === "contribution_operation_batch_items"
+                  ? { message: "item cleanup failed" }
+                  : null,
+            }).then(onfulfilled);
+          },
+        };
+        return builder;
+      },
+    };
+
+    try {
+      await markContributionBatchFailed({
+        supabaseAdmin: supabaseAdmin as never,
+        tenantId: "tenant_1",
+        batchId: "batch_1",
+      });
+
+      expect(batchUpdates[0]).toEqual(
+        expect.objectContaining({
+          status: "failed",
+          finished_at: expect.any(String),
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("never throws while marking a batch failed (best-effort cleanup)", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const supabaseAdmin = {
+      from() {
+        const builder = {
+          update() {
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          in() {
+            return builder;
+          },
+          then<TResult>(
+            onfulfilled: (value: { error: { message: string } }) => TResult,
+          ): Promise<TResult> {
+            return Promise.resolve({
+              error: { message: "connection lost" },
+            }).then(onfulfilled);
+          },
+        };
+        return builder;
+      },
+    };
+
+    try {
+      await expect(
+        markContributionBatchFailed({
+          supabaseAdmin: supabaseAdmin as never,
+          tenantId: "tenant_1",
+          batchId: "batch_1",
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
+describe("bulk contribution results", () => {
+  it("summarizes mixed results as complete with issues", () => {
+    expect(
+      summarizeContributionBatchResults([
+        { status: "succeeded" },
+        { status: "skipped" },
+        { status: "failed" },
+      ]),
+    ).toEqual({
+      status: "complete_with_issues",
+      processed: 3,
+      succeeded: 1,
+      skipped: 1,
+      failed: 1,
+      followUpTasksCreated: 0,
+    });
+  });
+
+  it("exports CSV with required result fields", () => {
+    const csv = buildContributionBatchCsv([
+      {
+        contributionId: "donation_1",
+        donorName: "Ada Donor",
+        donorEmail: "ada@example.com",
+        amount: 10000,
+        currency: "USD",
+        action: "resend_receipt",
+        status: "succeeded",
+        auditEventId: "audit_1",
+        taskId: null,
+        timestamp: "2026-05-26T00:00:00.000Z",
+      },
+    ]);
+
+    expect(csv).toContain("contributionId,donorName,donorEmail,amount");
+    expect(csv).toContain("donation_1,Ada Donor,ada@example.com,10000");
+  });
+});


### PR DESCRIPTION
## Summary

- Add contribution operation batch tables and service-role-only access for persisted batch runs.
- Add the `@asym/api/admin/contribution-batches` module plus admin route handlers for creating and processing batches.
- Use explicit, bounded `/process` chunks for persisted batches instead of `after()` background execution, with stale `running` item recovery and aggregate batch counts.
- Carry granular actor capabilities through bulk execution, verify high-risk preview snapshots with selected-count and record-id hash checks, use `bulk_action` source surfaces, and match duplicate persisted contribution rows by batch item id.
- Update the runtime map for the new admin API routes and add a batch item status index for chunk/recovery queries.

## Verification

- `node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/contribution-batches.test.ts`
- `node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/contribution-batches.test.ts tests/unit/packages/api/admin/mission-control-tasks.test.ts tests/unit/packages/api/admin/contribution-operations-actions.test.ts tests/unit/packages/api/admin/contribution-action-dependencies.test.ts`
- `bunx turbo run typecheck --filter=@asym/api --filter=@asym/admin`
- `bunx turbo run lint --filter=@asym/api --filter=@asym/admin`
- `bun run format:check`
- `bun run ci:preflight`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `contribution-batches` admin module: two new DB tables (`contribution_operation_batches` / `contribution_operation_batch_items`, service-role-only), a `POST /api/admin/contribution-batches` handler that persists large batches and returns a `nextAction` URL, and a `POST /api/admin/contribution-batches/[batchId]/process` handler that claims and executes items in bounded 25-item chunks with stale-item recovery.

- **Chunked background processing** replaces the earlier `after()` approach: callers poll `/process` repeatedly until `status` leaves `\"running\"`, with stale `running` items recovered after 5 minutes and abandoned batches timed out after 30 minutes from `created_at`.
- **High-risk guard**: `refund`, `amount_correction`, `allocation_correction`, and similar actions require a `previewSnapshot` whose `selectionHash` is verified server-side before the batch row is inserted, and always route to background execution mode.
- **One correctness gap found**: the sequential per-item DB update loop in `processPersistedContributionBatch` throws on the first failed write, leaving already-executed operations in `\"running\"` state where stale recovery will subsequently mark them `\"failed\"` regardless of their actual outcome.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for low-risk actions; the high-risk financial path (refund, amount_correction) carries a result-persistence gap where a DB write error mid-loop can cause the batch to misreport successfully-executed operations as failed.

The chunked processing design, stale recovery, and preview-snapshot verification are solid. The one concrete defect is in the sequential item-update loop: a transient DB error after some results are written leaves the remaining already-executed items in "running" state, which stale recovery later overwrites with "failed". For irreversible financial operations this corrupts the batch's outcome record and could prompt duplicate retries. The error is real and on the changed path, but requires a coincident DB failure to trigger, and actual execution of the underlying operations is unaffected.

packages/api/src/admin/contribution-batches/process-batch.ts — specifically the per-item update loop and the assertBatchProcessOwner error type.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-batches/process-batch.ts | Core processing engine for immediate and persisted batches; contains a result-persistence loop that throws on first DB error, leaving already-executed items stranded in "running" and later mislabeled by stale recovery. |
| packages/api/src/admin/contribution-batches/route.ts | POST and POST_PROCESS_BATCH handlers; properly validates high-risk snapshots, uses withOperation auth, and routes to persisted vs immediate paths correctly; assertBatchProcessOwner errors surface as 500 instead of 403. |
| supabase/migrations/20260526202500_contribution_operation_batches.sql | Adds contribution_operation_batches and contribution_operation_batch_items tables; RLS enabled, all access revoked from anon/authenticated and granted only to service_role; correct FK constraints and composite indexes. |
| packages/api/src/admin/contribution-batches/preview.ts | Batch preview logic and execution-mode selector; correctly classifies records as affected vs skipped based on action-specific payload requirements. |
| packages/api/src/admin/contribution-batches/action-catalog.ts | Action risk classification and policy; cleanly delegates to per-action risk levels with explicit bulk overrides; correctly drives preview/background requirements. |
| tests/unit/packages/api/admin/contribution-batches.test.ts | Tests cover catalog policy, preview classification, execution mode selection, result summarization, and processPersistedContributionBatch via mocked Supabase; partial-update-failure and cross-admin ownership error paths are not tested. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Admin Client
    participant POST as POST /contribution-batches
    participant PROC as POST /[batchId]/process
    participant DB as Supabase (service_role)
    participant EA as executeContributionAction

    C->>POST: "{ actionType, records, confirmationToken, previewSnapshot? }"
    POST->>POST: assertPreviewSnapshotMatchesBatchSelection (high-risk only)
    POST->>DB: "INSERT contribution_operation_batches (status=running)"
    POST->>DB: "INSERT contribution_operation_batch_items (status=pending) xN"
    POST-->>C: "{ batch.id, status: running, nextAction: POST /[id]/process }"

    loop "until status != running"
        C->>PROC: POST /[batchId]/process
        PROC->>DB: SELECT batch row (check status, owner, staleness)
        PROC->>DB: "SELECT pending items LIMIT 25 + UPDATE status=running"
        PROC->>EA: executeContributionAction x25
        PROC->>DB: UPDATE each item (succeeded/failed/skipped) + UPDATE batch counts
        alt no pending/running items remain
            PROC->>DB: "UPDATE batch status = complete | complete_with_issues | failed"
        end
        PROC-->>C: "{ batch: { status, summary } }"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Admin Client
    participant POST as POST /contribution-batches
    participant PROC as POST /[batchId]/process
    participant DB as Supabase (service_role)
    participant EA as executeContributionAction

    C->>POST: "{ actionType, records, confirmationToken, previewSnapshot? }"
    POST->>POST: assertPreviewSnapshotMatchesBatchSelection (high-risk only)
    POST->>DB: "INSERT contribution_operation_batches (status=running)"
    POST->>DB: "INSERT contribution_operation_batch_items (status=pending) xN"
    POST-->>C: "{ batch.id, status: running, nextAction: POST /[id]/process }"

    loop "until status != running"
        C->>PROC: POST /[batchId]/process
        PROC->>DB: SELECT batch row (check status, owner, staleness)
        PROC->>DB: "SELECT pending items LIMIT 25 + UPDATE status=running"
        PROC->>EA: executeContributionAction x25
        PROC->>DB: UPDATE each item (succeeded/failed/skipped) + UPDATE batch counts
        alt no pending/running items remain
            PROC->>DB: "UPDATE batch status = complete | complete_with_issues | failed"
        end
        PROC-->>C: "{ batch: { status, summary } }"
    end
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapi%2Fsrc%2Fadmin%2Fcontribution-batches%2Fprocess-batch.ts%3A643-674%0A**Partial%20DB%20update%20failure%20mislabels%20already-executed%20operations**%0A%0AThe%20item-update%20loop%20%60throw%60s%20on%20the%20first%20failed%20%60UPDATE%60.%20Any%20items%20whose%20result%20hasn't%20been%20written%20yet%20stay%20in%20%60%22running%22%60.%20After%20%60RUNNING_ITEM_STALE_AFTER_MS%60%20%285%20min%29%2C%20%60readSummaryAfterStaleRecovery%60%20marks%20them%20%60%22failed%22%60%20unconditionally%20%E2%80%94%20even%20when%20the%20underlying%20operation%20%28e.g.%2C%20a%20Stripe%20refund%20or%20amount%20correction%29%20actually%20succeeded.%20An%20admin%20reviewing%20the%20batch%20would%20see%20inflated%20%60failed_count%60%20and%20may%20retry%20those%20items%2C%20risking%20duplicate%20financial%20operations.%0A%0AThe%20minimal%20fix%20is%20to%20collect%20errors%20rather%20than%20throwing%20immediately%20so%20all%20results%20are%20persisted%20before%20surfacing%20any%20write%20failure%2C%20or%20to%20update%20items%20in%20a%20single%20batched%20upsert%20using%20the%20array%20of%20result%20objects%20instead%20of%20a%20sequential%20per-row%20loop.%0A%0A&pr=398&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["feat(api): add contribution operation ba..."](https://github.com/asymmetric-al/core/commit/53379db61dc9c3fcbc38893f805430bb5324f2ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38921434)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->