### PR TITLE
feat(admin): add CRM gift detail operations

### DIFF
--- a/apps/admin/app/contributions/operation-shell.tsx
+++ b/apps/admin/app/contributions/operation-shell.tsx
@@ -1,0 +1,649 @@
+"use client";
+
+import { formatSharedContributionAmount } from "@asym/api/admin/contribution-shared";
+import { Alert, AlertDescription } from "@asym/ui/components/shadcn/alert";
+import { Button } from "@asym/ui/components/shadcn/button";
+import { Checkbox } from "@asym/ui/components/shadcn/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@asym/ui/components/shadcn/dialog";
+import {
+  Field,
+  FieldContent,
+  FieldError,
+  FieldLabel,
+} from "@asym/ui/components/shadcn/field";
+import { Input } from "@asym/ui/components/shadcn/input";
+import { Label } from "@asym/ui/components/shadcn/label";
+import { Textarea } from "@asym/ui/components/shadcn/textarea";
+import { useQueryClient } from "@tanstack/react-query";
+import { CircleCheck, CircleX, LoaderCircle } from "lucide-react";
+import { useId, useMemo, useState } from "react";
+
+import {
+  invalidateContributionOperationQueries,
+  useContributionDetail,
+} from "./contribution-detail-overlay";
+
+import type {
+  ContributionActionResult,
+  ContributionActionType,
+  ContributionSourceSurface,
+} from "@asym/api/admin/contribution-operations";
+
+/**
+ * Reusable inline contribution operation shell (ADR-CD-033).
+ *
+ * The shell owns the shared behavior — server-computed blocked states,
+ * current effective values, downstream-effect framing, required reason and
+ * confirmation, submit/loading/error state, the in-place result panel, row
+ * refresh, and focus return. Each operation only supplies its specific
+ * fields, copy, and payload. Submissions always go through the same shared
+ * contribution operation contract as contribution detail.
+ */
+
+export type OperationCategory =
+  | "correction"
+  | "receipt"
+  | "refund"
+  | "crm"
+  | "provider";
+
+export interface OperationFieldValues {
+  amountDollars?: string;
+  fundId?: string;
+  reason: string;
+  confirmed: boolean;
+}
+
+export type SupportedOperationActionType = Extract<
+  ContributionActionType,
+  | "amount_correction"
+  | "fund_correction"
+  | "resend_receipt"
+  | "refund"
+  | "approve_staged_gift"
+  | "retry_staged_gift"
+  | "stripe_replay"
+>;
+
+export interface OperationDefinition {
+  actionType: SupportedOperationActionType;
+  title: string;
+  description: string;
+  category: OperationCategory;
+  /** Risky-operation framing shown above the form (ADR-CD-033). */
+  riskCopy: string | null;
+  downstreamEffects: string[];
+  requiresReason: boolean;
+  requiresConfirmation: boolean;
+  /** Which operation-specific inputs to render. */
+  fields: Array<"amount" | "fundId">;
+  buildPayload: (input: {
+    values: OperationFieldValues;
+    stagedGiftId: string | null;
+  }) => Record<string, unknown>;
+}
+
+export const OPERATION_DEFINITIONS: Record<
+  SupportedOperationActionType,
+  OperationDefinition
+> = {
+  amount_correction: {
+    actionType: "amount_correction",
+    title: "Correct gift amount",
+    description:
+      "Records an adjustment with the corrected amount. The original donation history is preserved.",
+    category: "correction",
+    riskCopy:
+      "This changes the gift's effective amount everywhere it appears, including receipts and reports. High-risk corrections may require approval.",
+    downstreamEffects: [
+      "Effective amount changes in CRM, the Contributions Hub, and reports.",
+      "A sent receipt becomes receipt-affected and may need an updated receipt.",
+    ],
+    requiresReason: true,
+    requiresConfirmation: true,
+    fields: ["amount"],
+    buildPayload: ({ values }) => ({
+      amount: Math.round(Number.parseFloat(values.amountDollars || "0") * 100),
+    }),
+  },
+  fund_correction: {
+    actionType: "fund_correction",
+    title: "Correct fund designation",
+    description:
+      "Moves this gift's designation to a different fund through an audited adjustment.",
+    category: "correction",
+    riskCopy:
+      "Changing the fund affects donor intent records, receipts, and CRM posting. High-risk corrections may require approval.",
+    downstreamEffects: [
+      "Designation summary changes in CRM and the Contributions Hub.",
+      "CRM posting and receipts may need follow-up.",
+    ],
+    requiresReason: true,
+    requiresConfirmation: true,
+    fields: ["fundId"],
+    buildPayload: ({ values }) => ({ fundId: values.fundId || null }),
+  },
+  resend_receipt: {
+    actionType: "resend_receipt",
+    title: "Send receipt",
+    description: "Sends the gift receipt to the donor again.",
+    category: "receipt",
+    riskCopy: null,
+    downstreamEffects: ["The donor receives a receipt email."],
+    requiresReason: false,
+    requiresConfirmation: false,
+    fields: [],
+    buildPayload: () => ({}),
+  },
+  refund: {
+    actionType: "refund",
+    title: "Refund gift",
+    description:
+      "Refunds the donor through the payment provider. Refunds follow tenant approval policy.",
+    category: "refund",
+    riskCopy:
+      "Money moves back to the donor. This cannot be undone and may require approval before it executes.",
+    downstreamEffects: [
+      "Refund state changes in CRM, the Contributions Hub, and donor history.",
+      "The provider charge is refunded for the entered amount.",
+    ],
+    requiresReason: true,
+    requiresConfirmation: true,
+    fields: ["amount"],
+    buildPayload: ({ values }) => ({
+      amount: Math.round(Number.parseFloat(values.amountDollars || "0") * 100),
+    }),
+  },
+  approve_staged_gift: {
+    actionType: "approve_staged_gift",
+    title: "Approve and post gift",
+    description: "Approves the staged gift and queues it for CRM posting.",
+    category: "crm",
+    riskCopy: null,
+    downstreamEffects: ["The gift posts to the CRM as workflow metadata."],
+    requiresReason: false,
+    requiresConfirmation: false,
+    fields: [],
+    buildPayload: () => ({}),
+  },
+  retry_staged_gift: {
+    actionType: "retry_staged_gift",
+    title: "Retry CRM posting",
+    description: "Retries the failed CRM posting for this gift.",
+    category: "crm",
+    riskCopy: null,
+    downstreamEffects: ["The gift reposts to the CRM."],
+    requiresReason: false,
+    requiresConfirmation: false,
+    fields: [],
+    buildPayload: () => ({}),
+  },
+  stripe_replay: {
+    actionType: "stripe_replay",
+    title: "Replay provider webhook",
+    description:
+      "Replays the stored provider event for technical recovery. Role-gated and audited.",
+    category: "provider",
+    riskCopy:
+      "Provider replay is a technical operation. It is idempotent and audited, but should only be used to recover missed events.",
+    downstreamEffects: ["The stored provider event is reprocessed."],
+    requiresReason: true,
+    requiresConfirmation: true,
+    fields: [],
+    buildPayload: () => ({}),
+  },
+};
+
+export const OPERATION_CATEGORY_LABELS: Record<OperationCategory, string> = {
+  correction: "Correction",
+  receipt: "Receipt",
+  refund: "Refund",
+  crm: "CRM / Twenty",
+  provider: "Provider / Admin",
+};
+
+type ShellPhase =
+  | { name: "form" }
+  | { name: "submitting" }
+  | { name: "success"; result: ContributionActionResult }
+  | { name: "failure"; message: string };
+
+async function submitOperation(input: {
+  actionType: ContributionActionType;
+  contributionId: string;
+  stagedGiftId: string | null;
+  sourceSurface: ContributionSourceSurface;
+  reason: string | null;
+  confirmationToken: string | null;
+  expectedRevision: string | null;
+  idempotencyKey: string;
+  payload: Record<string, unknown>;
+}): Promise<ContributionActionResult> {
+  const response = await fetch("/api/admin/contribution-operations/actions", {
+    body: JSON.stringify({
+      actionType: input.actionType,
+      contributionId: input.contributionId,
+      stagedGiftId: input.stagedGiftId,
+      sourceSurface: input.sourceSurface,
+      reason: input.reason,
+      confirmationToken: input.confirmationToken,
+      expectedRevision: input.expectedRevision,
+      idempotencyKey: input.idempotencyKey,
+      payload: input.payload,
+    }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+
+  const body = (await response.json().catch(() => null)) as {
+    result?: ContributionActionResult;
+    error?: string;
+  } | null;
+
+  if (!response.ok || !body?.result) {
+    throw new Error(body?.error ?? "The operation failed.");
+  }
+
+  return body.result;
+}
+
+export function ContributionOperationShell({
+  open,
+  onClose,
+  operation,
+  donationId,
+  sourceSurface,
+  onOpenFullDetail,
+  onRowRefresh,
+}: {
+  open: boolean;
+  onClose: () => void;
+  operation: OperationDefinition | null;
+  donationId: string | null;
+  sourceSurface: ContributionSourceSurface;
+  /** Optional secondary action — never an automatic redirect (ADR-CD-033). */
+  onOpenFullDetail?: (donationId: string) => void;
+  onRowRefresh?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const detailQuery = useContributionDetail(open ? donationId : null);
+  const [phase, setPhase] = useState<ShellPhase>({ name: "form" });
+  const [values, setValues] = useState<OperationFieldValues>({
+    reason: "",
+    confirmed: false,
+  });
+  const [idempotencyKey, setIdempotencyKey] = useState("");
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const reasonId = useId();
+  const amountId = useId();
+  const fundId = useId();
+  const confirmId = useId();
+
+  // Reset the form whenever a different operation/gift opens. State is
+  // adjusted during render (React's documented pattern) so no effect-driven
+  // cascading renders are needed.
+  const nextOpenKey = open
+    ? `${donationId ?? ""}:${operation?.actionType ?? ""}`
+    : null;
+  if (nextOpenKey !== openKey) {
+    setOpenKey(nextOpenKey);
+    if (nextOpenKey) {
+      setPhase({ name: "form" });
+      setValues({ reason: "", confirmed: false });
+      setIdempotencyKey(crypto.randomUUID());
+    }
+  }
+
+  const detail = detailQuery.data;
+  const availability = useMemo(() => {
+    if (!detail || !operation) {
+      return null;
+    }
+    return (
+      detail.actionAvailability.find(
+        (entry) => entry.actionType === operation.actionType,
+      ) ?? null
+    );
+  }, [detail, operation]);
+
+  if (!operation) {
+    return null;
+  }
+
+  const blocked = availability
+    ? !availability.available
+    : Boolean(detail && operation);
+  const blockedReason =
+    availability?.blockedReason ??
+    "This operation is not available for the current gift.";
+  const blockedNextStep =
+    availability?.nextStep ??
+    "Refresh the gift detail or choose another action.";
+  const amountError = (() => {
+    if (!operation.fields.includes("amount")) {
+      return null;
+    }
+    const parsed = Number.parseFloat(values.amountDollars || "");
+    return Number.isFinite(parsed) && parsed > 0
+      ? null
+      : "Enter a valid amount.";
+  })();
+  const fundError =
+    operation.fields.includes("fundId") && !values.fundId?.trim()
+      ? "Enter the destination fund."
+      : null;
+  const reasonError =
+    operation.requiresReason && !values.reason.trim()
+      ? "A reason is required for this operation."
+      : null;
+  const confirmError =
+    operation.requiresConfirmation && !values.confirmed
+      ? "Confirm the change to continue."
+      : null;
+  const validationMessage =
+    amountError ?? fundError ?? reasonError ?? confirmError;
+
+  const handleSubmit = async () => {
+    if (!donationId || validationMessage || blocked) {
+      return;
+    }
+    setPhase({ name: "submitting" });
+    try {
+      const result = await submitOperation({
+        actionType: operation.actionType,
+        contributionId: donationId,
+        stagedGiftId: detail?.stagedGift?.id ?? null,
+        sourceSurface,
+        reason: values.reason.trim() || null,
+        confirmationToken: operation.requiresConfirmation
+          ? idempotencyKey
+          : null,
+        expectedRevision: detail?.revision ?? null,
+        idempotencyKey,
+        payload: operation.buildPayload({
+          values,
+          stagedGiftId: detail?.stagedGift?.id ?? null,
+        }),
+      });
+      await invalidateContributionOperationQueries(queryClient);
+      onRowRefresh?.();
+      setPhase({ name: "success", result });
+    } catch (error) {
+      // Failure preserves the entered form state for recovery (ADR-CD-033).
+      setPhase({
+        name: "failure",
+        message:
+          error instanceof Error ? error.message : "The operation failed.",
+      });
+    }
+  };
+
+  const effectiveSummary = detail ? (
+    <dl className="grid grid-cols-2 gap-2 rounded-lg border border-border bg-muted/30 p-3 text-sm">
+      <dt className="text-muted-foreground">Current amount</dt>
+      <dd className="text-right font-mono font-semibold tabular-nums">
+        {formatSharedContributionAmount(
+          detail.shared.amountCents,
+          detail.shared.currencyCode,
+        )}
+      </dd>
+      <dt className="text-muted-foreground">Designation</dt>
+      <dd className="text-right font-medium">
+        {detail.shared.designationSummary.fundName}
+      </dd>
+      <dt className="text-muted-foreground">Receipt</dt>
+      <dd className="text-right font-medium capitalize">
+        {detail.shared.receiptStatus.replace(/_/g, " ")}
+      </dd>
+    </dl>
+  ) : null;
+  const amountCurrencyCode = detail?.shared.currencyCode ?? "USD";
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent
+        className="gap-4 p-5 max-sm:inset-x-0 max-sm:bottom-0 max-sm:top-auto max-sm:max-h-[92dvh] max-sm:w-full max-sm:max-w-none max-sm:translate-x-0 max-sm:translate-y-0 max-sm:overflow-y-auto max-sm:rounded-b-none sm:max-w-lg"
+        data-testid="contribution-operation-shell"
+      >
+        <DialogTitle className="text-base font-semibold">
+          {operation.title}
+        </DialogTitle>
+        <DialogDescription className="text-sm text-muted-foreground">
+          {operation.description}
+        </DialogDescription>
+
+        {detailQuery.isPending && (
+          <p role="status" className="text-sm text-muted-foreground">
+            Loading current gift values…
+          </p>
+        )}
+
+        {blocked && (
+          <div
+            role="note"
+            className="rounded-lg border border-border bg-muted/30 p-4 space-y-1"
+          >
+            <p className="text-sm font-medium text-foreground">
+              {blockedReason}
+            </p>
+            {blockedNextStep && (
+              <p className="text-xs text-muted-foreground">{blockedNextStep}</p>
+            )}
+          </div>
+        )}
+
+        {!blocked &&
+          phase.name !== "success" &&
+          phase.name !== "submitting" && (
+            <div className="space-y-4">
+              {effectiveSummary}
+
+              {operation.riskCopy && (
+                <Alert role="note">
+                  <AlertDescription className="text-xs">
+                    {operation.riskCopy}
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {operation.downstreamEffects.length > 0 && (
+                <ul className="list-disc space-y-0.5 pl-4 text-xs text-muted-foreground">
+                  {operation.downstreamEffects.map((effect) => (
+                    <li key={effect}>{effect}</li>
+                  ))}
+                </ul>
+              )}
+
+              {operation.fields.includes("amount") && (
+                <Field data-invalid={Boolean(amountError)}>
+                  <FieldLabel htmlFor={amountId}>
+                    Amount ({amountCurrencyCode})
+                  </FieldLabel>
+                  <Input
+                    id={amountId}
+                    aria-describedby={
+                      amountError ? `${amountId}-error` : undefined
+                    }
+                    aria-invalid={Boolean(amountError)}
+                    inputMode="decimal"
+                    value={values.amountDollars ?? ""}
+                    onChange={(event) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        amountDollars: event.target.value,
+                      }))
+                    }
+                    className="h-11"
+                  />
+                  <FieldError
+                    id={`${amountId}-error`}
+                    errors={amountError ? [{ message: amountError }] : []}
+                  />
+                </Field>
+              )}
+
+              {operation.fields.includes("fundId") && (
+                <Field data-invalid={Boolean(fundError)}>
+                  <FieldLabel htmlFor={fundId}>Destination fund ID</FieldLabel>
+                  <Input
+                    id={fundId}
+                    aria-describedby={fundError ? `${fundId}-error` : undefined}
+                    aria-invalid={Boolean(fundError)}
+                    value={values.fundId ?? ""}
+                    onChange={(event) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        fundId: event.target.value,
+                      }))
+                    }
+                    className="h-11"
+                  />
+                  <FieldError
+                    id={`${fundId}-error`}
+                    errors={fundError ? [{ message: fundError }] : []}
+                  />
+                </Field>
+              )}
+
+              {operation.requiresReason && (
+                <Field data-invalid={Boolean(reasonError)}>
+                  <FieldLabel htmlFor={reasonId}>Reason</FieldLabel>
+                  <Textarea
+                    id={reasonId}
+                    aria-describedby={
+                      reasonError ? `${reasonId}-error` : undefined
+                    }
+                    aria-invalid={Boolean(reasonError)}
+                    value={values.reason}
+                    onChange={(event) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        reason: event.target.value,
+                      }))
+                    }
+                    placeholder="Why is this change needed?"
+                  />
+                  <FieldError
+                    id={`${reasonId}-error`}
+                    errors={reasonError ? [{ message: reasonError }] : []}
+                  />
+                </Field>
+              )}
+
+              {operation.requiresConfirmation && (
+                <Field
+                  data-invalid={Boolean(confirmError)}
+                  orientation="horizontal"
+                >
+                  <Checkbox
+                    id={confirmId}
+                    aria-describedby={
+                      confirmError ? `${confirmId}-error` : undefined
+                    }
+                    aria-invalid={Boolean(confirmError)}
+                    checked={values.confirmed}
+                    onCheckedChange={(checked) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        confirmed: checked === true,
+                      }))
+                    }
+                    className="mt-0.5"
+                  />
+                  <FieldContent>
+                    <Label
+                      htmlFor={confirmId}
+                      className="text-sm font-normal leading-snug"
+                    >
+                      I reviewed the current values and downstream effects and
+                      want to submit this change.
+                    </Label>
+                    <FieldError
+                      id={`${confirmId}-error`}
+                      errors={confirmError ? [{ message: confirmError }] : []}
+                    />
+                  </FieldContent>
+                </Field>
+              )}
+
+              {phase.name === "failure" && (
+                <p role="alert" className="text-sm text-destructive">
+                  <CircleX className="mr-1 inline size-4" aria-hidden />
+                  {phase.message}
+                </p>
+              )}
+
+              <div className="flex flex-wrap justify-end gap-2 pt-1">
+                <Button variant="outline" className="h-11" onClick={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  className="h-11"
+                  disabled={Boolean(validationMessage) || detailQuery.isPending}
+                  onClick={() => void handleSubmit()}
+                >
+                  {phase.name === "failure" ? "Retry" : operation.title}
+                </Button>
+              </div>
+            </div>
+          )}
+
+        {phase.name === "submitting" && (
+          <p role="status" className="flex items-center gap-2 text-sm">
+            <LoaderCircle className="size-4 animate-spin" aria-hidden />
+            Submitting…
+          </p>
+        )}
+
+        {phase.name === "success" && (
+          <div className="space-y-3" data-testid="operation-result-panel">
+            <p
+              role="status"
+              className="flex items-center gap-2 text-sm font-medium text-foreground"
+            >
+              <CircleCheck className="size-4" aria-hidden />
+              {phase.result.approvalStatus === "pending_approval"
+                ? "Correction request submitted for approval."
+                : "Operation completed."}
+            </p>
+            <ul className="space-y-0.5 text-xs text-muted-foreground">
+              {phase.result.correctionRequestId && (
+                <li>Approval request: {phase.result.correctionRequestId}</li>
+              )}
+              {phase.result.adjustmentId && (
+                <li>Adjustment: {phase.result.adjustmentId}</li>
+              )}
+              {phase.result.receiptOutcome &&
+                phase.result.receiptOutcome.status !== "not_required" && (
+                  <li>
+                    Receipt:{" "}
+                    {phase.result.receiptOutcome.status.replace(/_/g, " ")}
+                  </li>
+                )}
+              <li>Audit event: {phase.result.auditEventId}</li>
+            </ul>
+            <div className="flex flex-wrap justify-end gap-2">
+              {onOpenFullDetail && donationId && (
+                <Button
+                  variant="outline"
+                  className="h-11"
+                  onClick={() => onOpenFullDetail(donationId)}
+                >
+                  View full contribution detail
+                </Button>
+              )}
+              <Button className="h-11" onClick={onClose}>
+                Done
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/app/crm/columns.tsx
+++ b/apps/admin/app/crm/columns.tsx
@@ -353,12 +353,11 @@ export function getCrmColumns({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
-                  aria-label={`Open actions for ${record.displayName ?? "CRM record"}`}
+                  aria-label={`CRM actions for ${record.displayName ?? "CRM record"}`}
                   variant="ghost"
                   className="size-8 p-0 text-muted-foreground hover:text-foreground rounded-xl"
                 >
-                  <span className="sr-only">Open menu</span>
-                  <MoreHorizontal className="size-4" />
+                  <MoreHorizontal className="size-4" aria-hidden="true" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-48 rounded-xl">

--- a/apps/admin/app/crm/crm-detail-shared.ts
+++ b/apps/admin/app/crm/crm-detail-shared.ts
@@ -1,0 +1,32 @@
+import { toast } from "sonner";
+
+import type {
+  CrmGiftHistoryColumnSettings,
+  CrmGiftHistoryFiltersSortSettings,
+} from "@asym/database/types";
+
+/** Placeholder shown for missing CRM record fields. */
+export const EMPTY_CELL_VALUE = "N/A";
+
+/**
+ * Per-scope view settings patch: absent = unchanged, null = scoped reset,
+ * value = replace (#272).
+ */
+export interface ViewSettingsPatch {
+  pinnedActionId?: string | null;
+  columns?: Partial<CrmGiftHistoryColumnSettings> | null;
+  filtersSort?: Partial<CrmGiftHistoryFiltersSortSettings> | null;
+  activeViewId?: string | null;
+}
+
+export function makeDisplayDate(value?: string | number | Date): Date {
+  return value === undefined
+    ? new globalThis.Date()
+    : new globalThis.Date(value);
+}
+
+export function viewMutationErrorToast(error: unknown) {
+  toast.error(
+    error instanceof Error ? error.message : "Failed to update named views.",
+  );
+}

--- a/apps/admin/app/crm/detail-drawer.tsx
+++ b/apps/admin/app/crm/detail-drawer.tsx
@@ -1,0 +1,1087 @@
+"use client";
+
+import {
+  formatSharedContributionAmount,
+  hasSharedContributionIssue,
+  matchesSharedContributionFilter,
+  SHARED_CRM_POST_STATUS_LABELS,
+  SHARED_RECEIPT_STATUS_LABELS,
+} from "@asym/api/admin/contribution-shared";
+import {
+  CRM_GIFT_HISTORY_TABLE_ID,
+  previewCrmViewSettingsReset,
+  resolveCrmGiftHistoryViewSettings,
+} from "@asym/api/admin/crm/table-preferences";
+import {
+  useAdminCrmRecordDetail,
+  useCreateCrmNamedView,
+  useCreateLinkedCrmNote,
+  useCrmNamedViews,
+  useCrmTablePreferences,
+  useDeleteCrmNamedView,
+  useSaveCrmRowActionPin,
+  useSaveCrmViewSettings,
+  useUpdateCrmNamedView,
+} from "@asym/database/hooks";
+import { motion, AnimatePresence } from "@asym/lib/motion";
+import { formatCurrency } from "@asym/lib/utils";
+import {
+  crmRecordAvatarTransitionName,
+  crmRecordTitleTransitionName,
+} from "@asym/lib/view-transitions";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@asym/ui/components/shadcn/alert";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@asym/ui/components/shadcn/avatar";
+import { Badge } from "@asym/ui/components/shadcn/badge";
+import { Button } from "@asym/ui/components/shadcn/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@asym/ui/components/shadcn/dialog";
+import { Input } from "@asym/ui/components/shadcn/input";
+import { Label } from "@asym/ui/components/shadcn/label";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@asym/ui/components/shadcn/radio-group";
+import { ScrollArea } from "@asym/ui/components/shadcn/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from "@asym/ui/components/shadcn/sheet";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@asym/ui/components/shadcn/tabs";
+import { Textarea } from "@asym/ui/components/shadcn/textarea";
+import { SharedNamedViewTransition } from "@asym/ui/components/view-transitions";
+import { cn } from "@asym/ui/lib/utils";
+import { FileText, History, Paperclip, User, X } from "lucide-react";
+import React, { useEffect, useId, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  EMPTY_CELL_VALUE,
+  makeDisplayDate,
+  viewMutationErrorToast,
+  type ViewSettingsPatch,
+} from "./crm-detail-shared";
+import { GiftHistoryViewSettingsMenu } from "./gift-history-view-settings-menu";
+import { GiftHistoryViewSwitcher } from "./gift-history-view-switcher";
+import { GiftInlineActionControls } from "./gift-inline-action-controls";
+import { PORTAL_BADGE_CLASS } from "./types";
+import {
+  ContributionOperationShell,
+  type OperationDefinition,
+} from "../contributions/operation-shell";
+
+import type { CrmRecord } from "./types";
+import type { CrmNamedView, CrmViewSettingsScope } from "@asym/database/types";
+
+export function DetailDrawer({
+  contact,
+  onClose,
+  onOpenGift,
+}: {
+  contact: CrmRecord;
+  onClose: () => void;
+  onOpenGift: (donationId: string) => void;
+}) {
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [noteBody, setNoteBody] = useState("");
+  const noteFieldId = useId();
+  const [summary, setSummary] = useState<{
+    category: string;
+    focus: string;
+    nextMove: string;
+  } | null>(null);
+  const detailQuery = useAdminCrmRecordDetail(contact.id);
+  const createNoteMutation = useCreateLinkedCrmNote(contact.id);
+  const tablePreferencesQuery = useCrmTablePreferences(
+    CRM_GIFT_HISTORY_TABLE_ID,
+  );
+  const savePinMutation = useSaveCrmRowActionPin(CRM_GIFT_HISTORY_TABLE_ID);
+  const saveViewSettingsMutation = useSaveCrmViewSettings(
+    CRM_GIFT_HISTORY_TABLE_ID,
+  );
+  const saveViewSettingsMutate = saveViewSettingsMutation.mutate;
+  const [inlineOperation, setInlineOperation] = useState<{
+    donationId: string;
+    operation: OperationDefinition;
+  } | null>(null);
+  const [pendingReset, setPendingReset] = useState<CrmViewSettingsScope | null>(
+    null,
+  );
+
+  const pinRowAction = (actionId: string | null) => {
+    savePinMutation.mutate(actionId, {
+      onError: (error) => {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to save the pinned row action.",
+        );
+      },
+    });
+  };
+
+  const saveViewSettings = (patch: ViewSettingsPatch) => {
+    saveViewSettingsMutate(patch, {
+      onError: (error) => {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to save view settings.",
+        );
+      },
+    });
+  };
+
+  const tablePreferences = tablePreferencesQuery.data;
+  const viewSettings = useMemo(
+    () =>
+      resolveCrmGiftHistoryViewSettings({
+        user: tablePreferences?.user?.settings ?? null,
+        tenantDefault: tablePreferences?.tenantDefault?.settings ?? null,
+      }).settings,
+    [tablePreferences],
+  );
+
+  // Named personal views (#273).
+  const namedViewsQuery = useCrmNamedViews(CRM_GIFT_HISTORY_TABLE_ID);
+  const createViewMutation = useCreateCrmNamedView(CRM_GIFT_HISTORY_TABLE_ID);
+  const updateViewMutation = useUpdateCrmNamedView(CRM_GIFT_HISTORY_TABLE_ID);
+  const deleteViewMutation = useDeleteCrmNamedView(CRM_GIFT_HISTORY_TABLE_ID);
+  const namedViews = useMemo(
+    () => namedViewsQuery.data?.views ?? [],
+    [namedViewsQuery.data],
+  );
+  const activeViewId = tablePreferences?.user?.settings?.activeViewId ?? null;
+  const [viewNameDialog, setViewNameDialog] = useState<{
+    mode: "create" | "rename" | "duplicate";
+    view?: CrmNamedView;
+  } | null>(null);
+  const [viewNameInput, setViewNameInput] = useState("");
+  const [deleteViewDialog, setDeleteViewDialog] = useState<CrmNamedView | null>(
+    null,
+  );
+  const [nextDefaultChoice, setNextDefaultChoice] = useState("");
+
+  const viewSettingsPatchFromNamedView = (
+    view: CrmNamedView,
+  ): ViewSettingsPatch => ({
+    columns: view.settings?.columns ?? null,
+    filtersSort: view.settings?.filtersSort ?? null,
+    pinnedActionId: view.pinnedActionId,
+    activeViewId: view.id,
+  });
+
+  /** Applying a view copies its snapshot into the working preference. */
+  const applyNamedView = (view: CrmNamedView) => {
+    saveViewSettingsMutate(viewSettingsPatchFromNamedView(view), {
+      onError: viewMutationErrorToast,
+    });
+  };
+
+  // The default named view loads automatically when the user has no working
+  // preference record yet (#273). The guard flips only after a successful save
+  // so a transient failure can retry after the preference queries refetch.
+  const appliedDefaultViewRef = React.useRef(false);
+  const defaultNamedView = useMemo(() => {
+    if (!tablePreferencesQuery.data || tablePreferencesQuery.data.user) {
+      return null;
+    }
+    return namedViews.find((view) => view.isDefault) ?? null;
+  }, [namedViews, tablePreferencesQuery.data]);
+  useEffect(() => {
+    if (appliedDefaultViewRef.current || !defaultNamedView) {
+      return;
+    }
+    appliedDefaultViewRef.current = true;
+    saveViewSettingsMutate(viewSettingsPatchFromNamedView(defaultNamedView), {
+      onError: (error) => {
+        appliedDefaultViewRef.current = false;
+        viewMutationErrorToast(error);
+      },
+    });
+  }, [defaultNamedView, saveViewSettingsMutate]);
+
+  const submitViewNameDialog = () => {
+    if (!viewNameDialog) {
+      return;
+    }
+    const name = viewNameInput.trim();
+    if (!name) {
+      return;
+    }
+
+    if (viewNameDialog.mode === "rename" && viewNameDialog.view) {
+      updateViewMutation.mutate(
+        { viewId: viewNameDialog.view.id, name },
+        { onError: viewMutationErrorToast },
+      );
+    } else if (viewNameDialog.mode === "duplicate" && viewNameDialog.view) {
+      createViewMutation.mutate(
+        {
+          name,
+          pinnedActionId: viewNameDialog.view.pinnedActionId,
+          columns: viewNameDialog.view.settings?.columns ?? undefined,
+          filtersSort: viewNameDialog.view.settings?.filtersSort ?? undefined,
+        },
+        { onError: viewMutationErrorToast },
+      );
+    } else {
+      // Save the current working settings and pin as a new view.
+      createViewMutation.mutate(
+        {
+          name,
+          pinnedActionId: tablePreferences?.user?.actionId ?? null,
+          columns: tablePreferences?.user?.settings?.columns ?? undefined,
+          filtersSort:
+            tablePreferences?.user?.settings?.filtersSort ?? undefined,
+        },
+        {
+          onError: viewMutationErrorToast,
+          onSuccess: ({ view }) => {
+            saveViewSettings({ activeViewId: view.id });
+          },
+        },
+      );
+    }
+    setViewNameDialog(null);
+    setViewNameInput("");
+  };
+
+  const confirmDeleteView = () => {
+    if (!deleteViewDialog) {
+      return;
+    }
+    const deletingActive = deleteViewDialog.id === activeViewId;
+    deleteViewMutation.mutate(
+      {
+        viewId: deleteViewDialog.id,
+        nextDefaultViewId:
+          deleteViewDialog.isDefault && nextDefaultChoice
+            ? nextDefaultChoice
+            : undefined,
+      },
+      {
+        onError: viewMutationErrorToast,
+        onSuccess: () => {
+          if (deletingActive) {
+            saveViewSettings({ activeViewId: null });
+          }
+        },
+      },
+    );
+    setDeleteViewDialog(null);
+    setNextDefaultChoice("");
+  };
+
+  const resetPreview = pendingReset
+    ? previewCrmViewSettingsReset({
+        scope: pendingReset,
+        user: {
+          settings: tablePreferences?.user?.settings ?? null,
+          pinnedActionId: tablePreferences?.user?.actionId ?? null,
+        },
+        tenantDefault: {
+          settings: tablePreferences?.tenantDefault?.settings ?? null,
+          pinnedActionId: tablePreferences?.tenantDefault?.actionId ?? null,
+        },
+      })
+    : null;
+
+  const confirmPendingReset = () => {
+    if (!pendingReset) {
+      return;
+    }
+    const patch: ViewSettingsPatch =
+      pendingReset === "columns"
+        ? { columns: null }
+        : pendingReset === "filtersSort"
+          ? { filtersSort: null }
+          : pendingReset === "pinnedAction"
+            ? { pinnedActionId: null }
+            : { columns: null, filtersSort: null, pinnedActionId: null };
+    saveViewSettings(patch);
+    setPendingReset(null);
+  };
+
+  const summarizeContact = async () => {
+    setIsAnalyzing(true);
+    let detail = detailQuery.data;
+    if (!detailQuery.data && !detailQuery.isFetching) {
+      const refetched = await detailQuery.refetch();
+      detail = refetched.data;
+    }
+    const primaryFund = detail?.support.byFund[0]?.fundName;
+    const duplicateCount = detail?.duplicateWarnings.length ?? 0;
+    setSummary({
+      category: contact.recordType ?? "Constituent",
+      focus:
+        detail?.donor.notesPreview ??
+        contact.notesPreview ??
+        (primaryFund ? `Primary designation: ${primaryFund}.` : null) ??
+        "No notes on file yet.",
+      nextMove:
+        duplicateCount > 0
+          ? "Review duplicate warnings before outreach."
+          : "Review gift history and schedule the next touchpoint.",
+    });
+    setIsAnalyzing(false);
+  };
+
+  const display = contact.displayName || "Unnamed record";
+  const detail = detailQuery.data;
+
+  // Effective view settings drive the gift list (#272): filters and sort
+  // apply before display; columns control which row fields render. Filters
+  // evaluate through the shared CRM/Hub definitions so the same gift matches
+  // identically on both surfaces (#274).
+  const giftRows = useMemo(() => {
+    const gifts = detail?.giftHistory ?? [];
+    const { filtersSort } = viewSettings;
+    const filtered = gifts.filter((gift) => {
+      const shared = gift.shared;
+      if (
+        filtersSort.paymentStatus !== "all" &&
+        !matchesSharedContributionFilter(
+          { shared },
+          { id: "payment_status", value: filtersSort.paymentStatus },
+        )
+      ) {
+        return false;
+      }
+      switch (filtersSort.issue) {
+        case "needs_attention":
+          return hasSharedContributionIssue({ shared });
+        case "receipt_affected":
+          return matchesSharedContributionFilter(
+            { shared },
+            { id: "receipt_affected" },
+          );
+        case "pending_correction":
+          return matchesSharedContributionFilter(
+            { shared },
+            { id: "pending_correction" },
+          );
+        default:
+          return true;
+      }
+    });
+    return [...filtered].sort((left, right) => {
+      const leftValue =
+        filtersSort.sortField === "amountCents"
+          ? left.amountCents
+          : new Date(left.giftDate ?? 0).getTime();
+      const rightValue =
+        filtersSort.sortField === "amountCents"
+          ? right.amountCents
+          : new Date(right.giftDate ?? 0).getTime();
+      return filtersSort.sortDirection === "asc"
+        ? leftValue - rightValue
+        : rightValue - leftValue;
+    });
+  }, [detail?.giftHistory, viewSettings]);
+
+  const timeline =
+    detail?.timeline ??
+    contact.activities.map((activity) => ({
+      amountCents: activity.amount ?? null,
+      currencyCode: null,
+      description: activity.description ?? null,
+      id: activity.id,
+      kind: activity.type,
+      occurredAt: activity.date,
+      source: "platform" as const,
+      title: activity.title,
+      visibility: "standard" as const,
+    }));
+
+  const saveNote = async () => {
+    const trimmed = noteBody.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    try {
+      await createNoteMutation.mutateAsync({
+        body: trimmed,
+        linkedRecordId: contact.id,
+        linkedRecordType: "donor_profile",
+        title: `Donor care note: ${display}`,
+        visibility: "standard",
+      });
+      setNoteBody("");
+      toast.success("CRM note queued.");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save note.",
+      );
+    }
+  };
+
+  return (
+    <>
+      <Sheet open={!!contact} onOpenChange={(open) => !open && onClose()}>
+        <SheetContent className="w-full sm:max-w-2xl p-0 gap-0 border-l border-border bg-background shadow-2xl overflow-hidden flex flex-col h-full text-left">
+          <SheetTitle className="sr-only">
+            {display}, CRM record details
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            Constituent summary, activity, and properties for this CRM record.
+          </SheetDescription>
+          <div className="h-14 bg-card border-b border-border flex items-center justify-between px-4 shrink-0 z-10">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <User className="size-4 text-muted-foreground" />
+              <span className="truncate max-w-[200px] sm:max-w-md">
+                {display}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-9 gap-2 rounded-xl border border-border bg-card text-xs font-semibold text-muted-foreground hover:bg-muted hover:text-foreground"
+                onClick={summarizeContact}
+                disabled={isAnalyzing}
+              >
+                <FileText
+                  className={cn("size-3.5", isAnalyzing && "animate-pulse")}
+                />
+                {isAnalyzing ? "Summarizing..." : "Quick Summary"}
+              </Button>
+              <div className="h-4 w-px bg-border mx-2" />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onClose}
+                aria-label="Close CRM record details"
+                className="size-8 text-muted-foreground"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+
+          <ScrollArea className="flex-1">
+            <div className="p-6 space-y-8">
+              <div className="flex gap-6 items-start">
+                <SharedNamedViewTransition
+                  name={crmRecordAvatarTransitionName(contact.id)}
+                >
+                  <Avatar className="size-20 border-4 border-background shadow-sm">
+                    <AvatarImage src={contact.avatarUrl ?? undefined} />
+                    <AvatarFallback className="bg-muted text-muted-foreground font-semibold text-xl">
+                      {display[0] ?? "?"}
+                    </AvatarFallback>
+                  </Avatar>
+                </SharedNamedViewTransition>
+                <div className="space-y-1 pt-1 min-w-0">
+                  <SharedNamedViewTransition
+                    name={crmRecordTitleTransitionName(contact.id)}
+                  >
+                    <h2 className="text-2xl font-semibold text-foreground tracking-tight">
+                      {display}
+                    </h2>
+                  </SharedNamedViewTransition>
+                  <p className="text-sm text-muted-foreground font-medium">
+                    {contact.title ? (
+                      <>
+                        {contact.title}
+                        {contact.primaryOrganization ? (
+                          <>
+                            {" "}
+                            at{" "}
+                            <span className="text-foreground">
+                              {contact.primaryOrganization}
+                            </span>
+                          </>
+                        ) : null}
+                      </>
+                    ) : contact.primaryOrganization ? (
+                      <span className="text-foreground">
+                        {contact.primaryOrganization}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">
+                        No title set
+                      </span>
+                    )}
+                  </p>
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] font-semibold uppercase"
+                    >
+                      {contact.lifecycleStatus ?? "Unknown status"}
+                    </Badge>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "text-[10px] font-semibold uppercase border shadow-none",
+                        PORTAL_BADGE_CLASS[contact.portalAccessLabel],
+                      )}
+                    >
+                      {contact.portalAccessLabel === "linked"
+                        ? "Portal linked"
+                        : "No portal"}
+                    </Badge>
+                    <Badge
+                      variant="secondary"
+                      className="h-5 text-[10px] font-semibold uppercase tracking-wider border-none bg-muted text-muted-foreground"
+                    >
+                      {formatCurrency(contact.lifetimeGiving)}
+                    </Badge>
+                  </div>
+                </div>
+              </div>
+
+              <AnimatePresence>
+                {summary && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    role="status"
+                    aria-live="polite"
+                    className="rounded-xl border border-border bg-card p-5 shadow-sm space-y-4"
+                  >
+                    <div className="flex items-center gap-2 text-foreground font-semibold text-[10px] uppercase tracking-[0.2em]">
+                      <FileText className="size-3.5 text-muted-foreground" />{" "}
+                      Highlights
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                      <div>
+                        <span className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                          Type
+                        </span>
+                        <p className="text-sm font-semibold text-foreground">
+                          {summary.category}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                          Notes
+                        </span>
+                        <p className="text-xs text-muted-foreground leading-relaxed font-medium">
+                          {summary.focus}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                          Next step
+                        </span>
+                        <p className="text-xs text-foreground font-semibold">
+                          {summary.nextMove}
+                        </p>
+                      </div>
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              <Tabs defaultValue="activity">
+                <TabsList className="bg-transparent h-9 p-0 gap-6 border-b border-border w-full rounded-none justify-start">
+                  <TabsTrigger
+                    value="activity"
+                    className="bg-transparent border-b-2 border-transparent data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none px-0 py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground shadow-none"
+                  >
+                    Activity
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="properties"
+                    className="bg-transparent border-b-2 border-transparent data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none px-0 py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground shadow-none"
+                  >
+                    Properties
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="activity" className="pt-6 space-y-6">
+                  <div className="bg-card p-4 rounded-xl border border-border shadow-sm space-y-3">
+                    <Label htmlFor={noteFieldId} className="sr-only">
+                      Note body
+                    </Label>
+                    <Textarea
+                      id={noteFieldId}
+                      placeholder="Log a note, call, or meeting..."
+                      value={noteBody}
+                      onChange={(event) => setNoteBody(event.target.value)}
+                      className="h-20 resize-none text-sm"
+                    />
+                    <div className="flex justify-between items-center pt-2 border-t border-muted">
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label="Attach file to note"
+                          disabled
+                          className="size-7 text-muted-foreground hover:text-foreground"
+                        >
+                          <Paperclip className="size-3.5" aria-hidden="true" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label="View note history"
+                          disabled
+                          className="size-7 text-muted-foreground hover:text-foreground"
+                        >
+                          <History className="size-3.5" aria-hidden="true" />
+                        </Button>
+                      </div>
+                      <Button
+                        size="sm"
+                        className="h-7 px-4 text-[10px] font-semibold uppercase tracking-wider"
+                        disabled={
+                          createNoteMutation.isPending || !noteBody.trim()
+                        }
+                        onClick={() => void saveNote()}
+                      >
+                        {createNoteMutation.isPending
+                          ? "Saving..."
+                          : "Save Note"}
+                      </Button>
+                    </div>
+                  </div>
+
+                  {detail?.duplicateWarnings.length ? (
+                    <Alert>
+                      <AlertTitle className="text-[10px] font-semibold uppercase tracking-[0.18em]">
+                        Duplicate warning
+                      </AlertTitle>
+                      <AlertDescription className="mt-2 space-y-2 text-xs">
+                        {detail.duplicateWarnings.map((warning) => (
+                          <p key={warning.id} className="leading-relaxed">
+                            {warning.reason}
+                            {warning.score != null ? ` (${warning.score})` : ""}
+                          </p>
+                        ))}
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
+
+                  {detail?.giftHistory.length ? (
+                    <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                          Gift history
+                        </p>
+                        <div className="flex items-center gap-1">
+                          <Badge variant="secondary" className="text-[10px]">
+                            {giftRows.length}
+                          </Badge>
+                          {detail.giftHistoryTruncated ? (
+                            <Badge variant="outline" className="text-[10px]">
+                              First 100 shown
+                            </Badge>
+                          ) : null}
+                          <GiftHistoryViewSwitcher
+                            views={namedViews}
+                            activeViewId={activeViewId}
+                            onApplyView={applyNamedView}
+                            onSaveCurrentAs={() => {
+                              setViewNameInput("");
+                              setViewNameDialog({ mode: "create" });
+                            }}
+                            onRename={(view) => {
+                              setViewNameInput(view.name);
+                              setViewNameDialog({ mode: "rename", view });
+                            }}
+                            onDuplicate={(view) => {
+                              setViewNameInput(`${view.name} copy`);
+                              setViewNameDialog({ mode: "duplicate", view });
+                            }}
+                            onSetDefault={(view) =>
+                              updateViewMutation.mutate(
+                                { viewId: view.id, isDefault: true },
+                                { onError: viewMutationErrorToast },
+                              )
+                            }
+                            onResetToSaved={applyNamedView}
+                            onDelete={(view) => {
+                              setNextDefaultChoice("");
+                              setDeleteViewDialog(view);
+                            }}
+                          />
+                          <GiftHistoryViewSettingsMenu
+                            settings={viewSettings}
+                            onPatch={saveViewSettings}
+                            onRequestReset={setPendingReset}
+                          />
+                        </div>
+                      </div>
+                      {detail.giftHistoryTruncated ? (
+                        <p className="mt-3 text-xs text-muted-foreground">
+                          Gift history is capped at the 100 most recent gifts.
+                        </p>
+                      ) : null}
+                      <div
+                        className="mt-3 divide-y divide-border"
+                        aria-live="polite"
+                      >
+                        {giftRows.length === 0 ? (
+                          <p className="py-3 text-xs text-muted-foreground">
+                            No gifts match the current view filters.
+                          </p>
+                        ) : null}
+                        {giftRows.slice(0, 6).map((gift) => {
+                          const shared = gift.shared;
+                          const formattedAmount =
+                            formatSharedContributionAmount(
+                              shared.amountCents,
+                              shared.currencyCode,
+                            );
+
+                          return (
+                            <div
+                              key={gift.id}
+                              className="flex items-center justify-between gap-4 py-3"
+                            >
+                              <button
+                                type="button"
+                                onClick={() => onOpenGift(gift.donationId)}
+                                className="min-w-0 rounded-lg text-left transition-colors hover:bg-muted/50 focus-visible:outline-2 focus-visible:outline-ring"
+                                aria-label={`Open gift detail for ${formattedAmount} to ${shared.designationSummary.fundName}`}
+                              >
+                                <p className="text-sm font-semibold text-foreground">
+                                  {formattedAmount}
+                                </p>
+                                {viewSettings.columns.designation ? (
+                                  <p className="truncate text-xs text-muted-foreground">
+                                    {shared.designationSummary.fundName}
+                                  </p>
+                                ) : null}
+                                {viewSettings.columns.statusLine ? (
+                                  <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                    {
+                                      SHARED_RECEIPT_STATUS_LABELS[
+                                        shared.receiptStatus
+                                      ]
+                                    }{" "}
+                                    /{" "}
+                                    {shared.crmPostStatus
+                                      ? SHARED_CRM_POST_STATUS_LABELS[
+                                          shared.crmPostStatus
+                                        ]
+                                      : "Not required"}
+                                  </p>
+                                ) : null}
+                              </button>
+                              <GiftInlineActionControls
+                                inlineActions={gift.inlineActions}
+                                preferences={tablePreferencesQuery.data}
+                                onPinChange={pinRowAction}
+                                onRunOperation={(operation) =>
+                                  setInlineOperation({
+                                    donationId: gift.donationId,
+                                    operation,
+                                  })
+                                }
+                              />
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : detailQuery.isLoading ? (
+                    <div className="rounded-xl border border-border bg-card p-4 text-sm text-muted-foreground">
+                      Loading donor workflow history…
+                    </div>
+                  ) : null}
+
+                  <div className="space-y-6 pl-4 border-l border-border ml-2">
+                    {timeline.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">
+                        No timeline entries yet. Activity from donations and
+                        tasks will appear here as the CRM read model expands.
+                      </p>
+                    ) : (
+                      timeline.map((act) => (
+                        <div key={act.id} className="relative group">
+                          <div className="absolute -left-[21px] top-0 size-4 rounded-full border-2 border-background bg-muted z-10 transition-colors group-hover:bg-foreground" />
+                          <div className="pb-4 space-y-1">
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs font-semibold text-foreground">
+                                {act.title}
+                              </span>
+                              <span className="text-[10px] text-muted-foreground font-semibold uppercase tracking-widest">
+                                {makeDisplayDate(
+                                  act.occurredAt,
+                                ).toLocaleDateString()}
+                              </span>
+                            </div>
+                            {act.description && (
+                              <p className="text-xs text-muted-foreground leading-relaxed bg-card p-3 rounded-lg border border-border shadow-sm">
+                                {act.description}
+                              </p>
+                            )}
+                            {act.amountCents && (
+                              <p className="text-xs font-semibold text-foreground">
+                                +{formatCurrency(act.amountCents)}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </TabsContent>
+
+                <TabsContent
+                  value="properties"
+                  className="pt-6 grid grid-cols-2 gap-8 text-left"
+                >
+                  <div className="space-y-6">
+                    <div className="space-y-1">
+                      <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                        Email
+                      </p>
+                      <p className="text-sm font-semibold text-foreground truncate hover:text-primary cursor-pointer">
+                        {contact.email ?? EMPTY_CELL_VALUE}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                        Phone
+                      </p>
+                      <p className="text-sm font-semibold text-foreground">
+                        {contact.phone ?? EMPTY_CELL_VALUE}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                        Location
+                      </p>
+                      <p className="text-sm font-semibold text-foreground">
+                        {contact.location ?? EMPTY_CELL_VALUE}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="space-y-6">
+                    <div className="space-y-1">
+                      <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                        Assigned missionary
+                      </p>
+                      <p className="text-sm font-semibold text-foreground">
+                        {detail?.support.byMissionary[0]?.missionaryName ??
+                          contact.assignedMissionaryName ??
+                          EMPTY_CELL_VALUE}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                        Support status
+                      </p>
+                      <div className="space-y-1 text-sm font-semibold text-foreground">
+                        <p>
+                          {detail
+                            ? formatCurrency(detail.support.lifetimeGivingCents)
+                            : formatCurrency(contact.lifetimeGiving)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {detail
+                            ? `${detail.support.activeRecurringCommitments} recurring / ${detail.support.atRiskCommitments} at risk`
+                            : "Recurring support not loaded"}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                        Privacy
+                      </p>
+                      <p className="text-xs font-medium text-muted-foreground">
+                        {detail?.privacy.missionaryContactDataExposed === false
+                          ? "Missionary users do not receive restricted donor contact data."
+                          : "Staff-only donor data."}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
+                        Tags
+                      </p>
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {(contact.tags ?? []).length === 0 ? (
+                          <span className="text-sm text-muted-foreground">
+                            {EMPTY_CELL_VALUE}
+                          </span>
+                        ) : (
+                          contact.tags.map((t) => (
+                            <Badge
+                              key={t}
+                              variant="secondary"
+                              className="text-[9px] px-1.5 h-4 bg-muted text-muted-foreground border-none shadow-none"
+                            >
+                              {t}
+                            </Badge>
+                          ))
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </TabsContent>
+              </Tabs>
+            </div>
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
+      <ContributionOperationShell
+        open={inlineOperation !== null}
+        onClose={() => setInlineOperation(null)}
+        operation={inlineOperation?.operation ?? null}
+        donationId={inlineOperation?.donationId ?? null}
+        sourceSurface="donor_crm_record"
+        onOpenFullDetail={(donationId) => {
+          setInlineOperation(null);
+          onOpenGift(donationId);
+        }}
+        onRowRefresh={() => void detailQuery.refetch()}
+      />
+      {pendingReset && resetPreview ? (
+        <Dialog open onOpenChange={(open) => !open && setPendingReset(null)}>
+          <DialogContent
+            className="sm:max-w-md"
+            data-testid="view-settings-reset-preview"
+          >
+            <DialogTitle>Reset view settings</DialogTitle>
+            <DialogDescription>{resetPreview.description}</DialogDescription>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                className="h-11"
+                onClick={() => setPendingReset(null)}
+              >
+                Cancel
+              </Button>
+              <Button className="h-11" onClick={confirmPendingReset}>
+                Reset
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+      {viewNameDialog ? (
+        <Dialog open onOpenChange={(open) => !open && setViewNameDialog(null)}>
+          <DialogContent
+            className="sm:max-w-md"
+            data-testid="named-view-name-dialog"
+          >
+            <DialogTitle>
+              {viewNameDialog.mode === "rename"
+                ? "Rename view"
+                : viewNameDialog.mode === "duplicate"
+                  ? "Duplicate view"
+                  : "Save current as view"}
+            </DialogTitle>
+            <DialogDescription>
+              Named views are personal — they save your columns, filters, sort,
+              and pinned row action.
+            </DialogDescription>
+            <div className="space-y-1.5">
+              <Label htmlFor="named-view-name">View name</Label>
+              <Input
+                id="named-view-name"
+                value={viewNameInput}
+                onChange={(event) => setViewNameInput(event.target.value)}
+                className="h-11"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                className="h-11"
+                onClick={() => setViewNameDialog(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                className="h-11"
+                disabled={!viewNameInput.trim()}
+                onClick={submitViewNameDialog}
+              >
+                Save view
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+      {deleteViewDialog ? (
+        <Dialog
+          open
+          onOpenChange={(open) => !open && setDeleteViewDialog(null)}
+        >
+          <DialogContent
+            className="sm:max-w-md"
+            data-testid="named-view-delete-dialog"
+          >
+            <DialogTitle>Delete “{deleteViewDialog.name}”</DialogTitle>
+            <DialogDescription>
+              {deleteViewDialog.isDefault
+                ? "This is your default view. Choose another default or fall back to the tenant/system default."
+                : "This personal view will be removed. Your current working settings stay as they are."}
+            </DialogDescription>
+            {deleteViewDialog.isDefault ? (
+              <RadioGroup
+                className="space-y-2"
+                value={nextDefaultChoice}
+                onValueChange={setNextDefaultChoice}
+              >
+                {namedViews
+                  .filter((view) => view.id !== deleteViewDialog.id)
+                  .map((view) => (
+                    <div
+                      key={view.id}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <RadioGroupItem
+                        value={view.id}
+                        id={`next-default-view-${view.id}`}
+                      />
+                      <Label htmlFor={`next-default-view-${view.id}`}>
+                        Make “{view.name}” the default
+                      </Label>
+                    </div>
+                  ))}
+                <div className="flex items-center gap-2 text-sm">
+                  <RadioGroupItem value="" id="next-default-view-none" />
+                  <Label htmlFor="next-default-view-none">
+                    No default (use tenant/system default)
+                  </Label>
+                </div>
+              </RadioGroup>
+            ) : null}
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                className="h-11"
+                onClick={() => setDeleteViewDialog(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                className="h-11"
+                onClick={confirmDeleteView}
+              >
+                Delete view
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </>
+  );
+}

--- a/apps/admin/app/crm/gift-history-view-settings-menu.tsx
+++ b/apps/admin/app/crm/gift-history-view-settings-menu.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { Button } from "@asym/ui/components/shadcn/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@asym/ui/components/shadcn/dropdown-menu";
+import { Settings2 } from "lucide-react";
+
+import type { ViewSettingsPatch } from "./crm-detail-shared";
+import type {
+  CrmGiftHistoryFiltersSortSettings,
+  CrmGiftHistoryViewSettings,
+  CrmViewSettingsScope,
+} from "@asym/database/types";
+
+/**
+ * One CRM gift-history view settings surface (#272): columns, filters/sort,
+ * and granular resets. The server preference record is authoritative;
+ * toggles save optimistically through the preferences mutation.
+ */
+export function GiftHistoryViewSettingsMenu({
+  settings,
+  onPatch,
+  onRequestReset,
+}: {
+  settings: CrmGiftHistoryViewSettings;
+  onPatch: (patch: ViewSettingsPatch) => void;
+  onRequestReset: (scope: CrmViewSettingsScope) => void;
+}) {
+  const sortValue = `${settings.filtersSort.sortField}:${settings.filtersSort.sortDirection}`;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 text-muted-foreground"
+          aria-label="Gift history view settings"
+        >
+          <Settings2 className="size-4" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          Columns
+        </DropdownMenuLabel>
+        <DropdownMenuCheckboxItem
+          checked={settings.columns.designation}
+          onCheckedChange={(checked) =>
+            onPatch({
+              columns: { ...settings.columns, designation: checked === true },
+            })
+          }
+        >
+          Designation
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={settings.columns.statusLine}
+          onCheckedChange={(checked) =>
+            onPatch({
+              columns: { ...settings.columns, statusLine: checked === true },
+            })
+          }
+        >
+          Receipt / CRM status
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          Sort
+        </DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={sortValue}
+          onValueChange={(value) => {
+            const [sortField, sortDirection] = value.split(":") as [
+              CrmGiftHistoryFiltersSortSettings["sortField"],
+              CrmGiftHistoryFiltersSortSettings["sortDirection"],
+            ];
+            onPatch({
+              filtersSort: {
+                ...settings.filtersSort,
+                sortField,
+                sortDirection,
+              },
+            });
+          }}
+        >
+          <DropdownMenuRadioItem value="giftDate:desc">
+            Newest first
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="giftDate:asc">
+            Oldest first
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="amountCents:desc">
+            Largest amount
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          Filter
+        </DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={settings.filtersSort.paymentStatus}
+          onValueChange={(value) =>
+            onPatch({
+              filtersSort: {
+                ...settings.filtersSort,
+                paymentStatus:
+                  value as CrmGiftHistoryFiltersSortSettings["paymentStatus"],
+              },
+            })
+          }
+        >
+          <DropdownMenuRadioItem value="all">
+            All payments
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="completed">
+            Completed only
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="refunded">
+            Refunded only
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          Issues
+        </DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={settings.filtersSort.issue}
+          onValueChange={(value) =>
+            onPatch({
+              filtersSort: {
+                ...settings.filtersSort,
+                issue: value as CrmGiftHistoryFiltersSortSettings["issue"],
+              },
+            })
+          }
+        >
+          <DropdownMenuRadioItem value="all">All gifts</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="needs_attention">
+            Needs attention
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="receipt_affected">
+            Receipt affected
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="pending_correction">
+            Pending correction
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>Reset view settings</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem onSelect={() => onRequestReset("columns")}>
+              Reset columns…
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onRequestReset("filtersSort")}>
+              Reset filters & sort…
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onRequestReset("pinnedAction")}>
+              Reset pinned row action…
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onRequestReset("all")}>
+              Reset all view settings…
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/admin/app/crm/gift-history-view-switcher.tsx
+++ b/apps/admin/app/crm/gift-history-view-switcher.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Button } from "@asym/ui/components/shadcn/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@asym/ui/components/shadcn/dropdown-menu";
+
+import type { CrmNamedView } from "@asym/database/types";
+
+/**
+ * Compact named-view switcher near the gift-history toolbar (#273).
+ * Views are personal-only; one can be the user's default.
+ */
+export function GiftHistoryViewSwitcher({
+  views,
+  activeViewId,
+  onApplyView,
+  onSaveCurrentAs,
+  onRename,
+  onDuplicate,
+  onSetDefault,
+  onResetToSaved,
+  onDelete,
+}: {
+  views: CrmNamedView[];
+  activeViewId: string | null;
+  onApplyView: (view: CrmNamedView) => void;
+  onSaveCurrentAs: () => void;
+  onRename: (view: CrmNamedView) => void;
+  onDuplicate: (view: CrmNamedView) => void;
+  onSetDefault: (view: CrmNamedView) => void;
+  onResetToSaved: (view: CrmNamedView) => void;
+  onDelete: (view: CrmNamedView) => void;
+}) {
+  const activeView = views.find((view) => view.id === activeViewId) ?? null;
+  const defaultView = views.find((view) => view.isDefault) ?? null;
+  const label = activeView?.name ?? defaultView?.name ?? "Views";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 max-w-36 gap-1 truncate text-xs"
+          aria-label="Gift history views"
+        >
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        {views.length > 0 ? (
+          <DropdownMenuRadioGroup
+            value={activeViewId ?? ""}
+            onValueChange={(value) => {
+              const view = views.find((candidate) => candidate.id === value);
+              if (view) {
+                onApplyView(view);
+              }
+            }}
+          >
+            {views.map((view) => (
+              <DropdownMenuRadioItem key={view.id} value={view.id}>
+                {view.name}
+                {view.isDefault ? (
+                  <DropdownMenuShortcut>Default</DropdownMenuShortcut>
+                ) : null}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        ) : (
+          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+            No saved views yet.
+          </DropdownMenuLabel>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onSaveCurrentAs}>
+          Save current as view…
+        </DropdownMenuItem>
+        {activeView ? (
+          <>
+            <DropdownMenuItem onSelect={() => onRename(activeView)}>
+              Rename “{activeView.name}”…
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onDuplicate(activeView)}>
+              Duplicate
+            </DropdownMenuItem>
+            {activeView.isDefault ? null : (
+              <DropdownMenuItem onSelect={() => onSetDefault(activeView)}>
+                Set as default
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem onSelect={() => onResetToSaved(activeView)}>
+              Reset to saved view
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              variant="destructive"
+              onSelect={() => onDelete(activeView)}
+            >
+              Delete view…
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/admin/app/crm/gift-inline-action-controls.tsx
+++ b/apps/admin/app/crm/gift-inline-action-controls.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { resolveCrmRowAction } from "@asym/api/admin/crm/table-preferences";
+import { Button } from "@asym/ui/components/shadcn/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@asym/ui/components/shadcn/dropdown-menu";
+import { MoreHorizontal, Pin } from "lucide-react";
+
+import {
+  OPERATION_CATEGORY_LABELS,
+  OPERATION_DEFINITIONS,
+  type OperationCategory,
+  type OperationDefinition,
+} from "../contributions/operation-shell";
+
+import type {
+  CrmGiftInlineActions,
+  CrmTablePreferencesResponse,
+} from "@asym/database/types";
+
+/**
+ * Server-computed inline operations for one gift row (#270): a single
+ * next-best action plus a capability/state-filtered menu grouped by
+ * operation category. Submissions run through the shared operation shell.
+ *
+ * The visible row action honors preferences (#271): valid user pin, then
+ * valid tenant default, then the system next-best. Resolution re-validates
+ * against the entries, so preferences never bypass capabilities or state.
+ */
+export function GiftInlineActionControls({
+  inlineActions,
+  preferences,
+  onRunOperation,
+  onPinChange,
+}: {
+  inlineActions: CrmGiftInlineActions | undefined;
+  preferences: CrmTablePreferencesResponse | undefined;
+  onRunOperation: (operation: OperationDefinition) => void;
+  onPinChange: (actionId: string | null) => void;
+}) {
+  const entries = inlineActions?.entries ?? [];
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const resolved = resolveCrmRowAction({
+    userPin: preferences?.user ?? null,
+    tenantDefault: preferences?.tenantDefault ?? null,
+    entries,
+  });
+  const rowAction = resolved.actionType
+    ? OPERATION_DEFINITIONS[resolved.actionType]
+    : undefined;
+
+  const categories = Object.keys(
+    OPERATION_CATEGORY_LABELS,
+  ) as OperationCategory[];
+  const groups = categories
+    .map((category) => ({
+      category,
+      items: entries.flatMap((entry) => {
+        const definition = OPERATION_DEFINITIONS[entry.actionType];
+        if (!definition || definition.category !== category) {
+          return [];
+        }
+        return [{ definition, entry }];
+      }),
+    }))
+    .filter((group) => group.items.length > 0);
+
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {rowAction ? (
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 gap-2 text-xs"
+          title={resolved.explanation ?? undefined}
+          onClick={() => onRunOperation(rowAction)}
+        >
+          {resolved.source === "user_pin" ? (
+            <Pin className="size-3" aria-hidden="true" />
+          ) : null}
+          {rowAction.title}
+        </Button>
+      ) : null}
+      {resolved.explanation ? (
+        <span role="note" className="sr-only">
+          {resolved.explanation}
+        </span>
+      ) : null}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 text-muted-foreground"
+            aria-label="More gift actions"
+          >
+            <MoreHorizontal className="size-4" aria-hidden="true" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-64">
+          {groups.map((group, index) => (
+            <DropdownMenuGroup key={group.category}>
+              {index > 0 ? <DropdownMenuSeparator /> : null}
+              <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                {OPERATION_CATEGORY_LABELS[group.category]}
+              </DropdownMenuLabel>
+              {group.items.map(({ definition, entry }) => (
+                <DropdownMenuItem
+                  key={entry.actionType}
+                  className={
+                    entry.available ? undefined : "text-muted-foreground"
+                  }
+                  disabled={!entry.available}
+                  onSelect={() => {
+                    if (entry.available) {
+                      onRunOperation(definition);
+                    }
+                  }}
+                >
+                  {definition.title}
+                  {entry.available ? null : (
+                    <DropdownMenuShortcut>Blocked</DropdownMenuShortcut>
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Pin className="size-3.5" aria-hidden="true" />
+              Pin row action
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup
+                value={preferences?.user?.actionId ?? ""}
+                onValueChange={(value) =>
+                  onPinChange(value === "" ? null : value)
+                }
+              >
+                <DropdownMenuRadioItem value="">
+                  System default
+                </DropdownMenuRadioItem>
+                {entries.map((entry) => {
+                  const definition = OPERATION_DEFINITIONS[entry.actionType];
+                  if (!definition) {
+                    return null;
+                  }
+                  return (
+                    <DropdownMenuRadioItem
+                      key={entry.actionType}
+                      value={entry.actionType}
+                    >
+                      {definition.title}
+                    </DropdownMenuRadioItem>
+                  );
+                })}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/admin/app/crm/kanban-view.tsx
+++ b/apps/admin/app/crm/kanban-view.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { formatCurrency } from "@asym/lib/utils";
+import {
+  crmRecordAvatarTransitionName,
+  crmRecordTitleTransitionName,
+} from "@asym/lib/view-transitions";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@asym/ui/components/shadcn/avatar";
+import { Badge } from "@asym/ui/components/shadcn/badge";
+import { SharedNamedViewTransition } from "@asym/ui/components/view-transitions";
+import { MoreHorizontal } from "lucide-react";
+import { useMemo } from "react";
+
+import { EMPTY_CELL_VALUE } from "./crm-detail-shared";
+
+import type { CrmGridRow } from "./types";
+
+export function KanbanView({
+  rows,
+  onSelectRow,
+}: {
+  rows: CrmGridRow[];
+  onSelectRow: (row: CrmGridRow) => void;
+}) {
+  const columns = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of rows) {
+      set.add(r.lifecycleStatus ?? "Unknown");
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [rows]);
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground text-sm">
+        Load records in table view first, or adjust filters, nothing to show on
+        the board yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-x-auto flex p-4 md:p-6 gap-4 items-start">
+      {columns.map((status) => (
+        <div
+          key={status}
+          className="flex-shrink-0 w-80 flex flex-col h-full bg-muted/30 rounded-xl border border-border/50 overflow-hidden"
+        >
+          <div className="p-3 bg-muted/50 border-b border-border flex items-center justify-between">
+            <Badge
+              variant="secondary"
+              className="px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.15em] rounded shadow-none border"
+            >
+              {status}
+            </Badge>
+            <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
+              {
+                rows.filter((r) => (r.lifecycleStatus ?? "Unknown") === status)
+                  .length
+              }
+            </span>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2 space-y-2">
+            {rows
+              .filter((r) => (r.lifecycleStatus ?? "Unknown") === status)
+              .map((c) => {
+                const name = c.displayName || "Unnamed";
+                const org = c.primaryOrganization ?? "";
+                const orgInitial = org.trim()[0] ?? "?";
+                return (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => onSelectRow(c)}
+                    className="w-full bg-card p-3 rounded-lg border border-border shadow-sm transition-shadow hover:shadow-md cursor-pointer space-y-3 text-left"
+                  >
+                    <div className="flex justify-between items-start">
+                      <SharedNamedViewTransition
+                        name={crmRecordTitleTransitionName(c.id)}
+                      >
+                        <span className="font-semibold text-foreground text-xs truncate leading-none inline-block max-w-[85%]">
+                          {name}
+                        </span>
+                      </SharedNamedViewTransition>
+                      <MoreHorizontal
+                        className="size-3.5 text-muted-foreground"
+                        aria-hidden="true"
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <div className="size-4 rounded bg-muted flex items-center justify-center text-[8px] font-semibold text-muted-foreground border border-border">
+                        {orgInitial}
+                      </div>
+                      <span className="text-[10px] text-muted-foreground font-medium truncate">
+                        {org || EMPTY_CELL_VALUE}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between pt-2 border-t border-muted">
+                      <span className="text-[10px] font-semibold text-foreground tabular-nums">
+                        {formatCurrency(c.lifetimeGiving)}
+                      </span>
+                      <SharedNamedViewTransition
+                        name={crmRecordAvatarTransitionName(c.id)}
+                      >
+                        <Avatar className="size-4">
+                          <AvatarImage src={c.avatarUrl ?? undefined} />
+                          <AvatarFallback className="text-[8px] font-semibold">
+                            {name[0] ?? "?"}
+                          </AvatarFallback>
+                        </Avatar>
+                      </SharedNamedViewTransition>
+                    </div>
+                  </button>
+                );
+              })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/app/crm/page-client.tsx
+++ b/apps/admin/app/crm/page-client.tsx
@@ -3,8 +3,6 @@
 import {
   useAdminCrmRecordDetail,
   useAdminCrmRecordsInfiniteGrid,
-  useCreateLinkedCrmNote,
-  useResendCrmGiftReceipt,
 } from "@asym/database/hooks";
 import { motion, AnimatePresence } from "@asym/lib/motion";
 import { formatCurrency } from "@asym/lib/utils";
@@ -24,31 +22,13 @@ import {
   DataTableResponsive,
   type DataTableFilterField,
 } from "@asym/ui/components/shadcn/data-table";
-import { ScrollArea } from "@asym/ui/components/shadcn/scroll-area";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetTitle,
-} from "@asym/ui/components/shadcn/sheet";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@asym/ui/components/shadcn/tabs";
 import { SharedNamedViewTransition } from "@asym/ui/components/view-transitions";
 import { cn } from "@asym/ui/lib/utils";
 import {
   Plus,
   List,
   Columns,
-  X,
   User,
-  Paperclip,
-  History,
-  FileText,
-  MoreHorizontal,
   Network,
   Receipt,
   Trash2,
@@ -56,633 +36,55 @@ import {
   GitCompareArrows,
 } from "lucide-react";
 import Link from "next/link";
-import React, { useState, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { getCrmColumns } from "./columns";
-import { PORTAL_BADGE_CLASS, toCrmRecord } from "./types";
+import { EMPTY_CELL_VALUE } from "./crm-detail-shared";
+import { DetailDrawer } from "./detail-drawer";
+import { KanbanView } from "./kanban-view";
+import { toCrmRecord, toCrmRecordFromDetail } from "./types";
+import {
+  ContributionDetailOverlay,
+  isContributionGiftParam,
+} from "../contributions/contribution-detail-overlay";
 
 import type { CrmGridRow, CrmRecord } from "./types";
-
-const EMPTY_CELL_VALUE = "N/A";
-
-function makeDisplayDate(value?: string | number | Date): Date {
-  return value === undefined
-    ? new globalThis.Date()
-    : new globalThis.Date(value);
-}
-
-function DetailDrawer({
-  contact,
-  onClose,
-}: {
-  contact: CrmRecord;
-  onClose: () => void;
-}) {
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [noteBody, setNoteBody] = useState("");
-  const [summary, setSummary] = useState<{
-    category: string;
-    focus: string;
-    nextMove: string;
-  } | null>(null);
-  const detailQuery = useAdminCrmRecordDetail(contact.id);
-  const createNoteMutation = useCreateLinkedCrmNote(contact.id);
-  const receiptMutation = useResendCrmGiftReceipt(contact.id);
-
-  const summarizeContact = async () => {
-    setIsAnalyzing(true);
-    let detail = detailQuery.data;
-    if (!detailQuery.data && !detailQuery.isFetching) {
-      const refetched = await detailQuery.refetch();
-      detail = refetched.data;
-    }
-    const primaryFund = detail?.support.byFund[0]?.fundName;
-    const duplicateCount = detail?.duplicateWarnings.length ?? 0;
-    setSummary({
-      category: contact.recordType ?? "Constituent",
-      focus:
-        detail?.donor.notesPreview ??
-        contact.notesPreview ??
-        (primaryFund ? `Primary designation: ${primaryFund}.` : null) ??
-        "No notes on file yet.",
-      nextMove:
-        duplicateCount > 0
-          ? "Review duplicate warnings before outreach."
-          : "Review gift history and schedule the next touchpoint.",
-    });
-    setIsAnalyzing(false);
-  };
-
-  const display = contact.displayName || "Unnamed record";
-  const detail = detailQuery.data;
-  const timeline =
-    detail?.timeline ??
-    contact.activities.map((activity) => ({
-      amountCents: activity.amount ?? null,
-      currencyCode: null,
-      description: activity.description ?? null,
-      id: activity.id,
-      kind: activity.type,
-      occurredAt: activity.date,
-      source: "platform" as const,
-      title: activity.title,
-      visibility: "standard" as const,
-    }));
-
-  const saveNote = async () => {
-    const trimmed = noteBody.trim();
-    if (!trimmed) {
-      return;
-    }
-
-    try {
-      await createNoteMutation.mutateAsync({
-        body: trimmed,
-        linkedRecordId: contact.id,
-        linkedRecordType: "donor_profile",
-        title: `Donor care note: ${display}`,
-        visibility: "standard",
-      });
-      setNoteBody("");
-      toast.success("CRM note queued.");
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to save note.",
-      );
-    }
-  };
-
-  const resendReceipt = async (stagedGiftId: string) => {
-    try {
-      await receiptMutation.mutateAsync({ stagedGiftId });
-      toast.success("Receipt resend queued.");
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to resend receipt.",
-      );
-    }
-  };
-
-  return (
-    <Sheet open={!!contact} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent className="w-full sm:max-w-2xl p-0 gap-0 border-l border-border bg-background shadow-2xl overflow-hidden flex flex-col h-full text-left">
-        <SheetTitle className="sr-only">
-          {display}, CRM record details
-        </SheetTitle>
-        <SheetDescription className="sr-only">
-          Constituent summary, activity, and properties for this CRM record.
-        </SheetDescription>
-        <div className="h-14 bg-card border-b border-border flex items-center justify-between px-4 shrink-0 z-10">
-          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-            <User className="size-4 text-muted-foreground" />
-            <span className="truncate max-w-[200px] sm:max-w-md">
-              {display}
-            </span>
-          </div>
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-9 gap-2 rounded-xl border border-border bg-card text-xs font-semibold text-muted-foreground hover:bg-muted hover:text-foreground"
-              onClick={summarizeContact}
-              disabled={isAnalyzing}
-            >
-              <FileText
-                className={cn("size-3.5", isAnalyzing && "animate-pulse")}
-              />
-              {isAnalyzing ? "Summarizing..." : "Quick Summary"}
-            </Button>
-            <div className="h-4 w-px bg-border mx-2" />
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onClose}
-              aria-label="Close CRM record details"
-              className="size-8 text-muted-foreground"
-            >
-              <X className="size-4" />
-            </Button>
-          </div>
-        </div>
-
-        <ScrollArea className="flex-1">
-          <div className="p-6 space-y-8">
-            <div className="flex gap-6 items-start">
-              <SharedNamedViewTransition
-                name={crmRecordAvatarTransitionName(contact.id)}
-              >
-                <Avatar className="size-20 border-4 border-background shadow-sm">
-                  <AvatarImage src={contact.avatarUrl ?? undefined} />
-                  <AvatarFallback className="bg-muted text-muted-foreground font-semibold text-xl">
-                    {display[0] ?? "?"}
-                  </AvatarFallback>
-                </Avatar>
-              </SharedNamedViewTransition>
-              <div className="space-y-1 pt-1 min-w-0">
-                <SharedNamedViewTransition
-                  name={crmRecordTitleTransitionName(contact.id)}
-                >
-                  <h2 className="text-2xl font-semibold text-foreground tracking-tight">
-                    {display}
-                  </h2>
-                </SharedNamedViewTransition>
-                <p className="text-sm text-muted-foreground font-medium">
-                  {contact.title ? (
-                    <>
-                      {contact.title}
-                      {contact.primaryOrganization ? (
-                        <>
-                          {" "}
-                          at{" "}
-                          <span className="text-foreground">
-                            {contact.primaryOrganization}
-                          </span>
-                        </>
-                      ) : null}
-                    </>
-                  ) : contact.primaryOrganization ? (
-                    <span className="text-foreground">
-                      {contact.primaryOrganization}
-                    </span>
-                  ) : (
-                    <span className="text-muted-foreground">No title set</span>
-                  )}
-                </p>
-                <div className="flex flex-wrap gap-2 pt-2">
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] font-semibold uppercase"
-                  >
-                    {contact.lifecycleStatus ?? "Unknown status"}
-                  </Badge>
-                  <Badge
-                    variant="outline"
-                    className={cn(
-                      "text-[10px] font-semibold uppercase border shadow-none",
-                      PORTAL_BADGE_CLASS[contact.portalAccessLabel],
-                    )}
-                  >
-                    {contact.portalAccessLabel === "linked"
-                      ? "Portal linked"
-                      : "No portal"}
-                  </Badge>
-                  <Badge
-                    variant="secondary"
-                    className="h-5 text-[10px] font-semibold uppercase tracking-wider border-none bg-muted text-muted-foreground"
-                  >
-                    {formatCurrency(contact.lifetimeGiving)}
-                  </Badge>
-                </div>
-              </div>
-            </div>
-
-            <AnimatePresence>
-              {summary && (
-                <motion.div
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  className="rounded-xl border border-border bg-card p-5 shadow-sm space-y-4"
-                >
-                  <div className="flex items-center gap-2 text-foreground font-semibold text-[10px] uppercase tracking-[0.2em]">
-                    <FileText className="size-3.5 text-muted-foreground" />{" "}
-                    Highlights
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div>
-                      <span className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                        Type
-                      </span>
-                      <p className="text-sm font-semibold text-foreground">
-                        {summary.category}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                        Notes
-                      </span>
-                      <p className="text-xs text-muted-foreground leading-relaxed font-medium">
-                        {summary.focus}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                        Next step
-                      </span>
-                      <p className="text-xs text-foreground font-semibold">
-                        {summary.nextMove}
-                      </p>
-                    </div>
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
-
-            <Tabs defaultValue="activity">
-              <TabsList className="bg-transparent h-9 p-0 gap-6 border-b border-border w-full rounded-none justify-start">
-                <TabsTrigger
-                  value="activity"
-                  className="bg-transparent border-b-2 border-transparent data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none px-0 py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground shadow-none"
-                >
-                  Activity
-                </TabsTrigger>
-                <TabsTrigger
-                  value="properties"
-                  className="bg-transparent border-b-2 border-transparent data-[state=active]:border-foreground data-[state=active]:text-foreground rounded-none px-0 py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground shadow-none"
-                >
-                  Properties
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="activity" className="pt-6 space-y-6">
-                <div className="bg-card p-4 rounded-xl border border-border shadow-sm space-y-3">
-                  <textarea
-                    placeholder="Log a note, call, or meeting..."
-                    value={noteBody}
-                    onChange={(event) => setNoteBody(event.target.value)}
-                    className="w-full h-20 bg-muted border-none focus:ring-0 text-sm resize-none p-3 rounded-lg"
-                  />
-                  <div className="flex justify-between items-center pt-2 border-t border-muted">
-                    <div className="flex gap-1">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-7 text-muted-foreground hover:text-foreground"
-                      >
-                        <Paperclip className="size-3.5" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-7 text-muted-foreground hover:text-foreground"
-                      >
-                        <History className="size-3.5" />
-                      </Button>
-                    </div>
-                    <Button
-                      size="sm"
-                      className="h-7 px-4 text-[10px] font-semibold uppercase tracking-wider"
-                      disabled={
-                        createNoteMutation.isPending || !noteBody.trim()
-                      }
-                      onClick={() => void saveNote()}
-                    >
-                      {createNoteMutation.isPending ? "Saving..." : "Save Note"}
-                    </Button>
-                  </div>
-                </div>
-
-                {detail?.duplicateWarnings.length ? (
-                  <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-950 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em]">
-                      Duplicate warning
-                    </p>
-                    <div className="mt-2 space-y-2">
-                      {detail.duplicateWarnings.map((warning) => (
-                        <p key={warning.id} className="text-xs leading-relaxed">
-                          {warning.reason}
-                          {warning.score != null ? ` (${warning.score})` : ""}
-                        </p>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-
-                {detail?.giftHistory.length ? (
-                  <div className="rounded-xl border border-border bg-card p-4 shadow-sm">
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                        Gift history
-                      </p>
-                      <Badge variant="secondary" className="text-[10px]">
-                        {detail.giftHistory.length}
-                      </Badge>
-                    </div>
-                    <div className="mt-3 divide-y divide-border">
-                      {detail.giftHistory.slice(0, 6).map((gift) => (
-                        <div
-                          key={gift.id}
-                          className="flex items-center justify-between gap-4 py-3"
-                        >
-                          <div className="min-w-0">
-                            <p className="text-sm font-semibold text-foreground">
-                              {formatCurrency(gift.amountCents)}
-                            </p>
-                            <p className="truncate text-xs text-muted-foreground">
-                              {gift.fundName ?? gift.missionaryName ?? "Gift"}
-                            </p>
-                            <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                              {gift.receiptStatus ?? "receipt unknown"} /{" "}
-                              {gift.crmPostStatus ?? "crm pending"}
-                            </p>
-                          </div>
-                          {gift.canResendReceipt && gift.stagedGiftId ? (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              className="h-8 shrink-0 gap-2 text-xs"
-                              disabled={receiptMutation.isPending}
-                              onClick={() =>
-                                void resendReceipt(gift.stagedGiftId!)
-                              }
-                            >
-                              <Receipt className="size-3.5" />
-                              Resend
-                            </Button>
-                          ) : null}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : detailQuery.isLoading ? (
-                  <div className="rounded-xl border border-border bg-card p-4 text-sm text-muted-foreground">
-                    Loading donor workflow history…
-                  </div>
-                ) : null}
-
-                <div className="space-y-6 pl-4 border-l border-border ml-2">
-                  {timeline.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                      No timeline entries yet. Activity from donations and tasks
-                      will appear here as the CRM read model expands.
-                    </p>
-                  ) : (
-                    timeline.map((act) => (
-                      <div key={act.id} className="relative group">
-                        <div className="absolute -left-[21px] top-0 size-4 rounded-full border-2 border-background bg-muted z-10 transition-colors group-hover:bg-foreground" />
-                        <div className="pb-4 space-y-1">
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs font-semibold text-foreground">
-                              {act.title}
-                            </span>
-                            <span className="text-[10px] text-muted-foreground font-semibold uppercase tracking-widest">
-                              {makeDisplayDate(
-                                act.occurredAt,
-                              ).toLocaleDateString()}
-                            </span>
-                          </div>
-                          {act.description && (
-                            <p className="text-xs text-muted-foreground leading-relaxed bg-card p-3 rounded-lg border border-border shadow-sm">
-                              {act.description}
-                            </p>
-                          )}
-                          {act.amountCents && (
-                            <p className="text-xs font-semibold text-emerald-600">
-                              +{formatCurrency(act.amountCents)}
-                            </p>
-                          )}
-                        </div>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </TabsContent>
-
-              <TabsContent
-                value="properties"
-                className="pt-6 grid grid-cols-2 gap-8 text-left"
-              >
-                <div className="space-y-6">
-                  <div className="space-y-1">
-                    <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                      Email
-                    </p>
-                    <p className="text-sm font-semibold text-foreground truncate hover:text-primary cursor-pointer">
-                      {contact.email ?? EMPTY_CELL_VALUE}
-                    </p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                      Phone
-                    </p>
-                    <p className="text-sm font-semibold text-foreground">
-                      {contact.phone ?? EMPTY_CELL_VALUE}
-                    </p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                      Location
-                    </p>
-                    <p className="text-sm font-semibold text-foreground">
-                      {contact.location ?? EMPTY_CELL_VALUE}
-                    </p>
-                  </div>
-                </div>
-                <div className="space-y-6">
-                  <div className="space-y-1">
-                    <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                      Assigned missionary
-                    </p>
-                    <p className="text-sm font-semibold text-foreground">
-                      {detail?.support.byMissionary[0]?.missionaryName ??
-                        contact.assignedMissionaryName ??
-                        EMPTY_CELL_VALUE}
-                    </p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                      Support status
-                    </p>
-                    <div className="space-y-1 text-sm font-semibold text-foreground">
-                      <p>
-                        {detail
-                          ? formatCurrency(detail.support.lifetimeGivingCents)
-                          : formatCurrency(contact.lifetimeGiving)}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {detail
-                          ? `${detail.support.activeRecurringCommitments} recurring / ${detail.support.atRiskCommitments} at risk`
-                          : "Recurring support not loaded"}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                      Privacy
-                    </p>
-                    <p className="text-xs font-medium text-muted-foreground">
-                      {detail?.privacy.missionaryContactDataExposed === false
-                        ? "Missionary users do not receive restricted donor contact data."
-                        : "Staff-only donor data."}
-                    </p>
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-[9px] font-semibold text-muted-foreground uppercase tracking-widest">
-                      Tags
-                    </p>
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {(contact.tags ?? []).length === 0 ? (
-                        <span className="text-sm text-muted-foreground">
-                          {EMPTY_CELL_VALUE}
-                        </span>
-                      ) : (
-                        contact.tags.map((t) => (
-                          <Badge
-                            key={t}
-                            variant="secondary"
-                            className="text-[9px] px-1.5 h-4 bg-muted text-muted-foreground border-none shadow-none"
-                          >
-                            {t}
-                          </Badge>
-                        ))
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </TabsContent>
-            </Tabs>
-          </div>
-        </ScrollArea>
-      </SheetContent>
-    </Sheet>
-  );
-}
-
-function KanbanView({
-  rows,
-  onSelectRow,
-}: {
-  rows: CrmGridRow[];
-  onSelectRow: (row: CrmGridRow) => void;
-}) {
-  const columns = useMemo(() => {
-    const set = new Set<string>();
-    for (const r of rows) {
-      set.add(r.lifecycleStatus ?? "Unknown");
-    }
-    return Array.from(set).sort((a, b) => a.localeCompare(b));
-  }, [rows]);
-
-  if (rows.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground text-sm">
-        Load records in table view first, or adjust filters, nothing to show on
-        the board yet.
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-full overflow-x-auto flex p-4 md:p-6 gap-4 items-start">
-      {columns.map((status) => (
-        <div
-          key={status}
-          className="flex-shrink-0 w-80 flex flex-col h-full bg-muted/30 rounded-xl border border-border/50 overflow-hidden"
-        >
-          <div className="p-3 bg-muted/50 border-b border-border flex items-center justify-between">
-            <Badge
-              variant="secondary"
-              className="px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.15em] rounded shadow-none border"
-            >
-              {status}
-            </Badge>
-            <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
-              {
-                rows.filter((r) => (r.lifecycleStatus ?? "Unknown") === status)
-                  .length
-              }
-            </span>
-          </div>
-          <div className="flex-1 overflow-y-auto p-2 space-y-2">
-            {rows
-              .filter((r) => (r.lifecycleStatus ?? "Unknown") === status)
-              .map((c) => {
-                const name = c.displayName || "Unnamed";
-                const org = c.primaryOrganization ?? "";
-                const orgInitial = org.trim()[0] ?? "?";
-                return (
-                  <button
-                    key={c.id}
-                    type="button"
-                    onClick={() => onSelectRow(c)}
-                    className="w-full bg-card p-3 rounded-lg border border-border shadow-sm hover:shadow-md transition-all cursor-pointer space-y-3 text-left"
-                  >
-                    <div className="flex justify-between items-start">
-                      <SharedNamedViewTransition
-                        name={crmRecordTitleTransitionName(c.id)}
-                      >
-                        <span className="font-semibold text-foreground text-xs truncate leading-none inline-block max-w-[85%]">
-                          {name}
-                        </span>
-                      </SharedNamedViewTransition>
-                      <MoreHorizontal className="size-3.5 text-muted-foreground" />
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <div className="size-4 rounded bg-muted flex items-center justify-center text-[8px] font-semibold text-muted-foreground border border-border">
-                        {orgInitial}
-                      </div>
-                      <span className="text-[10px] text-muted-foreground font-medium truncate">
-                        {org || EMPTY_CELL_VALUE}
-                      </span>
-                    </div>
-                    <div className="flex items-center justify-between pt-2 border-t border-muted">
-                      <span className="text-[10px] font-semibold text-foreground tabular-nums">
-                        {formatCurrency(c.lifetimeGiving)}
-                      </span>
-                      <SharedNamedViewTransition
-                        name={crmRecordAvatarTransitionName(c.id)}
-                      >
-                        <Avatar className="size-4">
-                          <AvatarImage src={c.avatarUrl ?? undefined} />
-                          <AvatarFallback className="text-[8px] font-semibold">
-                            {name[0] ?? "?"}
-                          </AvatarFallback>
-                        </Avatar>
-                      </SharedNamedViewTransition>
-                    </div>
-                  </button>
-                );
-              })}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
 
 export default function MissionControlCRM() {
   const [view, setView] = useState<"table" | "kanban">("table");
   const [selectedRecord, setSelectedRecord] = useState<CrmRecord | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const donorParam = searchParams.get("donor");
+  const giftParam = searchParams.get("gift");
+  const selectedGiftParam = isContributionGiftParam(giftParam)
+    ? giftParam
+    : null;
+  const hasInvalidGiftParam = giftParam != null && selectedGiftParam == null;
+  const [openGiftId, setOpenGiftId] = useState<string | null>(
+    () => selectedGiftParam,
+  );
+
+  useEffect(() => {
+    setOpenGiftId(selectedGiftParam);
+  }, [selectedGiftParam]);
+
+  useEffect(() => {
+    if (!hasInvalidGiftParam) {
+      return;
+    }
+
+    setOpenGiftId(null);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("gift");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, [hasInvalidGiftParam, pathname, router, searchParams]);
 
   const {
     columnFilters,
@@ -697,6 +99,97 @@ export default function MissionControlCRM() {
     sorting,
     tableError,
   } = useAdminCrmRecordsInfiniteGrid();
+
+  const routeDonorRow = useMemo(
+    () =>
+      donorParam
+        ? rows.find((candidate) => candidate.id === donorParam)
+        : undefined,
+    [donorParam, rows],
+  );
+  const shouldLoadRouteDonor =
+    Boolean(donorParam) && !routeDonorRow && selectedRecord?.id !== donorParam;
+  const routeDonorDetailQuery = useAdminCrmRecordDetail(
+    shouldLoadRouteDonor ? donorParam : null,
+  );
+
+  /**
+   * Restore the donor drawer from `?donor=` route state. Prefer the loaded grid
+   * row when present, and fall back to the canonical detail route so bookmarked
+   * links survive pagination, filters, and sort changes.
+   */
+  useEffect(() => {
+    if (!donorParam || selectedRecord?.id === donorParam) {
+      return;
+    }
+    if (routeDonorRow) {
+      setSelectedRecord(toCrmRecord(routeDonorRow));
+      return;
+    }
+    if (routeDonorDetailQuery.data?.donor.id === donorParam) {
+      setSelectedRecord(toCrmRecordFromDetail(routeDonorDetailQuery.data));
+    }
+  }, [
+    donorParam,
+    routeDonorDetailQuery.data,
+    routeDonorRow,
+    selectedRecord?.id,
+  ]);
+
+  const selectRecord = useCallback(
+    (record: CrmRecord | null) => {
+      setSelectedRecord(record);
+      setOpenGiftId(null);
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("gift");
+      if (record) {
+        params.set("donor", record.id);
+      } else {
+        params.delete("donor");
+      }
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const giftOpenerRef = React.useRef<HTMLElement | null>(null);
+
+  const openGift = useCallback(
+    (donationId: string) => {
+      // Smart close (ADR-CD-023): remember the gift row so closing restores
+      // focus to it while the donor drawer context stays untouched.
+      giftOpenerRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      setOpenGiftId(donationId);
+      const params = new URLSearchParams(searchParams.toString());
+      if (selectedRecord) {
+        params.set("donor", selectedRecord.id);
+      }
+      params.set("gift", donationId);
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [pathname, router, searchParams, selectedRecord],
+  );
+
+  const closeGift = useCallback(() => {
+    setOpenGiftId(null);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("gift");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+    // Restore focus after the sheet unmounts so its focus-trap cleanup
+    // cannot clobber the opener focus (ADR-CD-023 focus return).
+    const opener = giftOpenerRef.current;
+    giftOpenerRef.current = null;
+    window.setTimeout(() => opener?.focus(), 0);
+  }, [pathname, router, searchParams]);
 
   const tagOptions = useMemo(() => {
     const s = new Set<string>();
@@ -752,10 +245,10 @@ export default function MissionControlCRM() {
   const columns = useMemo(
     () =>
       getCrmColumns({
-        onViewRecord: (r) => setSelectedRecord(toCrmRecord(r)),
+        onViewRecord: (r) => selectRecord(toCrmRecord(r)),
         tagOptions,
       }),
-    [tagOptions],
+    [selectRecord, tagOptions],
   );
 
   const handleBulkArchive = (_selected: CrmGridRow[]) => {
@@ -852,9 +345,7 @@ export default function MissionControlCRM() {
                   onFiltersChange={onFiltersChange}
                   onSortingChange={onSortingChange}
                   onRefresh={() => void onRefresh()}
-                  onRowClick={(row) =>
-                    setSelectedRecord(toCrmRecord(row.original))
-                  }
+                  onRowClick={(row) => selectRecord(toCrmRecord(row.original))}
                   infiniteScroll={{
                     hasMore,
                     isFetchingMore,
@@ -941,7 +432,7 @@ export default function MissionControlCRM() {
                       return (
                         <button
                           type="button"
-                          onClick={() => setSelectedRecord(toCrmRecord(c))}
+                          onClick={() => selectRecord(toCrmRecord(c))}
                           className="w-full p-4 cursor-pointer space-y-3 text-left"
                         >
                           <div className="flex items-center justify-between">
@@ -1001,7 +492,7 @@ export default function MissionControlCRM() {
               >
                 <KanbanView
                   rows={rows}
-                  onSelectRow={(r) => setSelectedRecord(toCrmRecord(r))}
+                  onSelectRow={(r) => selectRecord(toCrmRecord(r))}
                 />
               </motion.div>
             )}
@@ -1012,9 +503,16 @@ export default function MissionControlCRM() {
       {selectedRecord && (
         <DetailDrawer
           contact={selectedRecord}
-          onClose={() => setSelectedRecord(null)}
+          onClose={() => selectRecord(null)}
+          onOpenGift={openGift}
         />
       )}
+
+      <ContributionDetailOverlay
+        donationId={openGiftId}
+        sourceSurface="donor_crm_record"
+        onClose={closeGift}
+      />
     </>
   );
 }

--- a/apps/admin/app/crm/page.tsx
+++ b/apps/admin/app/crm/page.tsx
@@ -1,5 +1,29 @@
+import { PageShell } from "@asym/ui/components/primitives/page-shell";
+import { Suspense } from "react";
+
 import PageClient from "./page-client";
 
+function CrmPageFallback() {
+  return (
+    <PageShell
+      title="CRM"
+      description="Manage contacts, donors, and partner relationships."
+      density="compact"
+    >
+      <div
+        role="status"
+        className="flex min-h-[400px] items-center justify-center rounded-lg border border-border bg-card text-sm text-muted-foreground"
+      >
+        Loading CRM workspace...
+      </div>
+    </PageShell>
+  );
+}
+
 export default function Page() {
-  return <PageClient />;
+  return (
+    <Suspense fallback={<CrmPageFallback />}>
+      <PageClient />
+    </Suspense>
+  );
 }

--- a/apps/admin/app/crm/types.ts
+++ b/apps/admin/app/crm/types.ts
@@ -1,4 +1,4 @@
-import type { CrmGridRow } from "@asym/database/types";
+import type { CrmDonorDetailResponse, CrmGridRow } from "@asym/database/types";
 
 export type { CrmGridRow };
 
@@ -26,6 +26,43 @@ export type CrmRecord = CrmGridRow & {
 
 export function toCrmRecord(row: CrmGridRow): CrmRecord {
   return { ...row, activities: [] };
+}
+
+export function toCrmRecordFromDetail(
+  detail: CrmDonorDetailResponse,
+): CrmRecord {
+  const donor = detail.donor;
+  const createdAt = donor.createdAt ?? new Date(0).toISOString();
+  const updatedAt = donor.updatedAt ?? createdAt;
+
+  return {
+    id: donor.id,
+    recordType: donor.type,
+    displayName: donor.name,
+    title: donor.title,
+    primaryOrganization: donor.organization,
+    primaryContactLine: donor.email ?? donor.phone,
+    location: donor.location,
+    lifecycleStatus: donor.status,
+    lastGiftAt: detail.support.lastGiftAt,
+    lifetimeGiving: detail.support.lifetimeGivingCents,
+    fundsGivenToSummary: detail.support.byFund[0]?.fundName ?? null,
+    lastTouchAt: updatedAt,
+    nextTaskSummary: null,
+    portalAccessLabel:
+      donor.profileId != null && donor.profileId.length > 0 ? "linked" : "none",
+    linkedAuthUserId: donor.profileId,
+    tags: donor.tags,
+    assignedMissionaryName:
+      detail.support.byMissionary[0]?.missionaryName ?? null,
+    avatarUrl: donor.avatarUrl,
+    email: donor.email,
+    phone: donor.phone,
+    notesPreview: donor.notesPreview,
+    createdAt,
+    updatedAt,
+    activities: [],
+  };
 }
 
 export const PORTAL_BADGE_CLASS: Record<

--- a/packages/api/src/admin/crm/detail/gift-history.ts
+++ b/packages/api/src/admin/crm/detail/gift-history.ts
@@ -1,0 +1,113 @@
+import { buildContributionActionAvailability } from "../../contribution-operations/action-availability";
+import { buildInlineContributionActions } from "../../contribution-operations/inline-actions";
+import {
+  buildSharedContributionRowFields,
+  type BuildSharedContributionRowFieldsInput,
+  type SharedContributionCorrectionInput,
+  type SharedContributionDonationInput,
+  type SharedContributionDonorInput,
+} from "../../contribution-shared/row-contract";
+
+import type {
+  ContributionDesignationSet,
+  CrmGiftHistoryRow,
+} from "@asym/database/types";
+
+export interface BuildCrmGiftHistoryRowInput {
+  donation: SharedContributionDonationInput & { status: string | null };
+  donor: SharedContributionDonorInput | null;
+  fund: { id: string; name: string | null } | null;
+  missionary: { id: string; display_name: string | null } | null;
+  stagedGift:
+    | (BuildSharedContributionRowFieldsInput["stagedGift"] & {
+        twenty_record_id?: string | null;
+      })
+    | null;
+  corrections?: SharedContributionCorrectionInput[];
+  designationSet?: ContributionDesignationSet;
+  /** Provider linkage drives refund/replay availability (never exposed raw). */
+  provider?: {
+    stripePaymentIntentId: string | null;
+    stripeChargeId: string | null;
+  };
+  /** Viewer capabilities filter which operations surface inline (#270). */
+  viewerCapabilities?: string[];
+}
+
+/**
+ * Adapter that maps CRM gift-history data onto the shared contribution row
+ * contract (ADR-CD-032). Overlapping CRM/Hub fields are copied from the shared
+ * derivation; only CRM-only workflow context is computed here.
+ */
+export function buildCrmGiftHistoryRow(
+  input: BuildCrmGiftHistoryRowInput,
+): CrmGiftHistoryRow {
+  const { donation, donor, fund, missionary, stagedGift } = input;
+
+  const shared = buildSharedContributionRowFields({
+    donation,
+    donor,
+    profile: null,
+    fund,
+    missionary,
+    stagedGift: stagedGift
+      ? {
+          id: stagedGift.id,
+          status: stagedGift.status,
+          receipt_status: stagedGift.receipt_status,
+          crm_post_status: stagedGift.crm_post_status,
+        }
+      : null,
+    corrections: input.corrections,
+    designationSet: input.designationSet,
+  });
+
+  // Inline operations reuse the exact availability derivation contribution
+  // detail uses, so blocked reasons and risk levels stay identical (#270).
+  const availability = buildContributionActionAvailability({
+    stagedGift: stagedGift
+      ? {
+          id: stagedGift.id,
+          status: stagedGift.status,
+          receiptStatus: stagedGift.receipt_status,
+          crmPostStatus: stagedGift.crm_post_status,
+        }
+      : null,
+    paymentStatus: donation.status,
+    refund: {
+      amountCents: shared.amountCents,
+      refundedAmountCents: shared.refundedAmountCents,
+      hasProviderCharge: Boolean(input.provider?.stripeChargeId),
+    },
+  });
+  const inlineActions = buildInlineContributionActions({
+    availability,
+    providerPaymentIntentId: input.provider?.stripePaymentIntentId ?? null,
+    viewerCapabilities: input.viewerCapabilities ?? [],
+  });
+  const receiptAvailability = availability.find(
+    (entry) => entry.actionType === "resend_receipt",
+  );
+
+  return {
+    shared,
+    id: shared.donationId,
+    donationId: shared.donationId,
+    amountCents: shared.amountCents,
+    currencyCode: shared.currencyCode,
+    giftDate: shared.giftDate,
+    paymentStatus: shared.paymentStatus,
+    receiptStatus: shared.receiptStatus,
+    crmPostStatus: shared.crmPostStatus,
+    refundState: shared.refundState,
+    correctionState: shared.correctionState,
+    fundId: shared.designationSummary.fundId,
+    fundName: shared.designationSummary.fundName,
+    missionaryId: shared.designationSummary.missionaryId,
+    missionaryName: shared.designationSummary.missionaryName,
+    canResendReceipt: receiptAvailability?.available ?? false,
+    stagedGiftId: stagedGift?.id ?? null,
+    twentyRecordId: stagedGift?.twenty_record_id ?? null,
+    inlineActions,
+  };
+}

--- a/packages/api/src/admin/crm/detail/index.ts
+++ b/packages/api/src/admin/crm/detail/index.ts
@@ -6,6 +6,7 @@ import { requireCrmAccess } from "../../../crm/auth/access";
 import { resolveCrmSyncRuntimeConfig } from "../../../crm/sync/config";
 import { ApiHttpError, toErrorResponse } from "../../../shared/http-errors";
 import { withOperation } from "../../../shared/with-operation";
+import { resolveContributionCapabilities } from "../../contribution-operations/permissions";
 
 function getRecordIdFromPath(request: Request) {
   const pathname = new URL(request.url).pathname;
@@ -35,6 +36,7 @@ export const GET = withOperation(
         role: actor.role,
         supabaseAdmin,
         tenantId: actor.tenantId,
+        viewerCapabilities: resolveContributionCapabilities(auth),
       });
 
       return NextResponse.json({ ...response, requestId });

--- a/packages/api/src/admin/crm/detail/service.ts
+++ b/packages/api/src/admin/crm/detail/service.ts
@@ -1,9 +1,19 @@
+import { buildCrmGiftHistoryRow } from "./gift-history";
 import { ApiHttpError } from "../../../shared/http-errors";
+import { buildContributionDesignationSet } from "../../contribution-shared/designation-set";
+import {
+  deriveEffectiveContribution,
+  mapContributionAdjustmentRow,
+  type ContributionAdjustmentRecord,
+  type EffectiveContributionResult,
+} from "../../contribution-shared/effective-values";
 
 import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
 import type { CrmDonorDetailResponse, UserRole } from "@asym/database/types";
 
 type SupabaseAdmin = AdminSupabaseClient;
+
+const GIFT_HISTORY_LIMIT = 100;
 
 interface DonorRow {
   id: string;
@@ -12,12 +22,18 @@ interface DonorRow {
   name: string | null;
   email: string | null;
   phone: string | null;
+  avatar_url: string | null;
+  location: string | null;
   organization: string | null;
+  title: string | null;
   type: string | null;
   status: string | null;
   total_given: number | string | null;
   last_gift_date: string | null;
+  tags: string[] | null;
   notes: string | null;
+  created_at: string | null;
+  updated_at: string | null;
 }
 
 interface DonationRow {
@@ -29,8 +45,39 @@ interface DonationRow {
   currency: string | null;
   status: string | null;
   is_recurring: boolean | null;
+  recurring_interval: string | null;
+  pledge_id: string | null;
   donation_type: string | null;
+  gift_date: string | null;
+  refund_amount: number | string | null;
+  refunded_at: string | null;
+  stripe_payment_intent_id: string | null;
+  stripe_charge_id: string | null;
   created_at: string | null;
+  updated_at: string | null;
+}
+
+interface CorrectionRow {
+  donation_id: string;
+  status: string;
+}
+
+interface AllocationRow {
+  id: string;
+  staged_gift_id: string;
+  amount: number | string | null;
+  fund_id: string | null;
+  missionary_id: string | null;
+  memo: string | null;
+}
+
+interface FundMetaRow {
+  id: string;
+  name: string | null;
+  missionary_id: string | null;
+  goal_amount: number | string | null;
+  start_date: string | null;
+  end_date: string | null;
 }
 
 interface StagedGiftRow {
@@ -113,10 +160,6 @@ function toCents(value: number | string | null | undefined): number {
   return Number.isFinite(numberValue) ? Math.round(numberValue) : 0;
 }
 
-function normalizeCurrency(value: string | null | undefined): string {
-  return (value ?? "usd").trim().toUpperCase();
-}
-
 function previewNotes(notes: string | null): string | null {
   if (!notes?.trim()) {
     return null;
@@ -126,19 +169,19 @@ function previewNotes(notes: string | null): string | null {
   return trimmed.length <= 160 ? trimmed : `${trimmed.slice(0, 157)}...`;
 }
 
-function profileName(row: LabelRow): string {
+function profileName(row: LabelRow): string | null {
   const profile = row.profile ?? {};
   return (
     profile.display_name?.trim() ||
     profile.full_name?.trim() ||
     [profile.first_name, profile.last_name].filter(Boolean).join(" ").trim() ||
     row.name?.trim() ||
-    "Unassigned"
+    null
   );
 }
 
 function getLabel(
-  map: Map<string, string>,
+  map: Map<string, string | null>,
   id: string | null,
   fallback: string,
 ) {
@@ -153,7 +196,7 @@ async function fetchLabels(
   supabaseAdmin: SupabaseAdmin,
   table: "funds" | "missionaries",
   ids: string[],
-): Promise<Map<string, string>> {
+): Promise<Map<string, string | null>> {
   if (ids.length === 0) {
     return new Map();
   }
@@ -171,7 +214,7 @@ async function fetchLabels(
   return new Map(
     ((data ?? []) as LabelRow[]).map((row) => [
       row.id,
-      table === "missionaries" ? profileName(row) : (row.name ?? "Unnamed"),
+      table === "missionaries" ? profileName(row) : (row.name ?? null),
     ]),
   );
 }
@@ -179,8 +222,8 @@ async function fetchLabels(
 function buildSupportSummary(input: {
   donor: DonorRow;
   donations: DonationRow[];
-  fundsById: Map<string, string>;
-  missionariesById: Map<string, string>;
+  fundsById: Map<string, string | null>;
+  missionariesById: Map<string, string | null>;
   pledges: PledgeRow[];
 }): CrmDonorDetailResponse["support"] {
   const byFund = new Map<string, { label: string; amountCents: number }>();
@@ -259,11 +302,13 @@ export async function getAdminCrmDonorDetail(input: {
   donorId: string;
   role: UserRole;
   crmWritesEnabled?: boolean;
+  /** Filters which contribution operations surface inline on gift rows (#270). */
+  viewerCapabilities?: string[];
 }): Promise<CrmDonorDetailResponse> {
   const donorResult = await input.supabaseAdmin
     .from("donors")
     .select(
-      "id, profile_id, missionary_id, name, email, phone, organization, type, status, total_given, last_gift_date, notes",
+      "id, profile_id, missionary_id, name, email, phone, avatar_url, location, organization, title, type, status, total_given, last_gift_date, tags, notes, created_at, updated_at",
     )
     .eq("tenant_id", input.tenantId)
     .eq("id", input.donorId)
@@ -277,33 +322,103 @@ export async function getAdminCrmDonorDetail(input: {
   const donationsResult = await input.supabaseAdmin
     .from("donations")
     .select(
-      "id, donor_id, missionary_id, fund_id, amount, currency, status, is_recurring, donation_type, created_at",
+      "id, donor_id, missionary_id, fund_id, amount, currency, status, is_recurring, recurring_interval, pledge_id, donation_type, gift_date, refund_amount, refunded_at, stripe_payment_intent_id, stripe_charge_id, created_at, updated_at",
     )
     .eq("tenant_id", input.tenantId)
     .eq("donor_id", donor.id)
     .order("created_at", { ascending: false })
-    .limit(100);
+    .limit(GIFT_HISTORY_LIMIT + 1);
   assertNoError(donationsResult.error, "Failed to load donor gifts.");
-  const donations = (donationsResult.data ?? []) as DonationRow[];
+  const donationRows = (donationsResult.data ?? []) as DonationRow[];
+  const giftHistoryTruncated = donationRows.length > GIFT_HISTORY_LIMIT;
+  const donations = donationRows.slice(0, GIFT_HISTORY_LIMIT);
 
   const donationIds = mergeUniqueIds(donations.map((donation) => donation.id));
-  const stagedGiftResult =
+  const [
+    stagedGiftResult,
+    correctionsResult,
+    correctionRequestsResult,
+    adjustmentsResult,
+    activityResult,
+    pledgeResult,
+    duplicateResult,
+  ] = await Promise.all([
     donationIds.length > 0
-      ? await input.supabaseAdmin
+      ? input.supabaseAdmin
           .from("staged_gifts")
           .select(
             "id, donation_id, fund_id, missionary_id, receipt_status, crm_post_status, status, twenty_record_id, posted_at, created_at",
           )
           .eq("tenant_id", input.tenantId)
           .in("donation_id", donationIds)
-      : { data: [], error: null };
+      : Promise.resolve({ data: [], error: null }),
+    donationIds.length > 0
+      ? input.supabaseAdmin
+          .from("contribution_corrections")
+          .select("donation_id, status")
+          .eq("tenant_id", input.tenantId)
+          .in("donation_id", donationIds)
+      : Promise.resolve({ data: [], error: null }),
+    donationIds.length > 0
+      ? input.supabaseAdmin
+          .from("contribution_correction_requests")
+          .select("donation_id, status")
+          .eq("tenant_id", input.tenantId)
+          .in("donation_id", donationIds)
+          .eq("status", "pending")
+      : Promise.resolve({ data: [], error: null }),
+    donationIds.length > 0
+      ? input.supabaseAdmin
+          .from("contribution_adjustments")
+          .select(
+            "id, donation_id, adjustment_type, status, effective_values, reason, actor_profile_id, source_surface, created_at",
+          )
+          .eq("tenant_id", input.tenantId)
+          .in("donation_id", donationIds)
+          .order("created_at", { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+    input.supabaseAdmin
+      .from("donor_activities")
+      .select("id, type, title, description, amount, date, created_at")
+      .eq("donor_id", donor.id)
+      .order("date", { ascending: false })
+      .limit(50),
+    input.supabaseAdmin
+      .from("donor_pledges")
+      .select(
+        "id, amount, frequency, status, missionary_id, fund_id, next_payment_date, updated_at",
+      )
+      .eq("donor_id", donor.id)
+      .order("updated_at", { ascending: false })
+      .limit(50),
+    input.supabaseAdmin
+      .from("crm_merge_candidates")
+      .select(
+        "id, candidate_twenty_record_id, confidence, score, match_reasons",
+      )
+      .eq("tenant_id", input.tenantId)
+      .eq("source_entity_type", "donor_profile")
+      .eq("source_entity_id", donor.id)
+      .eq("status", "pending")
+      .order("score", { ascending: false })
+      .limit(10),
+  ]);
   assertNoError(stagedGiftResult.error, "Failed to load staged gift links.");
+  assertNoError(correctionsResult.error, "Failed to load gift corrections.");
+  assertNoError(
+    correctionRequestsResult.error,
+    "Failed to load correction requests.",
+  );
+  assertNoError(adjustmentsResult.error, "Failed to load gift adjustments.");
+  assertNoError(activityResult.error, "Failed to load donor activities.");
+  assertNoError(pledgeResult.error, "Failed to load donor commitments.");
+  assertNoError(duplicateResult.error, "Failed to load duplicate warnings.");
   const stagedGifts = (stagedGiftResult.data ?? []) as StagedGiftRow[];
 
   const stagedGiftIds = mergeUniqueIds(stagedGifts.map((gift) => gift.id));
-  const linkResult =
+  const [linkResult, allocationsResult] = await Promise.all([
     stagedGiftIds.length > 0
-      ? await input.supabaseAdmin
+      ? input.supabaseAdmin
           .from("donation_crm_links")
           .select(
             "id, donation_id, staged_gift_id, link_status, twenty_record_id",
@@ -311,55 +426,137 @@ export async function getAdminCrmDonorDetail(input: {
           .eq("tenant_id", input.tenantId)
           .eq("scope", "parent")
           .in("staged_gift_id", stagedGiftIds)
-      : { data: [], error: null };
+      : Promise.resolve({ data: [], error: null }),
+    stagedGiftIds.length > 0
+      ? input.supabaseAdmin
+          .from("staged_gift_allocations")
+          .select("id, staged_gift_id, amount, fund_id, missionary_id, memo")
+          .eq("tenant_id", input.tenantId)
+          .in("staged_gift_id", stagedGiftIds)
+          .order("created_at", { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+  ]);
   assertNoError(linkResult.error, "Failed to load donation CRM links.");
+  assertNoError(allocationsResult.error, "Failed to load designation lines.");
   const links = (linkResult.data ?? []) as DonationCrmLinkRow[];
 
-  const activityResult = await input.supabaseAdmin
-    .from("donor_activities")
-    .select("id, type, title, description, amount, date, created_at")
-    .eq("donor_id", donor.id)
-    .order("date", { ascending: false })
-    .limit(50);
-  assertNoError(activityResult.error, "Failed to load donor activities.");
+  const correctionsByDonationId = new Map<string, Array<{ status: string }>>();
+  for (const correction of [
+    ...((correctionsResult.data ?? []) as CorrectionRow[]),
+    ...((correctionRequestsResult.data ?? []) as CorrectionRow[]),
+  ]) {
+    const existing = correctionsByDonationId.get(correction.donation_id) ?? [];
+    existing.push({ status: correction.status });
+    correctionsByDonationId.set(correction.donation_id, existing);
+  }
 
-  const pledgeResult = await input.supabaseAdmin
-    .from("donor_pledges")
-    .select(
-      "id, amount, frequency, status, missionary_id, fund_id, next_payment_date, updated_at",
-    )
-    .eq("donor_id", donor.id)
-    .order("updated_at", { ascending: false })
-    .limit(50);
-  assertNoError(pledgeResult.error, "Failed to load donor commitments.");
+  const adjustmentsByDonationId = new Map<
+    string,
+    ContributionAdjustmentRecord[]
+  >();
+  for (const row of (adjustmentsResult.data ?? []) as Array<
+    Record<string, unknown>
+  >) {
+    const donationId =
+      typeof row.donation_id === "string" ? row.donation_id : "";
+    const existing = adjustmentsByDonationId.get(donationId) ?? [];
+    existing.push(mapContributionAdjustmentRow(row));
+    adjustmentsByDonationId.set(donationId, existing);
+  }
+
+  const effectiveByDonationId = new Map<string, EffectiveContributionResult>(
+    donations.map((donation) => [
+      donation.id,
+      deriveEffectiveContribution({
+        original: {
+          amountCents: toCents(donation.amount),
+          fundId: donation.fund_id,
+          missionaryId: donation.missionary_id,
+          paymentStatus: donation.status ?? "pending",
+        },
+        adjustments: adjustmentsByDonationId.get(donation.id) ?? [],
+      }),
+    ]),
+  );
+
+  const allocationRows = (allocationsResult.data ?? []) as AllocationRow[];
+  const allocationsByStagedGiftId = new Map<
+    string,
+    Array<{
+      id: string;
+      amount: number;
+      fund_id: string | null;
+      missionary_id: string | null;
+      memo: string | null;
+    }>
+  >();
+  for (const allocation of allocationRows) {
+    const existing =
+      allocationsByStagedGiftId.get(allocation.staged_gift_id) ?? [];
+    existing.push({
+      id: allocation.id,
+      amount: toCents(allocation.amount),
+      fund_id: allocation.fund_id,
+      missionary_id: allocation.missionary_id,
+      memo: allocation.memo,
+    });
+    allocationsByStagedGiftId.set(allocation.staged_gift_id, existing);
+  }
+
   const pledges = (pledgeResult.data ?? []) as PledgeRow[];
 
-  const duplicateResult = await input.supabaseAdmin
-    .from("crm_merge_candidates")
-    .select("id, candidate_twenty_record_id, confidence, score, match_reasons")
-    .eq("tenant_id", input.tenantId)
-    .eq("source_entity_type", "donor_profile")
-    .eq("source_entity_id", donor.id)
-    .eq("status", "pending")
-    .order("score", { ascending: false })
-    .limit(10);
-  assertNoError(duplicateResult.error, "Failed to load duplicate warnings.");
-
+  const effectiveResults = Array.from(effectiveByDonationId.values());
   const fundIds = mergeUniqueIds([
     ...donations.map((donation) => donation.fund_id),
     ...stagedGifts.map((gift) => gift.fund_id),
     ...pledges.map((pledge) => pledge.fund_id),
+    ...allocationRows.map((allocation) => allocation.fund_id),
+    ...effectiveResults.map((result) => result.effective.fundId),
+    ...effectiveResults.flatMap(
+      (result) =>
+        result.effectiveDesignationLines?.map((line) => line.fundId) ?? [],
+    ),
   ]);
   const missionaryIds = mergeUniqueIds([
     ...donations.map((donation) => donation.missionary_id),
     ...stagedGifts.map((gift) => gift.missionary_id),
     ...pledges.map((pledge) => pledge.missionary_id),
+    ...allocationRows.map((allocation) => allocation.missionary_id),
+    ...effectiveResults.map((result) => result.effective.missionaryId),
+    ...effectiveResults.flatMap(
+      (result) =>
+        result.effectiveDesignationLines?.map((line) => line.missionaryId) ??
+        [],
+    ),
     donor.missionary_id,
   ]);
-  const [fundsById, missionariesById] = await Promise.all([
-    fetchLabels(input.supabaseAdmin, "funds", fundIds),
+  const [fundsMetaResult, missionariesById] = await Promise.all([
+    fundIds.length > 0
+      ? input.supabaseAdmin
+          .from("funds")
+          .select("id, name, missionary_id, goal_amount, start_date, end_date")
+          .in("id", fundIds)
+      : Promise.resolve({ data: [], error: null }),
     fetchLabels(input.supabaseAdmin, "missionaries", missionaryIds),
   ]);
+  assertNoError(fundsMetaResult.error, "Failed to load fund metadata.");
+  const fundsMetaById = new Map(
+    ((fundsMetaResult.data ?? []) as FundMetaRow[]).map((fund) => [
+      fund.id,
+      {
+        id: fund.id,
+        name: fund.name,
+        missionary_id: fund.missionary_id,
+        goal_amount:
+          fund.goal_amount == null ? null : toCents(fund.goal_amount),
+        start_date: fund.start_date,
+        end_date: fund.end_date,
+      },
+    ]),
+  );
+  const fundsById = new Map<string, string | null>(
+    Array.from(fundsMetaById.values()).map((fund) => [fund.id, fund.name]),
+  );
 
   const stagedByDonationId = new Map(
     stagedGifts.map((gift) => [gift.donation_id, gift]),
@@ -373,34 +570,91 @@ export async function getAdminCrmDonorDetail(input: {
   const giftHistory = donations.map((donation) => {
     const stagedGift = stagedByDonationId.get(donation.id) ?? null;
     const link = stagedGift ? linkByStagedGiftId.get(stagedGift.id) : null;
-    const fundId = stagedGift?.fund_id ?? donation.fund_id;
-    const missionaryId = stagedGift?.missionary_id ?? donation.missionary_id;
-
-    return {
+    const effectiveResult = effectiveByDonationId.get(donation.id);
+    const effective = effectiveResult?.effective ?? {
       amountCents: toCents(donation.amount),
-      canResendReceipt:
-        Boolean(stagedGift?.id) &&
-        donation.status === "completed" &&
-        stagedGift?.receipt_status !== "suppressed",
-      crmPostStatus: stagedGift?.crm_post_status ?? null,
-      currencyCode: normalizeCurrency(donation.currency),
-      donationId: donation.id,
-      fundId,
-      fundName: getLabel(fundsById, fundId, "Unassigned fund"),
-      giftDate: donation.created_at,
-      id: donation.id,
-      missionaryId,
-      missionaryName: getLabel(
-        missionariesById,
-        missionaryId,
-        "Unassigned missionary",
-      ),
-      paymentStatus: donation.status,
-      receiptStatus: stagedGift?.receipt_status ?? null,
-      stagedGiftId: stagedGift?.id ?? null,
-      twentyRecordId:
-        stagedGift?.twenty_record_id ?? link?.twenty_record_id ?? null,
+      fundId: donation.fund_id,
+      missionaryId: donation.missionary_id,
+      paymentStatus: donation.status ?? "pending",
     };
+    const allocations = effectiveResult?.effectiveDesignationLines
+      ? effectiveResult.effectiveDesignationLines.map((line) => ({
+          id: line.id,
+          amount: line.amountCents,
+          fund_id: line.fundId,
+          missionary_id: line.missionaryId,
+          memo: line.memo,
+        }))
+      : stagedGift
+        ? (allocationsByStagedGiftId.get(stagedGift.id) ?? [])
+        : [];
+    const designationSet = buildContributionDesignationSet({
+      donation: {
+        id: donation.id,
+        amount: effective.amountCents,
+        currency: donation.currency ?? "usd",
+        fund_id: effective.fundId,
+        missionary_id: effective.missionaryId,
+      },
+      effectiveAmountCents: effective.amountCents,
+      allocations,
+      funds: fundsMetaById,
+      missionaries: missionariesById,
+    });
+
+    return buildCrmGiftHistoryRow({
+      designationSet,
+      donation: {
+        id: donation.id,
+        donor_id: donation.donor_id,
+        missionary_id: effective.missionaryId,
+        fund_id: effective.fundId,
+        amount: effective.amountCents,
+        currency: donation.currency ?? "usd",
+        status: effective.paymentStatus,
+        gift_date: donation.gift_date,
+        refund_amount: toCents(donation.refund_amount),
+        refunded_at: donation.refunded_at,
+        created_at: donation.created_at ?? "",
+        updated_at: donation.updated_at ?? donation.created_at ?? "",
+        is_recurring: donation.is_recurring,
+        recurring_interval: donation.recurring_interval,
+        pledge_id: donation.pledge_id,
+      },
+      donor: {
+        id: donor.id,
+        name: donor.name,
+        email: donor.email,
+      },
+      fund: effective.fundId
+        ? {
+            id: effective.fundId,
+            name: fundsById.get(effective.fundId) ?? null,
+          }
+        : null,
+      missionary: effective.missionaryId
+        ? {
+            id: effective.missionaryId,
+            display_name: missionariesById.get(effective.missionaryId) ?? null,
+          }
+        : null,
+      stagedGift: stagedGift
+        ? {
+            id: stagedGift.id,
+            status: stagedGift.status,
+            receipt_status: stagedGift.receipt_status,
+            crm_post_status: stagedGift.crm_post_status,
+            twenty_record_id:
+              stagedGift.twenty_record_id ?? link?.twenty_record_id ?? null,
+          }
+        : null,
+      corrections: correctionsByDonationId.get(donation.id),
+      provider: {
+        stripePaymentIntentId: donation.stripe_payment_intent_id,
+        stripeChargeId: donation.stripe_charge_id,
+      },
+      viewerCapabilities: input.viewerCapabilities ?? [],
+    });
   });
 
   const timeline = [
@@ -410,7 +664,7 @@ export async function getAdminCrmDonorDetail(input: {
       description: gift.fundName,
       id: `gift:${gift.id}`,
       kind: "gift" as const,
-      occurredAt: gift.giftDate ?? new Date(0).toISOString(),
+      occurredAt: gift.giftDate || new Date(0).toISOString(),
       source: "platform" as const,
       title: "Gift received",
       visibility: "standard" as const,
@@ -446,8 +700,11 @@ export async function getAdminCrmDonorDetail(input: {
 
   return {
     donor: {
+      avatarUrl: donor.avatar_url,
+      createdAt: donor.created_at,
       email: donor.email,
       id: donor.id,
+      location: donor.location,
       missionaryId: donor.missionary_id,
       name: donor.name,
       notesPreview: previewNotes(donor.notes),
@@ -455,10 +712,14 @@ export async function getAdminCrmDonorDetail(input: {
       phone: donor.phone,
       profileId: donor.profile_id,
       status: donor.status,
+      tags: donor.tags ?? [],
+      title: donor.title,
       type: donor.type,
+      updatedAt: donor.updated_at,
     },
     duplicateWarnings,
     giftHistory,
+    giftHistoryTruncated,
     privacy: {
       missionaryContactDataExposed: false,
       restrictedNotesVisible:

--- a/packages/database/types/crm-detail.ts
+++ b/packages/database/types/crm-detail.ts
@@ -47,10 +47,10 @@ export interface CrmGiftInlineActions {
 
 export interface CrmGiftHistoryRow {
   /**
-   * Future shared contribution row contract fields (ADR-CD-032 display parity).
-   * Optional until the CRM/detail service slice starts populating them.
+   * Shared contribution row contract fields (ADR-CD-032 display parity).
+   * Populated by the CRM/detail service for every gift-history row.
    */
-  shared?: SharedContributionRowFields;
+  shared: SharedContributionRowFields;
   id: string;
   donationId: string;
   stagedGiftId: string | null;
@@ -115,16 +115,23 @@ export interface CrmDonorDetailResponse {
   donor: {
     id: string;
     name: string | null;
+    title: string | null;
     email: string | null;
     phone: string | null;
     organization: string | null;
+    location: string | null;
     status: string | null;
     type: string | null;
     profileId: string | null;
     missionaryId: string | null;
     notesPreview: string | null;
+    tags: string[];
+    avatarUrl: string | null;
+    createdAt: string | null;
+    updatedAt: string | null;
   };
   giftHistory: CrmGiftHistoryRow[];
+  giftHistoryTruncated: boolean;
   timeline: CrmTimelineEntry[];
   duplicateWarnings: CrmDuplicateWarning[];
   support: CrmSupportSummary;

--- a/tests/unit/apps/admin/app/contribution-operation-shell.test.tsx
+++ b/tests/unit/apps/admin/app/contribution-operation-shell.test.tsx
@@ -1,0 +1,411 @@
+/** @vitest-environment jsdom */
+
+import { QueryProvider } from "@asym/database/providers";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ContributionOperationShell,
+  OPERATION_DEFINITIONS,
+} from "../../../../../apps/admin/app/contributions/operation-shell";
+
+vi.mock("@asym/database/hooks", () => ({
+  ADMIN_CRM_RECORD_DETAIL_QUERY_KEY: ["admin", "crm", "records", "detail"],
+  ADMIN_CRM_RECORDS_QUERY_KEY: ["admin", "crm", "records"],
+  MISSION_CONTROL_NEEDS_ATTENTION_QUERY_KEY: [
+    "admin",
+    "mission-control",
+    "needs-attention",
+  ],
+}));
+
+vi.mock("sonner", () => ({
+  toast: { info: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
+const DONATION_ID = "00000000-0000-4000-8000-0000000000aa";
+
+function makeDetail(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: DONATION_ID,
+    shared: {
+      donationId: DONATION_ID,
+      amountCents: 25_000,
+      currencyCode: "USD",
+      giftDate: "2026-05-01",
+      donorId: "donor-1",
+      donorName: "Shell Donor",
+      designationSummary: {
+        fundId: "fund-1",
+        fundName: "Clean Water Initiative",
+        missionaryId: null,
+        missionaryName: null,
+        lineCount: 1,
+      },
+      paymentStatus: "completed",
+      receiptStatus: "sent",
+      crmPostStatus: "posted",
+      refundState: "none",
+      refundedAmountCents: 0,
+      correctionState: "none",
+      recurringLinkState: "none",
+    },
+    revision: "2026-05-01T00:00:00.000Z#0",
+    stagedGift: {
+      id: "staged-1",
+      status: "posted",
+      receiptStatus: "sent",
+      crmPostStatus: "posted",
+      reviewReason: null,
+      twentyRecordId: null,
+    },
+    actionAvailability: [
+      {
+        actionType: "amount_correction",
+        available: true,
+        blockedReason: null,
+        nextStep: null,
+        riskLevel: "high",
+      },
+      {
+        actionType: "refund",
+        available: false,
+        blockedReason:
+          "This gift has no payment provider charge to refund against.",
+        nextStep:
+          "Offline gifts are corrected through adjustments rather than provider refunds.",
+        riskLevel: "high",
+      },
+      {
+        actionType: "resend_receipt",
+        available: true,
+        blockedReason: null,
+        nextStep: null,
+        riskLevel: "low",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function fetchMockForShell(
+  actionResult: Record<string, unknown>,
+  detail = makeDetail(),
+) {
+  return vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    if (typeof url === "string" && url.includes("/actions")) {
+      return {
+        ok: true,
+        json: async () => ({ result: actionResult }),
+        init,
+      };
+    }
+    return {
+      ok: true,
+      json: async () => ({ contribution: detail }),
+    };
+  });
+}
+
+let fetchDescriptor: PropertyDescriptor | undefined;
+
+describe("ContributionOperationShell", () => {
+  beforeEach(() => {
+    fetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    if (fetchDescriptor) {
+      Object.defineProperty(globalThis, "fetch", fetchDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "fetch");
+    }
+  });
+
+  it("shows current values, requires reason and confirmation, and submits the shared contract", async () => {
+    const fetchMock = fetchMockForShell({
+      auditEventId: "audit-1",
+      adjustmentId: "adj-1",
+      approvalStatus: "applied",
+      taskIds: [],
+      canonicalContribution: {},
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+    const onRowRefresh = vi.fn();
+
+    const view = render(
+      <QueryProvider>
+        <ContributionOperationShell
+          open
+          onClose={vi.fn()}
+          operation={OPERATION_DEFINITIONS.amount_correction!}
+          donationId={DONATION_ID}
+          sourceSurface="donor_crm_record"
+          onRowRefresh={onRowRefresh}
+        />
+      </QueryProvider>,
+    );
+
+    // Risky operation shows current effective values before submission.
+    expect(await view.findByText("$250.00")).toBeTruthy();
+    expect(view.getByText("Clean Water Initiative")).toBeTruthy();
+    expect(
+      view.getByText(/high-risk corrections may require approval/i),
+    ).toBeTruthy();
+
+    const submit = view.getByRole("button", { name: "Correct gift amount" });
+    expect(submit).toHaveProperty("disabled", true);
+    const amountInput = view.getByLabelText("Amount (USD)");
+    expect(amountInput.getAttribute("aria-invalid")).toBe("true");
+    expect(view.getByText("Enter a valid amount.")).toBeTruthy();
+
+    fireEvent.change(amountInput, {
+      target: { value: "200" },
+    });
+    fireEvent.change(view.getByLabelText("Reason"), {
+      target: { value: "Donor reported the wrong amount" },
+    });
+    fireEvent.click(view.getByRole("checkbox"));
+
+    expect(submit).toHaveProperty("disabled", false);
+    expect(amountInput.getAttribute("aria-invalid")).toBe("false");
+    fireEvent.click(submit);
+
+    // The result panel stays inside the shell (no navigation away).
+    expect(await view.findByTestId("operation-result-panel")).toBeTruthy();
+    expect(view.getByText(/operation completed/i)).toBeTruthy();
+    expect(view.getByText(/audit event: audit-1/i)).toBeTruthy();
+    expect(onRowRefresh).toHaveBeenCalled();
+
+    const actionCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/actions"),
+    );
+    const body = JSON.parse((actionCall![1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      actionType: "amount_correction",
+      contributionId: DONATION_ID,
+      sourceSurface: "donor_crm_record",
+      reason: "Donor reported the wrong amount",
+      expectedRevision: "2026-05-01T00:00:00.000Z#0",
+      payload: { amount: 20_000 },
+    });
+    expect(typeof body.idempotencyKey).toBe("string");
+    expect(body.idempotencyKey.length).toBeGreaterThan(10);
+  });
+
+  it("labels amount fields with the loaded contribution currency", async () => {
+    const donationId = "00000000-0000-4000-8000-0000000000bb";
+    const detail = makeDetail();
+    const fetchMock = fetchMockForShell(
+      {
+        auditEventId: "audit-1",
+        approvalStatus: "applied",
+        taskIds: [],
+        canonicalContribution: {},
+      },
+      {
+        ...detail,
+        id: donationId,
+        shared: {
+          ...detail.shared,
+          donationId,
+          currencyCode: "GBP",
+        },
+      },
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <ContributionOperationShell
+          open
+          onClose={vi.fn()}
+          operation={OPERATION_DEFINITIONS.amount_correction!}
+          donationId={donationId}
+          sourceSurface="donor_crm_record"
+        />
+      </QueryProvider>,
+    );
+
+    expect(await view.findByLabelText("Amount (GBP)")).toBeTruthy();
+    expect(view.queryByLabelText("Amount (USD)")).toBeNull();
+  });
+
+  it("keeps staged gift ids at the shared request root for staged gift actions", async () => {
+    const fetchMock = fetchMockForShell({
+      auditEventId: "audit-1",
+      approvalStatus: "applied",
+      receiptOutcome: { status: "sent" },
+      taskIds: [],
+      canonicalContribution: {},
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <ContributionOperationShell
+          open
+          onClose={vi.fn()}
+          operation={OPERATION_DEFINITIONS.resend_receipt!}
+          donationId={DONATION_ID}
+          sourceSurface="donor_crm_record"
+        />
+      </QueryProvider>,
+    );
+
+    await view.findByText("$250.00");
+    fireEvent.click(view.getByRole("button", { name: "Send receipt" }));
+
+    await view.findByTestId("operation-result-panel");
+    const actionCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/actions"),
+    );
+    const body = JSON.parse((actionCall![1] as RequestInit).body as string);
+    expect(body.stagedGiftId).toBe("staged-1");
+    expect(body.payload).toEqual({});
+  });
+
+  it("renders the server-computed blocked state instead of a submit form", async () => {
+    const fetchMock = fetchMockForShell({});
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <ContributionOperationShell
+          open
+          onClose={vi.fn()}
+          operation={OPERATION_DEFINITIONS.refund!}
+          donationId={DONATION_ID}
+          sourceSurface="donor_crm_record"
+        />
+      </QueryProvider>,
+    );
+
+    expect(
+      await view.findByText(/no payment provider charge to refund against/i),
+    ).toBeTruthy();
+    expect(
+      view.getByText(/offline gifts are corrected through adjustments/i),
+    ).toBeTruthy();
+    expect(view.queryByRole("button", { name: "Refund gift" })).toBeNull();
+  });
+
+  it("fails closed when server availability omits the requested action", async () => {
+    const donationId = "00000000-0000-4000-8000-0000000000cc";
+    const detail = makeDetail();
+    const fetchMock = fetchMockForShell(
+      {},
+      {
+        ...detail,
+        id: donationId,
+        shared: {
+          ...detail.shared,
+          donationId,
+        },
+        actionAvailability: [
+          {
+            actionType: "refund",
+            available: true,
+            blockedReason: null,
+            nextStep: null,
+            riskLevel: "high",
+          },
+        ],
+      },
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <ContributionOperationShell
+          open
+          onClose={vi.fn()}
+          operation={OPERATION_DEFINITIONS.amount_correction!}
+          donationId={donationId}
+          sourceSurface="donor_crm_record"
+        />
+      </QueryProvider>,
+    );
+
+    expect(
+      await view.findByText(/not available for the current gift/i),
+    ).toBeTruthy();
+    expect(
+      view.queryByRole("button", { name: "Correct gift amount" }),
+    ).toBeNull();
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes("/actions")),
+    ).toBe(false);
+  });
+
+  it("preserves entered form state on failure and offers retry", async () => {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/actions")) {
+        return {
+          ok: false,
+          json: async () => ({ error: "The operation failed upstream." }),
+        };
+      }
+      return { ok: true, json: async () => ({ contribution: makeDetail() }) };
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <ContributionOperationShell
+          open
+          onClose={vi.fn()}
+          operation={OPERATION_DEFINITIONS.amount_correction!}
+          donationId={DONATION_ID}
+          sourceSurface="donor_crm_record"
+        />
+      </QueryProvider>,
+    );
+
+    await view.findByText("$250.00");
+    fireEvent.change(view.getByLabelText("Amount (USD)"), {
+      target: { value: "150" },
+    });
+    fireEvent.change(view.getByLabelText("Reason"), {
+      target: { value: "fix" },
+    });
+    fireEvent.click(view.getByRole("checkbox"));
+    fireEvent.click(view.getByRole("button", { name: "Correct gift amount" }));
+
+    expect(await view.findByRole("alert")).toBeTruthy();
+    expect(view.getByText(/failed upstream/i)).toBeTruthy();
+
+    // Entered values survive the failure for safe recovery.
+    const amountInput = view.getByLabelText("Amount (USD)") as HTMLInputElement;
+    expect(amountInput.value).toBe("150");
+    expect(view.getByRole("button", { name: "Retry" })).toBeTruthy();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(([url]) =>
+          String(url).includes("/actions"),
+        ),
+      ).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/apps/admin/app/crm-gift-detail-entry.test.tsx
+++ b/tests/unit/apps/admin/app/crm-gift-detail-entry.test.tsx
@@ -1,0 +1,1095 @@
+/** @vitest-environment jsdom */
+
+import { QueryProvider } from "@asym/database/providers";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { JSDOM } from "jsdom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type CrmPageComponent =
+  typeof import("../../../../../apps/admin/app/crm/page").default;
+
+const useAdminCrmRecordsInfiniteGridMock = vi.fn();
+const useAdminCrmRecordDetailMock = vi.fn();
+const useCreateLinkedCrmNoteMock = vi.fn();
+const useCrmTablePreferencesMock = vi.fn();
+const useSaveCrmRowActionPinMock = vi.fn();
+const useSaveCrmViewSettingsMock = vi.fn();
+const useCrmNamedViewsMock = vi.fn();
+const useCreateCrmNamedViewMock = vi.fn();
+const useUpdateCrmNamedViewMock = vi.fn();
+const useDeleteCrmNamedViewMock = vi.fn();
+
+vi.mock("@asym/database/hooks", () => ({
+  ADMIN_CRM_NAMED_VIEWS_QUERY_KEY: ["admin", "crm", "named-views"],
+  ADMIN_CRM_RECORD_DETAIL_QUERY_KEY: ["admin", "crm", "records", "detail"],
+  ADMIN_CRM_RECORDS_QUERY_KEY: ["admin", "crm", "records"],
+  ADMIN_CRM_TABLE_PREFERENCES_QUERY_KEY: ["admin", "crm", "table-preferences"],
+  MISSION_CONTROL_NEEDS_ATTENTION_QUERY_KEY: [
+    "admin",
+    "mission-control",
+    "needs-attention",
+  ],
+  useAdminCrmRecordDetail: useAdminCrmRecordDetailMock,
+  useAdminCrmRecordsInfiniteGrid: useAdminCrmRecordsInfiniteGridMock,
+  useCreateCrmNamedView: useCreateCrmNamedViewMock,
+  useCreateLinkedCrmNote: useCreateLinkedCrmNoteMock,
+  useCrmNamedViews: useCrmNamedViewsMock,
+  useCrmTablePreferences: useCrmTablePreferencesMock,
+  useDeleteCrmNamedView: useDeleteCrmNamedViewMock,
+  useSaveCrmRowActionPin: useSaveCrmRowActionPinMock,
+  useSaveCrmViewSettings: useSaveCrmViewSettingsMock,
+  useUpdateCrmNamedView: useUpdateCrmNamedViewMock,
+}));
+
+const routerPushMock = vi.fn();
+const routerReplaceMock = vi.fn();
+let mockSearch = "";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/crm",
+  useRouter: () => ({
+    push: routerPushMock,
+    replace: routerReplaceMock,
+  }),
+  useSearchParams: () => new URLSearchParams(mockSearch),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { info: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
+const DONOR_RECORD_ID = "record-donor-1";
+const DONATION_ID = "00000000-0000-4000-8000-00000000d001";
+
+const crmGridRow = {
+  id: DONOR_RECORD_ID,
+  recordType: "individual",
+  displayName: "Alice Johnson",
+  title: null,
+  primaryOrganization: null,
+  primaryContactLine: "alice@example.com",
+  location: null,
+  lifecycleStatus: "active",
+  lastGiftAt: "2026-05-01T00:00:00.000Z",
+  lifetimeGiving: 25_000,
+  fundsGivenToSummary: null,
+  lastTouchAt: null,
+  nextTaskSummary: null,
+  portalAccessLabel: "none" as const,
+  linkedAuthUserId: null,
+  tags: [],
+  assignedMissionaryName: null,
+  avatarUrl: null,
+  email: "alice@example.com",
+  phone: null,
+  notesPreview: null,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+const sharedGiftFields = {
+  donationId: DONATION_ID,
+  amountCents: 25_000,
+  currencyCode: "USD",
+  giftDate: "2026-05-01",
+  donorId: "donor-1",
+  donorName: "Alice Johnson",
+  designationSummary: {
+    fundId: "fund-1",
+    fundName: "Clean Water Initiative",
+    missionaryId: null,
+    missionaryName: null,
+  },
+  paymentStatus: "completed",
+  receiptStatus: "sent",
+  crmPostStatus: "posted",
+  refundState: "none",
+  refundedAmountCents: 0,
+  correctionState: "none",
+};
+
+const crmDonorDetail = {
+  donor: {
+    id: DONOR_RECORD_ID,
+    name: "Alice Johnson",
+    title: null,
+    email: "alice@example.com",
+    phone: null,
+    organization: null,
+    location: null,
+    status: "active",
+    type: "individual",
+    profileId: null,
+    missionaryId: null,
+    notesPreview: null,
+    tags: [],
+    avatarUrl: null,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+  },
+  giftHistory: [
+    {
+      shared: sharedGiftFields,
+      id: DONATION_ID,
+      donationId: DONATION_ID,
+      amountCents: 25_000,
+      currencyCode: "USD",
+      giftDate: "2026-05-01",
+      paymentStatus: "completed",
+      receiptStatus: "sent",
+      crmPostStatus: "posted",
+      refundState: "none",
+      correctionState: "none",
+      fundId: "fund-1",
+      fundName: "Clean Water Initiative",
+      missionaryId: null,
+      missionaryName: null,
+      stagedGiftId: "staged-1",
+      twentyRecordId: null,
+    },
+  ],
+  giftHistoryTruncated: false,
+  timeline: [],
+  duplicateWarnings: [],
+  support: {
+    lifetimeGivingCents: 25_000,
+    lastGiftAt: "2026-05-01T00:00:00.000Z",
+    activeRecurringCommitments: 0,
+    lapsedCommitments: 0,
+    atRiskCommitments: 0,
+    byFund: [],
+    byMissionary: [],
+  },
+  privacy: {
+    roleGate: "staff",
+    restrictedNotesVisible: false,
+    missionaryContactDataExposed: false,
+  },
+  reconciliation: {
+    crmWriteMode: "disabled",
+    twentyIsPaymentTruth: false,
+    platformPaymentTruth: true,
+  },
+};
+
+const contributionDetailPayload = {
+  contribution: {
+    id: DONATION_ID,
+    shared: sharedGiftFields,
+    donor: {
+      id: "donor-1",
+      profileId: null,
+      name: "Alice Johnson",
+      email: "alice@example.com",
+      phoneNumbers: [],
+      location: null,
+      organization: null,
+    },
+    gift: {
+      date: "2026-05-01",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      source: "online",
+      campaignId: null,
+      pledgeId: null,
+    },
+    amount: {
+      value: 25_000,
+      gross: 25_000,
+      net: null,
+      fee: null,
+      taxDeductible: null,
+      currency: "USD",
+    },
+    payment: {
+      type: "one_time",
+      method: "card",
+      status: "completed",
+      lastFour: null,
+      stripe: {
+        paymentIntentId: "pi_1",
+        chargeId: null,
+        refundIds: [],
+        replayContext: null,
+      },
+    },
+    designation: {
+      fundId: "fund-1",
+      fundName: "Clean Water Initiative",
+      missionaryId: null,
+      missionaryName: null,
+      projectId: null,
+    },
+    receipt: { status: "sent", statementStatus: null },
+    refund: { status: "none", amount: 0, refundedAt: null },
+    recurring: { isRecurring: false, interval: null, pledgeId: null },
+    stagedGift: {
+      id: "staged-1",
+      status: "posted",
+      receiptStatus: "sent",
+      crmPostStatus: "posted",
+      reviewReason: null,
+      twentyRecordId: null,
+    },
+    crm: { postStatus: "posted", twentyRecordId: null },
+    auditEvents: [],
+    corrections: [],
+    tasks: [],
+    batches: [],
+    donorVisible: {
+      status: "Succeeded",
+      historyUpdatedImmediately: true,
+      amount: 25_000,
+      currency: "USD",
+    },
+  },
+};
+
+const inlineActionsFixture = {
+  nextBestActionType: "resend_receipt",
+  entries: [
+    {
+      actionType: "amount_correction",
+      available: true,
+      blockedReason: null,
+      nextStep: null,
+      riskLevel: "high",
+    },
+    {
+      actionType: "fund_correction",
+      available: true,
+      blockedReason: null,
+      nextStep: null,
+      riskLevel: "high",
+    },
+    {
+      actionType: "resend_receipt",
+      available: true,
+      blockedReason: null,
+      nextStep: null,
+      riskLevel: "low",
+    },
+    {
+      actionType: "refund",
+      available: false,
+      blockedReason:
+        "This gift has no payment provider charge to refund against.",
+      nextStep: null,
+      riskLevel: "high",
+    },
+  ],
+};
+
+function crmDonorDetailFor(donationId: string) {
+  return {
+    ...crmDonorDetail,
+    giftHistory: [
+      {
+        ...crmDonorDetail.giftHistory[0]!,
+        id: donationId,
+        donationId,
+        shared: { ...sharedGiftFields, donationId },
+        inlineActions: inlineActionsFixture,
+      },
+    ],
+  };
+}
+
+function contributionDetailPayloadFor(donationId: string) {
+  return {
+    contribution: {
+      ...contributionDetailPayload.contribution,
+      id: donationId,
+      shared: { ...sharedGiftFields, donationId },
+      revision: "2026-05-01T00:00:00.000Z#0",
+      actionAvailability: inlineActionsFixture.entries,
+    },
+  };
+}
+
+let CrmPage: CrmPageComponent;
+let dom: JSDOM | undefined;
+let fetchDescriptor: PropertyDescriptor | undefined;
+
+function mockQuery(partial: Record<string, unknown>) {
+  return {
+    isError: false,
+    isPending: false,
+    isLoading: false,
+    isFetching: false,
+    data: undefined,
+    error: null as Error | null,
+    refetch: vi.fn().mockResolvedValue({}),
+    ...partial,
+  };
+}
+
+function installDom() {
+  dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/crm",
+  });
+
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+  globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+  globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+  globalThis.SVGElement = dom.window.SVGElement;
+  globalThis.Element = dom.window.Element;
+  globalThis.Node = dom.window.Node;
+  globalThis.Event = dom.window.Event;
+  globalThis.CustomEvent = dom.window.CustomEvent;
+  globalThis.DocumentFragment = dom.window.DocumentFragment;
+  globalThis.EventTarget = dom.window.EventTarget;
+  globalThis.NodeFilter = dom.window.NodeFilter;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+  globalThis.MutationObserver = dom.window.MutationObserver;
+  globalThis.getComputedStyle = dom.window.getComputedStyle;
+  globalThis.requestAnimationFrame = (callback) =>
+    window.setTimeout(callback, 0);
+  globalThis.cancelAnimationFrame = (id) => window.clearTimeout(id);
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  Object.defineProperty(globalThis.window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+describe("apps/admin/app/crm gift detail entry", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    if (fetchDescriptor) {
+      Object.defineProperty(globalThis, "fetch", fetchDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "fetch");
+    }
+    dom?.window.close();
+    dom = undefined;
+  });
+
+  beforeEach(async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://127.0.0.1:54321";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+    mockSearch = "";
+    fetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+    installDom();
+
+    const pageModule = await import("../../../../../apps/admin/app/crm/page");
+    CrmPage = pageModule.default;
+
+    useAdminCrmRecordsInfiniteGridMock.mockReturnValue({
+      columnFilters: [],
+      hasMore: false,
+      isFetchingMore: false,
+      isLoading: false,
+      loadMore: vi.fn(),
+      onFiltersChange: vi.fn(),
+      onRefresh: vi.fn().mockResolvedValue(undefined),
+      onSortingChange: vi.fn(),
+      rows: [crmGridRow],
+      sorting: [],
+      tableError: null,
+    });
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetail }),
+    );
+    useCreateLinkedCrmNoteMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({}),
+    });
+    useCrmTablePreferencesMock.mockReturnValue(mockQuery({ data: undefined }));
+    useSaveCrmRowActionPinMock.mockReturnValue({
+      isPending: false,
+      mutate: vi.fn(),
+    });
+    useSaveCrmViewSettingsMock.mockReturnValue({
+      isPending: false,
+      mutate: vi.fn(),
+    });
+    useCrmNamedViewsMock.mockReturnValue(mockQuery({ data: undefined }));
+    useCreateCrmNamedViewMock.mockReturnValue({
+      isPending: false,
+      mutate: vi.fn(),
+    });
+    useUpdateCrmNamedViewMock.mockReturnValue({
+      isPending: false,
+      mutate: vi.fn(),
+    });
+    useDeleteCrmNamedViewMock.mockReturnValue({
+      isPending: false,
+      mutate: vi.fn(),
+    });
+  }, 30_000);
+
+  it("opens the shared contribution detail for the same donation.id the Hub uses", async () => {
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => contributionDetailPayload,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    const giftButton = await view.findByRole("button", {
+      name: /open gift detail for \$250\.00/i,
+    });
+    fireEvent.click(giftButton);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/admin/contribution-operations/${DONATION_ID}`,
+        { headers: { accept: "application/json" } },
+      );
+    });
+
+    expect(routerPushMock).toHaveBeenCalledWith(
+      `/crm?donor=${DONOR_RECORD_ID}&gift=${DONATION_ID}`,
+      { scroll: false },
+    );
+
+    expect(await view.findByText("Clean Water Initiative")).toBeTruthy();
+    expect(view.getAllByText("Alice Johnson").length).toBeGreaterThan(0);
+  });
+
+  it("renders the next-best action and a grouped, filtered more-actions menu", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d002";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    // One server-computed next-best action per row (#270).
+    expect(
+      await view.findByRole("button", { name: "Send receipt" }),
+    ).toBeTruthy();
+
+    const trigger = view.getByRole("button", { name: "More gift actions" });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    // Capability/state-filtered entries grouped by operation category.
+    expect(await view.findByText("Correction")).toBeTruthy();
+    expect(view.getByText("Receipt")).toBeTruthy();
+    expect(view.getByText("Refund")).toBeTruthy();
+    expect(view.getByText("Correct gift amount")).toBeTruthy();
+    expect(view.getByText("Correct fund designation")).toBeTruthy();
+    const refundItem = view.getByText("Refund gift").closest("[role=menuitem]");
+    expect(refundItem?.textContent).toContain("Blocked");
+    expect(refundItem?.getAttribute("aria-disabled")).toBe("true");
+    expect(refundItem?.hasAttribute("data-disabled")).toBe(true);
+    fireEvent.click(refundItem!);
+    expect(view.queryByTestId("contribution-operation-shell")).toBeNull();
+    // Entries the server filtered out never render.
+    expect(view.queryByText("Replay provider webhook")).toBeNull();
+  });
+
+  it("restores donor drawer deep links even when the donor is off the loaded grid", async () => {
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordsInfiniteGridMock.mockReturnValue({
+      columnFilters: [],
+      hasMore: false,
+      isFetchingMore: false,
+      isLoading: false,
+      loadMore: vi.fn(),
+      onFiltersChange: vi.fn(),
+      onRefresh: vi.fn().mockResolvedValue(undefined),
+      onSortingChange: vi.fn(),
+      rows: [],
+      sorting: [],
+      tableError: null,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayload,
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    expect(await view.findByText("Gift history")).toBeTruthy();
+    expect(view.getAllByText("Alice Johnson").length).toBeGreaterThan(0);
+    expect(
+      await view.findByRole("button", {
+        name: /open gift detail for \$250\.00/i,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("submits inline operations through the shared contract and stays in CRM", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d003";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    const detailRefetch = vi.fn().mockResolvedValue({});
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({
+        data: crmDonorDetailFor(donationId),
+        refetch: detailRefetch,
+      }),
+    );
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        if (String(url).includes("/actions")) {
+          return {
+            ok: true,
+            init,
+            json: async () => ({
+              result: {
+                auditEventId: "audit-9",
+                approvalStatus: "applied",
+                taskIds: [],
+                canonicalContribution: {},
+              },
+            }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => contributionDetailPayloadFor(donationId),
+        };
+      });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    fireEvent.click(await view.findByRole("button", { name: "Send receipt" }));
+
+    // The reusable operation shell opens with the shared contract context.
+    const shell = await view.findByTestId("contribution-operation-shell");
+    const submit = await within(shell).findByRole("button", {
+      name: "Send receipt",
+    });
+    await waitFor(() => {
+      expect(submit).toHaveProperty("disabled", false);
+    });
+    fireEvent.click(submit);
+
+    // The result stays in CRM — no navigation away.
+    expect(await view.findByTestId("operation-result-panel")).toBeTruthy();
+    expect(view.getByText(/audit event: audit-9/i)).toBeTruthy();
+    expect(routerPushMock).not.toHaveBeenCalled();
+
+    // Same shared operation contract as contribution detail.
+    const actionCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/actions"),
+    );
+    const body = JSON.parse((actionCall![1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      actionType: "resend_receipt",
+      contributionId: donationId,
+      stagedGiftId: "staged-1",
+      sourceSurface: "donor_crm_record",
+      expectedRevision: "2026-05-01T00:00:00.000Z#0",
+      payload: {},
+    });
+    expect(typeof body.idempotencyKey).toBe("string");
+    expect(body.idempotencyKey.length).toBeGreaterThan(10);
+
+    // Shared row data refreshes in place after the operation.
+    expect(detailRefetch).toHaveBeenCalled();
+  });
+
+  it("strips malformed gift deep links while preserving donor context", async () => {
+    mockSearch = `donor=${DONOR_RECORD_ID}&gift=not-a-uuid`;
+    const fetchMock = vi.fn();
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith(
+        `/crm?donor=${DONOR_RECORD_ID}`,
+        { scroll: false },
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a valid pinned action as the row action", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d004";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    useCrmTablePreferencesMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          schemaVersion: 1,
+          user: { actionId: "amount_correction", schemaVersion: 1 },
+          tenantDefault: null,
+        },
+      }),
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    // The pin replaces the system next-best (Send receipt) as the row action.
+    expect(
+      await view.findByRole("button", { name: /correct gift amount/i }),
+    ).toBeTruthy();
+    expect(view.queryByRole("button", { name: "Send receipt" })).toBeNull();
+  });
+
+  it("falls back from a blocked pin to the tenant default with explanation", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d005";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    useCrmTablePreferencesMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          schemaVersion: 1,
+          // The fixture's refund entry is blocked for this gift.
+          user: { actionId: "refund", schemaVersion: 1 },
+          tenantDefault: { actionId: "fund_correction", schemaVersion: 1 },
+        },
+      }),
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    expect(
+      await view.findByRole("button", { name: /correct fund designation/i }),
+    ).toBeTruthy();
+    // The fallback is explained, never silent (#271).
+    expect(view.getByRole("note").textContent).toMatch(
+      /pinned action .* is blocked/i,
+    );
+  });
+
+  it("pins a row action by stable operation id from the menu", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d006";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    const pinMutate = vi.fn();
+    useSaveCrmRowActionPinMock.mockReturnValue({
+      isPending: false,
+      mutate: pinMutate,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    const trigger = await view.findByRole("button", {
+      name: "More gift actions",
+    });
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    const subTrigger = await view.findByText("Pin row action");
+    fireEvent.keyDown(subTrigger, { key: "ArrowRight" });
+
+    const pinOption = await view.findByRole("menuitemradio", {
+      name: "Correct gift amount",
+    });
+    fireEvent.click(pinOption);
+
+    await waitFor(() => {
+      expect(pinMutate).toHaveBeenCalledWith(
+        "amount_correction",
+        expect.anything(),
+      );
+    });
+  });
+
+  it("applies view settings columns, filter, and sort to the gift list", async () => {
+    const giftA = "00000000-0000-4000-8000-00000000d007";
+    const giftB = "00000000-0000-4000-8000-00000000d008";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    const base = crmDonorDetailFor(giftA).giftHistory[0]!;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({
+        data: {
+          ...crmDonorDetail,
+          giftHistory: [
+            base,
+            {
+              ...base,
+              id: giftB,
+              donationId: giftB,
+              amountCents: 10_000,
+              shared: {
+                ...sharedGiftFields,
+                donationId: giftB,
+                amountCents: 10_000,
+              },
+            },
+          ],
+        },
+      }),
+    );
+    useCrmTablePreferencesMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          schemaVersion: 1,
+          user: {
+            actionId: null,
+            schemaVersion: 1,
+            settings: {
+              columns: { designation: false },
+              filtersSort: {
+                sortField: "amountCents",
+                sortDirection: "asc",
+                paymentStatus: "all",
+              },
+            },
+          },
+          tenantDefault: null,
+        },
+      }),
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(giftA),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    const giftButtons = await view.findAllByRole("button", {
+      name: /open gift detail for/i,
+    });
+    // Ascending amount sort puts the $100 gift first.
+    expect(giftButtons[0]?.textContent).toContain("$100.00");
+    expect(giftButtons[1]?.textContent).toContain("$250.00");
+    // The designation column is hidden by the user preference.
+    expect(view.queryByText("Clean Water Initiative")).toBeNull();
+  });
+
+  it("previews a scoped reset before applying it", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d009";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    useCrmTablePreferencesMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          schemaVersion: 1,
+          user: {
+            actionId: null,
+            schemaVersion: 1,
+            settings: { columns: { designation: false } },
+          },
+          tenantDefault: {
+            actionId: null,
+            schemaVersion: 1,
+            settings: { columns: { designation: true, statusLine: true } },
+          },
+        },
+      }),
+    );
+    const viewSettingsMutate = vi.fn();
+    useSaveCrmViewSettingsMock.mockReturnValue({
+      isPending: false,
+      mutate: viewSettingsMutate,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    const trigger = await view.findByRole("button", {
+      name: "Gift history view settings",
+    });
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    const resetSubTrigger = await view.findByText("Reset view settings");
+    fireEvent.keyDown(resetSubTrigger, { key: "ArrowRight" });
+
+    fireEvent.click(await view.findByText("Reset columns…"));
+
+    // The reset previews the fallback before anything is applied.
+    const preview = await view.findByTestId("view-settings-reset-preview");
+    expect(preview.textContent).toMatch(
+      /columns return to the tenant default/i,
+    );
+    expect(viewSettingsMutate).not.toHaveBeenCalled();
+
+    fireEvent.click(view.getByRole("button", { name: "Reset" }));
+
+    await waitFor(() => {
+      expect(viewSettingsMutate).toHaveBeenCalledWith(
+        { columns: null },
+        expect.anything(),
+      );
+    });
+  });
+
+  it("applies the default named view automatically when no working preference exists", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d00a";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    useCrmTablePreferencesMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          schemaVersion: 1,
+          user: null,
+          tenantDefault: null,
+        },
+      }),
+    );
+    useCrmNamedViewsMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          views: [
+            {
+              id: "view-1",
+              name: "Receipts focus",
+              isDefault: true,
+              schemaVersion: 1,
+              pinnedActionId: "resend_receipt",
+              settings: { columns: { designation: false } },
+            },
+          ],
+        },
+      }),
+    );
+    const viewSettingsMutate = vi.fn();
+    useSaveCrmViewSettingsMock.mockReturnValue({
+      isPending: false,
+      mutate: viewSettingsMutate,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    await waitFor(() => {
+      expect(viewSettingsMutate).toHaveBeenCalledWith(
+        {
+          columns: { designation: false },
+          filtersSort: null,
+          pinnedActionId: "resend_receipt",
+          activeViewId: "view-1",
+        },
+        expect.anything(),
+      );
+    });
+  });
+
+  it("deleting the default view asks for a replacement default", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d00b";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    useCrmTablePreferencesMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          schemaVersion: 1,
+          user: {
+            actionId: null,
+            schemaVersion: 1,
+            settings: { activeViewId: "view-1" },
+          },
+          tenantDefault: null,
+        },
+      }),
+    );
+    useCrmNamedViewsMock.mockReturnValue(
+      mockQuery({
+        data: {
+          tableId: "crm.giftHistory",
+          views: [
+            {
+              id: "view-1",
+              name: "Default view",
+              isDefault: true,
+              schemaVersion: 1,
+              pinnedActionId: null,
+              settings: null,
+            },
+            {
+              id: "view-2",
+              name: "Backup view",
+              isDefault: false,
+              schemaVersion: 1,
+              pinnedActionId: null,
+              settings: null,
+            },
+          ],
+        },
+      }),
+    );
+    const deleteMutate = vi.fn();
+    useDeleteCrmNamedViewMock.mockReturnValue({
+      isPending: false,
+      mutate: deleteMutate,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    // The compact switcher sits near the gift-history toolbar and shows
+    // the active view name.
+    const switcher = await view.findByRole("button", {
+      name: "Gift history views",
+    });
+    expect(switcher.textContent).toContain("Default view");
+    fireEvent.keyDown(switcher, { key: "Enter" });
+
+    fireEvent.click(await view.findByText("Delete view…"));
+
+    const dialog = await view.findByTestId("named-view-delete-dialog");
+    expect(dialog.textContent).toMatch(/choose another default/i);
+
+    fireEvent.click(
+      within(dialog).getByLabelText(/make “backup view” the default/i),
+    );
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Delete view" }),
+    );
+
+    await waitFor(() => {
+      expect(deleteMutate).toHaveBeenCalledWith(
+        { viewId: "view-1", nextDefaultViewId: "view-2" },
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/tests/unit/packages/api/admin-crm-detail-report.test.ts
+++ b/tests/unit/packages/api/admin-crm-detail-report.test.ts
@@ -227,6 +227,7 @@ describe("Phase 5 CRM donor detail and reports", () => {
       stagedGiftId: "staged-gift-1",
       twentyRecordId: "twenty-gift-1",
     });
+    expect(detail.giftHistoryTruncated).toBe(false);
     expect(detail.timeline.map((entry) => entry.kind)).toEqual(
       expect.arrayContaining(["gift", "activity"]),
     );
@@ -245,6 +246,31 @@ describe("Phase 5 CRM donor detail and reports", () => {
       platformPaymentTruth: true,
       twentyIsPaymentTruth: false,
     });
+  });
+
+  it("marks gift history as truncated when the donor has more than 100 gifts", async () => {
+    const donationTemplate = baseTables.donations[0]!;
+    const donations = Array.from({ length: 101 }, (_, index) => ({
+      ...donationTemplate,
+      created_at: new Date(Date.UTC(2026, 0, index + 1)).toISOString(),
+      id: `donation-${String(index + 1).padStart(3, "0")}`,
+    }));
+
+    const detail = await getAdminCrmDonorDetail({
+      crmWritesEnabled: false,
+      donorId: "donor-1",
+      role: "staff",
+      supabaseAdmin: createSupabaseFixture({
+        ...baseTables,
+        donation_crm_links: [],
+        donations,
+        staged_gifts: [],
+      }) as never,
+      tenantId: "tenant-1",
+    });
+
+    expect(detail.giftHistory).toHaveLength(100);
+    expect(detail.giftHistoryTruncated).toBe(true);
   });
 
   it("builds auditable report slices and CSV exports", async () => {

--- a/tests/unit/packages/api/admin/crm-gift-history-row.test.ts
+++ b/tests/unit/packages/api/admin/crm-gift-history-row.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributionActionAvailability } from "../../../../../packages/api/src/admin/contribution-operations/action-availability";
+import { buildSharedContributionRowFields } from "../../../../../packages/api/src/admin/contribution-shared/row-contract";
+import { buildContributionGridRow } from "../../../../../packages/api/src/admin/contributions/model";
+import { buildCrmGiftHistoryRow } from "../../../../../packages/api/src/admin/crm/detail/gift-history";
+
+const donation = {
+  id: "donation-1",
+  donor_id: "donor-1",
+  missionary_id: "missionary-1",
+  fund_id: "fund-1",
+  amount: 25_000,
+  currency: "usd",
+  status: "completed",
+  gift_date: "2026-04-08",
+  refund_amount: 0,
+  refunded_at: null,
+  created_at: "2026-04-08T10:00:00.000Z",
+  updated_at: "2026-04-08T12:00:00.000Z",
+};
+
+const donor = {
+  id: "donor-1",
+  name: "Alice Johnson",
+  email: "alice@example.com",
+};
+
+const fund = { id: "fund-1", name: "Clean Water Initiative" };
+const missionary = { id: "missionary-1", display_name: "John Martinez" };
+
+const stagedGift = {
+  id: "staged-1",
+  status: "posted",
+  receipt_status: "sent",
+  crm_post_status: "posted",
+};
+
+describe("admin/crm/detail/gift-history", () => {
+  it("adapter-maps CRM gift history rows onto the shared row contract", () => {
+    const row = buildCrmGiftHistoryRow({
+      donation,
+      donor,
+      fund,
+      missionary,
+      stagedGift: { ...stagedGift, twenty_record_id: "twenty-1" },
+      corrections: [{ status: "applied" }],
+    });
+
+    expect(row.shared).toEqual(
+      buildSharedContributionRowFields({
+        donation,
+        donor,
+        profile: null,
+        fund,
+        missionary,
+        stagedGift,
+        corrections: [{ status: "applied" }],
+      }),
+    );
+
+    expect(row.donationId).toBe("donation-1");
+    expect(row.id).toBe("donation-1");
+    expect(row.amountCents).toBe(row.shared.amountCents);
+    expect(row.currencyCode).toBe(row.shared.currencyCode);
+    expect(row.giftDate).toBe(row.shared.giftDate);
+    expect(row.paymentStatus).toBe(row.shared.paymentStatus);
+    expect(row.receiptStatus).toBe(row.shared.receiptStatus);
+    expect(row.crmPostStatus).toBe(row.shared.crmPostStatus);
+    expect(row.fundName).toBe(row.shared.designationSummary.fundName);
+    expect(row.missionaryName).toBe(
+      row.shared.designationSummary.missionaryName,
+    );
+
+    expect(row.stagedGiftId).toBe("staged-1");
+    expect(row.twentyRecordId).toBe("twenty-1");
+  });
+
+  it("uses gift_date and General Fund fallback like the Hub does", () => {
+    const row = buildCrmGiftHistoryRow({
+      donation: { ...donation, fund_id: null, gift_date: null },
+      donor,
+      fund: null,
+      missionary: null,
+      stagedGift: null,
+      corrections: [],
+    });
+
+    expect(row.giftDate).toBe(donation.created_at);
+    expect(row.fundName).toBe("General Fund");
+    expect(row.stagedGiftId).toBeNull();
+  });
+
+  it("derives split-gift summaries from the same designation set as the Hub", () => {
+    const designationSet = {
+      lines: [
+        {
+          id: "alloc-1",
+          amountCents: 10_000,
+          currencyCode: "USD",
+          fundId: "fund-1",
+          fundName: "Clean Water Initiative",
+          fundType: "project" as const,
+          missionaryId: null,
+          missionaryName: null,
+          memo: null,
+          restriction: null,
+          correctionState: "none" as const,
+        },
+        {
+          id: "alloc-2",
+          amountCents: 15_000,
+          currencyCode: "USD",
+          fundId: "fund-2",
+          fundName: "Martinez Family Support",
+          fundType: "missionary" as const,
+          missionaryId: "missionary-1",
+          missionaryName: "John Martinez",
+          memo: null,
+          restriction: null,
+          correctionState: "none" as const,
+        },
+      ],
+      totalAmountCents: 25_000,
+      reconcilesToGiftAmount: true,
+      issues: [],
+    };
+
+    const crmRow = buildCrmGiftHistoryRow({
+      donation,
+      donor,
+      fund,
+      missionary,
+      stagedGift: { ...stagedGift, twenty_record_id: null },
+      designationSet,
+    });
+
+    const hubRow = buildContributionGridRow({
+      donation: {
+        ...donation,
+        donation_type: "one_time",
+        payment_method: "card",
+        is_recurring: false,
+        recurring_interval: null,
+        notes: null,
+        stripe_payment_intent_id: "pi_1",
+        campaign_id: null,
+        pledge_id: null,
+        processed_at: null,
+        completed_at: null,
+        failed_at: null,
+        error_code: null,
+        error_message: null,
+        stripe_charge_id: null,
+        source: "online",
+      },
+      donor: {
+        ...donor,
+        phone: null,
+        type: null,
+        location: null,
+        organization: null,
+        notes: null,
+      },
+      profile: null,
+      fund,
+      missionary,
+      stagedGift: {
+        ...stagedGift,
+        review_reason: null,
+        receipt_send_log_id: null,
+      },
+      designationSet,
+    });
+
+    expect(crmRow.shared.designationSummary).toEqual({
+      fundId: null,
+      fundName: "2 designations",
+      missionaryId: null,
+      missionaryName: null,
+      lineCount: 2,
+    });
+    expect(crmRow.shared.designationSummary).toEqual(
+      hubRow.shared.designationSummary,
+    );
+  });
+
+  it("produces the identical shared fields the Contributions Hub row produces", () => {
+    const corrections = [{ status: "pending" }];
+    const crmRow = buildCrmGiftHistoryRow({
+      donation,
+      donor,
+      fund,
+      missionary,
+      stagedGift: { ...stagedGift, twenty_record_id: null },
+      corrections,
+    });
+
+    const hubRow = buildContributionGridRow({
+      donation: {
+        ...donation,
+        donation_type: "one_time",
+        payment_method: "card",
+        is_recurring: false,
+        recurring_interval: null,
+        notes: null,
+        stripe_payment_intent_id: "pi_1",
+        campaign_id: null,
+        pledge_id: null,
+        processed_at: null,
+        completed_at: null,
+        failed_at: null,
+        error_code: null,
+        error_message: null,
+        stripe_charge_id: null,
+        source: "online",
+      },
+      donor: {
+        ...donor,
+        phone: null,
+        type: null,
+        location: null,
+        organization: null,
+        notes: null,
+      },
+      profile: null,
+      fund,
+      missionary,
+      stagedGift: {
+        ...stagedGift,
+        review_reason: null,
+        receipt_send_log_id: null,
+      },
+      corrections,
+    });
+
+    expect(crmRow.shared).toEqual(hubRow.shared);
+  });
+
+  it("exposes inline actions with detail-identical blocked reasons (#270)", () => {
+    const failedStagedGift = {
+      ...stagedGift,
+      crm_post_status: "failed",
+      twenty_record_id: null,
+    };
+    const row = buildCrmGiftHistoryRow({
+      donation,
+      donor,
+      fund,
+      missionary,
+      stagedGift: failedStagedGift,
+      provider: { stripePaymentIntentId: "pi_1", stripeChargeId: "ch_1" },
+      viewerCapabilities: [
+        "contributions.view_detail",
+        "contributions.request_corrections",
+        "contributions.apply_corrections",
+        "contributions.manage_receipts",
+        "contributions.retry_crm_post",
+        "contributions.run_refunds",
+        "contributions.use_provider_actions",
+      ],
+    });
+
+    // The detail surface derives availability from the same shared inputs;
+    // every overlapping entry must match exactly.
+    const detailAvailability = buildContributionActionAvailability({
+      stagedGift: {
+        id: failedStagedGift.id,
+        status: failedStagedGift.status,
+        receiptStatus: failedStagedGift.receipt_status,
+        crmPostStatus: failedStagedGift.crm_post_status,
+      },
+      paymentStatus: donation.status,
+      refund: {
+        amountCents: row.shared.amountCents,
+        refundedAmountCents: row.shared.refundedAmountCents,
+        hasProviderCharge: true,
+      },
+    });
+    for (const detailEntry of detailAvailability) {
+      expect(
+        row.inlineActions.entries.find(
+          (entry) => entry.actionType === detailEntry.actionType,
+        ),
+      ).toEqual(detailEntry);
+    }
+
+    expect(row.inlineActions.nextBestActionType).toBe("retry_staged_gift");
+    expect(
+      row.inlineActions.entries.map((entry) => entry.actionType),
+    ).toContain("stripe_replay");
+  });
+
+  it("hides inline operations the viewer has no capability for", () => {
+    const row = buildCrmGiftHistoryRow({
+      donation,
+      donor,
+      fund,
+      missionary,
+      stagedGift: { ...stagedGift, twenty_record_id: null },
+      provider: { stripePaymentIntentId: "pi_1", stripeChargeId: "ch_1" },
+      viewerCapabilities: [
+        "contributions.view_detail",
+        "contributions.request_corrections",
+      ],
+    });
+
+    expect(
+      row.inlineActions.entries.map((entry) => entry.actionType).sort(),
+    ).toEqual([
+      "amount_correction",
+      "fund_correction",
+      "refund",
+      "stripe_replay",
+    ]);
+    expect(row.inlineActions.nextBestActionType).toBeNull();
+  });
+});

--- a/tests/unit/packages/api/crm-link-scope-contract.test.ts
+++ b/tests/unit/packages/api/crm-link-scope-contract.test.ts
@@ -110,7 +110,7 @@ describe("CRM donation link parent-scope contract", () => {
   it("keeps CRM detail and report readers scoped to parent links", () => {
     const detail = sourceSection(
       crmDetailSource,
-      "const linkResult =",
+      "const [linkResult, allocationsResult] =",
       "assertNoError(linkResult.error",
     );
     const report = sourceSection(


### PR DESCRIPTION
## Summary
- add CRM donor detail drawer gift-history views, kanban/table controls, and inline contribution action entry points
- enrich CRM donor gift history rows with shared contribution detail data, provider proof, allocations, corrections, adjustments, and resolved action capabilities
- wire CRM `?gift=` deep links into the contribution operation shell with query-param validation and regression coverage

## Verification
- `node scripts/run-with-ci-env.mjs -- bunx vitest run tests/unit/packages/api/admin/crm-gift-history-row.test.ts tests/unit/packages/api/admin-crm-detail-report.test.ts tests/unit/apps/admin/app/contribution-operation-shell.test.tsx tests/unit/apps/admin/app/crm-gift-detail-entry.test.tsx`
- `bunx turbo run typecheck --filter=@asym/admin --filter=@asym/api`
- `bunx turbo run lint --filter=@asym/admin --filter=@asym/api`
- `bun run format`
- `bun run ci:preflight`
- push hook `ci:preflight`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires CRM gift-history rows with shared contribution data, inline action controls, and view-switching (kanban/table/named-views), and re-uses the same operation shell as the Contributions Hub for inline corrections, receipts, refunds, and CRM actions. The `?gift=` deep link is added to the CRM page with UUID validation and regression tests.

- **Service**: new parallel `Promise.all` block fetches corrections, correction-requests, adjustments, and allocations alongside the existing staged-gift query so all enrichment data arrives in two round-trip hops.
- **Operation shell** (`ContributionOperationShell`): new shared component that fetches full contribution detail for blocked-state validation, owns submit/loading/result state, and calls `onRowRefresh` after success to update the CRM drawer in place.
- **Deep-link handling**: `?gift=` param is validated as a UUID v1–5 before opening the detail overlay; malformed values are stripped via `router.replace` while preserving `?donor=` context.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All new queries are properly parallelised, tenant isolation is consistent, and the shared operation-shell contract is correctly reused from the CRM drawer.

The previous sequential query waterfall has been resolved — corrections, correction-requests, and adjustments now run in the same Promise.all as staged gifts, and allocations joins links in the second hop. The operation shell correctly disables submission while detail is pending, blocks actions absent from server-computed availability, and invalidates all affected query keys after success. Deep-link validation with UUID regex is in place. The only finding is a redundant CRM detail refetch that the query invalidation already handles — this is harmless but wasteful.

apps/admin/app/crm/detail-drawer.tsx — the onRowRefresh prop passed to ContributionOperationShell is redundant given the query-cache invalidation already covers the CRM record detail.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/crm/detail/service.ts | All new queries (corrections, correction_requests, adjustments) are correctly parallelised alongside stagedGifts in the first Promise.all. allocations runs in a second Promise.all with linkResult, keeping both hops minimal. Tenant isolation (eq tenant_id) is consistent throughout. |
| apps/admin/app/contributions/operation-shell.tsx | Reusable shell correctly fetches full contribution detail for server-computed blocked-state, owns submit/loading/result flow, and disables the submit button while detail is pending. A redundant CRM detail refetch occurs after success (see comment). |
| apps/admin/app/crm/detail-drawer.tsx | Drawer correctly threads inlineActions from gift rows into GiftInlineActionControls and mounts ContributionOperationShell outside the Sheet so the Dialog is not nested. Named-view auto-apply and reset-preview logic look correct. |
| apps/admin/app/crm/page-client.tsx | isContributionGiftParam UUID validation correctly strips malformed ?gift= values and strips the param via router.replace while preserving ?donor=. openGift uses router.push (history-entry) and closeGift uses router.replace; focus-return with giftOpenerRef is intact. |
| packages/api/src/admin/crm/detail/gift-history.ts | buildCrmGiftHistoryRow correctly delegates to buildSharedContributionRowFields and reuses buildContributionActionAvailability and buildInlineContributionActions, matching the contribution-detail derivation path exactly. |
| apps/admin/app/crm/gift-inline-action-controls.tsx | Correctly resolves row action from user-pin → tenant-default → system next-best. Missing definitions (server returned type not in OPERATION_DEFINITIONS) are handled with null guards; blocked items render with aria-disabled and show blockedReason in the tooltip. |
| tests/unit/apps/admin/app/crm-gift-detail-entry.test.tsx | Comprehensive integration tests covering deep-link entry, inline action rendering, operation submission with shared contract validation, malformed-param stripping, pin fallback, view settings, and named-view management. |
| packages/database/types/crm-detail.ts | inlineActions field added as optional to CrmGiftHistoryRow; CrmGiftInlineActions and CrmGiftInlineActionEntry types are consistent with SupportedOperationActionType in the shell. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant CRMPage as page-client.tsx
    participant DetailDrawer as detail-drawer.tsx
    participant Shell as ContributionOperationShell
    participant DetailAPI as /api/admin/contribution-operations/:id
    participant DetailService as CRM detail service
    participant OperationsAPI as /api/admin/contribution-operations/actions

    Browser->>CRMPage: "open ?donor=X"
    CRMPage->>DetailDrawer: renders DetailDrawer(contact)
    DetailDrawer->>DetailService: useAdminCrmRecordDetail(contactId)
    DetailService-->>DetailDrawer: giftHistory[].inlineActions (corrections, adjustments, allocations)

    Browser->>DetailDrawer: click inline action button
    DetailDrawer->>Shell: "open=true, donationId, operation"
    Shell->>DetailAPI: useContributionDetail(donationId)
    DetailAPI-->>Shell: actionAvailability, stagedGift, revision

    Browser->>Shell: submit operation
    Shell->>OperationsAPI: "POST /actions {actionType, contributionId, stagedGiftId, idempotencyKey...}"
    OperationsAPI-->>Shell: "{result: {auditEventId, approvalStatus, ...}}"
    Shell->>Shell: invalidateContributionOperationQueries()
    Note over Shell,DetailDrawer: Invalidates ADMIN_CRM_RECORD_DETAIL_QUERY_KEY → auto-refetch
    Shell->>Shell: onRowRefresh() → detailQuery.refetch() [redundant]
    Shell->>Browser: show success result panel (stays in CRM)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant CRMPage as page-client.tsx
    participant DetailDrawer as detail-drawer.tsx
    participant Shell as ContributionOperationShell
    participant DetailAPI as /api/admin/contribution-operations/:id
    participant DetailService as CRM detail service
    participant OperationsAPI as /api/admin/contribution-operations/actions

    Browser->>CRMPage: "open ?donor=X"
    CRMPage->>DetailDrawer: renders DetailDrawer(contact)
    DetailDrawer->>DetailService: useAdminCrmRecordDetail(contactId)
    DetailService-->>DetailDrawer: giftHistory[].inlineActions (corrections, adjustments, allocations)

    Browser->>DetailDrawer: click inline action button
    DetailDrawer->>Shell: "open=true, donationId, operation"
    Shell->>DetailAPI: useContributionDetail(donationId)
    DetailAPI-->>Shell: actionAvailability, stagedGift, revision

    Browser->>Shell: submit operation
    Shell->>OperationsAPI: "POST /actions {actionType, contributionId, stagedGiftId, idempotencyKey...}"
    OperationsAPI-->>Shell: "{result: {auditEventId, approvalStatus, ...}}"
    Shell->>Shell: invalidateContributionOperationQueries()
    Note over Shell,DetailDrawer: Invalidates ADMIN_CRM_RECORD_DETAIL_QUERY_KEY → auto-refetch
    Shell->>Shell: onRowRefresh() → detailQuery.refetch() [redundant]
    Shell->>Browser: show success result panel (stays in CRM)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(admin): add CRM gift detail operati..."](https://github.com/asymmetric-al/core/commit/1f9716e8ec6fe60155f4ab0a018699ef435aa290) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38960070)</sub>

<!-- /greptile_comment -->