### PR TITLE
fix(crm): remove dead gift receipt resend field

### DIFF
--- a/packages/api/src/admin/crm/detail/gift-history.ts
+++ b/packages/api/src/admin/crm/detail/gift-history.ts
@@ -85,9 +85,6 @@ export function buildCrmGiftHistoryRow(
     providerPaymentIntentId: input.provider?.stripePaymentIntentId ?? null,
     viewerCapabilities: input.viewerCapabilities ?? [],
   });
-  const receiptAvailability = availability.find(
-    (entry) => entry.actionType === "resend_receipt",
-  );
 
   return {
     shared,
@@ -105,7 +102,6 @@ export function buildCrmGiftHistoryRow(
     fundName: shared.designationSummary.fundName,
     missionaryId: shared.designationSummary.missionaryId,
     missionaryName: shared.designationSummary.missionaryName,
-    canResendReceipt: receiptAvailability?.available ?? false,
     stagedGiftId: stagedGift?.id ?? null,
     twentyRecordId: stagedGift?.twenty_record_id ?? null,
     inlineActions,

--- a/packages/database/hooks/admin-crm-detail.ts
+++ b/packages/database/hooks/admin-crm-detail.ts
@@ -82,32 +82,6 @@ async function createLinkedCrmNote(input: {
   return (await response.json()) as AdminCrmNoteCreateResponse;
 }
 
-async function resendStagedGiftReceipt(input: { stagedGiftId: string }) {
-  const response = await fetch(
-    `/api/admin/contributions/staged-gifts/${input.stagedGiftId}/receipt`,
-    {
-      body: JSON.stringify({}),
-      credentials: "same-origin",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-      method: "POST",
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(
-      await parseJsonError(
-        response,
-        `Failed to resend receipt (${response.status})`,
-      ),
-    );
-  }
-
-  return (await response.json()) as { receipt: unknown; requestId?: string };
-}
-
 export function useAdminCrmRecordDetail(recordId: string | null) {
   return useQuery({
     enabled: Boolean(recordId),
@@ -140,27 +114,6 @@ export function useCreateLinkedCrmNote(recordId: string | null) {
     },
     scope: {
       id: recordId ? `crm-note:${recordId}` : "crm-note",
-    },
-  });
-}
-
-export function useResendCrmGiftReceipt(recordId: string | null) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: resendStagedGiftReceipt,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: CRM_DETAIL_QUERY_KEY,
-        }),
-        queryClient.invalidateQueries({
-          queryKey: CRM_RECORDS_QUERY_KEY,
-        }),
-      ]);
-    },
-    scope: {
-      id: recordId ? `crm-receipt:${recordId}` : "crm-receipt",
     },
   });
 }

--- a/packages/database/hooks/index.ts
+++ b/packages/database/hooks/index.ts
@@ -18,7 +18,6 @@ export {
   ADMIN_CRM_RECORDS_QUERY_KEY,
   useAdminCrmRecordDetail,
   useCreateLinkedCrmNote,
-  useResendCrmGiftReceipt,
 } from "./admin-crm-detail";
 export { useAdminCrmNotesGrid } from "./admin-crm-notes";
 export {

--- a/packages/database/types/crm-detail.ts
+++ b/packages/database/types/crm-detail.ts
@@ -67,7 +67,6 @@ export interface CrmGiftHistoryRow {
   fundName: string | null;
   missionaryId: string | null;
   missionaryName: string | null;
-  canResendReceipt: boolean;
   /** Inline operation parity with contribution detail (issue #270). */
   inlineActions?: CrmGiftInlineActions;
 }

--- a/tests/unit/packages/api/admin-crm-detail-report.test.ts
+++ b/tests/unit/packages/api/admin-crm-detail-report.test.ts
@@ -222,7 +222,6 @@ describe("Phase 5 CRM donor detail and reports", () => {
 
     expect(detail.donor.name).toBe("Ada Donor");
     expect(detail.giftHistory[0]).toMatchObject({
-      canResendReceipt: true,
       currencyCode: "USD",
       stagedGiftId: "staged-gift-1",
       twentyRecordId: "twenty-gift-1",


### PR DESCRIPTION
## Summary
- remove the unused CRM staged-gift receipt resend hook/export
- drop the dead `CrmGiftHistoryRow.canResendReceipt` field from the CRM detail contract
- update the CRM detail fixture assertion to rely on the current inline action contract

Split 20 of #251. This lands the remaining hardening plan 001 before the docs PR is merged last.

## Verification
- `node scripts/run-with-ci-env.mjs -- bunx vitest run tests/unit/packages/api/admin-crm-detail-report.test.ts tests/unit/packages/api/admin/crm-gift-history-row.test.ts`
- `bunx turbo run typecheck --filter=@asym/api --filter=@asym/database`
- `bunx turbo run lint --filter=@asym/api --filter=@asym/database`
- pre-push `bun run ci:preflight`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Removes the unused CRM staged-gift receipt resend hook and package export.
- Drops `canResendReceipt` from the CRM gift history row contract and response builder.
- Updates the CRM detail fixture assertion to rely on the existing inline action contract.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are narrowly scoped to removing a dead CRM receipt resend field/export and updating the corresponding test expectation.

No correctness issues were identified in the finalized review data, and the PR description reports targeted unit, typecheck, lint, and preflight coverage for the affected API and database packages.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Viewed the CRM Gift History Contract before-and-after logs to capture the revision strings and key fields.
- Compared the before and after states to confirm canResendReceipt is present in the before top-level keys and removed in the after state, while inlineActions remain retry\_staged\_gift and resend\_receipt.
- Verified that row construction exited with code 0 in both states and that tests passed.

<a href="https://app.greptile.com/trex/runs/11828054/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(crm): remove dead gift receipt resen..."](https://github.com/asymmetric-al/core/commit/3790280842acfe41d10570f8076e25be16d040b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38976736)</sub>

<!-- /greptile_comment -->