### PR TITLE
feat(api): expose contribution operation routes

### DIFF
--- a/apps/admin/app/api/admin/contribution-operations/[contributionId]/route.ts
+++ b/apps/admin/app/api/admin/contribution-operations/[contributionId]/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "@asym/api/admin/contribution-operations/route";

--- a/apps/admin/app/api/admin/contribution-operations/actions/route.ts
+++ b/apps/admin/app/api/admin/contribution-operations/actions/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@asym/api/admin/contribution-operations/route";

--- a/apps/admin/app/api/admin/contribution-operations/correction-requests/[requestId]/decision/route.ts
+++ b/apps/admin/app/api/admin/contribution-operations/correction-requests/[requestId]/decision/route.ts
@@ -1,0 +1,1 @@
+export { POST_CORRECTION_REQUEST_DECISION as POST } from "@asym/api/admin/contribution-operations/route";

--- a/docs/guides/architecture/runtime-map.md
+++ b/docs/guides/architecture/runtime-map.md
@@ -181,3 +181,12 @@ commit when the deployment exposes a non-`unknown` commit.
 | missionary | `/api/posts/[postId]/prayer`                                   | Node.js (no `runtime` segment export) | `next/headers` cookies(), server client       |
 | missionary | `/api/profile`                                                 | Node.js (no `runtime` segment export) | `next/headers` cookies(), server client       |
 | missionary | `/api/webhooks/stripe`                                         | Node.js (no `runtime` segment export) | Stripe SDK, admin client                      |
+
+Contribution operation routes added after the main table to avoid reflowing the
+full inventory around long dynamic path names.
+
+| App   | Route family                                                                  | Runtime policy                        | Reason                                    |
+| ----- | ----------------------------------------------------------------------------- | ------------------------------------- | ----------------------------------------- |
+| admin | `/api/admin/contribution-operations/[contributionId]`                         | Node.js (no `runtime` segment export) | Contribution operation detail             |
+| admin | `/api/admin/contribution-operations/actions`                                  | Node.js (no `runtime` segment export) | Contribution operation action executor    |
+| admin | `/api/admin/contribution-operations/correction-requests/[requestId]/decision` | Node.js (no `runtime` segment export) | Contribution correction approval decision |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,6 +32,7 @@
     "./admin/users": "./src/admin/users.ts",
     "./admin/contribution-shared": "./src/admin/contribution-shared/index.ts",
     "./admin/contribution-operations": "./src/admin/contribution-operations/index.ts",
+    "./admin/contribution-operations/route": "./src/admin/contribution-operations/route.ts",
     "./admin/contribution-batches": "./src/admin/contribution-batches/index.ts",
     "./admin/contribution-batches/route": "./src/admin/contribution-batches/route.ts",
     "./admin/mission-control-tasks": "./src/admin/mission-control-tasks/index.ts",

--- a/packages/api/src/admin/contribution-operations/index.ts
+++ b/packages/api/src/admin/contribution-operations/index.ts
@@ -110,6 +110,7 @@ export {
   type TenantReceiptDeliveryPolicyRow,
 } from "./receipt-delivery";
 export {
+  projectContributionActionResultForViewer,
   projectContributionDetailForViewer,
   stripeReplayAvailability,
   type ContributionProviderProof,
@@ -131,6 +132,10 @@ export type {
   ContributionRiskLevel,
   ContributionSourceSurface,
   ExecuteContributionActionInput,
+} from "./types";
+export {
+  CONTRIBUTION_ACTION_TYPES,
+  CONTRIBUTION_SOURCE_SURFACES,
 } from "./types";
 export type {
   ContributionDetail,

--- a/packages/api/src/admin/contribution-operations/route.ts
+++ b/packages/api/src/admin/contribution-operations/route.ts
@@ -1,0 +1,289 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { executeContributionAction } from "./actions";
+import { recordCorrectionApprovalOutcome } from "./approval-notifications";
+import {
+  decideContributionCorrectionRequest,
+  loadCorrectionApprovalPolicy,
+} from "./correction-requests";
+import { createContributionActionDependencies } from "./dependencies";
+import { replayStripeEventThroughContributionOperations } from "./operations";
+import {
+  hasContributionPermission,
+  resolveContributionCapabilities,
+} from "./permissions";
+import { loadContributionDetailFromSupabase } from "./store";
+import { projectContributionDetailForViewer } from "./viewer-projection";
+import {
+  ApiHttpError,
+  ensureJsonBody,
+  toErrorResponse,
+} from "../../shared/http-errors";
+import { withOperation } from "../../shared/with-operation";
+
+import type { ContributionDetail } from "./detail-read-model";
+import type {
+  ContributionActionResult,
+  ContributionActionType,
+  ContributionPermission,
+  ContributionProviderOutcome,
+  ContributionSourceSurface,
+} from "./types";
+import type { AuthenticatedContext } from "@asym/auth/context";
+
+export { replayStripeEventThroughContributionOperations };
+
+/**
+ * Strip raw provider identifiers from a provider outcome for viewers lacking
+ * contributions.use_provider_actions. `referenceId` (e.g. a Stripe `re_`/`pi_`
+ * id), `raw` (the provider payload), and `errorMessage` (which can embed ids)
+ * are removed; the non-sensitive provider/status/errorCode workflow fields are
+ * kept so the UI can still show what happened.
+ */
+function redactProviderOutcomeForViewer(
+  outcome: ContributionProviderOutcome | null | undefined,
+): ContributionProviderOutcome | null | undefined {
+  if (!outcome) {
+    return outcome;
+  }
+
+  return {
+    provider: outcome.provider,
+    status: outcome.status,
+    errorCode: outcome.errorCode ?? null,
+    referenceId: null,
+  };
+}
+
+/**
+ * Apply the same viewer projection the GET detail endpoint uses to an action
+ * result before returning it (ADR-CD-014). Without this, a viewer lacking
+ * contributions.use_provider_actions (e.g. donor-care invoking resend_receipt,
+ * or finance-staff running a suppressed-approval refund) would receive raw
+ * Stripe identifiers carried on the result -- both on
+ * result.canonicalContribution (which the GET endpoint nulls) and on
+ * result.providerOutcome (the live refund/charge id and raw provider payload).
+ */
+export function projectContributionActionResultForViewer<
+  TResult extends ContributionActionResult,
+>(result: TResult, viewerCapabilities: string[]): TResult {
+  const hasProviderAccess = viewerCapabilities.includes(
+    "contributions.use_provider_actions",
+  );
+
+  const canonical = result.canonicalContribution;
+  const projected: TResult =
+    canonical && typeof canonical === "object"
+      ? {
+          ...result,
+          canonicalContribution: projectContributionDetailForViewer(
+            canonical as ContributionDetail,
+            viewerCapabilities,
+          ),
+        }
+      : result;
+
+  if (hasProviderAccess || result.providerOutcome == null) {
+    return projected;
+  }
+
+  return {
+    ...projected,
+    providerOutcome: redactProviderOutcomeForViewer(result.providerOutcome),
+  };
+}
+
+const actionTypeSchema = z.enum([
+  "resend_receipt",
+  "approve_staged_gift",
+  "retry_staged_gift",
+  "crm_repost",
+  "metadata_update",
+  "refund",
+  "donor_relink",
+  "amount_correction",
+  "designation_correction",
+  "fund_correction",
+  "allocation_correction",
+  "receipt_correction",
+  "statement_correction",
+  "payment_state_correction",
+  "stripe_replay",
+]);
+
+const sourceSurfaceSchema = z.enum([
+  "contribution_hub",
+  "donor_crm_record",
+  "automation",
+  "bulk_action",
+  "api",
+]);
+
+const actionRequestSchema = z.object({
+  contributionId: z.string().uuid(),
+  stagedGiftId: z.string().uuid().nullable().optional(),
+  actionType: actionTypeSchema,
+  sourceSurface: sourceSurfaceSchema.default("api"),
+  reason: z.string().max(1000).nullable().optional(),
+  confirmationToken: z.string().max(200).nullable().optional(),
+  expectedRevision: z.string().max(200).nullable().optional(),
+  idempotencyKey: z.string().max(200).nullable().optional(),
+  payload: z.record(z.string(), z.unknown()).default({}),
+});
+
+function getContributionIdFromPath(request: Request): string | null {
+  const pathname = new URL(request.url).pathname;
+  const segments = pathname.split("/").filter(Boolean);
+  const index = segments.indexOf("contribution-operations");
+  return index >= 0 ? (segments[index + 1] ?? null) : null;
+}
+
+function actorPermissionsFromAuth(
+  auth: AuthenticatedContext,
+): ContributionPermission[] {
+  return hasContributionPermission(auth, "finance:manage_contributions")
+    ? ["finance:manage_contributions"]
+    : [];
+}
+
+export const GET = withOperation(
+  async ({ request, supabaseAdmin, auth, requestId }) => {
+    try {
+      const contributionId = getContributionIdFromPath(request);
+      if (!contributionId) {
+        throw new ApiHttpError(400, "Missing contribution id.");
+      }
+
+      const detail = await loadContributionDetailFromSupabase({
+        supabaseAdmin,
+        tenantId: auth.tenantId,
+        contributionId,
+      });
+      const contribution = projectContributionDetailForViewer(
+        detail,
+        resolveContributionCapabilities(auth),
+      );
+
+      return NextResponse.json({ contribution, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to load contribution operation detail.",
+        requestId,
+      );
+    }
+  },
+  { roles: ["staff", "admin", "super_admin"] },
+);
+
+export const POST = withOperation(
+  async ({ request, supabaseAdmin, auth, requestId }) => {
+    try {
+      const body = actionRequestSchema.parse(await ensureJsonBody(request));
+      const approvalPolicy = await loadCorrectionApprovalPolicy({
+        supabaseAdmin,
+        tenantId: auth.tenantId,
+      });
+      const result = await executeContributionAction({
+        tenantId: auth.tenantId,
+        actorProfileId: auth.profileId,
+        actorPermissions: actorPermissionsFromAuth(auth),
+        actorCapabilities: resolveContributionCapabilities(auth),
+        approvalPolicy,
+        sourceSurface: body.sourceSurface as ContributionSourceSurface,
+        contributionId: body.contributionId,
+        stagedGiftId: body.stagedGiftId ?? null,
+        actionType: body.actionType as ContributionActionType,
+        reason: body.reason ?? null,
+        confirmationToken: body.confirmationToken ?? null,
+        expectedRevision: body.expectedRevision ?? null,
+        idempotencyKey: body.idempotencyKey ?? null,
+        payload: body.payload,
+        dependencies: createContributionActionDependencies(supabaseAdmin),
+      });
+
+      const projectedResult = projectContributionActionResultForViewer(
+        result,
+        resolveContributionCapabilities(auth),
+      );
+
+      return NextResponse.json({ result: projectedResult, requestId });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to execute contribution action.",
+        requestId,
+      );
+    }
+  },
+  { roles: ["staff", "admin", "super_admin"] },
+);
+
+const decisionRequestSchema = z.object({
+  decision: z.enum(["approve", "reject"]),
+  reason: z.string().max(1000).nullable().optional(),
+  receiptDelivery: z
+    .object({
+      choice: z.enum(["email", "pdf", "defer"]),
+      deferReason: z.string().max(1000).nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+function getCorrectionRequestIdFromPath(request: Request): string | null {
+  const pathname = new URL(request.url).pathname;
+  const segments = pathname.split("/").filter(Boolean);
+  const index = segments.indexOf("correction-requests");
+  return index >= 0 ? (segments[index + 1] ?? null) : null;
+}
+
+export const POST_CORRECTION_REQUEST_DECISION = withOperation(
+  async ({ request, supabaseAdmin, auth, requestId }) => {
+    try {
+      const correctionRequestId = getCorrectionRequestIdFromPath(request);
+      if (!correctionRequestId) {
+        throw new ApiHttpError(400, "Missing correction request id.");
+      }
+
+      const body = decisionRequestSchema.parse(await ensureJsonBody(request));
+      const outcome = await decideContributionCorrectionRequest({
+        supabaseAdmin,
+        tenantId: auth.tenantId,
+        requestId: correctionRequestId,
+        decision: body.decision,
+        reason: body.reason ?? null,
+        receiptDelivery: body.receiptDelivery ?? null,
+        deciderProfileId: auth.profileId,
+        deciderCapabilities: resolveContributionCapabilities(auth),
+        dependencies: createContributionActionDependencies(supabaseAdmin),
+        recordOutcome: recordCorrectionApprovalOutcome,
+      });
+
+      // Consistency with GET / POST actions: project provider identifiers for
+      // the viewer. Not a leak today (deciders already hold
+      // contributions.use_provider_actions) but kept defense-in-depth.
+      const projectedResult = outcome.result
+        ? projectContributionActionResultForViewer(
+            outcome.result,
+            resolveContributionCapabilities(auth),
+          )
+        : null;
+
+      return NextResponse.json({
+        request: outcome.request,
+        result: projectedResult,
+        idempotentReplay: outcome.idempotentReplay ?? false,
+        requestId,
+      });
+    } catch (error) {
+      return toErrorResponse(
+        error,
+        "Failed to decide correction request.",
+        requestId,
+      );
+    }
+  },
+  { roles: ["staff", "admin", "super_admin"] },
+);

--- a/packages/api/src/admin/contribution-operations/route.ts
+++ b/packages/api/src/admin/contribution-operations/route.ts
@@ -5,6 +5,7 @@ import { executeContributionAction } from "./actions";
 import { recordCorrectionApprovalOutcome } from "./approval-notifications";
 import {
   decideContributionCorrectionRequest,
+  loadContributionCorrectionRequest,
   loadCorrectionApprovalPolicy,
 } from "./correction-requests";
 import { createContributionActionDependencies } from "./dependencies";
@@ -14,113 +15,84 @@ import {
   resolveContributionCapabilities,
 } from "./permissions";
 import { loadContributionDetailFromSupabase } from "./store";
-import { projectContributionDetailForViewer } from "./viewer-projection";
+import {
+  CONTRIBUTION_ACTION_TYPES,
+  CONTRIBUTION_SOURCE_SURFACES,
+  type ContributionActionType,
+  type ContributionPermission,
+} from "./types";
+import {
+  projectContributionActionResultForViewer,
+  projectContributionDetailForViewer,
+} from "./viewer-projection";
 import {
   ApiHttpError,
   ensureJsonBody,
   toErrorResponse,
 } from "../../shared/http-errors";
-import { withOperation } from "../../shared/with-operation";
+import {
+  withOperation,
+  type OperationRouteContext,
+} from "../../shared/with-operation";
 
-import type { ContributionDetail } from "./detail-read-model";
-import type {
-  ContributionActionResult,
-  ContributionActionType,
-  ContributionPermission,
-  ContributionProviderOutcome,
-  ContributionSourceSurface,
-} from "./types";
 import type { AuthenticatedContext } from "@asym/auth/context";
 
 export { replayStripeEventThroughContributionOperations };
+export { projectContributionActionResultForViewer };
 
-/**
- * Strip raw provider identifiers from a provider outcome for viewers lacking
- * contributions.use_provider_actions. `referenceId` (e.g. a Stripe `re_`/`pi_`
- * id), `raw` (the provider payload), and `errorMessage` (which can embed ids)
- * are removed; the non-sensitive provider/status/errorCode workflow fields are
- * kept so the UI can still show what happened.
- */
-function redactProviderOutcomeForViewer(
-  outcome: ContributionProviderOutcome | null | undefined,
-): ContributionProviderOutcome | null | undefined {
-  if (!outcome) {
-    return outcome;
-  }
-
-  return {
-    provider: outcome.provider,
-    status: outcome.status,
-    errorCode: outcome.errorCode ?? null,
-    referenceId: null,
-  };
-}
-
-/**
- * Apply the same viewer projection the GET detail endpoint uses to an action
- * result before returning it (ADR-CD-014). Without this, a viewer lacking
- * contributions.use_provider_actions (e.g. donor-care invoking resend_receipt,
- * or finance-staff running a suppressed-approval refund) would receive raw
- * Stripe identifiers carried on the result -- both on
- * result.canonicalContribution (which the GET endpoint nulls) and on
- * result.providerOutcome (the live refund/charge id and raw provider payload).
- */
-export function projectContributionActionResultForViewer<
-  TResult extends ContributionActionResult,
->(result: TResult, viewerCapabilities: string[]): TResult {
-  const hasProviderAccess = viewerCapabilities.includes(
-    "contributions.use_provider_actions",
-  );
-
-  const canonical = result.canonicalContribution;
-  const projected: TResult =
-    canonical && typeof canonical === "object"
-      ? {
-          ...result,
-          canonicalContribution: projectContributionDetailForViewer(
-            canonical as ContributionDetail,
-            viewerCapabilities,
-          ),
-        }
-      : result;
-
-  if (hasProviderAccess || result.providerOutcome == null) {
-    return projected;
-  }
-
-  return {
-    ...projected,
-    providerOutcome: redactProviderOutcomeForViewer(result.providerOutcome),
-  };
-}
-
-const actionTypeSchema = z.enum([
-  "resend_receipt",
-  "approve_staged_gift",
-  "retry_staged_gift",
-  "crm_repost",
+const UNSUPPORTED_ROUTE_ACTION_TYPES = new Set<ContributionActionType>([
   "metadata_update",
   "refund",
   "donor_relink",
-  "amount_correction",
-  "designation_correction",
-  "fund_correction",
-  "allocation_correction",
-  "receipt_correction",
-  "statement_correction",
-  "payment_state_correction",
-  "stripe_replay",
 ]);
 
-const sourceSurfaceSchema = z.enum([
-  "contribution_hub",
-  "donor_crm_record",
-  "automation",
-  "bulk_action",
-  "api",
-]);
+export function isContributionRouteActionSupported(
+  actionType: ContributionActionType,
+): boolean {
+  return !UNSUPPORTED_ROUTE_ACTION_TYPES.has(actionType);
+}
 
-const actionRequestSchema = z.object({
+function unsupportedRouteActionMessage(
+  actionType: ContributionActionType,
+): string {
+  switch (actionType) {
+    case "metadata_update":
+      return "metadata_update is not supported by this route yet.";
+    case "refund":
+      return "refund is not supported by this route until provider refund dependencies are wired.";
+    case "donor_relink":
+      return "donor_relink is not supported by this route until donor relink dependencies are wired.";
+    default:
+      return `${actionType} is not supported by this route.`;
+  }
+}
+
+export function assertContributionRouteActionSupported(
+  actionType: ContributionActionType,
+): void {
+  if (isContributionRouteActionSupported(actionType)) {
+    return;
+  }
+
+  throw new ApiHttpError(501, unsupportedRouteActionMessage(actionType));
+}
+
+const actionTypeSchema = z
+  .enum(CONTRIBUTION_ACTION_TYPES)
+  .superRefine((actionType, ctx) => {
+    if (isContributionRouteActionSupported(actionType)) {
+      return;
+    }
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: unsupportedRouteActionMessage(actionType),
+    });
+  });
+
+const sourceSurfaceSchema = z.enum(CONTRIBUTION_SOURCE_SURFACES);
+
+export const actionRequestSchema = z.object({
   contributionId: z.string().uuid(),
   stagedGiftId: z.string().uuid().nullable().optional(),
   actionType: actionTypeSchema,
@@ -132,11 +104,19 @@ const actionRequestSchema = z.object({
   payload: z.record(z.string(), z.unknown()).default({}),
 });
 
-function getContributionIdFromPath(request: Request): string | null {
-  const pathname = new URL(request.url).pathname;
-  const segments = pathname.split("/").filter(Boolean);
-  const index = segments.indexOf("contribution-operations");
-  return index >= 0 ? (segments[index + 1] ?? null) : null;
+async function getRouteParam(
+  routeContext: OperationRouteContext | undefined,
+  paramName: string,
+  missingMessage: string,
+): Promise<string> {
+  const params = await routeContext?.params;
+  const value = params?.[paramName];
+  const resolved = Array.isArray(value) ? value[0] : value;
+  if (!resolved) {
+    throw new ApiHttpError(400, missingMessage);
+  }
+
+  return resolved;
 }
 
 function actorPermissionsFromAuth(
@@ -148,12 +128,13 @@ function actorPermissionsFromAuth(
 }
 
 export const GET = withOperation(
-  async ({ request, supabaseAdmin, auth, requestId }) => {
+  async ({ supabaseAdmin, auth, requestId, routeContext }) => {
     try {
-      const contributionId = getContributionIdFromPath(request);
-      if (!contributionId) {
-        throw new ApiHttpError(400, "Missing contribution id.");
-      }
+      const contributionId = await getRouteParam(
+        routeContext,
+        "contributionId",
+        "Missing contribution id.",
+      );
 
       const detail = await loadContributionDetailFromSupabase({
         supabaseAdmin,
@@ -191,10 +172,10 @@ export const POST = withOperation(
         actorPermissions: actorPermissionsFromAuth(auth),
         actorCapabilities: resolveContributionCapabilities(auth),
         approvalPolicy,
-        sourceSurface: body.sourceSurface as ContributionSourceSurface,
+        sourceSurface: body.sourceSurface,
         contributionId: body.contributionId,
         stagedGiftId: body.stagedGiftId ?? null,
-        actionType: body.actionType as ContributionActionType,
+        actionType: body.actionType,
         reason: body.reason ?? null,
         confirmationToken: body.confirmationToken ?? null,
         expectedRevision: body.expectedRevision ?? null,
@@ -220,7 +201,7 @@ export const POST = withOperation(
   { roles: ["staff", "admin", "super_admin"] },
 );
 
-const decisionRequestSchema = z.object({
+export const decisionRequestSchema = z.object({
   decision: z.enum(["approve", "reject"]),
   reason: z.string().max(1000).nullable().optional(),
   receiptDelivery: z
@@ -232,22 +213,25 @@ const decisionRequestSchema = z.object({
     .optional(),
 });
 
-function getCorrectionRequestIdFromPath(request: Request): string | null {
-  const pathname = new URL(request.url).pathname;
-  const segments = pathname.split("/").filter(Boolean);
-  const index = segments.indexOf("correction-requests");
-  return index >= 0 ? (segments[index + 1] ?? null) : null;
-}
-
 export const POST_CORRECTION_REQUEST_DECISION = withOperation(
-  async ({ request, supabaseAdmin, auth, requestId }) => {
+  async ({ request, supabaseAdmin, auth, requestId, routeContext }) => {
     try {
-      const correctionRequestId = getCorrectionRequestIdFromPath(request);
-      if (!correctionRequestId) {
-        throw new ApiHttpError(400, "Missing correction request id.");
-      }
+      const correctionRequestId = await getRouteParam(
+        routeContext,
+        "requestId",
+        "Missing correction request id.",
+      );
 
       const body = decisionRequestSchema.parse(await ensureJsonBody(request));
+      if (body.decision === "approve") {
+        const correctionRequest = await loadContributionCorrectionRequest({
+          supabaseAdmin,
+          tenantId: auth.tenantId,
+          requestId: correctionRequestId,
+        });
+        assertContributionRouteActionSupported(correctionRequest.actionType);
+      }
+
       const outcome = await decideContributionCorrectionRequest({
         supabaseAdmin,
         tenantId: auth.tenantId,

--- a/packages/api/src/admin/contribution-operations/types.ts
+++ b/packages/api/src/admin/contribution-operations/types.ts
@@ -21,12 +21,16 @@ export const CONTRIBUTION_ACTION_TYPES = [
 
 export type ContributionActionType = (typeof CONTRIBUTION_ACTION_TYPES)[number];
 
+export const CONTRIBUTION_SOURCE_SURFACES = [
+  "contribution_hub",
+  "donor_crm_record",
+  "automation",
+  "bulk_action",
+  "api",
+] as const;
+
 export type ContributionSourceSurface =
-  | "contribution_hub"
-  | "donor_crm_record"
-  | "automation"
-  | "bulk_action"
-  | "api";
+  (typeof CONTRIBUTION_SOURCE_SURFACES)[number];
 
 export type ContributionRiskLevel = "low" | "medium" | "high";
 

--- a/packages/api/src/admin/contribution-operations/viewer-projection.ts
+++ b/packages/api/src/admin/contribution-operations/viewer-projection.ts
@@ -1,5 +1,9 @@
 import type { ContributionActionAvailability } from "./action-availability";
 import type { ContributionDetail } from "./detail-read-model";
+import type {
+  ContributionActionResult,
+  ContributionProviderOutcome,
+} from "./types";
 
 /**
  * Role-gated provider proof (ADR-CD-014 / ADR-CD-015).
@@ -110,5 +114,62 @@ export function projectContributionDetailForViewer(
           : null,
       },
     },
+  };
+}
+
+/**
+ * Strip raw provider identifiers from a provider outcome for viewers lacking
+ * contributions.use_provider_actions. `referenceId` (e.g. a Stripe `re_`/`pi_`
+ * id), `raw` (the provider payload), and `errorMessage` (which can embed ids)
+ * are removed; the non-sensitive provider/status/errorCode workflow fields are
+ * kept so the UI can still show what happened.
+ */
+function redactProviderOutcomeForViewer(
+  outcome: ContributionProviderOutcome | null | undefined,
+): ContributionProviderOutcome | null | undefined {
+  if (!outcome) {
+    return outcome;
+  }
+
+  return {
+    provider: outcome.provider,
+    status: outcome.status,
+    errorCode: outcome.errorCode ?? null,
+    referenceId: null,
+  };
+}
+
+/**
+ * Apply the same viewer projection the GET detail endpoint uses to an action
+ * result before returning it (ADR-CD-014). Without this, a viewer lacking
+ * contributions.use_provider_actions would receive raw Stripe identifiers on
+ * result.canonicalContribution and result.providerOutcome.
+ */
+export function projectContributionActionResultForViewer<
+  TResult extends ContributionActionResult,
+>(result: TResult, viewerCapabilities: string[]): TResult {
+  const hasProviderAccess = viewerCapabilities.includes(
+    "contributions.use_provider_actions",
+  );
+
+  const canonical = result.canonicalContribution;
+  const projected: TResult =
+    canonical && typeof canonical === "object"
+      ? {
+          ...result,
+          canonicalContribution: projectContributionDetailForViewer(
+            canonical as ContributionDetail,
+            viewerCapabilities,
+          ),
+        }
+      : result;
+
+  if (hasProviderAccess || result.providerOutcome == null) {
+    return projected;
+  }
+
+  return {
+    ...projected,
+    providerOutcome: redactProviderOutcomeForViewer(result.providerOutcome),
   };
 }

--- a/tests/unit/apps/admin/app/contribution-operation-routes.test.ts
+++ b/tests/unit/apps/admin/app/contribution-operation-routes.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+function routeSource(...segments: string[]): string {
+  return readFileSync(path.resolve(__dirname, ...segments), "utf8").trim();
+}
+
+describe("admin app contribution operation route exports", () => {
+  it("exposes contribution detail GET through the API package route", () => {
+    expect(
+      routeSource(
+        "../../../../../apps/admin/app/api/admin/contribution-operations/[contributionId]/route.ts",
+      ),
+    ).toBe(
+      'export { GET } from "@asym/api/admin/contribution-operations/route";',
+    );
+  });
+
+  it("exposes contribution action POST through the API package route", () => {
+    expect(
+      routeSource(
+        "../../../../../apps/admin/app/api/admin/contribution-operations/actions/route.ts",
+      ),
+    ).toBe(
+      'export { POST } from "@asym/api/admin/contribution-operations/route";',
+    );
+  });
+
+  it("exposes correction-request decisions as POST through the API package route", () => {
+    expect(
+      routeSource(
+        "../../../../../apps/admin/app/api/admin/contribution-operations/correction-requests/[requestId]/decision/route.ts",
+      ),
+    ).toBe(
+      'export { POST_CORRECTION_REQUEST_DECISION as POST } from "@asym/api/admin/contribution-operations/route";',
+    );
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-action-result-projection.test.ts
+++ b/tests/unit/packages/api/admin/contribution-action-result-projection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildContributionDetail } from "../../../../../packages/api/src/admin/contribution-operations/detail-read-model";
-import { projectContributionActionResultForViewer } from "../../../../../packages/api/src/admin/contribution-operations/route";
+import { projectContributionActionResultForViewer } from "../../../../../packages/api/src/admin/contribution-operations/viewer-projection";
 
 import type { ContributionActionResult } from "../../../../../packages/api/src/admin/contribution-operations/types";
 

--- a/tests/unit/packages/api/admin/contribution-action-result-projection.test.ts
+++ b/tests/unit/packages/api/admin/contribution-action-result-projection.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributionDetail } from "../../../../../packages/api/src/admin/contribution-operations/detail-read-model";
+import { projectContributionActionResultForViewer } from "../../../../../packages/api/src/admin/contribution-operations/route";
+
+import type { ContributionActionResult } from "../../../../../packages/api/src/admin/contribution-operations/types";
+
+const DONOR_CARE_CAPABILITIES = [
+  "contributions.view_detail",
+  "contributions.request_corrections",
+  "contributions.manage_table_preferences",
+];
+
+const PROVIDER_CAPABILITIES = ["contributions.use_provider_actions"];
+
+function makeResult(): ContributionActionResult {
+  return {
+    canonicalContribution: buildContributionDetail({
+      donation: {
+        id: "donation_1",
+        tenantId: "tenant_1",
+        donorId: "donor_1",
+        missionaryId: null,
+        fundId: "fund_1",
+        amount: 25_000,
+        currency: "usd",
+        status: "completed",
+        donationType: "one_time",
+        paymentMethod: "card",
+        isRecurring: false,
+        recurringInterval: null,
+        notes: null,
+        stripePaymentIntentId: "pi_proof",
+        stripeChargeId: "ch_proof",
+        giftDate: "2026-05-10",
+        campaignId: null,
+        pledgeId: null,
+        processedAt: null,
+        completedAt: "2026-05-10T00:00:00.000Z",
+        failedAt: null,
+        errorCode: null,
+        errorMessage: null,
+        refundedAt: null,
+        refundAmount: 0,
+        source: "online",
+        createdAt: "2026-05-10T00:00:00.000Z",
+        updatedAt: "2026-05-10T00:00:00.000Z",
+      },
+      donor: {
+        id: "donor_1",
+        profileId: null,
+        name: "Proof Donor",
+        email: "proof@example.com",
+        phone: null,
+        location: null,
+        organization: null,
+      },
+      fund: { id: "fund_1", name: "General Fund" },
+    }),
+    auditEventId: "audit_1",
+    taskIds: [],
+    providerOutcome: {
+      provider: "stripe",
+      status: "succeeded",
+      referenceId: "re_live_refund_id",
+      raw: { amount: 25_000, currency: "usd", status: "succeeded" },
+    },
+  };
+}
+
+describe("admin/contribution-operations route action-result projection", () => {
+  it("redacts Stripe identifiers in the action result for non-provider viewers", () => {
+    const projected = projectContributionActionResultForViewer(
+      makeResult(),
+      DONOR_CARE_CAPABILITIES,
+    );
+
+    const canonical = projected.canonicalContribution as {
+      payment: {
+        stripe: { paymentIntentId: string | null; chargeId: string | null };
+      };
+    };
+    expect(canonical.payment.stripe.paymentIntentId).toBeNull();
+    expect(canonical.payment.stripe.chargeId).toBeNull();
+    // The provider outcome's raw identifiers (e.g. the live Stripe refund id)
+    // are also stripped, while workflow status stays visible.
+    expect(projected.providerOutcome?.referenceId).toBeNull();
+    expect(projected.providerOutcome?.raw).toBeUndefined();
+    expect(projected.providerOutcome?.status).toBe("succeeded");
+    // Non-canonical result fields are preserved.
+    expect(projected.auditEventId).toBe("audit_1");
+  });
+
+  it("preserves Stripe identifiers for provider-authorized viewers", () => {
+    const projected = projectContributionActionResultForViewer(
+      makeResult(),
+      PROVIDER_CAPABILITIES,
+    );
+
+    const canonical = projected.canonicalContribution as {
+      payment: {
+        stripe: { paymentIntentId: string | null; chargeId: string | null };
+      };
+    };
+    expect(canonical.payment.stripe.paymentIntentId).toBe("pi_proof");
+    expect(canonical.payment.stripe.chargeId).toBe("ch_proof");
+    // Provider-authorized viewers keep the raw provider outcome.
+    expect(projected.providerOutcome?.referenceId).toBe("re_live_refund_id");
+    expect(projected.providerOutcome?.raw).toEqual({
+      amount: 25_000,
+      currency: "usd",
+      status: "succeeded",
+    });
+  });
+
+  it("passes through a result whose canonicalContribution is not a detail object", () => {
+    const result: ContributionActionResult = {
+      canonicalContribution: null,
+      auditEventId: "audit_2",
+      taskIds: [],
+    };
+    expect(
+      projectContributionActionResultForViewer(result, DONOR_CARE_CAPABILITIES),
+    ).toBe(result);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-operations-route-contract.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-route-contract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const routeSource = readFileSync(
+  path.resolve(
+    __dirname,
+    "../../../../../packages/api/src/admin/contribution-operations/route.ts",
+  ),
+  "utf8",
+);
+
+describe("admin/contribution-operations route contract", () => {
+  it("redacts action results before returning POST action responses", () => {
+    expect(routeSource).toContain(
+      "const projectedResult = projectContributionActionResultForViewer(",
+    );
+    expect(routeSource).toContain(
+      "return NextResponse.json({ result: projectedResult, requestId });",
+    );
+  });
+
+  it("projects correction decision outcomes before returning them", () => {
+    expect(routeSource).toContain(
+      "export const POST_CORRECTION_REQUEST_DECISION",
+    );
+    expect(routeSource).toContain("result: projectedResult,");
+  });
+
+  it("accepts the routed action source surfaces used by UI and jobs", () => {
+    expect(routeSource).toContain('"contribution_hub"');
+    expect(routeSource).toContain('"donor_crm_record"');
+    expect(routeSource).toContain('"automation"');
+    expect(routeSource).toContain('"bulk_action"');
+    expect(routeSource).toContain('"api"');
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-operations-route-contract.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-route-contract.test.ts
@@ -1,38 +1,80 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
-
 import { describe, expect, it } from "vitest";
 
-const routeSource = readFileSync(
-  path.resolve(
-    __dirname,
-    "../../../../../packages/api/src/admin/contribution-operations/route.ts",
-  ),
-  "utf8",
-);
+import {
+  actionRequestSchema,
+  assertContributionRouteActionSupported,
+  decisionRequestSchema,
+  isContributionRouteActionSupported,
+} from "../../../../../packages/api/src/admin/contribution-operations/route";
+
+import type { ContributionActionType } from "../../../../../packages/api/src/admin/contribution-operations/types";
+
+const VALID_ACTION_REQUEST = {
+  contributionId: "00000000-0000-4000-8000-000000000001",
+  actionType: "amount_correction",
+  reason: "Correct donor-entered amount",
+  payload: { amount: 20_000 },
+};
 
 describe("admin/contribution-operations route contract", () => {
-  it("redacts action results before returning POST action responses", () => {
-    expect(routeSource).toContain(
-      "const projectedResult = projectContributionActionResultForViewer(",
-    );
-    expect(routeSource).toContain(
-      "return NextResponse.json({ result: projectedResult, requestId });",
-    );
-  });
-
-  it("projects correction decision outcomes before returning them", () => {
-    expect(routeSource).toContain(
-      "export const POST_CORRECTION_REQUEST_DECISION",
-    );
-    expect(routeSource).toContain("result: projectedResult,");
-  });
-
   it("accepts the routed action source surfaces used by UI and jobs", () => {
-    expect(routeSource).toContain('"contribution_hub"');
-    expect(routeSource).toContain('"donor_crm_record"');
-    expect(routeSource).toContain('"automation"');
-    expect(routeSource).toContain('"bulk_action"');
-    expect(routeSource).toContain('"api"');
+    for (const sourceSurface of [
+      "contribution_hub",
+      "donor_crm_record",
+      "automation",
+      "bulk_action",
+      "api",
+    ]) {
+      expect(
+        actionRequestSchema.parse({
+          ...VALID_ACTION_REQUEST,
+          sourceSurface,
+        }).sourceSurface,
+      ).toBe(sourceSurface);
+    }
+  });
+
+  it("defaults action requests to the api source surface", () => {
+    expect(actionRequestSchema.parse(VALID_ACTION_REQUEST).sourceSurface).toBe(
+      "api",
+    );
+  });
+
+  it("rejects action types this route dependency set cannot execute", () => {
+    const unsupportedActions: ContributionActionType[] = [
+      "metadata_update",
+      "refund",
+      "donor_relink",
+    ];
+
+    for (const actionType of unsupportedActions) {
+      const parsed = actionRequestSchema.safeParse({
+        ...VALID_ACTION_REQUEST,
+        actionType,
+      });
+
+      expect(isContributionRouteActionSupported(actionType)).toBe(false);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error?.issues[0]?.message).toContain(
+        "not supported by this route",
+      );
+      expect(() => assertContributionRouteActionSupported(actionType)).toThrow(
+        /not supported by this route|dependencies are wired/,
+      );
+    }
+  });
+
+  it("accepts correction decision payloads", () => {
+    expect(
+      decisionRequestSchema.parse({
+        decision: "approve",
+        reason: "Finance reviewed the request",
+        receiptDelivery: { choice: "defer", deferReason: "Batch later" },
+      }),
+    ).toEqual({
+      decision: "approve",
+      reason: "Finance reviewed the request",
+      receiptDelivery: { choice: "defer", deferReason: "Batch later" },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add the `@asym/api/admin/contribution-operations/route` module for contribution detail GET, action POST, and correction-request decision POST handlers.
- Expose the handlers through the admin app API routes.
- Add route projection/export contract tests and runtime-map entries for the new routes.

## Verification
- `node scripts/run-with-ci-env.mjs -- bun test tests/unit/packages/api/admin/contribution-action-result-projection.test.ts tests/unit/packages/api/admin/contribution-operations-route-contract.test.ts tests/unit/apps/admin/app/contribution-operation-routes.test.ts`
- `bun run format`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run verify:data-boundary`
- `bun run verify:workspace-contract`
- `bun run test:unit`
- Pre-push CI preflight passed: format, skills-verify, lint, data-boundary, workspace-contract, eslint/shadcn checks, typecheck, shared package build, admin build, donor build, missionary build, test-unit.

Part of splitting #251 after #399.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes three new admin API routes for contribution operations — GET detail, POST action executor, and POST correction-request decision — by wiring them through a new `@asym/api/admin/contribution-operations/route` module and registering them in the admin Next.js app.

- Adds the shared route module with `withOperation` auth wrappers, Zod schema validation, and an explicit `UNSUPPORTED_ROUTE_ACTION_TYPES` set that blocks `refund`, `donor_relink`, and `metadata_update` at both the schema and assertion layers.
- Adds `projectContributionActionResultForViewer` to redact raw provider identifiers (`referenceId`, `raw`, `errorMessage`) from action results for viewers without `contributions.use_provider_actions`, mirroring the existing detail projection (ADR-CD-014/015).
- Adds contract tests for the route schemas, action projection, and app-level route export assertions.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The new routes are correctly scoped to authenticated tenant contexts, unsupported action types are blocked at both the schema and assertion layers, and viewer projections properly strip raw provider identifiers before returning results.

All three new handlers enforce role-based auth via withOperation and capability-based auth deeper in the stack. Unsupported action types are rejected by the Zod schema before any DB access, and a second guard blocks them in the approval decision path. Tenant scoping is applied consistently. Contract tests and projection tests cover the key behavioral boundaries.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-operations/route.ts | New route module implementing GET detail, POST action, and POST decision handlers. Access control is layered correctly: withOperation enforces role, schema rejects unsupported action types, assertCanDecideCorrectionRequest enforces contributions.approve_corrections capability. Tenant scoping is applied throughout via auth.tenantId. |
| packages/api/src/admin/contribution-operations/viewer-projection.ts | Adds projectContributionActionResultForViewer and redactProviderOutcomeForViewer. Correctly strips referenceId, raw, and errorMessage from provider outcomes for non-provider viewers while preserving status/errorCode; mirrors the existing detail projection pattern. |
| packages/api/src/admin/contribution-operations/types.ts | Converts ContributionSourceSurface from a plain union to a const-array-backed type, adding CONTRIBUTION_SOURCE_SURFACES for runtime use in Zod schemas. Backward-compatible change. |
| tests/unit/packages/api/admin/contribution-operations-route-contract.test.ts | Contract tests cover: supported/unsupported action type discrimination, source surface defaults, and decision schema parsing. Good coverage of the schema-level guard. |
| tests/unit/packages/api/admin/contribution-action-result-projection.test.ts | Tests non-provider viewer redaction (Stripe identifiers, raw provider payload), provider-authorized viewer passthrough, and null canonical contribution passthrough. Comprehensive for the new projection function. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): narrow contribution operation ..."](https://github.com/asymmetric-al/core/commit/925ffacba763500d98203f987ce99734b32f70bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38943540)</sub>

<!-- /greptile_comment -->