### PR TITLE
feat(api): add CRM table preferences backend

### DIFF
--- a/apps/admin/app/api/admin/crm/table-preferences/route.ts
+++ b/apps/admin/app/api/admin/crm/table-preferences/route.ts
@@ -1,0 +1,1 @@
+export { GET, PUT } from "@asym/api/admin/crm/table-preferences/route";

--- a/apps/admin/app/api/admin/crm/table-preferences/tenant-default/route.ts
+++ b/apps/admin/app/api/admin/crm/table-preferences/tenant-default/route.ts
@@ -1,0 +1,1 @@
+export { PUT_TENANT_DEFAULT as PUT } from "@asym/api/admin/crm/table-preferences/route";

--- a/apps/admin/app/api/admin/crm/table-preferences/views/[viewId]/route.ts
+++ b/apps/admin/app/api/admin/crm/table-preferences/views/[viewId]/route.ts
@@ -1,0 +1,4 @@
+export {
+  DELETE_NAMED_VIEW as DELETE,
+  PUT_NAMED_VIEW as PUT,
+} from "@asym/api/admin/crm/table-preferences/route";

--- a/apps/admin/app/api/admin/crm/table-preferences/views/route.ts
+++ b/apps/admin/app/api/admin/crm/table-preferences/views/route.ts
@@ -1,0 +1,4 @@
+export {
+  GET_NAMED_VIEWS as GET,
+  POST_NAMED_VIEW as POST,
+} from "@asym/api/admin/crm/table-preferences/route";

--- a/docs/guides/architecture/runtime-map.md
+++ b/docs/guides/architecture/runtime-map.md
@@ -50,6 +50,10 @@ commit when the deployment exposes a non-`unknown` commit.
 | admin      | `/api/admin/crm/reports/export`                                | Node.js (no `runtime` segment export) | Audited CRM CSV export                        |
 | admin      | `/api/admin/crm/sync/reconcile`                                | Node.js (no `runtime` segment export) | Staff-only CRM reconciliation                 |
 | admin      | `/api/admin/crm/sync/replay`                                   | Node.js (no `runtime` segment export) | Staff-only CRM replay                         |
+| admin      | `/api/admin/crm/table-preferences`                             | Node.js (no `runtime` segment export) | Staff-only CRM view preferences               |
+| admin      | `/api/admin/crm/table-preferences/tenant-default`              | Node.js (no `runtime` segment export) | Audited CRM tenant default preferences        |
+| admin      | `/api/admin/crm/table-preferences/views`                       | Node.js (no `runtime` segment export) | Personal CRM named views                      |
+| admin      | `/api/admin/crm/table-preferences/views/[viewId]`              | Node.js (no `runtime` segment export) | Personal CRM named view mutation              |
 | admin      | `/api/admin/crm/webhooks/twenty`                               | Node.js (no `runtime` segment export) | Twenty HMAC webhook, admin client             |
 | admin      | `/api/admin/funds`                                             | Node.js (no `runtime` segment export) | Admin client                                  |
 | admin      | `/api/admin/locations`                                         | Node.js (no `runtime` segment export) | Admin client                                  |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -46,6 +46,8 @@
     "./admin/crm/gateway": "./src/admin/crm/gateway.ts",
     "./admin/crm/twenty-health": "./src/admin/crm/twenty-health.ts",
     "./admin/crm/detail": "./src/admin/crm/detail/index.ts",
+    "./admin/crm/table-preferences": "./src/admin/crm/table-preferences/index.ts",
+    "./admin/crm/table-preferences/route": "./src/admin/crm/table-preferences/route.ts",
     "./admin/crm/notes": "./src/admin/crm/notes/index.ts",
     "./admin/crm/projections": "./src/admin/crm/projections/index.ts",
     "./admin/crm/reports": "./src/admin/crm/reports/index.ts",

--- a/packages/api/src/admin/crm/detail/service.ts
+++ b/packages/api/src/admin/crm/detail/service.ts
@@ -309,6 +309,7 @@ export async function getAdminCrmDonorDetail(input: {
             "id, donation_id, staged_gift_id, link_status, twenty_record_id",
           )
           .eq("tenant_id", input.tenantId)
+          .eq("scope", "parent")
           .in("staged_gift_id", stagedGiftIds)
       : { data: [], error: null };
   assertNoError(linkResult.error, "Failed to load donation CRM links.");

--- a/packages/api/src/admin/crm/reports/service.ts
+++ b/packages/api/src/admin/crm/reports/service.ts
@@ -223,6 +223,7 @@ async function buildSyncFailureRows(
       .from("donation_crm_links")
       .select("id, link_status, updated_at")
       .eq("tenant_id", tenantId)
+      .eq("scope", "parent")
       .in("link_status", ["queued", "failed"])
       .limit(250),
   ]);

--- a/packages/api/src/admin/crm/table-preferences/index.ts
+++ b/packages/api/src/admin/crm/table-preferences/index.ts
@@ -1,0 +1,19 @@
+// Client-safe barrel: pure preference resolution only. Server handlers live
+// in ./route (route export path) and persistence in ./service (route-only).
+export {
+  CRM_GIFT_HISTORY_TABLE_ID,
+  CRM_ROW_ACTION_SCHEMA_VERSION,
+  migrateCrmRowActionId,
+  resolveCrmRowAction,
+  type CrmRowActionPreferenceInput,
+  type CrmRowActionSource,
+  type ResolvedCrmRowAction,
+} from "./row-action";
+export {
+  canManageCrmTenantDefaults,
+  CRM_GIFT_HISTORY_SYSTEM_VIEW_SETTINGS,
+  previewCrmViewSettingsReset,
+  resolveCrmGiftHistoryViewSettings,
+  type CrmViewSettingsResetPreview,
+  type ResolvedCrmViewSettings,
+} from "./view-settings";

--- a/packages/api/src/admin/crm/table-preferences/named-views.ts
+++ b/packages/api/src/admin/crm/table-preferences/named-views.ts
@@ -1,0 +1,255 @@
+import { applyCrmViewSettingsPatch } from "@asym/database/types";
+
+import {
+  CRM_ROW_ACTION_SCHEMA_VERSION,
+  migrateCrmRowActionId,
+  normalizeCrmPinnedActionId,
+} from "./row-action";
+import { ApiHttpError } from "../../../shared/http-errors";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+import type {
+  CrmNamedView,
+  CrmViewSettingsLayer,
+  CrmViewSettingsPatch,
+} from "@asym/database/types";
+
+type SupabaseAdmin = AdminSupabaseClient;
+
+/**
+ * Named personal CRM views (issue #273, ADR-CD-021).
+ *
+ * Views are personal-only snapshots of gift-history view settings (columns,
+ * filters/sort, pinned row action). One view per user/table can be the
+ * default. No sharing, publishing, or team views exist here.
+ */
+
+interface NamedViewRow {
+  id: string;
+  name: string;
+  is_default: boolean;
+  schema_version: number | null;
+  pinned_action_id: string | null;
+  settings: CrmViewSettingsLayer | null;
+}
+
+const VIEW_COLUMNS =
+  "id, name, is_default, schema_version, pinned_action_id, settings";
+
+function firstRpcValue(data: unknown): unknown {
+  return Array.isArray(data) ? data[0] : data;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNamedViewRpcRow(data: unknown): NamedViewRow | null {
+  const row = firstRpcValue(data);
+  if (!isRecord(row) || typeof row.id !== "string") {
+    return null;
+  }
+
+  return row as unknown as NamedViewRow;
+}
+
+function isUniqueViolationError(error: unknown): boolean {
+  return isRecord(error) && error.code === "23505";
+}
+
+function readDeleteRpcResult(data: unknown): {
+  deleted: boolean;
+  reason: string | null;
+} {
+  const result = firstRpcValue(data);
+  if (!isRecord(result)) {
+    return { deleted: false, reason: null };
+  }
+
+  return {
+    deleted: result.deleted === true,
+    reason: typeof result.reason === "string" ? result.reason : null,
+  };
+}
+
+function mapViewRow(row: NamedViewRow): CrmNamedView {
+  return {
+    id: row.id,
+    name: row.name,
+    isDefault: row.is_default,
+    schemaVersion: row.schema_version ?? CRM_ROW_ACTION_SCHEMA_VERSION,
+    // Stored pins from older schema versions migrate forward on read.
+    pinnedActionId: migrateCrmRowActionId(row.pinned_action_id),
+    settings: row.settings ?? null,
+  };
+}
+
+interface ViewScope {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  profileId: string;
+  tableId: string;
+}
+
+export async function listCrmNamedViews(
+  input: ViewScope,
+): Promise<CrmNamedView[]> {
+  const { data, error } = await input.supabaseAdmin
+    .from("crm_table_named_views")
+    .select(VIEW_COLUMNS)
+    .eq("tenant_id", input.tenantId)
+    .eq("profile_id", input.profileId)
+    .eq("table_id", input.tableId)
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new ApiHttpError(500, error.message);
+  }
+
+  return ((data ?? []) as NamedViewRow[]).map(mapViewRow);
+}
+
+export async function createCrmNamedView(
+  input: ViewScope & {
+    name: string;
+    isDefault?: boolean;
+    pinnedActionId?: string | null;
+    settings?: CrmViewSettingsPatch | null;
+  },
+): Promise<CrmNamedView> {
+  const name = input.name.trim();
+  if (!name) {
+    throw new ApiHttpError(400, "A view name is required.");
+  }
+
+  const pinnedActionId =
+    input.pinnedActionId === undefined
+      ? null
+      : normalizeCrmPinnedActionId(input.pinnedActionId);
+  const settings = applyCrmViewSettingsPatch(null, input.settings ?? {});
+  const { data, error } = await input.supabaseAdmin.rpc(
+    "create_crm_table_named_view",
+    {
+      p_tenant_id: input.tenantId,
+      p_profile_id: input.profileId,
+      p_table_id: input.tableId,
+      p_name: name,
+      p_is_default: input.isDefault ?? false,
+      p_schema_version: CRM_ROW_ACTION_SCHEMA_VERSION,
+      p_pinned_action_id: pinnedActionId,
+      p_settings: settings,
+    },
+  );
+  const row = readNamedViewRpcRow(data);
+
+  if (isUniqueViolationError(error)) {
+    throw new ApiHttpError(409, "A named view with this name already exists.");
+  }
+
+  if (error || !row) {
+    throw new ApiHttpError(
+      500,
+      error?.message ?? "Failed to save the named view.",
+    );
+  }
+
+  return mapViewRow(row);
+}
+
+export async function updateCrmNamedView(
+  input: ViewScope & {
+    viewId: string;
+    name?: string;
+    isDefault?: boolean;
+    pinnedActionId?: string | null;
+    settings?: CrmViewSettingsPatch | null;
+  },
+): Promise<CrmNamedView> {
+  const nameIsSet = input.name !== undefined;
+  let name: string | null = null;
+  if (input.name !== undefined) {
+    name = input.name.trim();
+    if (!name) {
+      throw new ApiHttpError(400, "A view name is required.");
+    }
+  }
+
+  const pinnedActionIdIsSet = input.pinnedActionId !== undefined;
+  let pinnedActionId: string | null = null;
+  if (input.pinnedActionId !== undefined) {
+    pinnedActionId = normalizeCrmPinnedActionId(input.pinnedActionId);
+  }
+
+  const settingsIsSet = input.settings !== undefined;
+  const settings = settingsIsSet ? (input.settings ?? {}) : null;
+
+  const { data, error } = await input.supabaseAdmin.rpc(
+    "update_crm_table_named_view",
+    {
+      p_tenant_id: input.tenantId,
+      p_profile_id: input.profileId,
+      p_table_id: input.tableId,
+      p_view_id: input.viewId,
+      p_name: name,
+      p_name_is_set: nameIsSet,
+      p_is_default: input.isDefault ?? null,
+      p_is_default_is_set: input.isDefault !== undefined,
+      p_schema_version: CRM_ROW_ACTION_SCHEMA_VERSION,
+      p_pinned_action_id: pinnedActionId,
+      p_pinned_action_id_is_set: pinnedActionIdIsSet,
+      p_settings: settings,
+      p_settings_is_set: settingsIsSet,
+    },
+  );
+
+  if (isUniqueViolationError(error)) {
+    throw new ApiHttpError(409, "A named view with this name already exists.");
+  }
+
+  if (error) {
+    throw new ApiHttpError(500, error.message);
+  }
+
+  const row = readNamedViewRpcRow(data);
+  if (!row) {
+    throw new ApiHttpError(404, "Named view not found.");
+  }
+
+  return mapViewRow(row);
+}
+
+/**
+ * Deletes a view. When the default view is deleted, the caller either
+ * promotes a chosen replacement or the user falls back to the tenant/system
+ * default (no named default remains).
+ */
+export async function deleteCrmNamedView(
+  input: ViewScope & {
+    viewId: string;
+    nextDefaultViewId?: string | null;
+  },
+): Promise<void> {
+  const { data, error } = await input.supabaseAdmin.rpc(
+    "delete_crm_table_named_view",
+    {
+      p_tenant_id: input.tenantId,
+      p_profile_id: input.profileId,
+      p_table_id: input.tableId,
+      p_view_id: input.viewId,
+      p_next_default_view_id: input.nextDefaultViewId ?? null,
+    },
+  );
+
+  if (error) {
+    throw new ApiHttpError(500, error.message);
+  }
+
+  const result = readDeleteRpcResult(data);
+  if (!result.deleted) {
+    const message =
+      result.reason === "next_default_not_found"
+        ? "Replacement default view not found."
+        : "Named view not found.";
+    throw new ApiHttpError(404, message);
+  }
+}

--- a/packages/api/src/admin/crm/table-preferences/route.ts
+++ b/packages/api/src/admin/crm/table-preferences/route.ts
@@ -1,0 +1,438 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  createCrmNamedView,
+  deleteCrmNamedView,
+  listCrmNamedViews,
+  updateCrmNamedView,
+} from "./named-views";
+import { CRM_GIFT_HISTORY_TABLE_ID } from "./row-action";
+import {
+  getCrmTablePreferences,
+  saveCrmTenantTableDefault,
+  saveCrmUserTablePreference,
+  type CrmViewSettingsPatch,
+} from "./service";
+import { canManageCrmTenantDefaults } from "./view-settings";
+import { requireCrmAccess } from "../../../crm/auth/access";
+import {
+  ApiHttpError,
+  ensureJsonBody,
+  toErrorResponse,
+} from "../../../shared/http-errors";
+import {
+  withOperation,
+  type OperationRouteContext,
+} from "../../../shared/with-operation";
+import { resolveContributionCapabilities } from "../../contribution-operations/permissions";
+
+const KNOWN_TABLE_IDS = [CRM_GIFT_HISTORY_TABLE_ID] as const;
+
+const tableIdSchema = z.enum(KNOWN_TABLE_IDS);
+const profileIdSchema = z.string().uuid();
+
+const columnsSchema = z
+  .object({
+    designation: z.boolean().optional(),
+    statusLine: z.boolean().optional(),
+  })
+  .strict();
+
+const filtersSortSchema = z
+  .object({
+    sortField: z.enum(["giftDate", "amountCents"]).optional(),
+    sortDirection: z.enum(["asc", "desc"]).optional(),
+    paymentStatus: z.enum(["all", "completed", "refunded"]).optional(),
+    issue: z
+      .enum([
+        "all",
+        "needs_attention",
+        "receipt_affected",
+        "pending_correction",
+      ])
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Per-scope semantics (#272): an absent key leaves that scope unchanged,
+ * null clears it (scoped reset), a value replaces it.
+ */
+const savePreferenceSchema = z.object({
+  tableId: tableIdSchema.default(CRM_GIFT_HISTORY_TABLE_ID),
+  pinnedActionId: z.string().min(1).nullable().optional(),
+  columns: columnsSchema.nullable().optional(),
+  filtersSort: filtersSortSchema.nullable().optional(),
+  activeViewId: z.string().uuid().nullable().optional(),
+});
+
+const tenantDefaultSchema = savePreferenceSchema
+  .omit({ activeViewId: true })
+  .extend({
+    delegatedManagerProfileIds: z.array(profileIdSchema).nullable().optional(),
+  });
+
+function settingsPatchFromBody(body: {
+  columns?: CrmViewSettingsPatch["columns"];
+  filtersSort?: CrmViewSettingsPatch["filtersSort"];
+  delegatedManagerProfileIds?: string[] | null;
+  activeViewId?: string | null;
+}): CrmViewSettingsPatch {
+  const patch: CrmViewSettingsPatch = {};
+  if (body.columns !== undefined) {
+    patch.columns = body.columns;
+  }
+  if (body.filtersSort !== undefined) {
+    patch.filtersSort = body.filtersSort;
+  }
+  if (body.delegatedManagerProfileIds !== undefined) {
+    patch.delegatedManagerProfileIds = body.delegatedManagerProfileIds;
+  }
+  if (body.activeViewId !== undefined) {
+    patch.activeViewId = body.activeViewId;
+  }
+  return patch;
+}
+
+const namedViewCreateSchema = z.object({
+  tableId: tableIdSchema.default(CRM_GIFT_HISTORY_TABLE_ID),
+  name: z.string().min(1).max(80),
+  isDefault: z.boolean().optional(),
+  pinnedActionId: z.string().min(1).nullable().optional(),
+  columns: columnsSchema.nullable().optional(),
+  filtersSort: filtersSortSchema.nullable().optional(),
+});
+
+const namedViewUpdateSchema = z.object({
+  tableId: tableIdSchema.default(CRM_GIFT_HISTORY_TABLE_ID),
+  name: z.string().min(1).max(80).optional(),
+  isDefault: z.boolean().optional(),
+  pinnedActionId: z.string().min(1).nullable().optional(),
+  columns: columnsSchema.nullable().optional(),
+  filtersSort: filtersSortSchema.nullable().optional(),
+});
+
+const optionalViewIdSchema = z.string().uuid().nullable();
+
+async function getViewIdFromRouteContext(
+  routeContext: OperationRouteContext | undefined,
+): Promise<string> {
+  const params = await routeContext?.params;
+  const viewId = params?.viewId;
+  const resolved = Array.isArray(viewId) ? viewId[0] : viewId;
+  if (!resolved) {
+    throw new ApiHttpError(400, "Missing named view id.");
+  }
+
+  return resolved;
+}
+
+function namedViewSettingsFromBody(body: {
+  columns?: CrmViewSettingsPatch["columns"];
+  filtersSort?: CrmViewSettingsPatch["filtersSort"];
+}): CrmViewSettingsPatch {
+  const patch: CrmViewSettingsPatch = {};
+  if (body.columns !== undefined) {
+    patch.columns = body.columns;
+  }
+  if (body.filtersSort !== undefined) {
+    patch.filtersSort = body.filtersSort;
+  }
+
+  return patch;
+}
+
+function requireProfileId(profileId: string | null): string {
+  if (!profileId) {
+    throw new ApiHttpError(
+      403,
+      "A profile is required to manage table preferences.",
+    );
+  }
+
+  return profileId;
+}
+
+function resolveTableId(request: Request): string {
+  const raw =
+    new URL(request.url).searchParams.get("tableId") ??
+    CRM_GIFT_HISTORY_TABLE_ID;
+  const parsed = tableIdSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ApiHttpError(400, `Unknown table id "${raw}".`);
+  }
+
+  return parsed.data;
+}
+
+export const GET = withOperation(
+  async ({ auth, request, requestId, supabaseAdmin }) => {
+    const actor = requireCrmAccess(auth, {
+      action: "crm.table_preferences.read",
+      resourceType: "record",
+    });
+
+    try {
+      const preferences = await getCrmTablePreferences({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        profileId: requireProfileId(actor.profileId),
+        tableId: resolveTableId(request),
+      });
+
+      return NextResponse.json({ ...preferences, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to load CRM table preferences.",
+        requestId,
+      );
+    }
+  },
+  {
+    roles: ["staff", "admin", "super_admin"],
+  },
+);
+
+export const PUT = withOperation(
+  async ({ auth, request, requestId, supabaseAdmin }) => {
+    const actor = requireCrmAccess(auth, {
+      action: "crm.table_preferences.write",
+      resourceType: "record",
+    });
+
+    try {
+      const body = savePreferenceSchema.parse(await ensureJsonBody(request));
+      const user = await saveCrmUserTablePreference({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        profileId: requireProfileId(actor.profileId),
+        tableId: body.tableId,
+        pinnedActionId: body.pinnedActionId,
+        settingsPatch: settingsPatchFromBody(body),
+      });
+
+      return NextResponse.json({ user, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to save table preferences.",
+        requestId,
+      );
+    }
+  },
+  {
+    roles: ["staff", "admin", "super_admin"],
+  },
+);
+
+export const PUT_TENANT_DEFAULT = withOperation(
+  async ({ auth, request, requestId, supabaseAdmin }) => {
+    const actor = requireCrmAccess(auth, {
+      action: "crm.table_preferences.manage_defaults",
+      resourceType: "record",
+    });
+
+    try {
+      const profileId = requireProfileId(actor.profileId);
+      const body = tenantDefaultSchema.parse(await ensureJsonBody(request));
+
+      // Tenant defaults are capability-gated and audited, never
+      // approval-gated (ADR-CD-021). Super admins hold the capability;
+      // delegated default managers are listed on the tenant default record.
+      // Neither grants contribution operation permissions.
+      const capabilities = resolveContributionCapabilities(auth);
+      const actorCanManageDefaults = capabilities.includes(
+        "crm.gift_history.manage_view_defaults",
+      );
+      const current = await getCrmTablePreferences({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        profileId,
+        tableId: body.tableId,
+      });
+      const delegatedManagerProfileIds =
+        current.tenantDefault?.settings?.delegatedManagerProfileIds ?? [];
+      if (
+        !canManageCrmTenantDefaults({
+          capabilities,
+          profileId,
+          delegatedManagerProfileIds,
+        })
+      ) {
+        throw new ApiHttpError(
+          403,
+          "Forbidden: requires crm.gift_history.manage_view_defaults",
+        );
+      }
+
+      // Only capability holders can change who the delegates are.
+      if (
+        body.delegatedManagerProfileIds !== undefined &&
+        !actorCanManageDefaults
+      ) {
+        throw new ApiHttpError(
+          403,
+          "Forbidden: only super admins can change delegated default managers.",
+        );
+      }
+
+      const tenantDefault = await saveCrmTenantTableDefault({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        tableId: body.tableId,
+        pinnedActionId: body.pinnedActionId,
+        settingsPatch: settingsPatchFromBody(body),
+        actorProfileId: profileId,
+        actorCanManageDefaults,
+      });
+
+      return NextResponse.json({ tenantDefault, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to save the tenant default.",
+        requestId,
+      );
+    }
+  },
+  {
+    roles: ["staff", "admin", "super_admin"],
+  },
+);
+
+export const GET_NAMED_VIEWS = withOperation(
+  async ({ auth, request, requestId, supabaseAdmin }) => {
+    const actor = requireCrmAccess(auth, {
+      action: "crm.table_preferences.read",
+      resourceType: "record",
+    });
+
+    try {
+      const tableId = resolveTableId(request);
+      const views = await listCrmNamedViews({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        profileId: requireProfileId(actor.profileId),
+        tableId,
+      });
+
+      return NextResponse.json({ tableId, views, requestId });
+    } catch (error) {
+      return toErrorResponse(error, "Failed to load named views.", requestId);
+    }
+  },
+  {
+    roles: ["staff", "admin", "super_admin"],
+  },
+);
+
+export const POST_NAMED_VIEW = withOperation(
+  async ({ auth, request, requestId, supabaseAdmin }) => {
+    const actor = requireCrmAccess(auth, {
+      action: "crm.table_preferences.write",
+      resourceType: "record",
+    });
+
+    try {
+      const body = namedViewCreateSchema.parse(await ensureJsonBody(request));
+      const view = await createCrmNamedView({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        profileId: requireProfileId(actor.profileId),
+        tableId: body.tableId,
+        name: body.name,
+        isDefault: body.isDefault,
+        pinnedActionId: body.pinnedActionId ?? null,
+        settings: namedViewSettingsFromBody(body),
+      });
+
+      return NextResponse.json({ view, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to save the named view.",
+        requestId,
+      );
+    }
+  },
+  {
+    roles: ["staff", "admin", "super_admin"],
+  },
+);
+
+export const PUT_NAMED_VIEW = withOperation(
+  async ({ auth, request, requestId, routeContext, supabaseAdmin }) => {
+    const actor = requireCrmAccess(auth, {
+      action: "crm.table_preferences.write",
+      resourceType: "record",
+    });
+
+    try {
+      const viewId = await getViewIdFromRouteContext(routeContext);
+      const body = namedViewUpdateSchema.parse(await ensureJsonBody(request));
+      const view = await updateCrmNamedView({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        profileId: requireProfileId(actor.profileId),
+        tableId: body.tableId,
+        viewId,
+        name: body.name,
+        isDefault: body.isDefault,
+        pinnedActionId: body.pinnedActionId,
+        settings:
+          body.columns !== undefined || body.filtersSort !== undefined
+            ? namedViewSettingsFromBody(body)
+            : undefined,
+      });
+
+      return NextResponse.json({ ok: true, view, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to update the named view.",
+        requestId,
+      );
+    }
+  },
+  {
+    roles: ["staff", "admin", "super_admin"],
+  },
+);
+
+export const DELETE_NAMED_VIEW = withOperation(
+  async ({ auth, request, requestId, routeContext, supabaseAdmin }) => {
+    const actor = requireCrmAccess(auth, {
+      action: "crm.table_preferences.write",
+      resourceType: "record",
+    });
+
+    try {
+      const viewId = await getViewIdFromRouteContext(routeContext);
+      const url = new URL(request.url);
+      const nextDefaultViewId = optionalViewIdSchema.parse(
+        url.searchParams.get("nextDefaultViewId"),
+      );
+      await deleteCrmNamedView({
+        supabaseAdmin,
+        tenantId: actor.tenantId,
+        profileId: requireProfileId(actor.profileId),
+        tableId: resolveTableId(request),
+        viewId,
+        nextDefaultViewId,
+      });
+
+      return NextResponse.json({ ok: true, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to delete the named view.",
+        requestId,
+      );
+    }
+  },
+  {
+    roles: ["staff", "admin", "super_admin"],
+  },
+);

--- a/packages/api/src/admin/crm/table-preferences/row-action.ts
+++ b/packages/api/src/admin/crm/table-preferences/row-action.ts
@@ -1,0 +1,166 @@
+import { ApiHttpError } from "../../../shared/http-errors";
+import {
+  isInlineContributionActionType,
+  pickNextBestInlineContributionAction,
+} from "../../contribution-operations/inline-actions";
+
+import type {
+  CrmGiftInlineActionEntry,
+  CrmGiftInlineActionType,
+} from "@asym/database/types";
+
+/**
+ * CRM row action preferences (issue #271, ADR-CD-021).
+ *
+ * Users may pin a preferred row action by stable operation id; tenant admins
+ * may set a tenant default. Preferences are personalization only — resolution
+ * always re-validates against the capability/state-filtered inline action
+ * entries, so a pin or default can never bypass capabilities, row state,
+ * tenant policy, blocked rules, or the shared operation contracts.
+ */
+
+export const CRM_GIFT_HISTORY_TABLE_ID = "crm.giftHistory";
+
+/**
+ * Version of the pinned-action preference schema. Stored preferences carry
+ * the version they were written with; older ids are migrated forward through
+ * the rename map below, and unknown (removed) ids resolve to null.
+ */
+export const CRM_ROW_ACTION_SCHEMA_VERSION = 1;
+
+/** Operation ids renamed in earlier iterations of the operation registry. */
+const RENAMED_ROW_ACTION_IDS: Record<string, CrmGiftInlineActionType> = {
+  approve_gift: "approve_staged_gift",
+  retry_crm_posting: "retry_staged_gift",
+  send_receipt: "resend_receipt",
+};
+
+export function migrateCrmRowActionId(
+  storedActionId: string | null,
+): CrmGiftInlineActionType | null {
+  if (!storedActionId) {
+    return null;
+  }
+
+  if (isInlineContributionActionType(storedActionId)) {
+    return storedActionId;
+  }
+
+  return RENAMED_ROW_ACTION_IDS[storedActionId] ?? null;
+}
+
+/**
+ * Validates a stored/pinned operation id before persistence. Renamed ids are
+ * written using the current stable id; unknown ids are rejected so saved
+ * preferences never accumulate stale operation identifiers.
+ */
+export function normalizeCrmPinnedActionId(
+  actionId: string | null,
+): CrmGiftInlineActionType | null {
+  if (actionId === null) {
+    return null;
+  }
+
+  const migrated = migrateCrmRowActionId(actionId);
+  if (!migrated) {
+    throw new ApiHttpError(400, `Unknown operation id "${actionId}".`);
+  }
+
+  return migrated;
+}
+
+export interface CrmRowActionPreferenceInput {
+  actionId: string | null;
+  schemaVersion?: number;
+}
+
+export type CrmRowActionSource = "user_pin" | "tenant_default" | "system";
+
+export interface ResolvedCrmRowAction {
+  actionType: CrmGiftInlineActionType | null;
+  source: CrmRowActionSource;
+  explanation: string | null;
+}
+
+function humanizeActionId(actionId: string): string {
+  return actionId.replace(/_/g, " ");
+}
+
+/**
+ * Validates one stored preference against the row's inline action entries.
+ * Returns the action when usable; otherwise records why it was skipped.
+ */
+function validatePreference(
+  label: "Your pinned action" | "The tenant default action",
+  preference: CrmRowActionPreferenceInput | null,
+  entries: CrmGiftInlineActionEntry[],
+  notes: string[],
+): CrmGiftInlineActionType | null {
+  if (!preference?.actionId) {
+    return null;
+  }
+
+  const migrated = migrateCrmRowActionId(preference.actionId);
+  if (!migrated) {
+    notes.push(
+      `${label} "${humanizeActionId(preference.actionId)}" no longer exists, so it was skipped.`,
+    );
+    return null;
+  }
+
+  const entry = entries.find((candidate) => candidate.actionType === migrated);
+  if (!entry) {
+    notes.push(
+      `${label} "${humanizeActionId(migrated)}" isn't available to you on this gift, so it was skipped.`,
+    );
+    return null;
+  }
+
+  if (!entry.available) {
+    const reason = entry.blockedReason ?? "It is blocked for this gift.";
+    notes.push(
+      `${label} "${humanizeActionId(migrated)}" is blocked: ${reason}`,
+    );
+    return null;
+  }
+
+  return migrated;
+}
+
+export function resolveCrmRowAction(input: {
+  userPin: CrmRowActionPreferenceInput | null;
+  tenantDefault: CrmRowActionPreferenceInput | null;
+  entries: CrmGiftInlineActionEntry[];
+}): ResolvedCrmRowAction {
+  const notes: string[] = [];
+
+  const pinnedAction = validatePreference(
+    "Your pinned action",
+    input.userPin,
+    input.entries,
+    notes,
+  );
+  if (pinnedAction) {
+    return { actionType: pinnedAction, source: "user_pin", explanation: null };
+  }
+
+  const tenantAction = validatePreference(
+    "The tenant default action",
+    input.tenantDefault,
+    input.entries,
+    notes,
+  );
+  if (tenantAction) {
+    return {
+      actionType: tenantAction,
+      source: "tenant_default",
+      explanation: notes.length > 0 ? notes.join(" ") : null,
+    };
+  }
+
+  return {
+    actionType: pickNextBestInlineContributionAction(input.entries),
+    source: "system",
+    explanation: notes.length > 0 ? notes.join(" ") : null,
+  };
+}

--- a/packages/api/src/admin/crm/table-preferences/service.ts
+++ b/packages/api/src/admin/crm/table-preferences/service.ts
@@ -1,0 +1,225 @@
+import {
+  CRM_ROW_ACTION_SCHEMA_VERSION,
+  normalizeCrmPinnedActionId,
+} from "./row-action";
+import { ApiHttpError } from "../../../shared/http-errors";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+import type {
+  CrmTablePreferencesResponse,
+  CrmTableRowActionPreference,
+  CrmViewSettingsLayer,
+  CrmViewSettingsPatch,
+} from "@asym/database/types";
+
+// Re-exported so existing consumers (route handlers) keep importing the patch
+// type from this module while the shared semantics live in @asym/database.
+export type { CrmViewSettingsPatch };
+
+type SupabaseAdmin = AdminSupabaseClient;
+
+interface PreferenceRow {
+  pinned_action_id: string | null;
+  schema_version: number | null;
+  settings: CrmViewSettingsLayer | null;
+}
+
+const PREFERENCE_COLUMNS = "pinned_action_id, schema_version, settings";
+
+function firstRpcValue(data: unknown): unknown {
+  return Array.isArray(data) ? data[0] : data;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readPreferenceRpcRow(data: unknown): PreferenceRow | null {
+  const row = firstRpcValue(data);
+  if (!isRecord(row)) {
+    return null;
+  }
+
+  return row as unknown as PreferenceRow;
+}
+
+function isInsufficientPrivilegeError(error: unknown): boolean {
+  return isRecord(error) && error.code === "42501";
+}
+
+function isNoDataFoundError(error: unknown): boolean {
+  return isRecord(error) && error.code === "P0002";
+}
+
+function isInvalidParameterValueError(error: unknown): boolean {
+  return isRecord(error) && error.code === "22023";
+}
+
+function mapPreferenceRow(
+  row: PreferenceRow | null,
+): CrmTableRowActionPreference | null {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    actionId: row.pinned_action_id,
+    schemaVersion: row.schema_version ?? CRM_ROW_ACTION_SCHEMA_VERSION,
+    settings: row.settings ?? null,
+  };
+}
+
+export async function getCrmTablePreferences(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  profileId: string;
+  tableId: string;
+}): Promise<CrmTablePreferencesResponse> {
+  const [userResult, tenantResult] = await Promise.all([
+    input.supabaseAdmin
+      .from("crm_table_user_preferences")
+      .select(PREFERENCE_COLUMNS)
+      .eq("tenant_id", input.tenantId)
+      .eq("profile_id", input.profileId)
+      .eq("table_id", input.tableId)
+      .maybeSingle(),
+    input.supabaseAdmin
+      .from("crm_table_tenant_defaults")
+      .select(PREFERENCE_COLUMNS)
+      .eq("tenant_id", input.tenantId)
+      .eq("table_id", input.tableId)
+      .maybeSingle(),
+  ]);
+
+  if (userResult.error) {
+    throw new ApiHttpError(500, userResult.error.message);
+  }
+  if (tenantResult.error) {
+    throw new ApiHttpError(500, tenantResult.error.message);
+  }
+
+  return {
+    tableId: input.tableId,
+    schemaVersion: CRM_ROW_ACTION_SCHEMA_VERSION,
+    user: mapPreferenceRow(userResult.data as PreferenceRow | null),
+    tenantDefault: mapPreferenceRow(tenantResult.data as PreferenceRow | null),
+  };
+}
+
+export interface SaveCrmTablePreferenceInput {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  tableId: string;
+  /** undefined = unchanged; null = unpin. */
+  pinnedActionId?: string | null;
+  settingsPatch?: CrmViewSettingsPatch;
+}
+
+export async function saveCrmUserTablePreference(
+  input: SaveCrmTablePreferenceInput & { profileId: string },
+): Promise<CrmTableRowActionPreference> {
+  const pinnedActionId =
+    input.pinnedActionId === undefined
+      ? null
+      : normalizeCrmPinnedActionId(input.pinnedActionId);
+  const { data, error } = await input.supabaseAdmin.rpc(
+    "save_crm_user_table_preference",
+    {
+      p_tenant_id: input.tenantId,
+      p_profile_id: input.profileId,
+      p_table_id: input.tableId,
+      p_pinned_action_id: pinnedActionId,
+      p_pinned_action_id_is_set: input.pinnedActionId !== undefined,
+      p_schema_version: CRM_ROW_ACTION_SCHEMA_VERSION,
+      p_settings_patch: input.settingsPatch ?? {},
+    },
+  );
+  const row = readPreferenceRpcRow(data);
+
+  if (isNoDataFoundError(error)) {
+    throw new ApiHttpError(
+      404,
+      error?.message ?? "Active named view not found.",
+    );
+  }
+
+  if (isInvalidParameterValueError(error)) {
+    throw new ApiHttpError(
+      400,
+      error?.message ?? "Active named view id is invalid.",
+    );
+  }
+
+  if (error || !row) {
+    throw new ApiHttpError(
+      500,
+      error?.message ?? "Failed to save table preferences.",
+    );
+  }
+
+  return mapPreferenceRow(row)!;
+}
+
+export async function saveCrmUserRowActionPin(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  profileId: string;
+  tableId: string;
+  pinnedActionId: string | null;
+}): Promise<CrmTableRowActionPreference> {
+  return saveCrmUserTablePreference(input);
+}
+
+export async function saveCrmTenantTableDefault(
+  input: SaveCrmTablePreferenceInput & {
+    actorCanManageDefaults: boolean;
+    actorProfileId: string;
+  },
+): Promise<CrmTableRowActionPreference> {
+  const pinnedActionId =
+    input.pinnedActionId === undefined
+      ? null
+      : normalizeCrmPinnedActionId(input.pinnedActionId);
+  const { data, error } = await input.supabaseAdmin.rpc(
+    "save_crm_tenant_table_default",
+    {
+      p_tenant_id: input.tenantId,
+      p_table_id: input.tableId,
+      p_pinned_action_id: pinnedActionId,
+      p_pinned_action_id_is_set: input.pinnedActionId !== undefined,
+      p_schema_version: CRM_ROW_ACTION_SCHEMA_VERSION,
+      p_settings_patch: input.settingsPatch ?? {},
+      p_actor_profile_id: input.actorProfileId,
+      p_actor_can_manage_defaults: input.actorCanManageDefaults,
+    },
+  );
+  const row = readPreferenceRpcRow(data);
+
+  if (isInsufficientPrivilegeError(error)) {
+    throw new ApiHttpError(
+      403,
+      error?.message ??
+        "Forbidden: requires crm.gift_history.manage_view_defaults",
+    );
+  }
+
+  if (error || !row) {
+    throw new ApiHttpError(
+      500,
+      error?.message ?? "Failed to save the tenant default.",
+    );
+  }
+
+  return mapPreferenceRow(row)!;
+}
+
+export async function saveCrmTenantRowActionDefault(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  tableId: string;
+  pinnedActionId: string | null;
+  actorCanManageDefaults: boolean;
+  actorProfileId: string;
+}): Promise<CrmTableRowActionPreference> {
+  return saveCrmTenantTableDefault(input);
+}

--- a/packages/api/src/admin/crm/table-preferences/view-settings.ts
+++ b/packages/api/src/admin/crm/table-preferences/view-settings.ts
@@ -1,0 +1,261 @@
+import type {
+  CrmGiftHistoryColumnSettings,
+  CrmGiftHistoryFiltersSortSettings,
+  CrmGiftHistoryViewSettings,
+  CrmViewSettingsLayer,
+  CrmViewSettingsScope,
+  CrmViewSettingsSource,
+} from "@asym/database/types";
+
+/**
+ * CRM gift-history view settings (issue #272, ADR-CD-021).
+ *
+ * One settings surface groups columns, filters/sort, and the pinned row
+ * action. The server record is the source of truth; every scope falls back
+ * from user preference to tenant default to system default, and granular
+ * resets clear only the selected scope with a preview of what changes.
+ */
+
+export const CRM_GIFT_HISTORY_SYSTEM_VIEW_SETTINGS: CrmGiftHistoryViewSettings =
+  {
+    columns: {
+      designation: true,
+      statusLine: true,
+    },
+    filtersSort: {
+      sortField: "giftDate",
+      sortDirection: "desc",
+      paymentStatus: "all",
+      issue: "all",
+    },
+  };
+
+function mergeColumns(
+  layer: Partial<CrmGiftHistoryColumnSettings> | null | undefined,
+  base: CrmGiftHistoryColumnSettings,
+): CrmGiftHistoryColumnSettings {
+  return {
+    designation:
+      typeof layer?.designation === "boolean"
+        ? layer.designation
+        : base.designation,
+    statusLine:
+      typeof layer?.statusLine === "boolean"
+        ? layer.statusLine
+        : base.statusLine,
+  };
+}
+
+const SORT_FIELDS: CrmGiftHistoryFiltersSortSettings["sortField"][] = [
+  "giftDate",
+  "amountCents",
+];
+const SORT_DIRECTIONS: CrmGiftHistoryFiltersSortSettings["sortDirection"][] = [
+  "asc",
+  "desc",
+];
+const PAYMENT_STATUS_FILTERS: CrmGiftHistoryFiltersSortSettings["paymentStatus"][] =
+  ["all", "completed", "refunded"];
+const ISSUE_FILTERS: CrmGiftHistoryFiltersSortSettings["issue"][] = [
+  "all",
+  "needs_attention",
+  "receipt_affected",
+  "pending_correction",
+];
+
+function mergeFiltersSort(
+  layer: Partial<CrmGiftHistoryFiltersSortSettings> | null | undefined,
+  base: CrmGiftHistoryFiltersSortSettings,
+): CrmGiftHistoryFiltersSortSettings {
+  return {
+    sortField: SORT_FIELDS.includes(
+      layer?.sortField as CrmGiftHistoryFiltersSortSettings["sortField"],
+    )
+      ? layer!.sortField!
+      : base.sortField,
+    sortDirection: SORT_DIRECTIONS.includes(
+      layer?.sortDirection as CrmGiftHistoryFiltersSortSettings["sortDirection"],
+    )
+      ? layer!.sortDirection!
+      : base.sortDirection,
+    paymentStatus: PAYMENT_STATUS_FILTERS.includes(
+      layer?.paymentStatus as CrmGiftHistoryFiltersSortSettings["paymentStatus"],
+    )
+      ? layer!.paymentStatus!
+      : base.paymentStatus,
+    issue: ISSUE_FILTERS.includes(
+      layer?.issue as CrmGiftHistoryFiltersSortSettings["issue"],
+    )
+      ? layer!.issue!
+      : base.issue,
+  };
+}
+
+export interface ResolvedCrmViewSettings {
+  settings: CrmGiftHistoryViewSettings;
+  sources: {
+    columns: CrmViewSettingsSource;
+    filtersSort: CrmViewSettingsSource;
+  };
+}
+
+/**
+ * Per-scope fallback: a scope comes wholesale from the highest layer that
+ * sets it (user, then tenant default), merged over system defaults so keys
+ * added in newer schema versions stay safe.
+ */
+export function resolveCrmGiftHistoryViewSettings(input: {
+  user: CrmViewSettingsLayer | null;
+  tenantDefault: CrmViewSettingsLayer | null;
+}): ResolvedCrmViewSettings {
+  const system = CRM_GIFT_HISTORY_SYSTEM_VIEW_SETTINGS;
+
+  const columnsSource: CrmViewSettingsSource = input.user?.columns
+    ? "user"
+    : input.tenantDefault?.columns
+      ? "tenant_default"
+      : "system";
+  const filtersSortSource: CrmViewSettingsSource = input.user?.filtersSort
+    ? "user"
+    : input.tenantDefault?.filtersSort
+      ? "tenant_default"
+      : "system";
+
+  const columnsLayer =
+    columnsSource === "user"
+      ? input.user?.columns
+      : columnsSource === "tenant_default"
+        ? input.tenantDefault?.columns
+        : null;
+  const filtersSortLayer =
+    filtersSortSource === "user"
+      ? input.user?.filtersSort
+      : filtersSortSource === "tenant_default"
+        ? input.tenantDefault?.filtersSort
+        : null;
+
+  return {
+    settings: {
+      columns: mergeColumns(columnsLayer, system.columns),
+      filtersSort: mergeFiltersSort(filtersSortLayer, system.filtersSort),
+    },
+    sources: {
+      columns: columnsSource,
+      filtersSort: filtersSortSource,
+    },
+  };
+}
+
+export interface CrmViewSettingsResetPreview {
+  scope: CrmViewSettingsScope;
+  description: string;
+  after: {
+    settings: CrmGiftHistoryViewSettings;
+    pinnedActionId: string | null;
+  };
+  sources: {
+    columns: CrmViewSettingsSource;
+    filtersSort: CrmViewSettingsSource;
+    pinnedAction: CrmViewSettingsSource;
+  };
+}
+
+interface PreferenceLayerWithPin {
+  settings: CrmViewSettingsLayer | null;
+  pinnedActionId: string | null;
+}
+
+function describeFallback(source: CrmViewSettingsSource): string {
+  return source === "tenant_default"
+    ? "the tenant default"
+    : "the system default";
+}
+
+/**
+ * Computes the effective state after resetting the selected scope, without
+ * applying anything — resets always preview before they run (ADR-CD-021).
+ */
+export function previewCrmViewSettingsReset(input: {
+  scope: CrmViewSettingsScope;
+  user: PreferenceLayerWithPin | null;
+  tenantDefault: PreferenceLayerWithPin | null;
+}): CrmViewSettingsResetPreview {
+  const resetColumns = input.scope === "columns" || input.scope === "all";
+  const resetFiltersSort =
+    input.scope === "filtersSort" || input.scope === "all";
+  const resetPin = input.scope === "pinnedAction" || input.scope === "all";
+
+  const userAfter: CrmViewSettingsLayer = {
+    columns: resetColumns ? null : (input.user?.settings?.columns ?? null),
+    filtersSort: resetFiltersSort
+      ? null
+      : (input.user?.settings?.filtersSort ?? null),
+  };
+
+  const resolved = resolveCrmGiftHistoryViewSettings({
+    user: userAfter,
+    tenantDefault: input.tenantDefault?.settings ?? null,
+  });
+
+  const userPinAfter = resetPin ? null : (input.user?.pinnedActionId ?? null);
+  const tenantPin = input.tenantDefault?.pinnedActionId ?? null;
+  const pinnedActionId = userPinAfter ?? tenantPin;
+  const pinnedActionSource: CrmViewSettingsSource = userPinAfter
+    ? "user"
+    : tenantPin
+      ? "tenant_default"
+      : "system";
+
+  const changes: string[] = [];
+  if (resetColumns) {
+    changes.push(
+      `Columns return to ${describeFallback(resolved.sources.columns)}.`,
+    );
+  }
+  if (resetFiltersSort) {
+    changes.push(
+      `Filters and sort return to ${describeFallback(resolved.sources.filtersSort)}.`,
+    );
+  }
+  if (resetPin) {
+    changes.push(
+      tenantPin
+        ? "The pinned row action returns to the tenant default."
+        : "The pinned row action returns to the system next-best action.",
+    );
+  }
+
+  return {
+    scope: input.scope,
+    description: changes.join(" "),
+    after: {
+      settings: resolved.settings,
+      pinnedActionId,
+    },
+    sources: {
+      columns: resolved.sources.columns,
+      filtersSort: resolved.sources.filtersSort,
+      pinnedAction: pinnedActionSource,
+    },
+  };
+}
+
+/**
+ * Tenant defaults are managed by capability holders (super admins, or staff
+ * the capability was delegated to via the tenant default record). The
+ * delegation never grants contribution operation permissions (ADR-CD-021).
+ */
+export function canManageCrmTenantDefaults(input: {
+  capabilities: string[];
+  profileId: string | null;
+  delegatedManagerProfileIds: string[];
+}): boolean {
+  if (input.capabilities.includes("crm.gift_history.manage_view_defaults")) {
+    return true;
+  }
+
+  return Boolean(
+    input.profileId &&
+    input.delegatedManagerProfileIds.includes(input.profileId),
+  );
+}

--- a/packages/api/src/crm/sync/store.ts
+++ b/packages/api/src/crm/sync/store.ts
@@ -479,6 +479,7 @@ export function createSupabaseCrmSyncStore(clientInput: unknown): CrmSyncStore {
         .eq("tenant_id", input.job.tenantId)
         .eq("staged_gift_id", stagedGiftId)
         .eq("crm_provider", "twenty")
+        .eq("scope", "parent")
         .maybeSingle();
       requireNoError(existing.error, "Failed to read donation CRM link.");
 
@@ -509,6 +510,7 @@ export function createSupabaseCrmSyncStore(clientInput: unknown): CrmSyncStore {
               ? input.job.payload.asymDonationId
               : null,
           staged_gift_id: stagedGiftId,
+          scope: "parent",
           crm_provider: "twenty",
           twenty_object_name: input.job.twentyObjectName,
           twenty_record_id: input.twentyRecordId,
@@ -554,6 +556,7 @@ export function createSupabaseCrmSyncStore(clientInput: unknown): CrmSyncStore {
         .eq("tenant_id", input.job.tenantId)
         .eq("staged_gift_id", stagedGiftId)
         .eq("crm_provider", "twenty")
+        .eq("scope", "parent")
         .maybeSingle();
       requireNoError(existing.error, "Failed to read donation CRM link.");
 
@@ -609,6 +612,7 @@ export function createSupabaseCrmSyncStore(clientInput: unknown): CrmSyncStore {
           "id,donation_id,staged_gift_id,link_status,twenty_record_id,metadata",
         )
         .eq("tenant_id", input.tenantId)
+        .eq("scope", "parent")
         .in("link_status", ["queued", "failed"]);
 
       requireNoError(orphanLinks.error, "Failed to read orphan CRM links.");

--- a/packages/api/src/crm/types/index.ts
+++ b/packages/api/src/crm/types/index.ts
@@ -17,7 +17,10 @@ export type CrmAction =
   | "crm.person.create"
   | "crm.person.update"
   | "crm.sync.replay"
-  | "crm.sync.reconcile";
+  | "crm.sync.reconcile"
+  | "crm.table_preferences.read"
+  | "crm.table_preferences.write"
+  | "crm.table_preferences.manage_defaults";
 
 export type CrmResourceType =
   | "crm_gateway"

--- a/packages/api/src/giving/staged-gifts.ts
+++ b/packages/api/src/giving/staged-gifts.ts
@@ -472,6 +472,7 @@ export async function queueStagedGiftPostingToTwenty(
     .eq("tenant_id", gift.tenantId)
     .eq("staged_gift_id", gift.id)
     .eq("crm_provider", "twenty")
+    .eq("scope", "parent")
     .maybeSingle();
   requireNoError(linked.error, "Failed to read donation CRM link.");
 
@@ -493,6 +494,7 @@ export async function queueStagedGiftPostingToTwenty(
         tenant_id: gift.tenantId,
         donation_id: gift.donationId,
         staged_gift_id: gift.id,
+        scope: "parent",
         crm_provider: "twenty",
         twenty_object_name: "giftSummaries",
         link_status: "queued",

--- a/supabase/migrations/20260611155000_crm_links_parent_child_scope.sql
+++ b/supabase/migrations/20260611155000_crm_links_parent_child_scope.sql
@@ -1,0 +1,113 @@
+-- Parent gift vs child designation CRM record links (ADR-CD-012).
+-- One parent gift link represents the donation in the CRM; designation lines
+-- may post as child records. Failures stay parent- or line-scoped so retries
+-- can target the failed scope.
+
+ALTER TABLE public.donation_crm_links
+    ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'parent'
+        CHECK (scope IN ('parent', 'designation')),
+    ADD COLUMN IF NOT EXISTS allocation_id UUID
+        REFERENCES public.staged_gift_allocations(id) ON DELETE CASCADE,
+    ADD COLUMN IF NOT EXISTS last_error TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'donation_crm_links_designation_allocation_check'
+          AND conrelid = 'public.donation_crm_links'::regclass
+    ) THEN
+        ALTER TABLE public.donation_crm_links
+            ADD CONSTRAINT donation_crm_links_designation_allocation_check
+            CHECK (scope <> 'designation' OR allocation_id IS NOT NULL);
+    END IF;
+END $$;
+
+DROP INDEX IF EXISTS public.idx_donation_crm_links_donation_record;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_parent_record
+    ON public.donation_crm_links (
+        tenant_id,
+        donation_id,
+        crm_provider,
+        twenty_object_name,
+        twenty_record_id,
+        scope
+    )
+    WHERE donation_id IS NOT NULL
+      AND twenty_object_name IS NOT NULL
+      AND twenty_record_id IS NOT NULL
+      AND scope = 'parent';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_designation_record
+    ON public.donation_crm_links (
+        tenant_id,
+        donation_id,
+        allocation_id,
+        crm_provider,
+        twenty_object_name,
+        twenty_record_id,
+        scope
+    )
+    WHERE donation_id IS NOT NULL
+      AND allocation_id IS NOT NULL
+      AND twenty_object_name IS NOT NULL
+      AND twenty_record_id IS NOT NULL
+      AND scope = 'designation';
+
+WITH ranked_parent_staged_gift_links AS (
+    SELECT
+        id,
+        staged_gift_id,
+        ROW_NUMBER() OVER (
+            PARTITION BY tenant_id, staged_gift_id, crm_provider
+            ORDER BY
+                CASE link_status
+                    WHEN 'active' THEN 0
+                    WHEN 'queued' THEN 1
+                    WHEN 'failed' THEN 2
+                    WHEN 'archived' THEN 3
+                    ELSE 4
+                END,
+                (twenty_record_id IS NOT NULL) DESC,
+                updated_at DESC,
+                created_at DESC,
+                id
+        ) AS row_rank
+    FROM public.donation_crm_links
+    WHERE staged_gift_id IS NOT NULL
+      AND scope = 'parent'
+),
+duplicate_parent_staged_gift_links AS (
+    SELECT id, staged_gift_id
+    FROM ranked_parent_staged_gift_links
+    WHERE row_rank > 1
+)
+UPDATE public.donation_crm_links AS duplicate
+SET staged_gift_id = NULL,
+    link_status = 'archived',
+    last_error = CONCAT_WS(
+        E'\n',
+        NULLIF(duplicate.last_error, ''),
+        'Archived duplicate parent staged gift link before parent staged gift singleton index.'
+    ),
+    metadata = duplicate.metadata || jsonb_build_object(
+        'archivedByMigration',
+        '20260611155000_crm_links_parent_child_scope',
+        'archivedDuplicateReason',
+        'duplicate_parent_staged_gift_link',
+        'archivedDuplicateStagedGiftId',
+        duplicate_parent_staged_gift_links.staged_gift_id::TEXT
+    ),
+    updated_at = NOW()
+FROM duplicate_parent_staged_gift_links
+WHERE duplicate.id = duplicate_parent_staged_gift_links.id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_parent_staged_gift
+    ON public.donation_crm_links (tenant_id, staged_gift_id, crm_provider)
+    WHERE staged_gift_id IS NOT NULL
+      AND scope = 'parent';
+
+CREATE INDEX IF NOT EXISTS idx_donation_crm_links_donation_scope
+    ON public.donation_crm_links (tenant_id, donation_id, scope);

--- a/supabase/migrations/20260611160000_crm_table_preferences.sql
+++ b/supabase/migrations/20260611160000_crm_table_preferences.sql
@@ -1,0 +1,353 @@
+-- CRM table preferences: user-pinned row actions and tenant defaults
+-- (ADR-CD-021, issue #271). The server record is the source of truth with
+-- schema versioning; preferences are personalization only and are always
+-- re-validated against capability/state-filtered inline actions before use.
+
+CREATE TABLE IF NOT EXISTS public.crm_table_user_preferences (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    table_id TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    pinned_action_id TEXT,
+    settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, profile_id, table_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.crm_table_tenant_defaults (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    table_id TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    pinned_action_id TEXT,
+    settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, table_id)
+);
+
+-- Tenant default changes are audited, not approval-gated (ADR-CD-021).
+CREATE TABLE IF NOT EXISTS public.crm_table_preference_audit_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    actor_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    table_id TEXT NOT NULL,
+    scope TEXT NOT NULL DEFAULT 'tenant_default' CHECK (scope IN ('tenant_default')),
+    before_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    after_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_crm_table_preference_audit_tenant
+    ON public.crm_table_preference_audit_events (tenant_id, table_id, created_at DESC);
+
+ALTER TABLE public.crm_table_user_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.crm_table_tenant_defaults ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.crm_table_preference_audit_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.crm_table_user_preferences FROM anon, authenticated;
+REVOKE ALL ON TABLE public.crm_table_tenant_defaults FROM anon, authenticated;
+REVOKE ALL ON TABLE public.crm_table_preference_audit_events FROM anon, authenticated;
+
+GRANT ALL ON TABLE public.crm_table_user_preferences TO service_role;
+GRANT ALL ON TABLE public.crm_table_tenant_defaults TO service_role;
+GRANT ALL ON TABLE public.crm_table_preference_audit_events TO service_role;
+
+CREATE OR REPLACE FUNCTION public.apply_crm_view_settings_patch(
+    p_existing JSONB,
+    p_patch JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public
+AS $$
+DECLARE
+    v_next JSONB := COALESCE(p_existing, '{}'::jsonb);
+    v_patch JSONB := COALESCE(p_patch, '{}'::jsonb);
+BEGIN
+    IF v_patch ? 'columns' THEN
+        IF jsonb_typeof(v_patch -> 'columns') = 'null' THEN
+            v_next := v_next - 'columns';
+        ELSE
+            v_next := jsonb_set(v_next, '{columns}', v_patch -> 'columns', TRUE);
+        END IF;
+    END IF;
+
+    IF v_patch ? 'filtersSort' THEN
+        IF jsonb_typeof(v_patch -> 'filtersSort') = 'null' THEN
+            v_next := v_next - 'filtersSort';
+        ELSE
+            v_next := jsonb_set(
+                v_next,
+                '{filtersSort}',
+                v_patch -> 'filtersSort',
+                TRUE
+            );
+        END IF;
+    END IF;
+
+    IF v_patch ? 'delegatedManagerProfileIds' THEN
+        IF jsonb_typeof(v_patch -> 'delegatedManagerProfileIds') = 'null' THEN
+            v_next := v_next - 'delegatedManagerProfileIds';
+        ELSE
+            v_next := jsonb_set(
+                v_next,
+                '{delegatedManagerProfileIds}',
+                v_patch -> 'delegatedManagerProfileIds',
+                TRUE
+            );
+        END IF;
+    END IF;
+
+    IF v_patch ? 'activeViewId' THEN
+        IF jsonb_typeof(v_patch -> 'activeViewId') = 'null' THEN
+            v_next := v_next - 'activeViewId';
+        ELSE
+            v_next := jsonb_set(
+                v_next,
+                '{activeViewId}',
+                v_patch -> 'activeViewId',
+                TRUE
+            );
+        END IF;
+    END IF;
+
+    RETURN v_next;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.save_crm_user_table_preference(
+    p_tenant_id UUID,
+    p_profile_id UUID,
+    p_table_id TEXT,
+    p_pinned_action_id TEXT,
+    p_pinned_action_id_is_set BOOLEAN,
+    p_schema_version INTEGER,
+    p_settings_patch JSONB
+)
+RETURNS public.crm_table_user_preferences
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_row public.crm_table_user_preferences;
+BEGIN
+    INSERT INTO public.crm_table_user_preferences (
+        tenant_id,
+        profile_id,
+        table_id,
+        pinned_action_id,
+        schema_version,
+        settings,
+        updated_at
+    )
+    VALUES (
+        p_tenant_id,
+        p_profile_id,
+        p_table_id,
+        CASE
+            WHEN p_pinned_action_id_is_set THEN p_pinned_action_id
+            ELSE NULL
+        END,
+        COALESCE(p_schema_version, 1),
+        public.apply_crm_view_settings_patch(
+            '{}'::jsonb,
+            COALESCE(p_settings_patch, '{}'::jsonb)
+        ),
+        NOW()
+    )
+    ON CONFLICT (tenant_id, profile_id, table_id)
+    DO UPDATE
+    SET pinned_action_id = CASE
+            WHEN p_pinned_action_id_is_set THEN EXCLUDED.pinned_action_id
+            ELSE public.crm_table_user_preferences.pinned_action_id
+        END,
+        schema_version = EXCLUDED.schema_version,
+        settings = public.apply_crm_view_settings_patch(
+            public.crm_table_user_preferences.settings,
+            COALESCE(p_settings_patch, '{}'::jsonb)
+        ),
+        updated_at = NOW()
+    RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.save_crm_tenant_table_default(
+    p_tenant_id UUID,
+    p_table_id TEXT,
+    p_pinned_action_id TEXT,
+    p_pinned_action_id_is_set BOOLEAN,
+    p_schema_version INTEGER,
+    p_settings_patch JSONB,
+    p_actor_profile_id UUID,
+    p_actor_can_manage_defaults BOOLEAN
+)
+RETURNS public.crm_table_tenant_defaults
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_before public.crm_table_tenant_defaults;
+    v_found BOOLEAN := FALSE;
+    v_pinned_action_id TEXT;
+    v_settings JSONB;
+    v_row public.crm_table_tenant_defaults;
+    v_delegated_manager_profile_ids JSONB;
+BEGIN
+    PERFORM pg_advisory_xact_lock(
+        hashtext('crm_table_tenant_defaults'),
+        hashtext(p_tenant_id::TEXT || ':' || p_table_id)
+    );
+
+    SELECT *
+    INTO v_before
+    FROM public.crm_table_tenant_defaults
+    WHERE tenant_id = p_tenant_id
+      AND table_id = p_table_id
+    FOR UPDATE;
+    v_found := FOUND;
+    v_delegated_manager_profile_ids := CASE
+        WHEN v_found THEN COALESCE(
+            v_before.settings -> 'delegatedManagerProfileIds',
+            '[]'::jsonb
+        )
+        ELSE '[]'::jsonb
+    END;
+
+    IF NOT COALESCE(p_actor_can_manage_defaults, FALSE) THEN
+        IF COALESCE(p_settings_patch, '{}'::jsonb) ? 'delegatedManagerProfileIds' THEN
+            RAISE EXCEPTION 'Forbidden: only super admins can change delegated default managers.'
+                USING ERRCODE = '42501';
+        END IF;
+
+        IF p_actor_profile_id IS NULL
+           OR jsonb_typeof(v_delegated_manager_profile_ids) <> 'array'
+           OR NOT (v_delegated_manager_profile_ids ? p_actor_profile_id::TEXT) THEN
+            RAISE EXCEPTION 'Forbidden: requires crm.gift_history.manage_view_defaults'
+                USING ERRCODE = '42501';
+        END IF;
+    END IF;
+
+    v_pinned_action_id := CASE
+        WHEN p_pinned_action_id_is_set THEN p_pinned_action_id
+        WHEN v_found THEN v_before.pinned_action_id
+        ELSE NULL
+    END;
+    v_settings := public.apply_crm_view_settings_patch(
+        CASE WHEN v_found THEN v_before.settings ELSE '{}'::jsonb END,
+        COALESCE(p_settings_patch, '{}'::jsonb)
+    );
+
+    IF v_found THEN
+        UPDATE public.crm_table_tenant_defaults
+        SET pinned_action_id = v_pinned_action_id,
+            schema_version = COALESCE(p_schema_version, 1),
+            settings = v_settings,
+            updated_by = p_actor_profile_id,
+            updated_at = NOW()
+        WHERE id = v_before.id
+        RETURNING * INTO v_row;
+    ELSE
+        INSERT INTO public.crm_table_tenant_defaults (
+            tenant_id,
+            table_id,
+            pinned_action_id,
+            schema_version,
+            settings,
+            updated_by,
+            updated_at
+        )
+        VALUES (
+            p_tenant_id,
+            p_table_id,
+            v_pinned_action_id,
+            COALESCE(p_schema_version, 1),
+            v_settings,
+            p_actor_profile_id,
+            NOW()
+        )
+        RETURNING * INTO v_row;
+    END IF;
+
+    INSERT INTO public.crm_table_preference_audit_events (
+        tenant_id,
+        actor_profile_id,
+        table_id,
+        scope,
+        before_snapshot,
+        after_snapshot
+    )
+    VALUES (
+        p_tenant_id,
+        p_actor_profile_id,
+        p_table_id,
+        'tenant_default',
+        jsonb_build_object(
+            'pinnedActionId',
+            CASE WHEN v_found THEN v_before.pinned_action_id ELSE NULL END,
+            'settings',
+            CASE WHEN v_found THEN v_before.settings ELSE NULL END
+        ),
+        jsonb_build_object(
+            'pinnedActionId',
+            v_pinned_action_id,
+            'settings',
+            v_settings
+        )
+    );
+
+    RETURN v_row;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.apply_crm_view_settings_patch(JSONB, JSONB)
+    FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.save_crm_user_table_preference(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    INTEGER,
+    JSONB
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.save_crm_tenant_table_default(
+    UUID,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    INTEGER,
+    JSONB,
+    UUID,
+    BOOLEAN
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.apply_crm_view_settings_patch(JSONB, JSONB)
+    TO service_role;
+GRANT EXECUTE ON FUNCTION public.save_crm_user_table_preference(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    INTEGER,
+    JSONB
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.save_crm_tenant_table_default(
+    UUID,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    INTEGER,
+    JSONB,
+    UUID,
+    BOOLEAN
+) TO service_role;

--- a/supabase/migrations/20260611170000_crm_table_named_views.sql
+++ b/supabase/migrations/20260611170000_crm_table_named_views.sql
@@ -1,0 +1,413 @@
+-- Named personal CRM gift-history views (ADR-CD-021, issue #273).
+-- Personal-only snapshots of view settings; one default per user/table.
+-- No sharing, publishing, or team views.
+
+CREATE TABLE IF NOT EXISTS public.crm_table_named_views (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    table_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    pinned_action_id TEXT,
+    settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, profile_id, table_id, name)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_crm_table_named_views_default
+    ON public.crm_table_named_views (tenant_id, profile_id, table_id)
+    WHERE is_default;
+
+ALTER TABLE public.crm_table_named_views ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.crm_table_named_views FROM anon, authenticated;
+
+GRANT ALL ON TABLE public.crm_table_named_views TO service_role;
+
+-- Once named views exist, user preferences can safely validate activeViewId
+-- inside the same RPC transaction that persists the setting.
+CREATE OR REPLACE FUNCTION public.save_crm_user_table_preference(
+    p_tenant_id UUID,
+    p_profile_id UUID,
+    p_table_id TEXT,
+    p_pinned_action_id TEXT,
+    p_pinned_action_id_is_set BOOLEAN,
+    p_schema_version INTEGER,
+    p_settings_patch JSONB
+)
+RETURNS public.crm_table_user_preferences
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_active_view_id TEXT;
+    v_row public.crm_table_user_preferences;
+    v_settings_patch JSONB;
+BEGIN
+    v_settings_patch := COALESCE(p_settings_patch, '{}'::jsonb);
+
+    IF v_settings_patch ? 'activeViewId'
+       AND jsonb_typeof(v_settings_patch -> 'activeViewId') <> 'null' THEN
+        IF jsonb_typeof(v_settings_patch -> 'activeViewId') <> 'string' THEN
+            RAISE EXCEPTION 'Active named view id must be a string.'
+                USING ERRCODE = '22023';
+        END IF;
+
+        v_active_view_id := v_settings_patch ->> 'activeViewId';
+        IF v_active_view_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+            RAISE EXCEPTION 'Active named view id must be a UUID.'
+                USING ERRCODE = '22023';
+        END IF;
+
+        PERFORM 1
+        FROM public.crm_table_named_views
+        WHERE tenant_id = p_tenant_id
+          AND profile_id = p_profile_id
+          AND table_id = p_table_id
+          AND id = v_active_view_id::UUID
+        FOR KEY SHARE;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'Active named view not found.'
+                USING ERRCODE = 'P0002';
+        END IF;
+    END IF;
+
+    INSERT INTO public.crm_table_user_preferences (
+        tenant_id,
+        profile_id,
+        table_id,
+        pinned_action_id,
+        schema_version,
+        settings,
+        updated_at
+    )
+    VALUES (
+        p_tenant_id,
+        p_profile_id,
+        p_table_id,
+        CASE
+            WHEN p_pinned_action_id_is_set THEN p_pinned_action_id
+            ELSE NULL
+        END,
+        COALESCE(p_schema_version, 1),
+        public.apply_crm_view_settings_patch('{}'::jsonb, v_settings_patch),
+        NOW()
+    )
+    ON CONFLICT (tenant_id, profile_id, table_id)
+    DO UPDATE
+    SET pinned_action_id = CASE
+            WHEN p_pinned_action_id_is_set THEN EXCLUDED.pinned_action_id
+            ELSE public.crm_table_user_preferences.pinned_action_id
+        END,
+        schema_version = EXCLUDED.schema_version,
+        settings = public.apply_crm_view_settings_patch(
+            public.crm_table_user_preferences.settings,
+            v_settings_patch
+        ),
+        updated_at = NOW()
+    RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_crm_table_named_view(
+    p_tenant_id UUID,
+    p_profile_id UUID,
+    p_table_id TEXT,
+    p_name TEXT,
+    p_is_default BOOLEAN,
+    p_schema_version INTEGER,
+    p_pinned_action_id TEXT,
+    p_settings JSONB
+)
+RETURNS public.crm_table_named_views
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_view public.crm_table_named_views;
+BEGIN
+    IF COALESCE(p_is_default, FALSE) THEN
+        UPDATE public.crm_table_named_views
+        SET is_default = FALSE,
+            updated_at = NOW()
+        WHERE tenant_id = p_tenant_id
+          AND profile_id = p_profile_id
+          AND table_id = p_table_id
+          AND is_default;
+    END IF;
+
+    INSERT INTO public.crm_table_named_views (
+        tenant_id,
+        profile_id,
+        table_id,
+        name,
+        is_default,
+        schema_version,
+        pinned_action_id,
+        settings
+    )
+    VALUES (
+        p_tenant_id,
+        p_profile_id,
+        p_table_id,
+        p_name,
+        COALESCE(p_is_default, FALSE),
+        COALESCE(p_schema_version, 1),
+        p_pinned_action_id,
+        COALESCE(p_settings, '{}'::jsonb)
+    )
+    RETURNING * INTO v_view;
+
+    RETURN v_view;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_crm_table_named_view(
+    p_tenant_id UUID,
+    p_profile_id UUID,
+    p_table_id TEXT,
+    p_view_id TEXT,
+    p_name TEXT,
+    p_name_is_set BOOLEAN,
+    p_is_default BOOLEAN,
+    p_is_default_is_set BOOLEAN,
+    p_schema_version INTEGER,
+    p_pinned_action_id TEXT,
+    p_pinned_action_id_is_set BOOLEAN,
+    p_settings JSONB,
+    p_settings_is_set BOOLEAN
+)
+RETURNS public.crm_table_named_views
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_view public.crm_table_named_views;
+BEGIN
+    SELECT *
+    INTO v_view
+    FROM public.crm_table_named_views
+    WHERE tenant_id = p_tenant_id
+      AND profile_id = p_profile_id
+      AND table_id = p_table_id
+      AND id::TEXT = p_view_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN NULL;
+    END IF;
+
+    IF COALESCE(p_is_default_is_set, FALSE)
+       AND COALESCE(p_is_default, FALSE) THEN
+        UPDATE public.crm_table_named_views
+        SET is_default = FALSE,
+            updated_at = NOW()
+        WHERE tenant_id = p_tenant_id
+          AND profile_id = p_profile_id
+          AND table_id = p_table_id
+          AND id <> v_view.id
+          AND is_default;
+    END IF;
+
+    UPDATE public.crm_table_named_views
+    SET name = CASE WHEN p_name_is_set THEN p_name ELSE name END,
+        is_default = CASE
+            WHEN p_is_default_is_set THEN COALESCE(p_is_default, FALSE)
+            ELSE is_default
+        END,
+        schema_version = CASE
+            WHEN p_pinned_action_id_is_set THEN COALESCE(p_schema_version, 1)
+            ELSE schema_version
+        END,
+        pinned_action_id = CASE
+            WHEN p_pinned_action_id_is_set THEN p_pinned_action_id
+            ELSE pinned_action_id
+        END,
+        settings = CASE
+            WHEN p_settings_is_set THEN public.apply_crm_view_settings_patch(
+                settings,
+                COALESCE(p_settings, '{}'::jsonb)
+            )
+            ELSE settings
+        END,
+        updated_at = NOW()
+    WHERE id = v_view.id
+    RETURNING * INTO v_view;
+
+    RETURN v_view;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.delete_crm_table_named_view(
+    p_tenant_id UUID,
+    p_profile_id UUID,
+    p_table_id TEXT,
+    p_view_id TEXT,
+    p_next_default_view_id TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_deleted public.crm_table_named_views;
+    v_next_default public.crm_table_named_views;
+BEGIN
+    SELECT *
+    INTO v_deleted
+    FROM public.crm_table_named_views
+    WHERE tenant_id = p_tenant_id
+      AND profile_id = p_profile_id
+      AND table_id = p_table_id
+      AND id::TEXT = p_view_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('deleted', FALSE, 'reason', 'view_not_found');
+    END IF;
+
+    IF p_next_default_view_id IS NOT NULL THEN
+        IF p_next_default_view_id = p_view_id THEN
+            RETURN jsonb_build_object(
+                'deleted',
+                FALSE,
+                'reason',
+                'next_default_not_found'
+            );
+        END IF;
+
+        SELECT *
+        INTO v_next_default
+        FROM public.crm_table_named_views
+        WHERE tenant_id = p_tenant_id
+          AND profile_id = p_profile_id
+          AND table_id = p_table_id
+          AND id::TEXT = p_next_default_view_id
+        FOR UPDATE;
+
+        IF NOT FOUND THEN
+            RETURN jsonb_build_object(
+                'deleted',
+                FALSE,
+                'reason',
+                'next_default_not_found'
+            );
+        END IF;
+    END IF;
+
+    DELETE FROM public.crm_table_named_views
+    WHERE id = v_deleted.id;
+
+    UPDATE public.crm_table_user_preferences
+    SET settings = public.apply_crm_view_settings_patch(
+            settings,
+            jsonb_build_object('activeViewId', p_next_default_view_id)
+        ),
+        updated_at = NOW()
+    WHERE tenant_id = p_tenant_id
+      AND profile_id = p_profile_id
+      AND table_id = p_table_id
+      AND settings ->> 'activeViewId' = p_view_id;
+
+    IF p_next_default_view_id IS NOT NULL
+       AND v_deleted.is_default THEN
+        UPDATE public.crm_table_named_views
+        SET is_default = FALSE,
+            updated_at = NOW()
+        WHERE tenant_id = p_tenant_id
+          AND profile_id = p_profile_id
+          AND table_id = p_table_id
+          AND id <> v_next_default.id
+          AND is_default;
+
+        UPDATE public.crm_table_named_views
+        SET is_default = TRUE,
+            updated_at = NOW()
+        WHERE id = v_next_default.id;
+    END IF;
+
+    RETURN jsonb_build_object(
+        'deleted',
+        TRUE,
+        'promoted',
+        p_next_default_view_id IS NOT NULL
+        AND v_deleted.is_default
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_crm_table_named_view(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    INTEGER,
+    TEXT,
+    JSONB
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.update_crm_table_named_view(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    BOOLEAN,
+    BOOLEAN,
+    INTEGER,
+    TEXT,
+    BOOLEAN,
+    JSONB,
+    BOOLEAN
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_crm_table_named_view(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.create_crm_table_named_view(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    INTEGER,
+    TEXT,
+    JSONB
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.update_crm_table_named_view(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    TEXT,
+    BOOLEAN,
+    BOOLEAN,
+    BOOLEAN,
+    INTEGER,
+    TEXT,
+    BOOLEAN,
+    JSONB,
+    BOOLEAN
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.delete_crm_table_named_view(
+    UUID,
+    UUID,
+    TEXT,
+    TEXT,
+    TEXT
+) TO service_role;

--- a/tests/unit/packages/api/admin-crm-detail-report.test.ts
+++ b/tests/unit/packages/api/admin-crm-detail-report.test.ts
@@ -303,6 +303,7 @@ describe("Phase 5 CRM donor detail and reports", () => {
           {
             id: "link-1",
             link_status: "queued",
+            scope: "parent",
             tenant_id: "tenant-1",
             updated_at: "2026-05-10T00:00:00.000Z",
           },

--- a/tests/unit/packages/api/admin/crm-named-views.test.ts
+++ b/tests/unit/packages/api/admin/crm-named-views.test.ts
@@ -1,0 +1,679 @@
+import { describe, expect, it } from "vitest";
+import { applyCrmViewSettingsPatch } from "@asym/database/types";
+
+import {
+  createCrmNamedView,
+  deleteCrmNamedView,
+  listCrmNamedViews,
+  updateCrmNamedView,
+} from "../../../../../packages/api/src/admin/crm/table-preferences/named-views";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+interface ViewRow {
+  id: string;
+  name: string;
+  is_default: boolean;
+  schema_version: number;
+  pinned_action_id: string | null;
+  settings: Record<string, unknown> | null;
+}
+
+function createSupabaseStub(initialRows: ViewRow[] = []) {
+  const rows = [...initialRows];
+  const updates: Array<{
+    payload: Record<string, unknown>;
+    filters: Record<string, unknown>;
+  }> = [];
+  const deletes: Array<Record<string, unknown>> = [];
+  const rpcCalls: Array<{
+    name: string;
+    params: Record<string, unknown>;
+  }> = [];
+
+  function applyFilters(
+    candidates: ViewRow[],
+    filters: Record<string, unknown>,
+  ) {
+    return candidates.filter((row) =>
+      Object.entries(filters).every(([key, value]) =>
+        key === "id" ? row.id === value : true,
+      ),
+    );
+  }
+
+  const stub = {
+    async rpc(name: string, params: Record<string, unknown>) {
+      rpcCalls.push({ name, params });
+
+      if (name === "create_crm_table_named_view") {
+        if (rows.some((row) => row.name === params.p_name)) {
+          return {
+            data: null,
+            error: {
+              code: "23505",
+              message: "duplicate key value violates unique constraint",
+            },
+          };
+        }
+
+        if (params.p_is_default === true) {
+          for (const row of rows) {
+            row.is_default = false;
+          }
+        }
+
+        const row: ViewRow = {
+          id: `view-${rows.length + 1}`,
+          name: String(params.p_name),
+          is_default: params.p_is_default === true,
+          schema_version: Number(params.p_schema_version ?? 1),
+          pinned_action_id:
+            (params.p_pinned_action_id as string | null) ?? null,
+          settings: (params.p_settings as Record<string, unknown>) ?? null,
+        };
+        rows.push(row);
+
+        return { data: row, error: null };
+      }
+
+      if (name === "update_crm_table_named_view") {
+        const row = rows.find((candidate) => candidate.id === params.p_view_id);
+        if (!row) {
+          return { data: null, error: null };
+        }
+
+        if (
+          params.p_is_default_is_set === true &&
+          params.p_is_default === true
+        ) {
+          for (const candidate of rows) {
+            if (candidate.id !== row.id) {
+              candidate.is_default = false;
+            }
+          }
+        }
+
+        if (params.p_name_is_set === true) {
+          if (
+            rows.some(
+              (candidate) =>
+                candidate.id !== row.id && candidate.name === params.p_name,
+            )
+          ) {
+            return {
+              data: null,
+              error: {
+                code: "23505",
+                message: "duplicate key value violates unique constraint",
+              },
+            };
+          }
+
+          row.name = String(params.p_name);
+        }
+        if (params.p_is_default_is_set === true) {
+          row.is_default = params.p_is_default === true;
+        }
+        if (params.p_pinned_action_id_is_set === true) {
+          row.schema_version = Number(params.p_schema_version ?? 1);
+          row.pinned_action_id =
+            (params.p_pinned_action_id as string | null) ?? null;
+        }
+        if (params.p_settings_is_set === true) {
+          row.settings = applyCrmViewSettingsPatch(
+            row.settings,
+            (params.p_settings as Record<string, unknown>) ?? {},
+          );
+        }
+
+        return { data: row, error: null };
+      }
+
+      if (name === "delete_crm_table_named_view") {
+        const viewId = String(params.p_view_id);
+        const nextDefaultViewId =
+          typeof params.p_next_default_view_id === "string"
+            ? params.p_next_default_view_id
+            : null;
+        const rowIndex = rows.findIndex((row) => row.id === viewId);
+        if (rowIndex < 0) {
+          return {
+            data: { deleted: false, reason: "view_not_found" },
+            error: null,
+          };
+        }
+
+        if (nextDefaultViewId) {
+          const nextDefault = rows.find((row) => row.id === nextDefaultViewId);
+          if (!nextDefault || nextDefault.id === viewId) {
+            return {
+              data: { deleted: false, reason: "next_default_not_found" },
+              error: null,
+            };
+          }
+        }
+
+        const deletedRow = rows[rowIndex];
+        rows.splice(rowIndex, 1);
+        const shouldPromoteDefault =
+          nextDefaultViewId !== null && deletedRow?.is_default === true;
+        if (shouldPromoteDefault) {
+          for (const row of rows) {
+            row.is_default = row.id === nextDefaultViewId;
+          }
+        }
+
+        return {
+          data: { deleted: true, promoted: shouldPromoteDefault },
+          error: null,
+        };
+      }
+
+      throw new Error(`Unexpected RPC: ${name}`);
+    },
+    from(_table: string) {
+      const filters: Record<string, unknown> = {};
+      const builder = {
+        select() {
+          return builder;
+        },
+        eq(column: string, value: unknown) {
+          filters[column] = value;
+          return builder;
+        },
+        order() {
+          return builder;
+        },
+        insert(payload: Record<string, unknown>) {
+          const row: ViewRow = {
+            id: `view-${rows.length + 1}`,
+            name: String(payload.name),
+            is_default: Boolean(payload.is_default),
+            schema_version: Number(payload.schema_version),
+            pinned_action_id:
+              (payload.pinned_action_id as string | null) ?? null,
+            settings: (payload.settings as Record<string, unknown>) ?? null,
+          };
+          rows.push(row);
+          return {
+            select() {
+              return {
+                async single() {
+                  return {
+                    data: row,
+                    error: null,
+                  };
+                },
+              };
+            },
+          };
+        },
+        update(payload: Record<string, unknown>) {
+          const updateBuilder = {
+            eq(column: string, value: unknown) {
+              filters[column] = value;
+              return updateBuilder;
+            },
+            then(resolve: (result: { error: null }) => void) {
+              updates.push({ payload, filters: { ...filters } });
+              for (const row of applyFilters(rows, filters)) {
+                if (payload.is_default !== undefined) {
+                  row.is_default = Boolean(payload.is_default);
+                }
+                if (payload.name !== undefined) {
+                  row.name = String(payload.name);
+                }
+                if (payload.pinned_action_id !== undefined) {
+                  row.pinned_action_id = payload.pinned_action_id as
+                    | string
+                    | null;
+                }
+                if (payload.settings !== undefined) {
+                  row.settings = payload.settings as Record<string, unknown>;
+                }
+              }
+              resolve({ error: null });
+            },
+          };
+          return updateBuilder;
+        },
+        delete() {
+          const deleteBuilder = {
+            eq(column: string, value: unknown) {
+              filters[column] = value;
+              return deleteBuilder;
+            },
+            then(resolve: (result: { error: null }) => void) {
+              deletes.push({ ...filters });
+              const remaining = rows.filter(
+                (row) => !(filters.id && row.id === filters.id),
+              );
+              rows.length = 0;
+              rows.push(...remaining);
+              resolve({ error: null });
+            },
+          };
+          return deleteBuilder;
+        },
+        async maybeSingle() {
+          const match = applyFilters(rows, filters)[0] ?? null;
+          return { data: match, error: null };
+        },
+        then(resolve: (result: { data: ViewRow[]; error: null }) => void) {
+          resolve({ data: applyFilters(rows, filters), error: null });
+        },
+      };
+      return builder;
+    },
+  };
+
+  return {
+    supabaseAdmin: stub as unknown as AdminSupabaseClient,
+    rows,
+    updates,
+    deletes,
+    rpcCalls,
+  };
+}
+
+const SCOPE = {
+  tenantId: "tenant-1",
+  profileId: "profile-1",
+  tableId: "crm.giftHistory",
+};
+
+describe("admin/crm/table-preferences/named-views", () => {
+  it("migrates renamed pinned operation ids when listing views", async () => {
+    const { supabaseAdmin } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Receipts",
+        is_default: true,
+        schema_version: 0,
+        pinned_action_id: "send_receipt",
+        settings: { columns: { designation: false } },
+      },
+    ]);
+
+    const views = await listCrmNamedViews({ supabaseAdmin, ...SCOPE });
+
+    expect(views).toEqual([
+      {
+        id: "view-1",
+        name: "Receipts",
+        isDefault: true,
+        schemaVersion: 0,
+        pinnedActionId: "resend_receipt",
+        settings: { columns: { designation: false } },
+      },
+    ]);
+  });
+
+  it("creating a default view clears the previous default", async () => {
+    const { rpcCalls, supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Old default",
+        is_default: true,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    const created = await createCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      name: "New default",
+      isDefault: true,
+      pinnedActionId: "resend_receipt",
+      settings: { filtersSort: { sortDirection: "asc" } },
+    });
+
+    expect(created.isDefault).toBe(true);
+    expect(rpcCalls).toHaveLength(1);
+    expect(rpcCalls[0]?.name).toBe("create_crm_table_named_view");
+    expect(rpcCalls[0]?.params).toMatchObject({
+      p_is_default: true,
+      p_pinned_action_id: "resend_receipt",
+    });
+    expect(rows.find((row) => row.id === "view-1")?.is_default).toBe(false);
+  });
+
+  it("normalizes renamed pinned operation ids before saving views", async () => {
+    const { rpcCalls, supabaseAdmin } = createSupabaseStub();
+
+    const created = await createCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      name: "Receipts",
+      pinnedActionId: "send_receipt",
+    });
+
+    expect(created.pinnedActionId).toBe("resend_receipt");
+    expect(rpcCalls[0]?.params.p_pinned_action_id).toBe("resend_receipt");
+  });
+
+  it("rejects unknown pinned operation ids before saving views", async () => {
+    const { rpcCalls, supabaseAdmin } = createSupabaseStub();
+
+    await expect(
+      createCrmNamedView({
+        supabaseAdmin,
+        ...SCOPE,
+        name: "Receipts",
+        pinnedActionId: "unknown_action",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'Unknown operation id "unknown_action".',
+    });
+    expect(rpcCalls).toHaveLength(0);
+  });
+
+  it("maps duplicate named view creates to conflict responses", async () => {
+    const { supabaseAdmin } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Receipts",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    await expect(
+      createCrmNamedView({
+        supabaseAdmin,
+        ...SCOPE,
+        name: "Receipts",
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      message: "A named view with this name already exists.",
+    });
+  });
+
+  it("set-default through update clears other defaults first", async () => {
+    const { rpcCalls, supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "A",
+        is_default: true,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+      {
+        id: "view-2",
+        name: "B",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    await updateCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      viewId: "view-2",
+      isDefault: true,
+    });
+
+    expect(rows.find((row) => row.id === "view-1")?.is_default).toBe(false);
+    expect(rows.find((row) => row.id === "view-2")?.is_default).toBe(true);
+    expect(rpcCalls.at(-1)?.name).toBe("update_crm_table_named_view");
+    expect(rpcCalls.at(-1)?.params).toMatchObject({
+      p_view_id: "view-2",
+      p_is_default: true,
+      p_is_default_is_set: true,
+    });
+  });
+
+  it("returns 404 when updating a missing named view", async () => {
+    const { supabaseAdmin } = createSupabaseStub();
+
+    await expect(
+      updateCrmNamedView({
+        supabaseAdmin,
+        ...SCOPE,
+        viewId: "missing-view",
+        name: "Does not exist",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Named view not found.",
+    });
+  });
+
+  it("maps duplicate named view updates to conflict responses", async () => {
+    const { supabaseAdmin } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Receipts",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+      {
+        id: "view-2",
+        name: "Corrections",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    await expect(
+      updateCrmNamedView({
+        supabaseAdmin,
+        ...SCOPE,
+        viewId: "view-2",
+        name: "Receipts",
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      message: "A named view with this name already exists.",
+    });
+  });
+
+  it("merges partial settings updates without wiping sibling scopes", async () => {
+    const { supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Receipts",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: {
+          columns: { designation: false },
+          filtersSort: { sortDirection: "asc" },
+        },
+      },
+    ]);
+
+    const updated = await updateCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      viewId: "view-1",
+      settings: { columns: { statusLine: false } },
+    });
+
+    const expectedSettings = {
+      columns: { statusLine: false },
+      filtersSort: { sortDirection: "asc" },
+    };
+    expect(rows[0]?.settings).toEqual(expectedSettings);
+    expect(updated.settings).toEqual(expectedSettings);
+  });
+
+  it("applies null settings updates as scoped resets", async () => {
+    const { supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Receipts",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: {
+          columns: { designation: false },
+          filtersSort: { sortDirection: "asc" },
+        },
+      },
+    ]);
+
+    await updateCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      viewId: "view-1",
+      settings: { columns: null },
+    });
+
+    expect(rows[0]?.settings).toEqual({
+      filtersSort: { sortDirection: "asc" },
+    });
+  });
+
+  it("deleting the default view can promote a chosen replacement", async () => {
+    const { supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Default",
+        is_default: true,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+      {
+        id: "view-2",
+        name: "Other",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    await deleteCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      viewId: "view-1",
+      nextDefaultViewId: "view-2",
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["view-2"]);
+    expect(rows[0]?.is_default).toBe(true);
+  });
+
+  it("does not promote a replacement when deleting a non-default view", async () => {
+    const { supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Default",
+        is_default: true,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+      {
+        id: "view-2",
+        name: "Replacement",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+      {
+        id: "view-3",
+        name: "Deleted",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    await deleteCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      viewId: "view-3",
+      nextDefaultViewId: "view-2",
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["view-1", "view-2"]);
+    expect(rows.find((row) => row.id === "view-1")?.is_default).toBe(true);
+    expect(rows.find((row) => row.id === "view-2")?.is_default).toBe(false);
+  });
+
+  it("keeps the deleted view when the replacement default is missing", async () => {
+    const { supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Default",
+        is_default: true,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+      {
+        id: "view-2",
+        name: "Other",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    await expect(
+      deleteCrmNamedView({
+        supabaseAdmin,
+        ...SCOPE,
+        viewId: "view-1",
+        nextDefaultViewId: "missing-view",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Replacement default view not found.",
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["view-1", "view-2"]);
+    expect(rows.find((row) => row.id === "view-1")?.is_default).toBe(true);
+    expect(rows.find((row) => row.id === "view-2")?.is_default).toBe(false);
+  });
+
+  it("deleting the default without a replacement leaves no default (tenant/system fallback)", async () => {
+    const { supabaseAdmin, rows } = createSupabaseStub([
+      {
+        id: "view-1",
+        name: "Default",
+        is_default: true,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+      {
+        id: "view-2",
+        name: "Other",
+        is_default: false,
+        schema_version: 1,
+        pinned_action_id: null,
+        settings: null,
+      },
+    ]);
+
+    await deleteCrmNamedView({
+      supabaseAdmin,
+      ...SCOPE,
+      viewId: "view-1",
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["view-2"]);
+    expect(rows.some((row) => row.is_default)).toBe(false);
+  });
+});

--- a/tests/unit/packages/api/admin/crm-row-action-preferences.test.ts
+++ b/tests/unit/packages/api/admin/crm-row-action-preferences.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CRM_GIFT_HISTORY_TABLE_ID,
+  CRM_ROW_ACTION_SCHEMA_VERSION,
+  migrateCrmRowActionId,
+  resolveCrmRowAction,
+} from "../../../../../packages/api/src/admin/crm/table-preferences/row-action";
+
+import type { CrmGiftInlineActionEntry } from "../../../../../packages/database/types/crm-detail";
+
+function entry(
+  actionType: CrmGiftInlineActionEntry["actionType"],
+  overrides: Partial<CrmGiftInlineActionEntry> = {},
+): CrmGiftInlineActionEntry {
+  return {
+    actionType,
+    available: true,
+    blockedReason: null,
+    nextStep: null,
+    riskLevel: "low",
+    ...overrides,
+  };
+}
+
+const ENTRIES: CrmGiftInlineActionEntry[] = [
+  entry("amount_correction", { riskLevel: "high" }),
+  entry("fund_correction", { riskLevel: "high" }),
+  entry("resend_receipt"),
+  entry("retry_staged_gift", {
+    available: false,
+    blockedReason: "There is no failed or blocked posting to retry.",
+    nextStep:
+      "Retry becomes available when staged gift processing or CRM posting fails.",
+  }),
+  entry("refund", {
+    riskLevel: "high",
+    available: false,
+    blockedReason: "This gift is already fully refunded.",
+  }),
+];
+
+describe("admin/crm/table-preferences/row-action", () => {
+  it("exposes a stable table id and schema version", () => {
+    expect(CRM_GIFT_HISTORY_TABLE_ID).toBe("crm.giftHistory");
+    expect(CRM_ROW_ACTION_SCHEMA_VERSION).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses a valid user pin first", () => {
+    const resolved = resolveCrmRowAction({
+      userPin: { actionId: "amount_correction" },
+      tenantDefault: { actionId: "resend_receipt" },
+      entries: ENTRIES,
+    });
+
+    expect(resolved).toEqual({
+      actionType: "amount_correction",
+      source: "user_pin",
+      explanation: null,
+    });
+  });
+
+  it("falls back from a blocked pin to a valid tenant default with explanation", () => {
+    const resolved = resolveCrmRowAction({
+      userPin: { actionId: "retry_staged_gift" },
+      tenantDefault: { actionId: "fund_correction" },
+      entries: ENTRIES,
+    });
+
+    expect(resolved.actionType).toBe("fund_correction");
+    expect(resolved.source).toBe("tenant_default");
+    expect(resolved.explanation).toMatch(/pinned action/i);
+    expect(resolved.explanation).toMatch(
+      /no failed or blocked posting to retry/i,
+    );
+  });
+
+  it("falls back from a pin the viewer has no capability for", () => {
+    // stripe_replay is not in the capability-filtered entries at all.
+    const resolved = resolveCrmRowAction({
+      userPin: { actionId: "stripe_replay" },
+      tenantDefault: null,
+      entries: ENTRIES,
+    });
+
+    expect(resolved.actionType).toBe("resend_receipt");
+    expect(resolved.source).toBe("system");
+    expect(resolved.explanation).toMatch(/isn't available to you/i);
+  });
+
+  it("falls back from an invalid tenant default to the system next-best", () => {
+    const resolved = resolveCrmRowAction({
+      userPin: null,
+      tenantDefault: { actionId: "refund" },
+      entries: ENTRIES,
+    });
+
+    expect(resolved.actionType).toBe("resend_receipt");
+    expect(resolved.source).toBe("system");
+    expect(resolved.explanation).toMatch(/tenant default/i);
+    expect(resolved.explanation).toMatch(/already fully refunded/i);
+  });
+
+  it("resolves to the system next-best when no preference is set", () => {
+    const resolved = resolveCrmRowAction({
+      userPin: null,
+      tenantDefault: null,
+      entries: ENTRIES,
+    });
+
+    expect(resolved).toEqual({
+      actionType: "resend_receipt",
+      source: "system",
+      explanation: null,
+    });
+  });
+
+  it("migrates renamed operation ids stored by older schema versions", () => {
+    expect(migrateCrmRowActionId("send_receipt")).toBe("resend_receipt");
+    expect(migrateCrmRowActionId("retry_crm_posting")).toBe(
+      "retry_staged_gift",
+    );
+    expect(migrateCrmRowActionId("resend_receipt")).toBe("resend_receipt");
+
+    const resolved = resolveCrmRowAction({
+      userPin: { actionId: "send_receipt", schemaVersion: 0 },
+      tenantDefault: null,
+      entries: ENTRIES,
+    });
+    expect(resolved.actionType).toBe("resend_receipt");
+    expect(resolved.source).toBe("user_pin");
+  });
+
+  it("drops removed operation ids with a clear explanation", () => {
+    expect(migrateCrmRowActionId("legacy_export_gift")).toBeNull();
+
+    const resolved = resolveCrmRowAction({
+      userPin: { actionId: "legacy_export_gift" },
+      tenantDefault: null,
+      entries: ENTRIES,
+    });
+    expect(resolved.actionType).toBe("resend_receipt");
+    expect(resolved.source).toBe("system");
+    expect(resolved.explanation).toMatch(/no longer exists/i);
+  });
+
+  it("returns null when nothing valid remains (never invents an action)", () => {
+    const blockedOnly = [
+      entry("retry_staged_gift", {
+        available: false,
+        blockedReason: "There is no failed or blocked posting to retry.",
+      }),
+    ];
+    const resolved = resolveCrmRowAction({
+      userPin: { actionId: "retry_staged_gift" },
+      tenantDefault: null,
+      entries: blockedOnly,
+    });
+
+    expect(resolved.actionType).toBeNull();
+    expect(resolved.source).toBe("system");
+    expect(resolved.explanation).toMatch(/blocked/i);
+  });
+});

--- a/tests/unit/packages/api/admin/crm-table-preferences-route-contract.test.ts
+++ b/tests/unit/packages/api/admin/crm-table-preferences-route-contract.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const routeSource = readFileSync(
+  new URL(
+    "../../../../../packages/api/src/admin/crm/table-preferences/route.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function sourceSection(
+  source: string,
+  startMarker: string,
+  endMarker: string,
+): string {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  expect(end).toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe("admin/crm/table-preferences route contract", () => {
+  it("accepts null to clear delegated tenant-default managers and validates ids", () => {
+    const tenantDefaultSchema = sourceSection(
+      routeSource,
+      "const tenantDefaultSchema =",
+      "function settingsPatchFromBody",
+    );
+    const settingsPatchFromBody = sourceSection(
+      routeSource,
+      "function settingsPatchFromBody",
+      "const namedViewCreateSchema",
+    );
+
+    expect(routeSource).toContain("const profileIdSchema = z.string().uuid();");
+    expect(tenantDefaultSchema).toMatch(
+      /delegatedManagerProfileIds:\s*z\s*\.\s*array\(profileIdSchema\)\s*\.\s*nullable\(\)\s*\.\s*optional\(\)/,
+    );
+    expect(settingsPatchFromBody).toContain(
+      "delegatedManagerProfileIds?: string[] | null;",
+    );
+  });
+
+  it("keeps named-view PUT compatible with hooks expecting an ok flag", () => {
+    const putNamedView = sourceSection(
+      routeSource,
+      "export const PUT_NAMED_VIEW =",
+      "export const DELETE_NAMED_VIEW =",
+    );
+
+    expect(putNamedView).toContain(
+      "return NextResponse.json({ ok: true, view, requestId });",
+    );
+  });
+});

--- a/tests/unit/packages/api/admin/crm-table-preferences-service.test.ts
+++ b/tests/unit/packages/api/admin/crm-table-preferences-service.test.ts
@@ -1,0 +1,604 @@
+import { applyCrmViewSettingsPatch } from "@asym/database/types";
+import { describe, expect, it } from "vitest";
+
+import {
+  getCrmTablePreferences,
+  saveCrmTenantRowActionDefault,
+  saveCrmTenantTableDefault,
+  saveCrmUserRowActionPin,
+  saveCrmUserTablePreference,
+} from "../../../../../packages/api/src/admin/crm/table-preferences/service";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+interface StubState {
+  dropActiveViewBeforeUserPreferenceRpc?: boolean;
+  namedViews?: Array<Record<string, unknown>>;
+  rowsByTable?: Record<string, Record<string, unknown> | null>;
+}
+
+function delegatedManagerProfileIds(
+  row: Record<string, unknown> | null,
+): string[] {
+  const settings = row?.settings;
+  if (typeof settings !== "object" || settings === null) {
+    return [];
+  }
+
+  const value = (settings as Record<string, unknown>)
+    .delegatedManagerProfileIds;
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function createSupabaseStub(state: StubState = {}) {
+  const namedViews = [...(state.namedViews ?? [])];
+  const rowsByTable = { ...(state.rowsByTable ?? {}) };
+  const upserts: Array<{ table: string; payload: Record<string, unknown> }> =
+    [];
+  const inserts: Array<{ table: string; payload: Record<string, unknown> }> =
+    [];
+  const rpcCalls: Array<{
+    name: string;
+    params: Record<string, unknown>;
+  }> = [];
+  const auditEvents: Array<Record<string, unknown>> = [];
+
+  const stub = {
+    async rpc(name: string, params: Record<string, unknown>) {
+      rpcCalls.push({ name, params });
+
+      if (name === "save_crm_user_table_preference") {
+        const existing = rowsByTable.crm_table_user_preferences ?? null;
+        const settingsPatch =
+          (params.p_settings_patch as Record<string, unknown>) ?? {};
+        const activeViewId = settingsPatch.activeViewId;
+
+        if (typeof activeViewId === "string") {
+          if (!uuidPattern.test(activeViewId)) {
+            return {
+              data: null,
+              error: {
+                code: "22023",
+                message: "Active named view id must be a UUID.",
+              },
+            };
+          }
+
+          if (state.dropActiveViewBeforeUserPreferenceRpc) {
+            namedViews.length = 0;
+          }
+
+          const activeViewExists = namedViews.some(
+            (row) =>
+              row.id === activeViewId &&
+              row.tenant_id === params.p_tenant_id &&
+              row.profile_id === params.p_profile_id &&
+              row.table_id === params.p_table_id,
+          );
+
+          if (!activeViewExists) {
+            return {
+              data: null,
+              error: {
+                code: "P0002",
+                message: "Active named view not found.",
+              },
+            };
+          }
+        }
+
+        const settings = applyCrmViewSettingsPatch(
+          (existing?.settings as Record<string, unknown> | null) ?? null,
+          settingsPatch,
+        );
+        const row = {
+          pinned_action_id:
+            params.p_pinned_action_id_is_set === true
+              ? params.p_pinned_action_id
+              : (existing?.pinned_action_id ?? null),
+          schema_version: params.p_schema_version,
+          settings,
+        };
+        rowsByTable.crm_table_user_preferences = row;
+
+        return { data: row, error: null };
+      }
+
+      if (name === "save_crm_tenant_table_default") {
+        const existing = rowsByTable.crm_table_tenant_defaults ?? null;
+        const settingsPatch =
+          (params.p_settings_patch as Record<string, unknown>) ?? {};
+        const actorCanManageDefaults =
+          params.p_actor_can_manage_defaults === true;
+        const actorProfileId =
+          typeof params.p_actor_profile_id === "string"
+            ? params.p_actor_profile_id
+            : null;
+
+        if (!actorCanManageDefaults) {
+          if (
+            Object.prototype.hasOwnProperty.call(
+              settingsPatch,
+              "delegatedManagerProfileIds",
+            )
+          ) {
+            return {
+              data: null,
+              error: {
+                code: "42501",
+                message:
+                  "Forbidden: only super admins can change delegated default managers.",
+              },
+            };
+          }
+
+          const delegatedIds = delegatedManagerProfileIds(existing);
+          if (!actorProfileId || !delegatedIds.includes(actorProfileId)) {
+            return {
+              data: null,
+              error: {
+                code: "42501",
+                message:
+                  "Forbidden: requires crm.gift_history.manage_view_defaults",
+              },
+            };
+          }
+        }
+
+        const settings = applyCrmViewSettingsPatch(
+          (existing?.settings as Record<string, unknown> | null) ?? null,
+          settingsPatch,
+        );
+        const row = {
+          pinned_action_id:
+            params.p_pinned_action_id_is_set === true
+              ? params.p_pinned_action_id
+              : (existing?.pinned_action_id ?? null),
+          schema_version: params.p_schema_version,
+          settings,
+        };
+        rowsByTable.crm_table_tenant_defaults = row;
+        auditEvents.push({
+          tenant_id: params.p_tenant_id,
+          actor_profile_id: params.p_actor_profile_id,
+          table_id: params.p_table_id,
+          before_snapshot: {
+            pinnedActionId: existing?.pinned_action_id ?? null,
+            settings: existing?.settings ?? null,
+          },
+          after_snapshot: {
+            pinnedActionId: row.pinned_action_id,
+            settings,
+          },
+        });
+
+        return { data: row, error: null };
+      }
+
+      throw new Error(`Unexpected RPC: ${name}`);
+    },
+    from(table: string) {
+      const filters: Record<string, unknown> = {};
+      const builder = {
+        select() {
+          return builder;
+        },
+        eq(column: string, value: unknown) {
+          filters[column] = value;
+          return builder;
+        },
+        async maybeSingle() {
+          if (table === "crm_table_named_views") {
+            const match =
+              namedViews.find((row) =>
+                Object.entries(filters).every(
+                  ([column, value]) => row[column] === value,
+                ),
+              ) ?? null;
+
+            return { data: match, error: null };
+          }
+
+          return { data: rowsByTable[table] ?? null, error: null };
+        },
+        upsert(payload: Record<string, unknown>) {
+          upserts.push({ table, payload });
+          return {
+            select() {
+              return {
+                async single() {
+                  return {
+                    data: {
+                      pinned_action_id: payload.pinned_action_id,
+                      schema_version: payload.schema_version,
+                    },
+                    error: null,
+                  };
+                },
+              };
+            },
+          };
+        },
+        insert(payload: Record<string, unknown>) {
+          inserts.push({ table, payload });
+          return Promise.resolve({ error: null });
+        },
+      };
+      return builder;
+    },
+  };
+
+  return {
+    supabaseAdmin: stub as unknown as AdminSupabaseClient,
+    auditEvents,
+    namedViews,
+    upserts,
+    inserts,
+    rpcCalls,
+    rowsByTable,
+  };
+}
+
+describe("admin/crm/table-preferences/service", () => {
+  it("loads user and tenant preference records as the server source of truth", async () => {
+    const { supabaseAdmin } = createSupabaseStub({
+      rowsByTable: {
+        crm_table_user_preferences: {
+          pinned_action_id: "amount_correction",
+          schema_version: 1,
+        },
+        crm_table_tenant_defaults: {
+          pinned_action_id: "resend_receipt",
+          schema_version: 1,
+        },
+      },
+    });
+
+    const preferences = await getCrmTablePreferences({
+      supabaseAdmin,
+      tenantId: "tenant-1",
+      profileId: "profile-1",
+      tableId: "crm.giftHistory",
+    });
+
+    expect(preferences).toEqual({
+      tableId: "crm.giftHistory",
+      schemaVersion: 1,
+      user: { actionId: "amount_correction", schemaVersion: 1, settings: null },
+      tenantDefault: {
+        actionId: "resend_receipt",
+        schemaVersion: 1,
+        settings: null,
+      },
+    });
+  });
+
+  it("migrates renamed operation ids forward before persisting a pin", async () => {
+    const { rpcCalls, supabaseAdmin } = createSupabaseStub();
+
+    const saved = await saveCrmUserRowActionPin({
+      supabaseAdmin,
+      tenantId: "tenant-1",
+      profileId: "profile-1",
+      tableId: "crm.giftHistory",
+      pinnedActionId: "send_receipt",
+    });
+
+    expect(saved.actionId).toBe("resend_receipt");
+    expect(rpcCalls[0]).toMatchObject({
+      name: "save_crm_user_table_preference",
+      params: {
+        p_tenant_id: "tenant-1",
+        p_profile_id: "profile-1",
+        p_table_id: "crm.giftHistory",
+        p_pinned_action_id: "resend_receipt",
+        p_pinned_action_id_is_set: true,
+        p_schema_version: 1,
+      },
+    });
+  });
+
+  it("rejects unknown operation ids instead of storing garbage", async () => {
+    const { supabaseAdmin } = createSupabaseStub();
+
+    await expect(
+      saveCrmUserRowActionPin({
+        supabaseAdmin,
+        tenantId: "tenant-1",
+        profileId: "profile-1",
+        tableId: "crm.giftHistory",
+        pinnedActionId: "made_up_operation",
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("persists view-settings scopes and clears them on scoped reset", async () => {
+    const { rowsByTable, rpcCalls, supabaseAdmin } = createSupabaseStub({
+      rowsByTable: {
+        crm_table_user_preferences: {
+          pinned_action_id: "amount_correction",
+          schema_version: 1,
+          settings: {
+            columns: { designation: false },
+            filtersSort: { sortDirection: "asc" },
+          },
+        },
+      },
+    });
+
+    // Update one scope; the other scope and the pin stay untouched.
+    await saveCrmUserTablePreference({
+      supabaseAdmin,
+      tenantId: "tenant-1",
+      profileId: "profile-1",
+      tableId: "crm.giftHistory",
+      settingsPatch: { columns: { designation: true, statusLine: false } },
+    });
+    expect(rpcCalls[0]).toMatchObject({
+      name: "save_crm_user_table_preference",
+      params: {
+        p_pinned_action_id: null,
+        p_pinned_action_id_is_set: false,
+        p_settings_patch: {
+          columns: { designation: true, statusLine: false },
+        },
+      },
+    });
+    expect(savedSettings(rowsByTable, "crm_table_user_preferences")).toEqual({
+      columns: { designation: true, statusLine: false },
+      filtersSort: { sortDirection: "asc" },
+    });
+
+    // Scoped reset (null) removes only the selected scope.
+    await saveCrmUserTablePreference({
+      supabaseAdmin,
+      tenantId: "tenant-1",
+      profileId: "profile-1",
+      tableId: "crm.giftHistory",
+      settingsPatch: { filtersSort: null },
+    });
+    expect(savedSettings(rowsByTable, "crm_table_user_preferences")).toEqual({
+      columns: { designation: true, statusLine: false },
+    });
+  });
+
+  it("lets the save RPC validate active named views atomically", async () => {
+    const activeViewId = "9f4d1a80-a772-4df3-b3d0-9f8a89301bb8";
+    const { rowsByTable, rpcCalls, supabaseAdmin } = createSupabaseStub({
+      namedViews: [
+        {
+          id: activeViewId,
+          tenant_id: "tenant-1",
+          profile_id: "profile-1",
+          table_id: "crm.giftHistory",
+        },
+      ],
+    });
+
+    await saveCrmUserTablePreference({
+      supabaseAdmin,
+      tenantId: "tenant-1",
+      profileId: "profile-1",
+      tableId: "crm.giftHistory",
+      settingsPatch: { activeViewId },
+    });
+
+    expect(rpcCalls[0]).toMatchObject({
+      name: "save_crm_user_table_preference",
+      params: {
+        p_settings_patch: { activeViewId },
+      },
+    });
+    expect(savedSettings(rowsByTable, "crm_table_user_preferences")).toEqual({
+      activeViewId,
+    });
+  });
+
+  it("rejects orphan active named views returned by the save RPC", async () => {
+    const { rpcCalls, supabaseAdmin } = createSupabaseStub();
+
+    await expect(
+      saveCrmUserTablePreference({
+        supabaseAdmin,
+        tenantId: "tenant-1",
+        profileId: "profile-1",
+        tableId: "crm.giftHistory",
+        settingsPatch: {
+          activeViewId: "bcb23c24-76a1-49be-96fa-a75db164e3d5",
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Active named view not found.",
+    });
+    expect(rpcCalls).toHaveLength(1);
+  });
+
+  it("rejects active named views deleted before the save RPC validates them", async () => {
+    const activeViewId = "9f4d1a80-a772-4df3-b3d0-9f8a89301bb8";
+    const { rpcCalls, supabaseAdmin } = createSupabaseStub({
+      dropActiveViewBeforeUserPreferenceRpc: true,
+      namedViews: [
+        {
+          id: activeViewId,
+          tenant_id: "tenant-1",
+          profile_id: "profile-1",
+          table_id: "crm.giftHistory",
+        },
+      ],
+    });
+
+    await expect(
+      saveCrmUserTablePreference({
+        supabaseAdmin,
+        tenantId: "tenant-1",
+        profileId: "profile-1",
+        tableId: "crm.giftHistory",
+        settingsPatch: { activeViewId },
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      message: "Active named view not found.",
+    });
+    expect(rpcCalls).toHaveLength(1);
+  });
+
+  it("rejects malformed active named view ids returned by the save RPC", async () => {
+    const { rpcCalls, supabaseAdmin } = createSupabaseStub();
+
+    await expect(
+      saveCrmUserTablePreference({
+        supabaseAdmin,
+        tenantId: "tenant-1",
+        profileId: "profile-1",
+        tableId: "crm.giftHistory",
+        settingsPatch: { activeViewId: "not-a-uuid" },
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "Active named view id must be a UUID.",
+    });
+    expect(rpcCalls).toHaveLength(1);
+  });
+
+  it("stores delegated default managers on the tenant default record", async () => {
+    const { rowsByTable, rpcCalls, supabaseAdmin } = createSupabaseStub();
+
+    await saveCrmTenantTableDefault({
+      supabaseAdmin,
+      tenantId: "tenant-1",
+      tableId: "crm.giftHistory",
+      actorProfileId: "super-admin-1",
+      actorCanManageDefaults: true,
+      settingsPatch: { delegatedManagerProfileIds: ["lead-1", "lead-2"] },
+    });
+
+    expect(rpcCalls[0]).toMatchObject({
+      name: "save_crm_tenant_table_default",
+      params: {
+        p_actor_profile_id: "super-admin-1",
+        p_actor_can_manage_defaults: true,
+        p_settings_patch: {
+          delegatedManagerProfileIds: ["lead-1", "lead-2"],
+        },
+      },
+    });
+    expect(savedSettings(rowsByTable, "crm_table_tenant_defaults")).toEqual({
+      delegatedManagerProfileIds: ["lead-1", "lead-2"],
+    });
+  });
+
+  it("delegates tenant default changes and audit to one atomic RPC", async () => {
+    const { auditEvents, rpcCalls, supabaseAdmin } = createSupabaseStub({
+      rowsByTable: {
+        crm_table_tenant_defaults: {
+          pinned_action_id: "resend_receipt",
+          schema_version: 1,
+          settings: {
+            delegatedManagerProfileIds: ["admin-1"],
+          },
+        },
+      },
+    });
+
+    await saveCrmTenantRowActionDefault({
+      supabaseAdmin,
+      tenantId: "tenant-1",
+      tableId: "crm.giftHistory",
+      pinnedActionId: "fund_correction",
+      actorCanManageDefaults: false,
+      actorProfileId: "admin-1",
+    });
+
+    expect(rpcCalls[0]).toMatchObject({
+      name: "save_crm_tenant_table_default",
+      params: {
+        p_pinned_action_id: "fund_correction",
+        p_pinned_action_id_is_set: true,
+        p_actor_profile_id: "admin-1",
+        p_actor_can_manage_defaults: false,
+      },
+    });
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]).toMatchObject({
+      tenant_id: "tenant-1",
+      actor_profile_id: "admin-1",
+      table_id: "crm.giftHistory",
+      before_snapshot: { pinnedActionId: "resend_receipt" },
+      after_snapshot: { pinnedActionId: "fund_correction" },
+    });
+  });
+
+  it("rejects stale delegated tenant default writes inside the RPC", async () => {
+    const { auditEvents, supabaseAdmin } = createSupabaseStub({
+      rowsByTable: {
+        crm_table_tenant_defaults: {
+          pinned_action_id: "resend_receipt",
+          schema_version: 1,
+          settings: {
+            delegatedManagerProfileIds: ["other-manager"],
+          },
+        },
+      },
+    });
+
+    await expect(
+      saveCrmTenantRowActionDefault({
+        supabaseAdmin,
+        tenantId: "tenant-1",
+        tableId: "crm.giftHistory",
+        pinnedActionId: "fund_correction",
+        actorCanManageDefaults: false,
+        actorProfileId: "admin-1",
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      message: "Forbidden: requires crm.gift_history.manage_view_defaults",
+    });
+    expect(auditEvents).toHaveLength(0);
+  });
+
+  it("keeps delegate-list edits restricted to global tenant-default managers", async () => {
+    const { auditEvents, supabaseAdmin } = createSupabaseStub({
+      rowsByTable: {
+        crm_table_tenant_defaults: {
+          pinned_action_id: "resend_receipt",
+          schema_version: 1,
+          settings: {
+            delegatedManagerProfileIds: ["admin-1"],
+          },
+        },
+      },
+    });
+
+    await expect(
+      saveCrmTenantTableDefault({
+        supabaseAdmin,
+        tenantId: "tenant-1",
+        tableId: "crm.giftHistory",
+        actorCanManageDefaults: false,
+        actorProfileId: "admin-1",
+        settingsPatch: { delegatedManagerProfileIds: ["admin-2"] },
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      message:
+        "Forbidden: only super admins can change delegated default managers.",
+    });
+    expect(auditEvents).toHaveLength(0);
+  });
+});
+
+function savedSettings(
+  rowsByTable: Record<string, Record<string, unknown> | null>,
+  table: string,
+): Record<string, unknown> | null {
+  const row = rowsByTable[table];
+
+  return (row?.settings as Record<string, unknown> | null | undefined) ?? null;
+}

--- a/tests/unit/packages/api/admin/crm-view-settings.test.ts
+++ b/tests/unit/packages/api/admin/crm-view-settings.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canManageCrmTenantDefaults,
+  CRM_GIFT_HISTORY_SYSTEM_VIEW_SETTINGS,
+  previewCrmViewSettingsReset,
+  resolveCrmGiftHistoryViewSettings,
+} from "../../../../../packages/api/src/admin/crm/table-preferences/view-settings";
+
+describe("admin/crm/table-preferences/view-settings", () => {
+  it("resolves system defaults when no preference layers exist", () => {
+    const resolved = resolveCrmGiftHistoryViewSettings({
+      user: null,
+      tenantDefault: null,
+    });
+
+    expect(resolved.settings).toEqual(CRM_GIFT_HISTORY_SYSTEM_VIEW_SETTINGS);
+    expect(resolved.sources).toEqual({
+      columns: "system",
+      filtersSort: "system",
+    });
+  });
+
+  it("prefers user scopes, then tenant default scopes, then system", () => {
+    const resolved = resolveCrmGiftHistoryViewSettings({
+      user: { columns: { designation: false } },
+      tenantDefault: {
+        columns: { designation: true, statusLine: false },
+        filtersSort: { sortDirection: "asc" },
+      },
+    });
+
+    // User columns win and merge over system defaults for missing keys.
+    expect(resolved.settings.columns).toEqual({
+      designation: false,
+      statusLine: true,
+    });
+    expect(resolved.sources.columns).toBe("user");
+
+    // Filters/sort fall through to the tenant default scope.
+    expect(resolved.settings.filtersSort.sortDirection).toBe("asc");
+    expect(resolved.settings.filtersSort.sortField).toBe("giftDate");
+    expect(resolved.sources.filtersSort).toBe("tenant_default");
+  });
+
+  it("ignores unknown keys from older/newer schema versions", () => {
+    const resolved = resolveCrmGiftHistoryViewSettings({
+      user: {
+        columns: {
+          designation: false,
+          legacyColumn: true,
+        } as Record<string, boolean>,
+      },
+      tenantDefault: null,
+    });
+
+    expect(resolved.settings.columns).toEqual({
+      designation: false,
+      statusLine: true,
+    });
+  });
+
+  it("previews a scoped columns reset falling back to the tenant default", () => {
+    const preview = previewCrmViewSettingsReset({
+      scope: "columns",
+      user: {
+        settings: { columns: { designation: false, statusLine: false } },
+        pinnedActionId: "amount_correction",
+      },
+      tenantDefault: {
+        settings: { columns: { designation: true, statusLine: false } },
+        pinnedActionId: null,
+      },
+    });
+
+    expect(preview.after.settings.columns).toEqual({
+      designation: true,
+      statusLine: false,
+    });
+    // Only the selected scope resets; the pin stays.
+    expect(preview.after.pinnedActionId).toBe("amount_correction");
+    expect(preview.sources.columns).toBe("tenant_default");
+    expect(preview.description).toMatch(/columns/i);
+    expect(preview.description).toMatch(/tenant default/i);
+  });
+
+  it("previews a pinned action reset falling back to system next-best", () => {
+    const preview = previewCrmViewSettingsReset({
+      scope: "pinnedAction",
+      user: {
+        settings: null,
+        pinnedActionId: "amount_correction",
+      },
+      tenantDefault: null,
+    });
+
+    expect(preview.after.pinnedActionId).toBeNull();
+    expect(preview.sources.pinnedAction).toBe("system");
+    expect(preview.description).toMatch(/pinned row action/i);
+    expect(preview.description).toMatch(/system/i);
+  });
+
+  it("previews reset-all across every scope", () => {
+    const preview = previewCrmViewSettingsReset({
+      scope: "all",
+      user: {
+        settings: {
+          columns: { designation: false },
+          filtersSort: { sortDirection: "asc" },
+        },
+        pinnedActionId: "refund",
+      },
+      tenantDefault: {
+        settings: { filtersSort: { sortDirection: "desc" } },
+        pinnedActionId: "resend_receipt",
+      },
+    });
+
+    expect(preview.after.settings.columns).toEqual(
+      CRM_GIFT_HISTORY_SYSTEM_VIEW_SETTINGS.columns,
+    );
+    expect(preview.after.settings.filtersSort.sortDirection).toBe("desc");
+    expect(preview.after.pinnedActionId).toBe("resend_receipt");
+    expect(preview.sources).toEqual({
+      columns: "system",
+      filtersSort: "tenant_default",
+      pinnedAction: "tenant_default",
+    });
+  });
+
+  it("gates tenant default management to capability holders or delegates", () => {
+    expect(
+      canManageCrmTenantDefaults({
+        capabilities: ["crm.gift_history.manage_view_defaults"],
+        profileId: "profile-1",
+        delegatedManagerProfileIds: [],
+      }),
+    ).toBe(true);
+
+    expect(
+      canManageCrmTenantDefaults({
+        capabilities: [],
+        profileId: "profile-2",
+        delegatedManagerProfileIds: ["profile-2"],
+      }),
+    ).toBe(true);
+
+    expect(
+      canManageCrmTenantDefaults({
+        capabilities: ["contributions.run_refunds"],
+        profileId: "profile-3",
+        delegatedManagerProfileIds: ["profile-2"],
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/packages/api/crm-link-scope-contract.test.ts
+++ b/tests/unit/packages/api/crm-link-scope-contract.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const storeSource = readFileSync(
+  new URL("../../../../packages/api/src/crm/sync/store.ts", import.meta.url),
+  "utf8",
+);
+const stagedGiftsSource = readFileSync(
+  new URL(
+    "../../../../packages/api/src/giving/staged-gifts.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const crmDetailSource = readFileSync(
+  new URL(
+    "../../../../packages/api/src/admin/crm/detail/service.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const crmReportsSource = readFileSync(
+  new URL(
+    "../../../../packages/api/src/admin/crm/reports/service.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const crmLinksMigrationSource = readFileSync(
+  new URL(
+    "../../../../supabase/migrations/20260611155000_crm_links_parent_child_scope.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function sourceSection(
+  source: string,
+  startMarker: string,
+  endMarker?: string,
+): string {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const end = endMarker
+    ? source.indexOf(endMarker, start + startMarker.length)
+    : source.length;
+  expect(end).toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+const parentLinkSingletonRead =
+  /\.from\("donation_crm_links"\)[\s\S]*?\.eq\("scope", "parent"\)[\s\S]*?\.maybeSingle\(\)/;
+const parentLinkCollectionRead =
+  /\.from\("donation_crm_links"\)[\s\S]*?\.eq\("scope", "parent"\)[\s\S]*?(?:\.in\(|\.limit\()/;
+
+describe("CRM donation link parent-scope contract", () => {
+  it("keeps outbound success/failure singleton reads scoped to parent links", () => {
+    const success = sourceSection(
+      storeSource,
+      "async recordOutboundSuccess(input)",
+      "async recordOutboundFailure(input)",
+    );
+    const failure = sourceSection(
+      storeSource,
+      "async recordOutboundFailure(input)",
+      "async loadReconciliationSnapshot(input)",
+    );
+
+    expect(success).toMatch(parentLinkSingletonRead);
+    expect(success).toContain('scope: "parent"');
+    expect(failure).toMatch(parentLinkSingletonRead);
+  });
+
+  it("keeps reconciliation gift-link drift scoped to parent links", () => {
+    const reconciliation = sourceSection(
+      storeSource,
+      "async loadReconciliationSnapshot(input)",
+      "requireNoError(orphanLinks.error",
+    );
+
+    expect(reconciliation).toMatch(parentLinkCollectionRead);
+  });
+
+  it("keeps staged gift queueing scoped to parent links", () => {
+    const queueStagedGiftPostingToTwenty = sourceSection(
+      stagedGiftsSource,
+      "export async function queueStagedGiftPostingToTwenty(",
+    );
+
+    expect(queueStagedGiftPostingToTwenty).toMatch(parentLinkSingletonRead);
+    expect(queueStagedGiftPostingToTwenty).toContain('scope: "parent"');
+  });
+
+  it("backs parent staged gift singleton reads with a partial unique index", () => {
+    expect(crmLinksMigrationSource).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_parent_staged_gift",
+    );
+    expect(crmLinksMigrationSource).toContain(
+      "ON public.donation_crm_links (tenant_id, staged_gift_id, crm_provider)",
+    );
+    expect(crmLinksMigrationSource).toContain(
+      "WHERE staged_gift_id IS NOT NULL",
+    );
+    expect(crmLinksMigrationSource).toContain("AND scope = 'parent'");
+  });
+
+  it("keeps CRM detail and report readers scoped to parent links", () => {
+    const detail = sourceSection(
+      crmDetailSource,
+      "const linkResult =",
+      "assertNoError(linkResult.error",
+    );
+    const report = sourceSection(
+      crmReportsSource,
+      "async function buildSyncFailureRows(",
+      "assertNoError(jobsResult.error",
+    );
+
+    expect(detail).toMatch(parentLinkCollectionRead);
+    expect(report).toMatch(parentLinkCollectionRead);
+  });
+});

--- a/tests/unit/supabase/crm-table-preferences-migration.test.ts
+++ b/tests/unit/supabase/crm-table-preferences-migration.test.ts
@@ -1,0 +1,213 @@
+import { readdirSync, readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migrationsDir = new URL("../../../supabase/migrations/", import.meta.url);
+
+function readMigration(filename: string) {
+  return readFileSync(new URL(filename, migrationsDir), "utf8");
+}
+
+const crmLinksSql = readMigration(
+  "20260611155000_crm_links_parent_child_scope.sql",
+);
+const tablePreferencesSql = readMigration(
+  "20260611160000_crm_table_preferences.sql",
+);
+const namedViewsSql = readMigration("20260611170000_crm_table_named_views.sql");
+
+describe("CRM table preference migrations", () => {
+  it("keeps Supabase migration versions unique", () => {
+    const versions = readdirSync(migrationsDir)
+      .filter((filename) => /^\d+_.*\.sql$/.test(filename))
+      .map((filename) => filename.split("_")[0]);
+
+    expect(new Set(versions).size).toBe(versions.length);
+  });
+
+  it("adds parent and designation scope fields to CRM link records", () => {
+    expect(crmLinksSql).toContain("ALTER TABLE public.donation_crm_links");
+    expect(crmLinksSql).toContain("ADD COLUMN IF NOT EXISTS scope TEXT");
+    expect(crmLinksSql).toContain("CHECK (scope IN ('parent', 'designation'))");
+    expect(crmLinksSql).toContain(
+      "ADD COLUMN IF NOT EXISTS allocation_id UUID",
+    );
+    expect(crmLinksSql).toContain(
+      "REFERENCES public.staged_gift_allocations(id) ON DELETE CASCADE",
+    );
+    expect(crmLinksSql).toContain("ADD COLUMN IF NOT EXISTS last_error TEXT");
+    expect(crmLinksSql).toContain(
+      "donation_crm_links_designation_allocation_check",
+    );
+    expect(crmLinksSql).toContain(
+      "CHECK (scope <> 'designation' OR allocation_id IS NOT NULL)",
+    );
+    expect(crmLinksSql).toContain(
+      "DROP INDEX IF EXISTS public.idx_donation_crm_links_donation_record",
+    );
+    expect(crmLinksSql).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_parent_record",
+    );
+    expect(crmLinksSql).toContain("AND scope = 'parent'");
+    expect(crmLinksSql).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_designation_record",
+    );
+    expect(crmLinksSql).toContain("AND allocation_id IS NOT NULL");
+    expect(crmLinksSql).toContain("AND scope = 'designation'");
+    expect(crmLinksSql).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_parent_staged_gift",
+    );
+    expect(crmLinksSql).toContain(
+      "ON public.donation_crm_links (tenant_id, staged_gift_id, crm_provider)",
+    );
+    expect(crmLinksSql).toContain("WHERE staged_gift_id IS NOT NULL");
+    expect(crmLinksSql).toContain("idx_donation_crm_links_donation_scope");
+  });
+
+  it("deduplicates parent staged gift links before adding the singleton index", () => {
+    expect(crmLinksSql).toContain("ranked_parent_staged_gift_links");
+    expect(crmLinksSql).toContain(
+      "PARTITION BY tenant_id, staged_gift_id, crm_provider",
+    );
+    expect(crmLinksSql).toContain("duplicate_parent_staged_gift_links");
+    expect(crmLinksSql).toContain("SET staged_gift_id = NULL");
+    expect(crmLinksSql).toContain("link_status = 'archived'");
+    expect(crmLinksSql).toContain("'archivedDuplicateStagedGiftId'");
+    expect(
+      crmLinksSql.indexOf("duplicate_parent_staged_gift_links"),
+    ).toBeLessThan(
+      crmLinksSql.indexOf(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_donation_crm_links_parent_staged_gift",
+      ),
+    );
+  });
+
+  it("creates server-only CRM table preference records and audit events", () => {
+    for (const tableName of [
+      "public.crm_table_user_preferences",
+      "public.crm_table_tenant_defaults",
+      "public.crm_table_preference_audit_events",
+    ]) {
+      expect(tablePreferencesSql).toContain(
+        `CREATE TABLE IF NOT EXISTS ${tableName}`,
+      );
+      expect(tablePreferencesSql).toContain(
+        `ALTER TABLE ${tableName} ENABLE ROW LEVEL SECURITY`,
+      );
+      expect(tablePreferencesSql).toContain(
+        `REVOKE ALL ON TABLE ${tableName} FROM anon, authenticated`,
+      );
+      expect(tablePreferencesSql).toContain(
+        `GRANT ALL ON TABLE ${tableName} TO service_role`,
+      );
+    }
+
+    expect(tablePreferencesSql).toContain(
+      "UNIQUE (tenant_id, profile_id, table_id)",
+    );
+    expect(tablePreferencesSql).toContain("UNIQUE (tenant_id, table_id)");
+    expect(tablePreferencesSql).toContain(
+      "idx_crm_table_preference_audit_tenant",
+    );
+  });
+
+  it("creates service-role-only RPCs for atomic table preference mutations", () => {
+    for (const functionName of [
+      "public.apply_crm_view_settings_patch",
+      "public.save_crm_user_table_preference",
+      "public.save_crm_tenant_table_default",
+    ]) {
+      expect(tablePreferencesSql).toContain(
+        `CREATE OR REPLACE FUNCTION ${functionName}`,
+      );
+      expect(tablePreferencesSql).toContain(
+        `REVOKE ALL ON FUNCTION ${functionName}`,
+      );
+      expect(tablePreferencesSql).toContain(
+        `GRANT EXECUTE ON FUNCTION ${functionName}`,
+      );
+    }
+
+    expect(tablePreferencesSql).toContain(
+      "public.apply_crm_view_settings_patch(",
+    );
+    expect(tablePreferencesSql).toContain(
+      "ON CONFLICT (tenant_id, profile_id, table_id)",
+    );
+    expect(tablePreferencesSql).toContain("pg_advisory_xact_lock(");
+    expect(tablePreferencesSql).toContain(
+      "INSERT INTO public.crm_table_preference_audit_events",
+    );
+    expect(tablePreferencesSql).toContain(
+      "p_actor_can_manage_defaults BOOLEAN",
+    );
+    expect(tablePreferencesSql).toContain("delegatedManagerProfileIds");
+    expect(tablePreferencesSql).toContain("USING ERRCODE = '42501'");
+  });
+
+  it("creates personal named views with one default per user and table", () => {
+    expect(namedViewsSql).toContain(
+      "CREATE TABLE IF NOT EXISTS public.crm_table_named_views",
+    );
+    expect(namedViewsSql).toContain(
+      "UNIQUE (tenant_id, profile_id, table_id, name)",
+    );
+    expect(namedViewsSql).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_crm_table_named_views_default",
+    );
+    expect(namedViewsSql).toContain("WHERE is_default");
+    expect(namedViewsSql).toContain(
+      "ALTER TABLE public.crm_table_named_views ENABLE ROW LEVEL SECURITY",
+    );
+    expect(namedViewsSql).toContain(
+      "REVOKE ALL ON TABLE public.crm_table_named_views FROM anon, authenticated",
+    );
+    expect(namedViewsSql).toContain(
+      "GRANT ALL ON TABLE public.crm_table_named_views TO service_role",
+    );
+  });
+
+  it("creates service-role-only RPCs for atomic named-view mutations", () => {
+    for (const functionName of [
+      "public.create_crm_table_named_view",
+      "public.update_crm_table_named_view",
+      "public.delete_crm_table_named_view",
+    ]) {
+      expect(namedViewsSql).toContain(
+        `CREATE OR REPLACE FUNCTION ${functionName}`,
+      );
+      expect(namedViewsSql).toContain(`REVOKE ALL ON FUNCTION ${functionName}`);
+      expect(namedViewsSql).toContain(
+        `GRANT EXECUTE ON FUNCTION ${functionName}`,
+      );
+    }
+
+    expect(namedViewsSql).toContain("SECURITY DEFINER");
+    expect(namedViewsSql).toContain("SET search_path = public");
+    expect(namedViewsSql).toContain("FOR UPDATE");
+    expect(namedViewsSql).toContain(
+      "CREATE OR REPLACE FUNCTION public.save_crm_user_table_preference",
+    );
+    expect(namedViewsSql).toContain("v_settings_patch ? 'activeViewId'");
+    expect(namedViewsSql).toContain("v_active_view_id !~*");
+    expect(namedViewsSql).toContain("Active named view id must be a UUID.");
+    expect(namedViewsSql).toContain("id = v_active_view_id::UUID");
+    expect(namedViewsSql).toContain("FOR KEY SHARE");
+    expect(namedViewsSql).toContain("USING ERRCODE = 'P0002'");
+    expect(namedViewsSql).toContain("public.apply_crm_view_settings_patch(");
+    expect(namedViewsSql).toContain(
+      "RETURN jsonb_build_object('deleted', FALSE, 'reason', 'view_not_found')",
+    );
+    expect(namedViewsSql).toContain("UPDATE public.crm_table_user_preferences");
+    expect(namedViewsSql).toContain(
+      "jsonb_build_object('activeViewId', p_next_default_view_id)",
+    );
+    expect(namedViewsSql).toContain("settings ->> 'activeViewId' = p_view_id");
+    expect(namedViewsSql).toMatch(
+      /IF p_next_default_view_id IS NOT NULL\s+AND v_deleted\.is_default THEN/,
+    );
+    expect(namedViewsSql).toMatch(
+      /'promoted',\s+p_next_default_view_id IS NOT NULL\s+AND v_deleted\.is_default/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Splits the CRM table preferences backend out of the remaining #251 branch into a dependency-sized PR.

- Adds the admin CRM table preference, tenant default, and named view API backend with thin Next route handlers.
- Adds CRM table preference and named view migrations, plus the CRM links parent/child scope migration with a unique migration timestamp.
- Exports the new API modules and CRM table preference permission actions.
- Updates the runtime route inventory for the new admin API routes.
- Adds focused unit and migration coverage for services, row actions, named views, view settings, and migration invariants.

Docs/OpenSpec content from #251 is intentionally left for the final docs slice.

## Verification

- `node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/crm-table-preferences-service.test.ts tests/unit/packages/api/admin/crm-named-views.test.ts tests/unit/packages/api/admin/crm-row-action-preferences.test.ts tests/unit/packages/api/admin/crm-view-settings.test.ts tests/unit/supabase/crm-table-preferences-migration.test.ts`
- `bunx turbo run typecheck --filter=@asym/api --filter=@asym/admin`
- `bunx turbo run lint --filter=@asym/api --filter=@asym/admin`
- `bun run format:check`
- `node scripts/verify-workspace-contract.mjs`
- `bun run ci:preflight` (312 test files, 1515 passed, 1 skipped)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the CRM table preferences backend: user-level preference saves, tenant-wide defaults with delegation and audit, and personal named views — all backed by atomic SQL RPCs and three migrations with appropriate RLS posture. The scope migration for parent/designation CRM links completes the foundation work that makes multi-scope gift posting safe.

- **Atomic mutations throughout**: every preference write, named-view CRUD, and tenant-default save is an RPC that commits in a single DB transaction; the tenant-default RPC additionally takes an advisory lock and re-reads delegatedManagerProfileIds under `FOR KEY SHARE`/`FOR UPDATE` to eliminate the TOCTOU window from previous review rounds.
- **Parent-scope isolation complete**: `scope = 'parent'` filters are applied consistently across `store.ts`, `staged-gifts.ts`, `detail/service.ts`, and `reports/service.ts`, backed by the new partial unique index and locked in by `crm-link-scope-contract.test.ts`.
- **All previously raised issues resolved**: non-atomic clear-then-set, silent update success, null-reset pass-through, concurrent-save overwrite, audit non-atomicity, missing scope in indexes, TOCTOU on delegate auth, dedupe ordering, response shape mismatch, and delegate UUID validation are each addressed and tested.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all atomic-write, scope-isolation, and authorization concerns from previous rounds have been addressed and are covered by the new test suite.

Every mutation path (user preference save, tenant default, named-view CRUD, audit) runs inside a single PL/pgSQL RPC that commits or rolls back as a unit. The tenant-default advisory lock with in-transaction re-read closes the authorization race. Parent CRM link reads are uniformly scoped and locked in by contract tests. The deduplication step before the singleton index prevents the migration from failing on production data. No correctness, security, or data-integrity gaps remain in the changed paths.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api/src/admin/crm/table-preferences/service.ts | New service layer; previously flagged non-atomic audit+upsert issue resolved by delegating both writes to the save_crm_tenant_table_default RPC, which commits them in a single DB transaction under an advisory lock. |
| packages/api/src/admin/crm/table-preferences/named-views.ts | New named-view CRUD layer; previously flagged non-atomic clear-then-set and silent-success issues resolved — all mutations delegate to RPCs, making each operation a single DB transaction with FOR UPDATE locking and a NULL-return → 404 on not-found. |
| packages/api/src/admin/crm/table-preferences/route.ts | Route handler barrel; previously flagged issues resolved — PUT_NAMED_VIEW returns { ok: true, view, requestId }, namedViewSettingsFromBody uses !== undefined so null resets pass through, and delegatedManagerProfileIds validated as z.array(z.string().uuid()). |
| supabase/migrations/20260611155000_crm_links_parent_child_scope.sql | Adds scope/allocation_id columns, replaces the old donation-record unique index with scoped parent/designation variants, deduplicates parent staged-gift links before creating the singleton index. Previously flagged scope-index gap, dedupe-before-index, and scope-read issues all addressed. |
| supabase/migrations/20260611160000_crm_table_preferences.sql | Creates crm_table_user_preferences, crm_table_tenant_defaults, and crm_table_preference_audit_events with RLS enabled, service_role-only access, and atomic RPCs. The tenant-default RPC is correctly transactional with advisory lock + FOR UPDATE + in-transaction auth re-check. |
| supabase/migrations/20260611170000_crm_table_named_views.sql | Creates crm_table_named_views with a partial unique index enforcing one default per user+table, three atomic RPCs for CRUD, and replaces save_crm_user_table_preference to add activeViewId validation with FOR KEY SHARE locking against concurrent deletes. |
| packages/api/src/crm/sync/store.ts | Adds scope = 'parent' filter to outbound-success reads, outbound-failure reads, and the reconciliation orphan-link query, preventing designation child links from appearing as parent gift drift. |
| packages/api/src/giving/staged-gifts.ts | Adds scope = 'parent' filter to the queued-gift read and scope: 'parent' to the insert in queueStagedGiftPostingToTwenty, consistent with the CRM link scoping migration. |
| tests/unit/supabase/crm-table-preferences-migration.test.ts | Comprehensive migration invariant suite covering deduplication-before-index ordering, RLS posture, advisory lock, audit insert, FOR KEY SHARE, activeViewId cleanup, and JSONB default promotion. |
| tests/unit/packages/api/crm-link-scope-contract.test.ts | Locks the parent-scope read contract across store, staged-gifts, detail, and reports services with regex assertions against source text. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/api/src/admin/crm/table-preferences/service.ts`, line 1032-1048 ([link](https://github.com/asymmetric-al/core/blob/8eb365d224960054f9df570c3c4917b7343b2fa0/packages/api/src/admin/crm/table-preferences/service.ts#L1032-L1048)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Tenant default write and audit event are not atomic**

   The `upsert` to `crm_table_tenant_defaults` auto-commits before the subsequent `INSERT` into `crm_table_preference_audit_events`. If the audit insert fails (transient DB error, table lock, etc.), the function throws a 500 but the tenant default change is already persisted — the data mutation succeeds with no audit trail. Given that ADR-CD-021 positions this audit as the accountability mechanism for tenant default changes, a partial write here silently breaks that contract. Wrap both writes in a single Supabase RPC or use a DB-level transaction via `supabaseAdmin.rpc`.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapi%2Fsrc%2Fadmin%2Fcrm%2Ftable-preferences%2Fservice.ts%0ALine%3A%201032-1048%0A%0AComment%3A%0A**Tenant%20default%20write%20and%20audit%20event%20are%20not%20atomic**%0A%0AThe%20%60upsert%60%20to%20%60crm_table_tenant_defaults%60%20auto-commits%20before%20the%20subsequent%20%60INSERT%60%20into%20%60crm_table_preference_audit_events%60.%20If%20the%20audit%20insert%20fails%20%28transient%20DB%20error%2C%20table%20lock%2C%20etc.%29%2C%20the%20function%20throws%20a%20500%20but%20the%20tenant%20default%20change%20is%20already%20persisted%20%E2%80%94%20the%20data%20mutation%20succeeds%20with%20no%20audit%20trail.%20Given%20that%20ADR-CD-021%20positions%20this%20audit%20as%20the%20accountability%20mechanism%20for%20tenant%20default%20changes%2C%20a%20partial%20write%20here%20silently%20breaks%20that%20contract.%20Wrap%20both%20writes%20in%20a%20single%20Supabase%20RPC%20or%20use%20a%20DB-level%20transaction%20via%20%60supabaseAdmin.rpc%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=399&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/api/src/crm/sync/store.ts`, line 609-615 ([link](https://github.com/asymmetric-al/core/blob/ee4eb7616b89e12b09160f3510269992f22dede2/packages/api/src/crm/sync/store.ts#L609-L615)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Scope reconciliation drift**

   This reconciliation query still reads every queued or failed `donation_crm_links` row for the tenant. After this PR adds designation-scoped child links, a queued or failed child designation link will be reported through the parent gift drift path using `gift_link_still_queued` / `gift_link_failed`. Operators can receive incorrect parent gift drift findings even when the parent gift link is healthy. Filter this query to parent links, or split parent and designation findings into separate reconciliation buckets.

   **Context Used:** supabase/AGENTS.md ([source](https://app.greptile.com/asymmetric-al/github/asymmetric-al/core/-/custom-context?memory=960f86f9-fcd1-470b-a40d-3db9b34f89db))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Repro: focused script that invokes the real reconciliation snapshot store with scoped donation link fixtures](https://app.greptile.com/trex/artifacts/e0a4d334-d3bb-47e5-a564-5c97b522f2cf)**
   
   - Contains supporting evidence from the run (text/typescript; charset=utf-8).
   
   **[Repro: execution output showing fixture rows, query filters, and child scoped links classified as gift drift](https://app.greptile.com/trex/artifacts/22befef3-90ef-4bd3-a4e4-2295722540fe)**
   
   - Keeps the command output available without making the summary code-heavy.
   
   <a href="https://app.greptile.com/trex/runs/11806379/artifacts?artifact=e0a4d334-d3bb-47e5-a564-5c97b522f2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapi%2Fsrc%2Fcrm%2Fsync%2Fstore.ts%0ALine%3A%20609-615%0A%0AComment%3A%0A**Scope%20reconciliation%20drift**%0A%0AThis%20reconciliation%20query%20still%20reads%20every%20queued%20or%20failed%20%60donation_crm_links%60%20row%20for%20the%20tenant.%20After%20this%20PR%20adds%20designation-scoped%20child%20links%2C%20a%20queued%20or%20failed%20child%20designation%20link%20will%20be%20reported%20through%20the%20parent%20gift%20drift%20path%20using%20%60gift_link_still_queued%60%20%2F%20%60gift_link_failed%60.%20Operators%20can%20receive%20incorrect%20parent%20gift%20drift%20findings%20even%20when%20the%20parent%20gift%20link%20is%20healthy.%20Filter%20this%20query%20to%20parent%20links%2C%20or%20split%20parent%20and%20designation%20findings%20into%20separate%20reconciliation%20buckets.%0A%0A**Context%20Used%3A**%20supabase%2FAGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fasymmetric-al%2Fgithub%2Fasymmetric-al%2Fcore%2F-%2Fcustom-context%3Fmemory%3D960f86f9-fcd1-470b-a40d-3db9b34f89db%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=399&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Named-view service imports Next response utilities through shared http-errors, breaking Bun service tests**

   - **Bug**
     - The new named-view service contract cannot be executed in the repository's provided focused Bun test runtime. Running `node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/crm-table-preferences-service.test.ts tests/unit/packages/api/admin/crm-named-views.test.ts tests/unit/packages/api/admin/crm-row-action-preferences.test.ts tests/unit/packages/api/admin/crm-view-settings.test.ts` on head fails during module loading with `Cannot find module 'next/server' from '/home/user/repo/packages/api/src/shared/http-errors.ts'`. This blocks the executable validation of GET/POST/PUT/DELETE named view service scenarios in the claimed backend surface.
   - **Cause**
     - `packages/api/src/admin/crm/table-preferences/named-views.ts` imports `ApiHttpError` from `../../../shared/http-errors`, and that shared module imports `NextResponse` from `next/server`. The service-layer unit test runtime does not have `next/server` resolvable, so importing the service pulls in a Next route dependency.
   - **Fix**
     - Split the framework-independent `ApiHttpError` class into a server/runtime-neutral module and have service files import that neutral error type. Keep `NextResponse`/`toErrorResponse` in the Next route layer only, or otherwise ensure the Bun unit-test runtime can resolve Next server modules before adding service-level imports that transitively depend on them.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["feat(api): add crm table preferences bac..."](https://github.com/asymmetric-al/core/commit/c90be6d2aadb84af825709862c1148f2a7c8f761) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38927332)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/asymmetric-al/github/asymmetric-al/core/-/custom-context?memory=009f2e3e-315a-4b6b-987d-828e444ffa70))
- Context used - supabase/AGENTS.md ([source](https://app.greptile.com/asymmetric-al/github/asymmetric-al/core/-/custom-context?memory=960f86f9-fcd1-470b-a40d-3db9b34f89db))

<!-- /greptile_comment -->