### PR TITLE
feat(admin): wire automations dashboard to persisted rules

### DIFF
--- a/apps/admin/app/automations/page-client.tsx
+++ b/apps/admin/app/automations/page-client.tsx
@@ -1,318 +1,511 @@
 "use client";
 
-import { motion } from "@asym/lib/motion";
+import {
+  useMissionControlAutomations,
+  type MissionControlAutomationRuleDto,
+  type MissionControlAutomationSummary,
+} from "@asym/database/hooks";
+import { resolveMissionControlAutomationLifecycle } from "@asym/database/mission-control-automations";
+import { motion, useReducedMotion } from "@asym/lib/motion";
+import { propsHeroEntrance, STAGGER_TIGHT } from "@asym/lib/motion-presets";
 import { PageShell } from "@asym/ui/components/primitives/page-shell";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@asym/ui/components/shadcn/alert";
 import { Badge } from "@asym/ui/components/shadcn/badge";
-import { Button } from "@asym/ui/components/shadcn/button";
 import {
   Card,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
-  CardDescription,
 } from "@asym/ui/components/shadcn/card";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@asym/ui/components/shadcn/empty";
 import { Input } from "@asym/ui/components/shadcn/input";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+} from "@asym/ui/components/shadcn/item";
+import { Label } from "@asym/ui/components/shadcn/label";
+import { Skeleton } from "@asym/ui/components/shadcn/skeleton";
 import { cn } from "@asym/ui/lib/utils";
 import {
-  Zap,
-  Link2,
   AlertTriangle,
-  History,
+  ClipboardList,
+  Link2,
   Play,
-  CheckCircle,
-  Plus,
   Search,
-  MoreHorizontal,
-  ArrowUpRight,
-  Settings,
+  Zap,
 } from "lucide-react";
-import React from "react";
+import { Fragment, useMemo, useState, type ReactNode } from "react";
 
-interface AutomationFlow {
-  name: string;
-  trigger: string;
-  app: string;
-  status: "Active" | "Paused";
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+function formatCount(value: number): string {
+  return numberFormatter.format(value);
 }
 
-interface IntegrationConnection {
-  name: string;
-  status: "Operational" | "Issue Detected";
-  icon: React.ComponentType<{ className?: string }>;
-  iconContainerClassName: string;
+function formatTriggerKind(kind: string): string {
+  return kind
+    .split("_")
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
 }
 
-const RECENT_FLOWS: AutomationFlow[] = [
-  {
-    name: "mobilize.advance-to-interview",
-    trigger: "Stage Change",
-    app: "Mobilize",
-    status: "Active",
-  },
-  {
-    name: "giving.send-thank-you",
-    trigger: "New Gift",
-    app: "Stripe",
-    status: "Active",
-  },
-  {
-    name: "care.alert-on-gap",
-    trigger: "Inactivity",
-    app: "Reports",
-    status: "Active",
-  },
-  {
-    name: "crm.sync-to-mailchimp",
-    trigger: "New Contact",
-    app: "CRM",
-    status: "Paused",
-  },
-];
+export function filterAutomationRules(
+  automationRules: MissionControlAutomationRuleDto[],
+  search: string,
+): MissionControlAutomationRuleDto[] {
+  const normalizedSearch = search.trim().toLowerCase();
+  if (!normalizedSearch) {
+    return automationRules;
+  }
 
-const INTEGRATION_CONNECTIONS: IntegrationConnection[] = [
-  {
-    name: "Stripe",
-    status: "Operational",
-    icon: Link2,
-    iconContainerClassName: "bg-blue-50 text-blue-600 border border-blue-100",
-  },
-  {
-    name: "Mailchimp",
-    status: "Operational",
-    icon: Link2,
-    iconContainerClassName:
-      "bg-amber-50 text-amber-600 border border-amber-100",
-  },
-  {
-    name: "Slack",
-    status: "Issue Detected",
-    icon: AlertTriangle,
-    iconContainerClassName: "bg-rose-50 text-rose-600 border border-rose-100",
-  },
-  {
-    name: "Postmark",
-    status: "Operational",
-    icon: Link2,
-    iconContainerClassName:
-      "bg-emerald-50 text-emerald-600 border border-emerald-100",
-  },
-];
+  return automationRules.filter((rule) => {
+    const trigger = formatTriggerKind(rule.trigger.kind).toLowerCase();
+    const status =
+      resolveMissionControlAutomationLifecycle(
+        rule,
+      ).displayStatus.toLowerCase();
+    return (
+      rule.name.toLowerCase().includes(normalizedSearch) ||
+      trigger.includes(normalizedSearch) ||
+      status.includes(normalizedSearch)
+    );
+  });
+}
 
-const STAT_CARDS = [
-  {
-    label: "Active Flows",
-    value: "28",
-    sub: "across 12 integrations",
-    icon: Zap,
-    iconClassName: "text-amber-500",
-  },
-  {
-    label: "Executions (24h)",
-    value: "1,247",
-    sub: "99.2% success",
-    icon: Play,
-    iconClassName: "text-blue-600",
-    hasCheck: true,
-  },
-  {
-    label: "Connections",
-    value: "12",
-    sub: "all systems operational",
-    icon: Link2,
-    iconClassName: "text-indigo-600",
-  },
-  {
-    label: "Failed Runs",
-    value: "8",
-    sub: "require manual review",
-    icon: AlertTriangle,
-    iconClassName: "text-rose-600",
-    valueClassName: "text-rose-600",
-  },
-];
-
-function AutomationStatsRow() {
+function LoadingStatCard() {
   return (
-    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 text-left">
-      {STAT_CARDS.map((stat, i) => (
+    <Card className="border-border bg-card shadow-sm">
+      <CardContent aria-busy="true" className="p-6">
+        <div className="flex items-center justify-between pb-2">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="size-4 rounded" />
+        </div>
+        <Skeleton className="mt-3 h-8 w-16" />
+        <Skeleton className="mt-2 h-3 w-32" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  sublabel,
+  value,
+  valueClassName,
+}: {
+  icon: ReactNode;
+  label: string;
+  sublabel: string;
+  value: number;
+  valueClassName?: string;
+}) {
+  return (
+    <Card className="border-border bg-card text-card-foreground shadow-sm">
+      <CardContent className="p-6">
+        <div className="flex flex-row items-center justify-between pb-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {label}
+          </span>
+          {icon}
+        </div>
+        <div>
+          <div
+            className={cn(
+              "text-3xl font-semibold tabular-nums tracking-tight text-foreground",
+              valueClassName,
+            )}
+          >
+            {formatCount(value)}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">{sublabel}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AutomationStatsRow({
+  isLoading,
+  summary,
+}: {
+  isLoading: boolean;
+  summary?: MissionControlAutomationSummary;
+}) {
+  const reduceMotion = useReducedMotion();
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 text-left md:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }, (_, index) => (
+          <LoadingStatCard key={`automation-stat-loading-${index}`} />
+        ))}
+      </div>
+    );
+  }
+
+  if (!summary) {
+    return null;
+  }
+
+  const stats = [
+    {
+      label: "Active Rules",
+      value: summary.activeRules,
+      sublabel: "Enabled persisted rules",
+      icon: <Zap aria-hidden="true" className="size-4 text-muted-foreground" />,
+    },
+    {
+      label: "Total Rules",
+      value: summary.totalRules,
+      sublabel: "Rules stored for this tenant",
+      icon: (
+        <ClipboardList
+          aria-hidden="true"
+          className="size-4 text-muted-foreground"
+        />
+      ),
+    },
+    {
+      label: "Executions (24h)",
+      value: summary.executions24h,
+      sublabel: "Persisted activity log rows",
+      icon: (
+        <Play aria-hidden="true" className="size-4 text-muted-foreground" />
+      ),
+    },
+    {
+      label: "Invalid Rules",
+      value: summary.invalidRules,
+      sublabel: "Rows with contradictory lifecycle state",
+      icon: (
+        <AlertTriangle aria-hidden="true" className="size-4 text-destructive" />
+      ),
+      valueClassName: summary.invalidRules > 0 ? "text-destructive" : "",
+    },
+    {
+      label: "Failed Runs (24h)",
+      value: summary.failedRuns24h,
+      sublabel: "Activity logs with failures",
+      icon: (
+        <AlertTriangle aria-hidden="true" className="size-4 text-destructive" />
+      ),
+      valueClassName: summary.failedRuns24h > 0 ? "text-destructive" : "",
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 text-left md:grid-cols-2 lg:grid-cols-5">
+      {stats.map((stat, index) => (
         <motion.div
           key={stat.label}
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: i * 0.05 }}
+          {...propsHeroEntrance(reduceMotion, index * STAGGER_TIGHT, 12)}
         >
-          <div className="rounded-2xl border border-zinc-100 bg-white shadow-sm p-6">
-            <div className="flex flex-row items-center justify-between pb-2">
-              <span className="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-400">
-                {stat.label}
-              </span>
-              <stat.icon className={cn("size-4", stat.iconClassName)} />
-            </div>
-            <div>
-              <div
-                className={cn(
-                  "text-3xl font-black tabular-nums tracking-tight text-zinc-900",
-                  stat.valueClassName,
-                )}
-              >
-                {stat.value}
-              </div>
-              <div className="flex items-center gap-1 mt-1">
-                {stat.hasCheck && (
-                  <CheckCircle className="size-3 text-emerald-600" />
-                )}
-                <span className="text-xs text-zinc-500">{stat.sub}</span>
-              </div>
-            </div>
-          </div>
+          <StatCard {...stat} />
         </motion.div>
       ))}
     </div>
   );
 }
 
-function RecentFlowsCard() {
+function RulesLoadingState() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="Loading automation rules"
+      className="space-y-4 p-6"
+    >
+      <p className="text-sm text-muted-foreground">
+        Loading automation dashboard
+      </p>
+      {Array.from({ length: 3 }, (_, index) => (
+        <div
+          key={`automation-rule-loading-${index}`}
+          className="flex items-center justify-between gap-4"
+        >
+          <div className="flex items-center gap-3">
+            <Skeleton className="size-9 rounded-lg" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-3 w-64" />
+            </div>
+          </div>
+          <Skeleton className="h-6 w-16 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AutomationRulesEmptyState({
+  description,
+  icon,
+  title,
+}: {
+  description: string;
+  icon: ReactNode;
+  title: string;
+}) {
+  return (
+    <Empty className="border-0 py-14">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">{icon}</EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}
+
+function AutomationRuleRow({
+  index,
+  isLast,
+  rule,
+}: {
+  index: number;
+  isLast: boolean;
+  rule: MissionControlAutomationRuleDto;
+}) {
+  const status = resolveMissionControlAutomationLifecycle(rule).displayStatus;
+
+  return (
+    <Fragment key={rule.id ?? `${rule.name}-${index}`}>
+      <Item
+        className="flex-nowrap rounded-none border-0"
+        role="listitem"
+        size="default"
+      >
+        <ItemMedia
+          className="size-9 rounded-lg border border-border bg-muted text-muted-foreground"
+          variant="icon"
+        >
+          <Zap aria-hidden="true" className="size-4" />
+        </ItemMedia>
+        <ItemContent className="min-w-0">
+          <ItemTitle className="max-w-full truncate font-semibold">
+            {rule.name}
+          </ItemTitle>
+          <ItemDescription className="truncate text-xs text-muted-foreground">
+            Trigger: {formatTriggerKind(rule.trigger.kind)}
+          </ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Badge
+            className="shrink-0 text-xs"
+            variant={status === "Active" ? "default" : "outline"}
+          >
+            {status}
+          </Badge>
+        </ItemActions>
+      </Item>
+      {isLast ? null : <ItemSeparator />}
+    </Fragment>
+  );
+}
+
+function RulesCardBody({
+  allRuleCount,
+  filteredRules,
+  isBlocked,
+  isLoading,
+}: {
+  allRuleCount: number;
+  filteredRules: MissionControlAutomationRuleDto[];
+  isBlocked: boolean;
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return <RulesLoadingState />;
+  }
+
+  if (isBlocked) {
+    return (
+      <AutomationRulesEmptyState
+        description="Automation rules cannot be displayed until the persisted dashboard response loads successfully."
+        icon={<AlertTriangle className="size-5" />}
+        title="Automation rules unavailable"
+      />
+    );
+  }
+
+  if (allRuleCount === 0) {
+    return (
+      <AutomationRulesEmptyState
+        description="This tenant has no persisted Mission Control automation rules."
+        icon={<Zap className="size-5" />}
+        title="No automation rules yet"
+      />
+    );
+  }
+
+  if (filteredRules.length === 0) {
+    return (
+      <AutomationRulesEmptyState
+        description="No persisted automation rules match the current filter."
+        icon={<Search className="size-5" />}
+        title="No matching automation rules"
+      />
+    );
+  }
+
+  return (
+    <ItemGroup>
+      {filteredRules.map((rule, index) => (
+        <AutomationRuleRow
+          key={rule.id ?? `${rule.name}-${index}`}
+          index={index}
+          isLast={index === filteredRules.length - 1}
+          rule={rule}
+        />
+      ))}
+    </ItemGroup>
+  );
+}
+
+function AutomationRulesCard({
+  allRuleCount,
+  filteredRules,
+  isBlocked,
+  isLoading,
+  onSearchChange,
+  search,
+}: {
+  allRuleCount: number;
+  filteredRules: MissionControlAutomationRuleDto[];
+  isBlocked: boolean;
+  isLoading: boolean;
+  onSearchChange: (value: string) => void;
+  search: string;
+}) {
+  const reduceMotion = useReducedMotion();
+
   return (
     <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, delay: 0.2 }}
+      className="md:col-span-4"
+      {...propsHeroEntrance(reduceMotion, STAGGER_TIGHT * 4, 12)}
     >
-      <Card className="col-span-4 shadow-sm border-zinc-200">
-        <CardHeader className="border-b border-zinc-50 flex flex-row items-center justify-between">
+      <Card className="border-border bg-card shadow-sm">
+        <CardHeader className="flex flex-col gap-4 border-b border-border sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <CardTitle className="text-base font-bold">Recent Flows</CardTitle>
+            <CardTitle className="text-base font-semibold">
+              Automation Rules
+            </CardTitle>
             <CardDescription className="text-xs">
-              Your most active automation workflows.
+              Rules configured for Mission Control automations.
             </CardDescription>
           </div>
-          <div className="relative w-48">
-            <Search className="absolute left-2.5 top-2.5 size-3.5 text-zinc-400" />
+          <div className="relative w-full sm:w-56">
+            <Label className="sr-only" htmlFor="automation-rule-filter">
+              Filter automation rules
+            </Label>
+            <Search
+              aria-hidden="true"
+              className="pointer-events-none absolute left-2.5 top-2.5 size-3.5 text-muted-foreground"
+            />
             <Input
-              placeholder="Filter flows..."
-              className="pl-8 h-8 text-xs bg-zinc-50 border-none"
+              className="h-8 bg-background pl-8 text-xs"
+              disabled={isLoading || isBlocked || allRuleCount === 0}
+              id="automation-rule-filter"
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder="Filter rules..."
+              type="search"
+              value={search}
             />
           </div>
         </CardHeader>
         <CardContent className="p-0">
-          <div className="divide-y divide-zinc-50">
-            {RECENT_FLOWS.map((flow) => (
-              <div
-                key={flow.name}
-                className="flex items-center justify-between p-4 hover:bg-zinc-50/50 transition-colors group cursor-pointer"
-              >
-                <div className="flex items-center gap-3">
-                  <div
-                    className={cn(
-                      "size-8 rounded-lg flex items-center justify-center border",
-                      flow.status === "Active"
-                        ? "bg-emerald-50 text-emerald-600 border-emerald-100"
-                        : "bg-zinc-50 text-zinc-400 border-zinc-100",
-                    )}
-                  >
-                    <Zap className="size-4" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-bold text-zinc-900">
-                      {flow.name}
-                    </p>
-                    <p className="text-xs text-zinc-500">
-                      Trigger: {flow.trigger} • via {flow.app}
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-4">
-                  <Badge
-                    variant="outline"
-                    className={cn(
-                      "text-[10px] font-bold h-5 shadow-none",
-                      flow.status === "Active"
-                        ? "bg-emerald-50 text-emerald-700 border-emerald-200"
-                        : "bg-zinc-100 text-zinc-500 border-zinc-200",
-                    )}
-                  >
-                    {flow.status}
-                  </Badge>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-8 text-zinc-400 group-hover:text-zinc-900"
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
+          <RulesCardBody
+            allRuleCount={allRuleCount}
+            filteredRules={filteredRules}
+            isBlocked={isBlocked}
+            isLoading={isLoading}
+          />
         </CardContent>
-        <div className="p-3 border-t border-zinc-50 bg-zinc-50/30 text-center">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-xs text-zinc-500 hover:text-zinc-900 w-full h-8 group"
-          >
-            View All Flows{" "}
-            <ArrowUpRight className="ml-1 size-3 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform" />
-          </Button>
-        </div>
       </Card>
     </motion.div>
   );
 }
 
-function IntegrationHealthCard() {
+function IntegrationTelemetryCard({
+  isLoading,
+  summary,
+}: {
+  isLoading: boolean;
+  summary?: MissionControlAutomationSummary;
+}) {
+  const telemetryBacked = summary?.integrationHealthBacked === true;
+  const reduceMotion = useReducedMotion();
+
   return (
     <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, delay: 0.25 }}
+      className="md:col-span-3"
+      {...propsHeroEntrance(reduceMotion, STAGGER_TIGHT * 5, 12)}
     >
-      <Card className="col-span-3 shadow-sm border-zinc-200">
-        <CardHeader className="border-b border-zinc-50">
-          <CardTitle className="text-base font-bold">
-            Integration Health
+      <Card className="border-border bg-card shadow-sm">
+        <CardHeader className="border-b border-border">
+          <CardTitle className="text-base font-semibold">
+            Connection Telemetry
           </CardTitle>
           <CardDescription className="text-xs">
-            Status of third-party platform connections.
+            Provider health appears here only after it is backed by persisted
+            telemetry.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4 p-6">
-          {INTEGRATION_CONNECTIONS.map((conn) => (
+        <CardContent className="p-6">
+          {isLoading ? (
             <div
-              key={conn.name}
-              className="flex items-center justify-between p-3 rounded-xl border border-zinc-100 bg-zinc-50/50"
+              aria-busy="true"
+              aria-label="Loading integration telemetry"
+              className="space-y-4"
             >
-              <div className="flex items-center gap-3">
-                <div
-                  className={cn(
-                    "size-8 rounded-lg flex items-center justify-center",
-                    conn.iconContainerClassName,
-                  )}
-                >
-                  <conn.icon className="size-4" />
-                </div>
-                <span className="text-sm font-semibold text-zinc-700">
-                  {conn.name}
-                </span>
-              </div>
-              <Badge
-                className={cn(
-                  "text-[10px] font-bold h-5 shadow-none",
-                  conn.status === "Operational"
-                    ? "bg-emerald-50 text-emerald-700 border-emerald-200"
-                    : "bg-rose-50 text-rose-700 border-rose-200",
-                )}
-              >
-                {conn.status}
-              </Badge>
+              <Skeleton className="size-10 rounded-lg" />
+              <Skeleton className="h-4 w-56" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-4/5" />
             </div>
-          ))}
-          <Button
-            variant="outline"
-            className="w-full h-11 px-4 rounded-xl border-zinc-200 hover:bg-zinc-50 font-bold uppercase tracking-widest text-[10px] text-zinc-600 gap-2 mt-2"
-          >
-            <Settings className="mr-2 size-3.5" /> Manage Connections
-          </Button>
+          ) : (
+            <div className="rounded-lg border border-border bg-background p-4">
+              <div className="flex items-start gap-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                  <Link2 aria-hidden="true" className="size-5" />
+                </div>
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-sm font-semibold text-foreground">
+                      {telemetryBacked
+                        ? "Connection telemetry is backed by persisted data"
+                        : "Connection telemetry is not wired yet"}
+                    </h3>
+                    <Badge variant="outline" className="text-xs">
+                      {telemetryBacked ? "Backed" : "Not wired yet"}
+                    </Badge>
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    Live provider statuses will be shown only after a real
+                    integration telemetry source is connected.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
     </motion.div>
@@ -320,41 +513,41 @@ function IntegrationHealthCard() {
 }
 
 function AutomationBestPracticesCard() {
+  const reduceMotion = useReducedMotion();
+
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, delay: 0.3 }}
-    >
-      <Card className="border-zinc-200 text-left">
+    <motion.div {...propsHeroEntrance(reduceMotion, STAGGER_TIGHT * 6, 12)}>
+      <Card className="border-border bg-card text-left">
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-bold uppercase tracking-wider text-zinc-400">
-            Automation Best Practices
+          <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Automation Guardrails
           </CardTitle>
         </CardHeader>
-        <CardContent className="text-sm text-zinc-600 space-y-2">
-          <ul className="list-disc list-inside space-y-1 ml-2">
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <ul className="ml-2 list-inside list-disc space-y-1">
             <li>
               Use{" "}
-              <code className="bg-zinc-100 px-1.5 py-0.5 rounded text-zinc-900">
+              <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">
                 idempotency keys
               </code>{" "}
-              on all create actions to prevent duplicates.
+              on create actions to prevent duplicates.
             </li>
             <li>
-              Always prefix flow names by domain:{" "}
-              <code className="bg-zinc-100 px-1.5 py-0.5 rounded text-zinc-900">
+              Keep rule names domain-prefixed, such as{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">
                 mobilize.
-              </code>
-              ,{" "}
-              <code className="bg-zinc-100 px-1.5 py-0.5 rounded text-zinc-900">
+              </code>{" "}
+              or{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">
                 giving.
               </code>
-              , etc.
             </li>
-            <li>Owners must subscribe to failure alerts via Slack or Email.</li>
             <li>
-              Test flows in isolation before deploying to production streams.
+              Assign a clear owner for failure review before enabling a rule.
+            </li>
+            <li>
+              Review persisted activity logs before treating an automation as
+              production-ready.
             </li>
           </ul>
         </CardContent>
@@ -363,36 +556,91 @@ function AutomationBestPracticesCard() {
   );
 }
 
-export default function AutomationsPage() {
+function AutomationsErrorAlert({ message }: { message: string }) {
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="size-4" />
+      <AlertTitle>Could not load automations</AlertTitle>
+      <AlertDescription>{message}</AlertDescription>
+    </Alert>
+  );
+}
+
+export function AutomationsPageView({
+  automationRules,
+  errorMessage,
+  hasLoadedData = true,
+  isError,
+  isLoading,
+  summary,
+}: {
+  automationRules: MissionControlAutomationRuleDto[];
+  errorMessage?: string;
+  hasLoadedData?: boolean;
+  isError: boolean;
+  isLoading: boolean;
+  summary?: MissionControlAutomationSummary;
+}) {
+  const [search, setSearch] = useState("");
+  const queryError =
+    errorMessage ?? "Could not load persisted automation data.";
+  const missingSummary = !isLoading && !isError && hasLoadedData && !summary;
+
+  const filteredRules = useMemo(
+    () => filterAutomationRules(automationRules, search),
+    [automationRules, search],
+  );
+
   return (
     <PageShell
       title="Automations"
       description="Workflow automation and integration management."
       density="compact"
-      actions={
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            className="h-11 px-4 rounded-xl border-zinc-200 hover:bg-zinc-50 font-bold uppercase tracking-widest text-[10px] gap-2"
-          >
-            <History className="size-4 text-zinc-400" /> History
-          </Button>
-          <Button className="h-11 px-6 rounded-xl bg-zinc-900 text-white hover:bg-zinc-800 font-black uppercase tracking-widest text-[10px] shadow-lg shadow-zinc-200 gap-2">
-            <Plus className="size-4" /> New Flow
-          </Button>
-        </div>
-      }
     >
-      <div className="space-y-8 animate-in fade-in duration-500">
-        <AutomationStatsRow />
+      <div className="space-y-8">
+        <AutomationStatsRow isLoading={isLoading} summary={summary} />
 
-        <div className="grid gap-6 md:grid-cols-7 text-left">
-          <RecentFlowsCard />
-          <IntegrationHealthCard />
+        {isError ? <AutomationsErrorAlert message={queryError} /> : null}
+
+        {missingSummary ? (
+          <AutomationsErrorAlert message="The automations response did not include a persisted dashboard summary." />
+        ) : null}
+
+        <div className="grid gap-6 text-left md:grid-cols-7">
+          <AutomationRulesCard
+            allRuleCount={automationRules.length}
+            filteredRules={filteredRules}
+            isBlocked={isError || Boolean(missingSummary)}
+            isLoading={isLoading}
+            onSearchChange={setSearch}
+            search={search}
+          />
+          <IntegrationTelemetryCard isLoading={isLoading} summary={summary} />
         </div>
 
         <AutomationBestPracticesCard />
       </div>
     </PageShell>
+  );
+}
+
+export default function AutomationsPage() {
+  const automationsQuery = useMissionControlAutomations();
+  const errorMessage =
+    automationsQuery.error instanceof Error
+      ? automationsQuery.error.message
+      : automationsQuery.error
+        ? String(automationsQuery.error)
+        : undefined;
+
+  return (
+    <AutomationsPageView
+      automationRules={automationsQuery.data?.automationRules ?? []}
+      errorMessage={errorMessage}
+      hasLoadedData={Boolean(automationsQuery.data)}
+      isError={automationsQuery.isError}
+      isLoading={automationsQuery.isPending}
+      summary={automationsQuery.data?.summary}
+    />
   );
 }

--- a/packages/api/src/admin/mission-control-automations/store.ts
+++ b/packages/api/src/admin/mission-control-automations/store.ts
@@ -1,3 +1,5 @@
+import { resolveMissionControlAutomationLifecycle } from "@asym/database/mission-control-automations";
+
 import {
   getActivationReadinessFailure,
   type AutomationActivationReadiness,
@@ -63,35 +65,43 @@ function countRuleSummary(
   automationRules: AutomationRule[],
 ): Pick<
   MissionControlAutomationSummary,
-  "activeRules" | "draftRules" | "pausedRules" | "readyRules" | "totalRules"
+  | "activeRules"
+  | "draftRules"
+  | "invalidRules"
+  | "pausedRules"
+  | "readyRules"
+  | "totalRules"
 > {
   let activeRules = 0;
   let draftRules = 0;
+  let invalidRules = 0;
   let pausedRules = 0;
   let readyRules = 0;
 
   for (const rule of automationRules) {
-    if (rule.enabled && rule.activationStatus === "active") {
+    const lifecycle = resolveMissionControlAutomationLifecycle(rule);
+
+    if (lifecycle.summaryBucket === "activeRules") {
       activeRules += 1;
       continue;
     }
 
-    if (
-      rule.activationStatus === "paused" ||
-      rule.activationStatus === "disabled"
-    ) {
+    if (lifecycle.summaryBucket === "invalidRules") {
+      invalidRules += 1;
+      continue;
+    }
+
+    if (lifecycle.summaryBucket === "pausedRules") {
       pausedRules += 1;
       continue;
     }
 
-    if (rule.activationStatus === "ready") {
+    if (lifecycle.summaryBucket === "readyRules") {
       readyRules += 1;
       continue;
     }
 
-    if (rule.activationStatus === "draft") {
-      draftRules += 1;
-    }
+    draftRules += 1;
   }
 
   return {
@@ -100,6 +110,7 @@ function countRuleSummary(
     pausedRules,
     readyRules,
     draftRules,
+    invalidRules,
   };
 }
 

--- a/packages/api/src/admin/mission-control-automations/types.ts
+++ b/packages/api/src/admin/mission-control-automations/types.ts
@@ -90,6 +90,7 @@ export interface MissionControlAutomationSummary {
   pausedRules: number;
   readyRules: number;
   draftRules: number;
+  invalidRules: number;
   executions24h: number;
   failedRuns24h: number;
   activityLogBacked: boolean;

--- a/packages/database/hooks/mission-control-automations.ts
+++ b/packages/database/hooks/mission-control-automations.ts
@@ -2,12 +2,9 @@
 
 import { useQuery } from "@tanstack/react-query";
 
-export type MissionControlAutomationActivationStatus =
-  | "draft"
-  | "ready"
-  | "active"
-  | "paused"
-  | "disabled";
+import type { MissionControlAutomationActivationStatus } from "@asym/database/mission-control-automations";
+
+export type { MissionControlAutomationActivationStatus };
 
 export interface MissionControlAutomationRuleDto {
   id?: string;
@@ -27,6 +24,7 @@ export interface MissionControlAutomationSummary {
   pausedRules: number;
   readyRules: number;
   draftRules: number;
+  invalidRules: number;
   executions24h: number;
   failedRuns24h: number;
   activityLogBacked: boolean;

--- a/packages/database/mission-control-automations.ts
+++ b/packages/database/mission-control-automations.ts
@@ -1,0 +1,55 @@
+export type MissionControlAutomationActivationStatus =
+  | "draft"
+  | "ready"
+  | "active"
+  | "paused"
+  | "disabled";
+
+export type MissionControlAutomationDisplayStatus =
+  | "Active"
+  | "Invalid"
+  | "Paused"
+  | "Disabled"
+  | "Ready"
+  | "Draft";
+
+export type MissionControlAutomationSummaryBucket =
+  | "activeRules"
+  | "invalidRules"
+  | "pausedRules"
+  | "readyRules"
+  | "draftRules";
+
+export interface MissionControlAutomationLifecycleRule {
+  enabled: boolean;
+  activationStatus?: MissionControlAutomationActivationStatus;
+}
+
+export function resolveMissionControlAutomationLifecycle(
+  rule: MissionControlAutomationLifecycleRule,
+): {
+  displayStatus: MissionControlAutomationDisplayStatus;
+  summaryBucket: MissionControlAutomationSummaryBucket;
+} {
+  if (rule.enabled && rule.activationStatus === "active") {
+    return { displayStatus: "Active", summaryBucket: "activeRules" };
+  }
+
+  if (rule.activationStatus === "active") {
+    return { displayStatus: "Invalid", summaryBucket: "invalidRules" };
+  }
+
+  if (rule.activationStatus === "paused") {
+    return { displayStatus: "Paused", summaryBucket: "pausedRules" };
+  }
+
+  if (rule.activationStatus === "disabled") {
+    return { displayStatus: "Disabled", summaryBucket: "pausedRules" };
+  }
+
+  if (rule.activationStatus === "ready") {
+    return { displayStatus: "Ready", summaryBucket: "readyRules" };
+  }
+
+  return { displayStatus: "Draft", summaryBucket: "draftRules" };
+}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -51,6 +51,10 @@
     "./query-keys": {
       "types": "./query-keys.ts",
       "default": "./query-keys.ts"
+    },
+    "./mission-control-automations": {
+      "types": "./mission-control-automations.ts",
+      "default": "./mission-control-automations.ts"
     }
   },
   "scripts": {

--- a/tests/unit/apps/admin/app/automations-page.test.tsx
+++ b/tests/unit/apps/admin/app/automations-page.test.tsx
@@ -1,0 +1,460 @@
+/** @vitest-environment jsdom */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { JSDOM } from "jsdom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { useMissionControlAutomationsMock } = vi.hoisted(() => ({
+  useMissionControlAutomationsMock: vi.fn(),
+}));
+
+vi.mock("@asym/database/hooks", () => ({
+  useMissionControlAutomations: useMissionControlAutomationsMock,
+}));
+
+const repoRoot = process.cwd();
+type AutomationsPageComponent =
+  typeof import("../../../../../apps/admin/app/automations/page-client").default;
+type AutomationsPageViewComponent =
+  typeof import("../../../../../apps/admin/app/automations/page-client").AutomationsPageView;
+type FilterAutomationRules =
+  typeof import("../../../../../apps/admin/app/automations/page-client").filterAutomationRules;
+type AutomationRuleFixture = Parameters<FilterAutomationRules>[0][number];
+let AutomationsPage: AutomationsPageComponent;
+let AutomationsPageView: AutomationsPageViewComponent;
+let filterAutomationRules: FilterAutomationRules;
+let dom: JSDOM | undefined;
+
+const emptySummary = {
+  totalRules: 0,
+  activeRules: 0,
+  pausedRules: 0,
+  readyRules: 0,
+  draftRules: 0,
+  invalidRules: 0,
+  executions24h: 0,
+  failedRuns24h: 0,
+  activityLogBacked: true,
+  integrationHealthBacked: false,
+};
+
+const pendingControlLabels = [
+  "View All Flows",
+  "Manage Connections",
+  "History",
+  "New Flow",
+] as const;
+
+function readRepoFile(path: string) {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+
+function createAutomationRule(
+  overrides: Partial<AutomationRuleFixture> = {},
+): AutomationRuleFixture {
+  return {
+    id: "rule_1",
+    name: "Automation rule",
+    mode: "advanced",
+    trigger: { kind: "contribution_issue_created" },
+    conditions: [],
+    actions: [],
+    runMode: "automatic",
+    enabled: false,
+    activationStatus: "draft",
+    ...overrides,
+  };
+}
+
+describe("apps/admin/app/automations/page-client", () => {
+  beforeEach(async () => {
+    useMissionControlAutomationsMock.mockReset();
+    process.env.NEXT_PUBLIC_SUPABASE_URL ??= "http://127.0.0.1:54321";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";
+    dom = new JSDOM("<!doctype html><html><body></body></html>", {
+      url: "http://localhost",
+    });
+    globalThis.window = dom.window as unknown as Window & typeof globalThis;
+    globalThis.document = dom.window.document;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.SVGElement = dom.window.SVGElement;
+    globalThis.Node = dom.window.Node;
+    globalThis.Event = dom.window.Event;
+    globalThis.InputEvent = dom.window.InputEvent;
+    globalThis.MutationObserver = dom.window.MutationObserver;
+    globalThis.getComputedStyle = dom.window.getComputedStyle;
+    globalThis.requestAnimationFrame = (callback) =>
+      window.setTimeout(callback, 0);
+    globalThis.cancelAnimationFrame = (id) => window.clearTimeout(id);
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: dom.window.navigator,
+    });
+    Object.defineProperty(globalThis.window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+
+    if (!AutomationsPage || !AutomationsPageView || !filterAutomationRules) {
+      const pageClient =
+        await import("../../../../../apps/admin/app/automations/page-client");
+      AutomationsPage = pageClient.default;
+      AutomationsPageView = pageClient.AutomationsPageView;
+      filterAutomationRules = pageClient.filterAutomationRules;
+    }
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    dom?.window.close();
+    dom = undefined;
+  });
+
+  it("does not render demo flows while loading", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[]}
+        hasLoadedData={false}
+        isError={false}
+        isLoading
+      />,
+    );
+
+    expect(view.getByText("Loading automation dashboard")).toBeTruthy();
+    expect(view.queryByText("mobilize.advance-to-interview")).toBeNull();
+    expect(view.queryByText("crm.sync-to-mailchimp")).toBeNull();
+  });
+
+  it("does not render demo flows when the query fails", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[]}
+        errorMessage="Unable to reach automations"
+        hasLoadedData={false}
+        isError
+        isLoading={false}
+      />,
+    );
+
+    expect(view.getByText("Could not load automations")).toBeTruthy();
+    expect(view.getByText("Unable to reach automations")).toBeTruthy();
+    expect(view.queryByText("giving.send-thank-you")).toBeNull();
+    expect(view.queryByText("care.alert-on-gap")).toBeNull();
+  });
+
+  it("renders an honest empty state when no automation rules exist", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[]}
+        isError={false}
+        isLoading={false}
+        summary={emptySummary}
+      />,
+    );
+
+    expect(view.getByText("No automation rules yet")).toBeTruthy();
+    expect(
+      view.getByText(
+        "This tenant has no persisted Mission Control automation rules.",
+      ),
+    ).toBeTruthy();
+    expect(view.queryByText("mobilize.advance-to-interview")).toBeNull();
+  });
+
+  it("associates the automation rules filter with a real label", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[]}
+        isError={false}
+        isLoading={false}
+        summary={emptySummary}
+      />,
+    );
+
+    const filterInput = view.getByRole("searchbox", {
+      name: /filter automation rules/i,
+    });
+
+    expect(filterInput.getAttribute("id")).toBe("automation-rule-filter");
+    expect(
+      view.container.querySelector('label[for="automation-rule-filter"]')
+        ?.textContent,
+    ).toContain("Filter automation rules");
+  });
+
+  it("renders real summary values and real automation rules", async () => {
+    const automationRules: Parameters<FilterAutomationRules>[0] = [
+      createAutomationRule({
+        id: "rule_1",
+        name: "Receipt follow-up",
+        trigger: { kind: "contribution_issue_created" },
+        enabled: true,
+        activationStatus: "active",
+      }),
+      createAutomationRule({
+        id: "rule_2",
+        name: "CRM task review",
+        trigger: { kind: "contribution_action_completed" },
+        runMode: "review_first",
+        enabled: false,
+        activationStatus: "draft",
+      }),
+    ];
+    const view = render(
+      <AutomationsPageView
+        automationRules={automationRules}
+        isError={false}
+        isLoading={false}
+        summary={{
+          totalRules: 2,
+          activeRules: 1,
+          pausedRules: 0,
+          readyRules: 0,
+          draftRules: 1,
+          invalidRules: 0,
+          executions24h: 3,
+          failedRuns24h: 1,
+          activityLogBacked: true,
+          integrationHealthBacked: false,
+        }}
+      />,
+    );
+
+    expect(view.getByText("Active Rules")).toBeTruthy();
+    expect(view.getByText("Total Rules")).toBeTruthy();
+    expect(view.getByText("Executions (24h)")).toBeTruthy();
+    expect(view.getByText("Invalid Rules")).toBeTruthy();
+    expect(view.getByText("Failed Runs (24h)")).toBeTruthy();
+    expect(view.getByText("Receipt follow-up")).toBeTruthy();
+    expect(view.getByText("CRM task review")).toBeTruthy();
+    expect(
+      view.queryByRole("button", { name: /automation actions for/i }),
+    ).toBeNull();
+  });
+
+  it("filters automation rules by search query", () => {
+    const automationRules: Parameters<FilterAutomationRules>[0] = [
+      createAutomationRule({
+        id: "rule_1",
+        name: "Receipt follow-up",
+        trigger: { kind: "contribution_issue_created" },
+        enabled: true,
+        activationStatus: "active",
+      }),
+      createAutomationRule({
+        id: "rule_2",
+        name: "CRM task review",
+        trigger: { kind: "contribution_action_completed" },
+        runMode: "review_first",
+        enabled: false,
+        activationStatus: "draft",
+      }),
+    ];
+
+    const filteredRules = filterAutomationRules(automationRules, "crm");
+
+    expect(filteredRules.map((rule) => rule.name)).toEqual(["CRM task review"]);
+  });
+
+  it("keeps rule status badges and status filtering aligned with persisted summary semantics", () => {
+    const automationRules = [
+      createAutomationRule({
+        id: "rule_active",
+        name: "Valid active rule",
+        enabled: true,
+        activationStatus: "active",
+      }),
+      createAutomationRule({
+        id: "rule_disabled_active",
+        name: "Legacy disabled lifecycle rule",
+        enabled: false,
+        activationStatus: "active",
+      }),
+      createAutomationRule({
+        id: "rule_enabled_draft",
+        name: "Enabled draft rule",
+        enabled: true,
+        activationStatus: "draft",
+      }),
+      createAutomationRule({
+        id: "rule_paused",
+        name: "Paused rule",
+        enabled: false,
+        activationStatus: "paused",
+      }),
+    ];
+    const view = render(
+      <AutomationsPageView
+        automationRules={automationRules}
+        isError={false}
+        isLoading={false}
+        summary={{
+          totalRules: 4,
+          activeRules: 1,
+          pausedRules: 1,
+          readyRules: 0,
+          draftRules: 1,
+          invalidRules: 1,
+          executions24h: 0,
+          failedRuns24h: 0,
+          activityLogBacked: true,
+          integrationHealthBacked: false,
+        }}
+      />,
+    );
+
+    expect(view.getByText("Valid active rule")).toBeTruthy();
+    expect(view.getByText("Legacy disabled lifecycle rule")).toBeTruthy();
+    expect(view.getAllByText("Active")).toHaveLength(1);
+    expect(view.getAllByText("Invalid")).toHaveLength(1);
+    expect(view.getAllByText("Draft")).toHaveLength(1);
+    expect(view.getAllByText("Paused")).toHaveLength(1);
+
+    const activeMatches = filterAutomationRules(automationRules, "active");
+    expect(activeMatches.map((rule) => rule.id)).toEqual(["rule_active"]);
+  });
+
+  it("renders the filtered empty state when a rule search has no matches", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[
+          createAutomationRule({
+            id: "rule_filter",
+            name: "Receipt follow-up",
+            enabled: true,
+            activationStatus: "active",
+          }),
+        ]}
+        isError={false}
+        isLoading={false}
+        summary={{
+          ...emptySummary,
+          totalRules: 1,
+          activeRules: 1,
+          invalidRules: 0,
+        }}
+      />,
+    );
+
+    fireEvent.change(
+      view.getByRole("searchbox", { name: /filter automation rules/i }),
+      { target: { value: "zzznomatch" } },
+    );
+
+    expect(view.getByText("No matching automation rules")).toBeTruthy();
+    expect(
+      view.getByText("No persisted automation rules match the current filter."),
+    ).toBeTruthy();
+  });
+
+  it("blocks the rules list when loaded data is missing the persisted summary", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[
+          createAutomationRule({
+            id: "rule_missing_summary",
+            name: "Rule with malformed response",
+          }),
+        ]}
+        hasLoadedData
+        isError={false}
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      view.getByText(
+        "The automations response did not include a persisted dashboard summary.",
+      ),
+    ).toBeTruthy();
+    expect(view.getByText("Automation rules unavailable")).toBeTruthy();
+    expect(view.queryByText("Rule with malformed response")).toBeNull();
+  });
+
+  it("normalizes non-Error hook failures in the default page export", () => {
+    useMissionControlAutomationsMock.mockReturnValue({
+      data: undefined,
+      error: "Server returned a string failure",
+      isError: true,
+      isPending: false,
+    });
+
+    const view = render(<AutomationsPage />);
+
+    expect(useMissionControlAutomationsMock).toHaveBeenCalledTimes(1);
+    expect(view.getByText("Could not load automations")).toBeTruthy();
+    expect(view.getByText("Server returned a string failure")).toBeTruthy();
+  });
+
+  it("communicates that integration telemetry is not wired yet", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[]}
+        isError={false}
+        isLoading={false}
+        summary={emptySummary}
+      />,
+    );
+
+    expect(
+      view.getByText("Connection telemetry is not wired yet"),
+    ).toBeTruthy();
+    expect(view.queryByText("Stripe")).toBeNull();
+    expect(view.queryByText("Mailchimp")).toBeNull();
+    expect(view.queryByText("Slack")).toBeNull();
+    expect(view.queryByText("Postmark")).toBeNull();
+  });
+
+  it("does not render pending automation controls as fake actions", () => {
+    const view = render(
+      <AutomationsPageView
+        automationRules={[]}
+        isError={false}
+        isLoading={false}
+        summary={emptySummary}
+      />,
+    );
+
+    for (const label of pendingControlLabels) {
+      expect(view.queryByRole("button", { name: label })).toBeNull();
+      expect(view.queryByRole("link", { name: label })).toBeNull();
+      expect(view.queryByText(label)).toBeNull();
+    }
+  });
+
+  it("does not keep production fallback demo data in the page source", () => {
+    const source = readRepoFile("apps/admin/app/automations/page-client.tsx");
+
+    for (const banned of [
+      "RECENT_FLOWS",
+      "STAT_CARDS",
+      "INTEGRATION_CONNECTIONS",
+      "1,247",
+      "all systems operational",
+      "Issue Detected",
+      "most active",
+      "MoreHorizontal",
+      ...pendingControlLabels,
+    ]) {
+      expect(source).not.toContain(banned);
+    }
+  });
+});

--- a/tests/unit/packages/api/admin/mission-control-automations.test.ts
+++ b/tests/unit/packages/api/admin/mission-control-automations.test.ts
@@ -592,11 +592,19 @@ describe("mission control automation dashboard summary", () => {
       draftRules: 1,
       pausedRules: 1,
       readyRules: 1,
+      invalidRules: 1,
       executions24h: 0,
       failedRuns24h: 0,
       activityLogBacked: true,
       integrationHealthBacked: false,
     });
+    expect(
+      dashboard.summary.activeRules +
+        dashboard.summary.draftRules +
+        dashboard.summary.invalidRules +
+        dashboard.summary.pausedRules +
+        dashboard.summary.readyRules,
+    ).toBe(dashboard.summary.totalRules);
     expect(dashboard.automationRules[0]).toHaveProperty(
       "activationStatus",
       "active",
@@ -698,6 +706,7 @@ describe("mission control automation dashboard summary", () => {
       pausedRules: 0,
       readyRules: 0,
       draftRules: 0,
+      invalidRules: 0,
       executions24h: 0,
       failedRuns24h: 0,
       activityLogBacked: true,


### PR DESCRIPTION
## Summary
- replace the Automations page demo flows/stats/provider health with the persisted Mission Control automations dashboard hook
- add loading, error, empty, filtered, and telemetry-not-wired states using shared UI primitives
- add focused unit coverage that locks out the old demo data and fake controls

## Verification
- node scripts/run-with-ci-env.mjs -- bunx vitest run tests/unit/apps/admin/app/automations-page.test.tsx tests/unit/packages/api/admin/mission-control-automations.test.ts tests/unit/packages/api/admin/mission-control-automations-route.test.ts
- bunx turbo run typecheck --filter=@asym/admin --filter=@asym/database
- bunx turbo run lint --filter=@asym/admin --filter=@asym/database
- bun run ci:preflight

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the Automations page's hardcoded demo data with live data from the persisted `useMissionControlAutomations` hook, and extracts a new shared `resolveMissionControlAutomationLifecycle` utility in `packages/database/mission-control-automations.ts` that correctly resolves display status and summary bucket from `enabled`/`activationStatus` — fixing the previously reported mislabel where `enabled: true` overrode `activationStatus`.

- **`packages/database/mission-control-automations.ts`** (new): single source of truth for lifecycle resolution; `activationStatus: "active"` with `enabled: false` → "Invalid", all other non-active statuses resolved independently of `enabled`, falling through to "Draft" when `activationStatus` is absent.
- **`apps/admin/app/automations/page-client.tsx`**: replaces four hardcoded constants with real hook data, adds loading skeletons, error alerts, empty states (no rules, filtered no-match, missing summary, and error-blocked), and exports `AutomationsPageView`/`filterAutomationRules` as named exports for unit testability.
- **`packages/api/…/store.ts` + `types.ts`**: introduces the `invalidRules` bucket and routes `countRuleSummary` through the shared lifecycle resolver; the store-level test adds a sum-invariant assertion that all buckets total `totalRules`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changed paths are guarded by explicit error/loading/empty states and the new shared lifecycle resolver correctly handles every enabled/activationStatus combination.

The previously reported mislabel (Active shown when activationStatus was paused) is eliminated by centralizing resolution in resolveMissionControlAutomationLifecycle. Demo constants are fully removed, the invalidRules bucket is wired end-to-end from types through store to UI, and the new test suite locks down every rendering branch. No data integrity, auth, schema, or runtime correctness issues were found in the changed files.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/database/mission-control-automations.ts | New module centralizing lifecycle resolution logic; correctly handles all enabled/activationStatus combinations including the previously-reported mislabel bug. |
| apps/admin/app/automations/page-client.tsx | Full replacement of hardcoded demo data with live hook data; adds loading/error/empty/filtered states, delegates status resolution to the new shared module, and exports AutomationsPageView/filterAutomationRules for test isolation. |
| packages/api/src/admin/mission-control-automations/store.ts | Refactors countRuleSummary to route through resolveMissionControlAutomationLifecycle and adds the new invalidRules bucket; disabled rules continue to land in pausedRules consistent with prior behavior. |
| packages/api/src/admin/mission-control-automations/types.ts | Adds invalidRules: number to MissionControlAutomationSummary; kept in sync with the hooks-layer interface. |
| packages/database/hooks/mission-control-automations.ts | De-duplicates MissionControlAutomationActivationStatus by re-exporting from the new shared module; adds invalidRules to the summary DTO. |
| packages/database/package.json | Registers the new ./mission-control-automations export entry; follows the established pattern of exporting .ts sources directly. |
| tests/unit/apps/admin/app/automations-page.test.tsx | New test file with thorough coverage of loading, error, empty, filtered, and telemetry-not-wired states; includes fixture for the previously-reported invalid lifecycle combination. |
| tests/unit/packages/api/admin/mission-control-automations.test.ts | Adds invalidRules assertions and a sum-invariant check that validates all bucket counts total to totalRules. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["AutomationsPage (default export)"] -->|"useMissionControlAutomations()"| B["TanStack Query"]
    B -->|"data / error / isPending"| C["AutomationsPageView (named export)"]

    C --> D{"isLoading?"}
    D -->|yes| E["Skeleton stat cards\n+ RulesLoadingState"]
    D -->|no| F{"isError?"}
    F -->|yes| G["AutomationsErrorAlert\n+ RulesCardBody isBlocked=true"]
    F -->|no| H{"missingSummary?"}
    H -->|yes| I["AutomationsErrorAlert 'missing summary'\n+ RulesCardBody isBlocked=true"]
    H -->|no| J{"allRuleCount === 0?"}
    J -->|yes| K["Empty: No automation rules yet"]
    J -->|no| L{"filteredRules.length === 0?"}
    L -->|yes| M["Empty: No matching rules"]
    L -->|no| N["AutomationRuleRow list"]

    N --> O["resolveMissionControlAutomationLifecycle(rule)"]
    O --> P{"enabled && status=active?"}
    P -->|yes| Q["Active / activeRules"]
    P -->|no| R{"status=active?"}
    R -->|yes| S["Invalid / invalidRules"]
    R -->|no| T{"status=paused?"}
    T -->|yes| U["Paused / pausedRules"]
    T -->|no| V{"status=disabled?"}
    V -->|yes| W["Disabled / pausedRules"]
    V -->|no| X{"status=ready?"}
    X -->|yes| Y["Ready / readyRules"]
    X -->|no| Z["Draft / draftRules"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["AutomationsPage (default export)"] -->|"useMissionControlAutomations()"| B["TanStack Query"]
    B -->|"data / error / isPending"| C["AutomationsPageView (named export)"]

    C --> D{"isLoading?"}
    D -->|yes| E["Skeleton stat cards\n+ RulesLoadingState"]
    D -->|no| F{"isError?"}
    F -->|yes| G["AutomationsErrorAlert\n+ RulesCardBody isBlocked=true"]
    F -->|no| H{"missingSummary?"}
    H -->|yes| I["AutomationsErrorAlert 'missing summary'\n+ RulesCardBody isBlocked=true"]
    H -->|no| J{"allRuleCount === 0?"}
    J -->|yes| K["Empty: No automation rules yet"]
    J -->|no| L{"filteredRules.length === 0?"}
    L -->|yes| M["Empty: No matching rules"]
    L -->|no| N["AutomationRuleRow list"]

    N --> O["resolveMissionControlAutomationLifecycle(rule)"]
    O --> P{"enabled && status=active?"}
    P -->|yes| Q["Active / activeRules"]
    P -->|no| R{"status=active?"}
    R -->|yes| S["Invalid / invalidRules"]
    R -->|no| T{"status=paused?"}
    T -->|yes| U["Paused / pausedRules"]
    T -->|no| V{"status=disabled?"}
    V -->|yes| W["Disabled / pausedRules"]
    V -->|no| X{"status=ready?"}
    X -->|yes| Y["Ready / readyRules"]
    X -->|no| Z["Draft / draftRules"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/unit/apps/admin/app/automations-page.test.tsx`, line 1018-1073 ([link](https://github.com/asymmetric-al/core/blob/e2f20e4d2bd3566f57dc4ac5cc37f529f6781616/tests/unit/apps/admin/app/automations-page.test.tsx#L1018-L1073)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing coverage for `enabled`/`activationStatus` conflict in `getRuleStatus`**

   The test fixture only exercises combinations where `enabled` and `activationStatus` agree (`enabled:true` + `"active"`, `enabled:false` + `"draft"`). There is no test for a rule with `enabled:true` and `activationStatus:"paused"` (or `"disabled"`), which is the exact combination where the current logic silently produces a wrong badge. Adding a case for that combination would have caught the bug in `getRuleStatus` and protects against future regressions.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Funit%2Fapps%2Fadmin%2Fapp%2Fautomations-page.test.tsx%0ALine%3A%201018-1073%0A%0AComment%3A%0A**Missing%20coverage%20for%20%60enabled%60%2F%60activationStatus%60%20conflict%20in%20%60getRuleStatus%60**%0A%0AThe%20test%20fixture%20only%20exercises%20combinations%20where%20%60enabled%60%20and%20%60activationStatus%60%20agree%20%28%60enabled%3Atrue%60%20%2B%20%60%22active%22%60%2C%20%60enabled%3Afalse%60%20%2B%20%60%22draft%22%60%29.%20There%20is%20no%20test%20for%20a%20rule%20with%20%60enabled%3Atrue%60%20and%20%60activationStatus%3A%22paused%22%60%20%28or%20%60%22disabled%22%60%29%2C%20which%20is%20the%20exact%20combination%20where%20the%20current%20logic%20silently%20produces%20a%20wrong%20badge.%20Adding%20a%20case%20for%20that%20combination%20would%20have%20caught%20the%20bug%20in%20%60getRuleStatus%60%20and%20protects%20against%20future%20regressions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=404&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["feat(admin): wire automations dashboard ..."](https://github.com/asymmetric-al/core/commit/781ad51381d9a62d4e34c10f448d5c4bd0930828) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38965623)</sub>

<!-- /greptile_comment -->