### PR TITLE
Preserve contribution detail loader coverage

### DIFF
--- a/packages/api/src/admin/contribution-operations/operations.ts
+++ b/packages/api/src/admin/contribution-operations/operations.ts
@@ -12,8 +12,12 @@ import {
   loadStripeRawEventForReplay,
   markStripeRawEventForReplay,
 } from "../../stripe/replay";
-import { mapContributionAdjustmentRow } from "../contribution-shared/effective-values";
+import {
+  deriveEffectiveContribution,
+  mapContributionAdjustmentRow,
+} from "../contribution-shared/effective-values";
 
+import type { CrmPostLinkInput } from "./crm-post-state";
 import type { ContributionDetail } from "./detail-read-model";
 import type {
   ReceiptDeliveryOutcome,
@@ -24,7 +28,10 @@ import type {
   ContributionActionType,
   ContributionSourceSurface,
 } from "./types";
-import type { DesignationFundInput } from "../contribution-shared/designation-set";
+import type {
+  DesignationAllocationInput,
+  DesignationFundInput,
+} from "../contribution-shared/designation-set";
 import type {
   ContributionAdjustmentEffectiveValues,
   ContributionAdjustmentRecord,
@@ -47,6 +54,10 @@ function asString(value: unknown): string | null {
 
 function asNumber(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function asNullableNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function assertNoError(
@@ -113,59 +124,207 @@ async function loadContributionAdjustments(input: {
   return ((data ?? []) as JsonRecord[]).map(mapContributionAdjustmentRow);
 }
 
-function collectAdjustmentFundIds(input: {
-  donationFundId: string | null;
-  adjustments: ContributionAdjustmentRecord[];
-}) {
-  const fundIds = new Set<string>();
-  const addFundId = (value: unknown) => {
-    if (typeof value === "string" && value.trim().length > 0) {
-      fundIds.add(value);
-    }
-  };
-
-  addFundId(input.donationFundId);
-
-  for (const adjustment of input.adjustments) {
-    addFundId(adjustment.effectiveValues.fundId);
-
-    for (const line of adjustment.effectiveValues.designationLines ?? []) {
-      addFundId(line.fundId);
-    }
-  }
-
-  return [...fundIds];
-}
-
-async function loadDesignationFunds(input: {
+async function maybeFetchTenantRow(input: {
   supabaseAdmin: SupabaseAdmin;
+  table: string;
   tenantId: string;
-  fundIds: string[];
-}): Promise<DesignationFundInput[]> {
-  const queryableIds = input.fundIds.filter(isUuid);
-
-  if (queryableIds.length === 0) {
-    return [];
+  id: string | null;
+  select: string;
+}): Promise<JsonRecord | null> {
+  if (!input.id) {
+    return null;
   }
 
   const { data, error } = await input.supabaseAdmin
-    .from("funds")
-    .select("id, name, missionary_id, goal_amount, start_date, end_date")
+    .from(input.table)
+    .select(input.select)
     .eq("tenant_id", input.tenantId)
-    .in("id", queryableIds);
+    .eq("id", input.id)
+    .maybeSingle();
 
-  assertNoError(error, "Failed to load contribution fund metadata.");
+  assertNoError(error, `Failed to load ${input.table}.`);
+  return isRecord(data) ? data : null;
+}
 
-  return ((data ?? []) as JsonRecord[]).map((row) => ({
+function profileDisplayName(profile: unknown): string | null {
+  const profileRecord = isRecord(profile) ? profile : {};
+  const firstLastName = [
+    asString(profileRecord.first_name),
+    asString(profileRecord.last_name),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return (
+    asString(profileRecord.display_name) ??
+    asString(profileRecord.full_name) ??
+    asString(firstLastName) ??
+    asString(profileRecord.email)
+  );
+}
+
+async function fetchMissionaryLabel(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  missionaryId: string | null;
+}): Promise<{ id: string; name: string | null } | null> {
+  if (!input.missionaryId || !isUuid(input.missionaryId)) {
+    return null;
+  }
+
+  const { data, error } = await input.supabaseAdmin
+    .from("missionaries")
+    .select(
+      "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)",
+    )
+    .eq("tenant_id", input.tenantId)
+    .eq("id", input.missionaryId)
+    .maybeSingle();
+
+  assertNoError(error, "Failed to load missionary.");
+  if (!isRecord(data)) {
+    return null;
+  }
+
+  return {
+    id: asString(data.id) ?? input.missionaryId,
+    name: profileDisplayName(data.profile),
+  };
+}
+
+function uniqueReferenceIds(ids: Array<string | null | undefined>): string[] {
+  return Array.from(
+    new Set(
+      ids.filter((id): id is string => typeof id === "string" && id !== ""),
+    ),
+  );
+}
+
+async function loadDesignationSetData(input: {
+  supabaseAdmin: SupabaseAdmin;
+  tenantId: string;
+  stagedGiftId: string | null;
+  donationFundId: string | null;
+  extraFundIds: Array<string | null | undefined>;
+  extraMissionaryIds: Array<string | null | undefined>;
+}): Promise<{
+  allocations: DesignationAllocationInput[];
+  funds: DesignationFundInput[];
+  missionaries: Array<{ id: string; display_name: string | null }>;
+}> {
+  const allocationsResult = input.stagedGiftId
+    ? await input.supabaseAdmin
+        .from("staged_gift_allocations")
+        .select("id, amount, fund_id, missionary_id, memo")
+        .eq("tenant_id", input.tenantId)
+        .eq("staged_gift_id", input.stagedGiftId)
+        .order("created_at", { ascending: true })
+    : { data: [], error: null };
+
+  assertNoError(allocationsResult.error, "Failed to load designation lines.");
+
+  const allocations = ((allocationsResult.data ?? []) as JsonRecord[]).map(
+    (row) => ({
+      id: asString(row.id) ?? "",
+      amount: asNumber(row.amount),
+      fund_id: asString(row.fund_id),
+      missionary_id: asString(row.missionary_id),
+      memo: asString(row.memo),
+    }),
+  );
+
+  const fundIds = uniqueReferenceIds([
+    input.donationFundId,
+    ...input.extraFundIds,
+    ...allocations.map((allocation) => allocation.fund_id),
+  ]);
+  const missionaryIds = uniqueReferenceIds([
+    ...input.extraMissionaryIds,
+    ...allocations.map((allocation) => allocation.missionary_id),
+  ]);
+  const queryableFundIds = fundIds.filter(isUuid);
+  const queryableMissionaryIds = missionaryIds.filter(isUuid);
+
+  const [fundsResult, missionariesResult] = await Promise.all([
+    queryableFundIds.length > 0
+      ? input.supabaseAdmin
+          .from("funds")
+          .select("id, name, missionary_id, goal_amount, start_date, end_date")
+          .eq("tenant_id", input.tenantId)
+          .in("id", queryableFundIds)
+      : Promise.resolve({ data: [], error: null }),
+    queryableMissionaryIds.length > 0
+      ? input.supabaseAdmin
+          .from("missionaries")
+          .select(
+            "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)",
+          )
+          .eq("tenant_id", input.tenantId)
+          .in("id", queryableMissionaryIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  assertNoError(
+    fundsResult.error,
+    "Failed to load contribution fund metadata.",
+  );
+  assertNoError(
+    missionariesResult.error,
+    "Failed to load contribution missionary metadata.",
+  );
+
+  const funds = ((fundsResult.data ?? []) as JsonRecord[]).map((row) => ({
     id: asString(row.id) ?? "",
     name: asString(row.name),
     missionary_id: asString(row.missionary_id),
-    goal_amount:
-      typeof row.goal_amount === "number" && Number.isFinite(row.goal_amount)
-        ? row.goal_amount
-        : null,
+    goal_amount: asNullableNumber(row.goal_amount),
     start_date: asString(row.start_date),
     end_date: asString(row.end_date),
+  }));
+
+  const missionaries = ((missionariesResult.data ?? []) as JsonRecord[]).map(
+    (row) => ({
+      id: asString(row.id) ?? "",
+      display_name: profileDisplayName(row.profile),
+    }),
+  );
+
+  return { allocations, funds, missionaries };
+}
+
+type EffectiveContributionDesignationLines = NonNullable<
+  ContributionAdjustmentEffectiveValues["designationLines"]
+> | null;
+
+function collectEffectiveReferenceIds(input: {
+  effective: { fundId: string | null; missionaryId: string | null };
+  effectiveDesignationLines: EffectiveContributionDesignationLines | null;
+}): {
+  fundIds: Array<string | null | undefined>;
+  missionaryIds: Array<string | null | undefined>;
+} {
+  const fundIds: Array<string | null | undefined> = [input.effective.fundId];
+  const missionaryIds: Array<string | null | undefined> = [
+    input.effective.missionaryId,
+  ];
+
+  for (const line of input.effectiveDesignationLines ?? []) {
+    fundIds.push(line.fundId);
+    missionaryIds.push(line.missionaryId);
+  }
+
+  return { fundIds, missionaryIds };
+}
+
+function mapCrmLinks(rows: unknown): CrmPostLinkInput[] {
+  return ((rows ?? []) as JsonRecord[]).map((link) => ({
+    id: asString(link.id) ?? "",
+    scope: link.scope === "designation" ? "designation" : "parent",
+    allocationId: asString(link.allocation_id),
+    linkStatus: asString(link.link_status),
+    twentyRecordId: asString(link.twenty_record_id),
+    lastError: asString(link.last_error),
   }));
 }
 
@@ -188,32 +347,92 @@ async function loadContributionOperationDetail(input: {
   }
 
   const donation = normalizeDonation(donationResult.data);
-  const [adjustments, stagedGiftResult, auditResult, correctionResult] =
-    await Promise.all([
-      loadContributionAdjustments(input),
-      input.supabaseAdmin
-        .from("staged_gifts")
-        .select(
-          "id, donation_id, status, review_reason, receipt_status, crm_post_status, twenty_record_id",
-        )
-        .eq("tenant_id", input.tenantId)
-        .eq("donation_id", input.contributionId)
-        .maybeSingle(),
-      input.supabaseAdmin
-        .from("contribution_operation_audit_events")
-        .select("id, operation, source_surface, reason, created_at")
-        .eq("tenant_id", input.tenantId)
-        .eq("donation_id", input.contributionId)
-        .order("created_at", { ascending: false })
-        .limit(50),
-      input.supabaseAdmin
-        .from("contribution_corrections")
-        .select("id, correction_type, status")
-        .eq("tenant_id", input.tenantId)
-        .eq("donation_id", input.contributionId)
-        .order("created_at", { ascending: false })
-        .limit(50),
-    ]);
+  const adjustments = await loadContributionAdjustments(input);
+  const effectivePreview = deriveEffectiveContribution({
+    original: {
+      amountCents: donation.amount,
+      fundId: donation.fundId,
+      missionaryId: donation.missionaryId,
+      paymentStatus: donation.status ?? "pending",
+    },
+    adjustments,
+  });
+  const effectiveReferences = collectEffectiveReferenceIds({
+    effective: effectivePreview.effective,
+    effectiveDesignationLines: effectivePreview.effectiveDesignationLines,
+  });
+
+  const [
+    donorRow,
+    missionary,
+    stagedGiftResult,
+    auditResult,
+    correctionResult,
+    correctionRequestResult,
+    crmLinksResult,
+    pledgeRow,
+  ] = await Promise.all([
+    maybeFetchTenantRow({
+      supabaseAdmin: input.supabaseAdmin,
+      table: "donors",
+      tenantId: input.tenantId,
+      id: donation.donorId,
+      select:
+        "id, profile_id, name, email, phone, mobile, location, organization",
+    }),
+    fetchMissionaryLabel({
+      supabaseAdmin: input.supabaseAdmin,
+      tenantId: input.tenantId,
+      missionaryId: donation.missionaryId,
+    }),
+    input.supabaseAdmin
+      .from("staged_gifts")
+      .select(
+        "id, donation_id, status, review_reason, receipt_status, crm_post_status, twenty_record_id",
+      )
+      .eq("tenant_id", input.tenantId)
+      .eq("donation_id", input.contributionId)
+      .maybeSingle(),
+    input.supabaseAdmin
+      .from("contribution_operation_audit_events")
+      .select("id, operation, source_surface, reason, created_at")
+      .eq("tenant_id", input.tenantId)
+      .eq("donation_id", input.contributionId)
+      .order("created_at", { ascending: false })
+      .limit(50),
+    input.supabaseAdmin
+      .from("contribution_corrections")
+      .select("id, correction_type, status")
+      .eq("tenant_id", input.tenantId)
+      .eq("donation_id", input.contributionId)
+      .order("created_at", { ascending: false })
+      .limit(50),
+    input.supabaseAdmin
+      .from("contribution_correction_requests")
+      .select(
+        "id, action_type, status, reason, requested_by_profile_id, created_at",
+      )
+      .eq("tenant_id", input.tenantId)
+      .eq("donation_id", input.contributionId)
+      .order("created_at", { ascending: false })
+      .limit(50),
+    input.supabaseAdmin
+      .from("donation_crm_links")
+      .select(
+        "id, scope, allocation_id, link_status, twenty_record_id, last_error",
+      )
+      .eq("tenant_id", input.tenantId)
+      .eq("donation_id", input.contributionId)
+      .order("created_at", { ascending: true }),
+    maybeFetchTenantRow({
+      supabaseAdmin: input.supabaseAdmin,
+      table: "donor_pledges",
+      tenantId: input.tenantId,
+      id: donation.pledgeId,
+      select:
+        "id, status, frequency, amount, currency, fund_id, missionary_id, next_payment_date, next_charge_at, stripe_subscription_id",
+    }),
+  ]);
 
   assertNoError(stagedGiftResult.error, "Failed to load staged gift.");
   assertNoError(auditResult.error, "Failed to load contribution audit.");
@@ -221,6 +440,11 @@ async function loadContributionOperationDetail(input: {
     correctionResult.error,
     "Failed to load contribution corrections.",
   );
+  assertNoError(
+    correctionRequestResult.error,
+    "Failed to load correction requests.",
+  );
+  assertNoError(crmLinksResult.error, "Failed to load CRM record links.");
 
   const stagedGift = isRecord(stagedGiftResult.data)
     ? {
@@ -232,17 +456,27 @@ async function loadContributionOperationDetail(input: {
         twentyRecordId: asString(stagedGiftResult.data.twenty_record_id),
       }
     : null;
-  const allocationFunds = await loadDesignationFunds({
+
+  const designationData = await loadDesignationSetData({
     supabaseAdmin: input.supabaseAdmin,
     tenantId: input.tenantId,
-    fundIds: collectAdjustmentFundIds({
-      donationFundId: donation.fundId,
-      adjustments,
-    }),
+    stagedGiftId: stagedGift?.id ?? null,
+    donationFundId: donation.fundId,
+    extraFundIds: effectiveReferences.fundIds,
+    extraMissionaryIds: effectiveReferences.missionaryIds,
   });
+  const pledgeFund = pledgeRow
+    ? await maybeFetchTenantRow({
+        supabaseAdmin: input.supabaseAdmin,
+        table: "funds",
+        tenantId: input.tenantId,
+        id: asString(pledgeRow.fund_id),
+        select: "id, name",
+      })
+    : null;
   const primaryFund =
     donation.fundId !== null
-      ? (allocationFunds.find((fund) => fund.id === donation.fundId) ?? {
+      ? (designationData.funds.find((fund) => fund.id === donation.fundId) ?? {
           id: donation.fundId,
           name: null,
         })
@@ -250,21 +484,35 @@ async function loadContributionOperationDetail(input: {
 
   return buildContributionDetail({
     donation,
-    donor: donation.donorId
+    donor: donorRow
       ? {
-          id: donation.donorId,
-          profileId: null,
-          name: null,
-          email: null,
-          phone: null,
-          location: null,
-          organization: null,
+          id: asString(donorRow.id) ?? donation.donorId ?? "",
+          profileId: asString(donorRow.profile_id),
+          name: asString(donorRow.name),
+          email: asString(donorRow.email),
+          phone: asString(donorRow.phone),
+          mobile: asString(donorRow.mobile),
+          location: asString(donorRow.location),
+          organization: asString(donorRow.organization),
         }
-      : null,
+      : donation.donorId
+        ? {
+            id: donation.donorId,
+            profileId: null,
+            name: null,
+            email: null,
+            phone: null,
+            mobile: null,
+            location: null,
+            organization: null,
+          }
+        : null,
     fund: primaryFund,
-    missionary: donation.missionaryId
-      ? { id: donation.missionaryId, name: null }
-      : null,
+    missionary:
+      missionary ??
+      (donation.missionaryId
+        ? { id: donation.missionaryId, name: null }
+        : null),
     stagedGift,
     auditEvents: ((auditResult.data ?? []) as JsonRecord[]).map((event) => ({
       id: asString(event.id) ?? "",
@@ -280,12 +528,37 @@ async function loadContributionOperationDetail(input: {
         status: asString(correction.status) ?? "pending",
       }),
     ),
-    correctionRequests: [],
+    correctionRequests: (
+      (correctionRequestResult.data ?? []) as JsonRecord[]
+    ).map((request) => ({
+      id: asString(request.id) ?? "",
+      actionType: asString(request.action_type) ?? "unknown",
+      status: asString(request.status) ?? "pending",
+      reason: asString(request.reason) ?? "",
+      requestedByProfileId: asString(request.requested_by_profile_id),
+      createdAt: asString(request.created_at) ?? new Date(0).toISOString(),
+    })),
     adjustments,
-    allocations: [],
-    allocationFunds,
-    allocationMissionaries: [],
-    crmLinks: [],
+    allocations: designationData.allocations,
+    allocationFunds: designationData.funds,
+    allocationMissionaries: designationData.missionaries,
+    crmLinks: mapCrmLinks(crmLinksResult.data),
+    recurringAgreement: pledgeRow
+      ? {
+          id: asString(pledgeRow.id) ?? donation.pledgeId ?? "",
+          status: asString(pledgeRow.status),
+          frequency: asString(pledgeRow.frequency),
+          amountCents: asNumber(pledgeRow.amount),
+          currencyCode: (asString(pledgeRow.currency) ?? "usd").toUpperCase(),
+          fundId: asString(pledgeRow.fund_id),
+          fundName: pledgeFund ? asString(pledgeFund.name) : null,
+          missionaryId: asString(pledgeRow.missionary_id),
+          nextExpectedGiftAt:
+            asString(pledgeRow.next_charge_at) ??
+            asString(pledgeRow.next_payment_date),
+          stripeSubscriptionId: asString(pledgeRow.stripe_subscription_id),
+        }
+      : null,
   });
 }
 

--- a/packages/api/src/admin/contribution-operations/operations.ts
+++ b/packages/api/src/admin/contribution-operations/operations.ts
@@ -16,6 +16,7 @@ import {
   deriveEffectiveContribution,
   mapContributionAdjustmentRow,
 } from "../contribution-shared/effective-values";
+import { resolveContributionProfileLabel } from "../contribution-shared/profile-label";
 
 import type { CrmPostLinkInput } from "./crm-post-state";
 import type { ContributionDetail } from "./detail-read-model";
@@ -146,53 +147,6 @@ async function maybeFetchTenantRow(input: {
   return isRecord(data) ? data : null;
 }
 
-function profileDisplayName(profile: unknown): string | null {
-  const profileRecord = isRecord(profile) ? profile : {};
-  const firstLastName = [
-    asString(profileRecord.first_name),
-    asString(profileRecord.last_name),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
-
-  return (
-    asString(profileRecord.display_name) ??
-    asString(profileRecord.full_name) ??
-    asString(firstLastName) ??
-    asString(profileRecord.email)
-  );
-}
-
-async function fetchMissionaryLabel(input: {
-  supabaseAdmin: SupabaseAdmin;
-  tenantId: string;
-  missionaryId: string | null;
-}): Promise<{ id: string; name: string | null } | null> {
-  if (!input.missionaryId || !isUuid(input.missionaryId)) {
-    return null;
-  }
-
-  const { data, error } = await input.supabaseAdmin
-    .from("missionaries")
-    .select(
-      "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)",
-    )
-    .eq("tenant_id", input.tenantId)
-    .eq("id", input.missionaryId)
-    .maybeSingle();
-
-  assertNoError(error, "Failed to load missionary.");
-  if (!isRecord(data)) {
-    return null;
-  }
-
-  return {
-    id: asString(data.id) ?? input.missionaryId,
-    name: profileDisplayName(data.profile),
-  };
-}
-
 function uniqueReferenceIds(ids: Array<string | null | undefined>): string[] {
   return Array.from(
     new Set(
@@ -286,7 +240,9 @@ async function loadDesignationSetData(input: {
   const missionaries = ((missionariesResult.data ?? []) as JsonRecord[]).map(
     (row) => ({
       id: asString(row.id) ?? "",
-      display_name: profileDisplayName(row.profile),
+      display_name: resolveContributionProfileLabel(
+        isRecord(row.profile) ? row.profile : null,
+      ),
     }),
   );
 
@@ -364,7 +320,6 @@ async function loadContributionOperationDetail(input: {
 
   const [
     donorRow,
-    missionary,
     stagedGiftResult,
     auditResult,
     correctionResult,
@@ -379,11 +334,6 @@ async function loadContributionOperationDetail(input: {
       id: donation.donorId,
       select:
         "id, profile_id, name, email, phone, mobile, location, organization",
-    }),
-    fetchMissionaryLabel({
-      supabaseAdmin: input.supabaseAdmin,
-      tenantId: input.tenantId,
-      missionaryId: donation.missionaryId,
     }),
     input.supabaseAdmin
       .from("staged_gifts")
@@ -457,22 +407,17 @@ async function loadContributionOperationDetail(input: {
       }
     : null;
 
+  const pledgeFundId = pledgeRow ? asString(pledgeRow.fund_id) : null;
   const designationData = await loadDesignationSetData({
     supabaseAdmin: input.supabaseAdmin,
     tenantId: input.tenantId,
     stagedGiftId: stagedGift?.id ?? null,
     donationFundId: donation.fundId,
-    extraFundIds: effectiveReferences.fundIds,
+    extraFundIds: [...effectiveReferences.fundIds, pledgeFundId],
     extraMissionaryIds: effectiveReferences.missionaryIds,
   });
-  const pledgeFund = pledgeRow
-    ? await maybeFetchTenantRow({
-        supabaseAdmin: input.supabaseAdmin,
-        table: "funds",
-        tenantId: input.tenantId,
-        id: asString(pledgeRow.fund_id),
-        select: "id, name",
-      })
+  const pledgeFund = pledgeFundId
+    ? (designationData.funds.find((fund) => fund.id === pledgeFundId) ?? null)
     : null;
   const primaryFund =
     donation.fundId !== null
@@ -481,6 +426,12 @@ async function loadContributionOperationDetail(input: {
           name: null,
         })
       : null;
+  const primaryMissionary = effectivePreview.effective.missionaryId
+    ? (designationData.missionaries.find(
+        (missionary) =>
+          missionary.id === effectivePreview.effective.missionaryId,
+      ) ?? null)
+    : null;
 
   return buildContributionDetail({
     donation,
@@ -508,11 +459,9 @@ async function loadContributionOperationDetail(input: {
           }
         : null,
     fund: primaryFund,
-    missionary:
-      missionary ??
-      (donation.missionaryId
-        ? { id: donation.missionaryId, name: null }
-        : null),
+    missionary: primaryMissionary
+      ? { id: primaryMissionary.id, name: primaryMissionary.display_name }
+      : null,
     stagedGift,
     auditEvents: ((auditResult.data ?? []) as JsonRecord[]).map((event) => ({
       id: asString(event.id) ?? "",

--- a/packages/api/src/admin/contribution-shared/index.ts
+++ b/packages/api/src/admin/contribution-shared/index.ts
@@ -17,6 +17,10 @@ export {
   type OriginalContributionValues,
 } from "./effective-values";
 export {
+  resolveContributionProfileLabel,
+  type ContributionProfileLabelInput,
+} from "./profile-label";
+export {
   buildContributionDesignationSet,
   deriveFundType,
   summarizeContributionDesignationSet,

--- a/packages/api/src/admin/contribution-shared/profile-label.ts
+++ b/packages/api/src/admin/contribution-shared/profile-label.ts
@@ -1,0 +1,26 @@
+export interface ContributionProfileLabelInput {
+  display_name?: string | null;
+  full_name?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  email?: string | null;
+}
+
+export function resolveContributionProfileLabel(
+  profile: ContributionProfileLabelInput | null | undefined,
+  fallback: string | null = null,
+): string | null {
+  const fullName = [profile?.first_name, profile?.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return (
+    profile?.display_name?.trim() ||
+    profile?.full_name?.trim() ||
+    fullName ||
+    profile?.email?.trim() ||
+    fallback?.trim() ||
+    null
+  );
+}

--- a/packages/api/src/admin/contributions/service.ts
+++ b/packages/api/src/admin/contributions/service.ts
@@ -5,6 +5,7 @@ import {
   type ContributionSortField,
 } from "./query";
 import { ApiHttpError } from "../../shared/http-errors";
+import { resolveContributionProfileLabel } from "../contribution-shared/profile-label";
 
 import type {
   AdminContributionsListResponse,
@@ -507,14 +508,7 @@ export async function listAdminContributions(
       missionary: missionaryProfile
         ? {
             id: missionary?.id ?? donation.missionary_id ?? "",
-            display_name:
-              (missionaryProfile.display_name ??
-                missionaryProfile.full_name ??
-                [missionaryProfile.first_name, missionaryProfile.last_name]
-                  .filter(Boolean)
-                  .join(" ")
-                  .trim()) ||
-              missionaryProfile.email,
+            display_name: resolveContributionProfileLabel(missionaryProfile),
           }
         : null,
       stagedGift: stagedGift ?? null,

--- a/packages/api/src/admin/crm/detail/service.ts
+++ b/packages/api/src/admin/crm/detail/service.ts
@@ -7,6 +7,7 @@ import {
   type ContributionAdjustmentRecord,
   type EffectiveContributionResult,
 } from "../../contribution-shared/effective-values";
+import { resolveContributionProfileLabel } from "../../contribution-shared/profile-label";
 
 import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
 import type { CrmDonorDetailResponse, UserRole } from "@asym/database/types";
@@ -110,6 +111,7 @@ interface LabelRow {
     full_name?: string | null;
     first_name?: string | null;
     last_name?: string | null;
+    email?: string | null;
   } | null;
 }
 
@@ -170,14 +172,7 @@ function previewNotes(notes: string | null): string | null {
 }
 
 function profileName(row: LabelRow): string | null {
-  const profile = row.profile ?? {};
-  return (
-    profile.display_name?.trim() ||
-    profile.full_name?.trim() ||
-    [profile.first_name, profile.last_name].filter(Boolean).join(" ").trim() ||
-    row.name?.trim() ||
-    null
-  );
+  return resolveContributionProfileLabel(row.profile, row.name ?? null);
 }
 
 function getLabel(
@@ -203,7 +198,7 @@ async function fetchLabels(
 
   const select =
     table === "missionaries"
-      ? "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name)"
+      ? "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)"
       : "id, name";
   const { data, error } = await supabaseAdmin
     .from(table)

--- a/packages/api/src/admin/crm/reports/service.ts
+++ b/packages/api/src/admin/crm/reports/service.ts
@@ -1,4 +1,5 @@
 import { ApiHttpError } from "../../../shared/http-errors";
+import { resolveContributionProfileLabel } from "../../contribution-shared/profile-label";
 
 import type { AdminCrmReportParams } from "./query";
 import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
@@ -34,6 +35,7 @@ interface LabelRow {
     full_name?: string | null;
     first_name?: string | null;
     last_name?: string | null;
+    email?: string | null;
   } | null;
 }
 
@@ -73,12 +75,8 @@ function matchesSearch(label: string, search: string | null) {
 }
 
 function profileName(row: LabelRow): string {
-  const profile = row.profile ?? {};
   return (
-    profile.display_name?.trim() ||
-    profile.full_name?.trim() ||
-    [profile.first_name, profile.last_name].filter(Boolean).join(" ").trim() ||
-    row.name?.trim() ||
+    resolveContributionProfileLabel(row.profile, row.name ?? null) ??
     "Unassigned"
   );
 }
@@ -136,7 +134,7 @@ async function fetchMissionaryLabels(
   const { data, error } = await supabaseAdmin
     .from("missionaries")
     .select(
-      "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name)",
+      "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)",
     )
     .in("id", ids);
   assertNoError(error, "Failed to load missionary labels.");

--- a/packages/api/src/admin/crm/service.ts
+++ b/packages/api/src/admin/crm/service.ts
@@ -5,6 +5,7 @@ import {
   type CrmSortField,
 } from "./query";
 import { ApiHttpError } from "../../shared/http-errors";
+import { resolveContributionProfileLabel } from "../contribution-shared/profile-label";
 
 import type { AdminCrmListResponse } from "./types";
 import type {
@@ -135,7 +136,7 @@ async function fetchMissionaryNames(
 
   const { data, error } = await supabaseAdmin
     .from("profiles")
-    .select("id, display_name, full_name, first_name, last_name")
+    .select("id, display_name, full_name, first_name, last_name, email")
     .in("id", missionaryProfileIds);
 
   if (error) {
@@ -150,12 +151,9 @@ async function fetchMissionaryNames(
       full_name: string | null;
       first_name: string | null;
       last_name: string | null;
+      email: string | null;
     };
-    const name =
-      r.display_name?.trim() ||
-      r.full_name?.trim() ||
-      [r.first_name, r.last_name].filter(Boolean).join(" ").trim() ||
-      null;
+    const name = resolveContributionProfileLabel(r);
     if (name) {
       map.set(r.id, name);
     }

--- a/tests/unit/packages/api/admin/contribution-effective-values.test.ts
+++ b/tests/unit/packages/api/admin/contribution-effective-values.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveEffectiveContribution } from "../../../../../packages/api/src/admin/contribution-shared/effective-values";
+
+const original = {
+  amountCents: 25_000,
+  fundId: "fund-1",
+  missionaryId: null,
+  paymentStatus: "completed",
+};
+
+function adjustment(
+  overrides: Partial<{
+    id: string;
+    adjustmentType: string;
+    status: "applied" | "reversed";
+    effectiveValues: Record<string, unknown>;
+    createdAt: string;
+  }> = {},
+) {
+  return {
+    id: "adj-1",
+    adjustmentType: "amount_correction",
+    status: "applied" as const,
+    effectiveValues: {},
+    reason: "data entry error",
+    actorProfileId: "profile-1",
+    sourceSurface: "contribution_hub",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("admin/contribution-shared/effective-values", () => {
+  it("derives effective values from the original donation plus applied adjustments", () => {
+    const result = deriveEffectiveContribution({
+      original,
+      adjustments: [
+        adjustment({
+          id: "adj-1",
+          effectiveValues: { amountCents: 20_000 },
+          createdAt: "2026-06-01T00:00:00.000Z",
+        }),
+        adjustment({
+          id: "adj-2",
+          adjustmentType: "fund_correction",
+          effectiveValues: { fundId: "fund-2" },
+          createdAt: "2026-06-02T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(result.effective).toEqual({
+      amountCents: 20_000,
+      fundId: "fund-2",
+      missionaryId: null,
+      paymentStatus: "completed",
+    });
+    expect(result.changedFields.sort()).toEqual(["amountCents", "fundId"]);
+    expect(result.materiallyDiffers).toBe(true);
+  });
+
+  it("ignores reversed adjustments and preserves the original untouched", () => {
+    const result = deriveEffectiveContribution({
+      original,
+      adjustments: [
+        adjustment({
+          status: "reversed",
+          effectiveValues: { amountCents: 1 },
+        }),
+      ],
+    });
+
+    expect(result.effective.amountCents).toBe(25_000);
+    expect(result.materiallyDiffers).toBe(false);
+    expect(original.amountCents).toBe(25_000);
+  });
+
+  it("applies adjustments in chronological order so the latest value wins", () => {
+    const result = deriveEffectiveContribution({
+      original,
+      adjustments: [
+        adjustment({
+          id: "adj-late",
+          effectiveValues: { amountCents: 18_000 },
+          createdAt: "2026-06-05T00:00:00.000Z",
+        }),
+        adjustment({
+          id: "adj-early",
+          effectiveValues: { amountCents: 22_000 },
+          createdAt: "2026-06-01T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(result.effective.amountCents).toBe(18_000);
+  });
+
+  it("returns no changes for a donation without adjustments", () => {
+    const result = deriveEffectiveContribution({
+      original,
+      adjustments: [],
+    });
+
+    expect(result.effective).toEqual(original);
+    expect(result.changedFields).toEqual([]);
+    expect(result.materiallyDiffers).toBe(false);
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-operations-store.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-store.test.ts
@@ -9,35 +9,68 @@ type QueryResult = {
   error: null;
 };
 
+type SupabaseQueryState = {
+  table: string;
+  select: string | null;
+  eqFilters: Map<string, unknown>;
+  inFilters: Map<string, unknown[]>;
+  orderBy: Array<{ column: string; ascending?: boolean }>;
+  limitCount: number | null;
+};
+
+type QueryResolver = QueryResult | ((query: SupabaseQueryState) => QueryResult);
+
+const emptyRows = { data: [], error: null } satisfies QueryResult;
+const nullRow = { data: null, error: null } satisfies QueryResult;
+
 class SupabaseQueryStub {
-  constructor(private readonly result: QueryResult) {}
+  private readonly state: SupabaseQueryState;
 
-  select(): this {
+  constructor(
+    table: string,
+    private readonly resolver: QueryResolver,
+  ) {
+    this.state = {
+      table,
+      select: null,
+      eqFilters: new Map(),
+      inFilters: new Map(),
+      orderBy: [],
+      limitCount: null,
+    };
+  }
+
+  select(columns: string): this {
+    this.state.select = columns;
     return this;
   }
 
-  eq(): this {
+  eq(column: string, value: unknown): this {
+    this.state.eqFilters.set(column, value);
     return this;
   }
 
-  in(): this {
+  in(column: string, values: unknown[]): this {
+    this.state.inFilters.set(column, values);
     return this;
   }
 
-  order(): this {
+  order(column: string, options?: { ascending?: boolean }): this {
+    this.state.orderBy.push({ column, ascending: options?.ascending });
     return this;
   }
 
-  limit(): Promise<QueryResult> {
-    return Promise.resolve(this.result);
+  limit(count: number): Promise<QueryResult> {
+    this.state.limitCount = count;
+    return this.resolve();
   }
 
   maybeSingle(): Promise<QueryResult> {
-    return Promise.resolve(this.result);
+    return this.resolve();
   }
 
   single(): Promise<QueryResult> {
-    return Promise.resolve(this.result);
+    return this.resolve();
   }
 
   then<TResult1 = QueryResult, TResult2 = never>(
@@ -46,29 +79,54 @@ class SupabaseQueryStub {
       | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2> {
-    return Promise.resolve(this.result).then(onfulfilled, onrejected);
+    return this.resolve().then(onfulfilled, onrejected);
+  }
+
+  private resolve(): Promise<QueryResult> {
+    const result =
+      typeof this.resolver === "function"
+        ? this.resolver(this.state)
+        : this.resolver;
+    return Promise.resolve(result);
   }
 }
 
 function createSupabaseStub(
-  resultsByTable: Record<string, QueryResult | QueryResult[]>,
+  resultsByTable: Record<string, QueryResolver>,
 ): AdminSupabaseClient {
-  const remainingResults = new Map(
-    Object.entries(resultsByTable).map(([table, result]) => [
-      table,
-      Array.isArray(result) ? [...result] : [result],
-    ]),
-  );
-
   return {
     from(table: string) {
-      const tableResults = remainingResults.get(table) ?? [];
-      const nextResult = tableResults.shift() ?? { data: null, error: null };
-      remainingResults.set(table, tableResults);
+      const resolver = resultsByTable[table];
+      if (!resolver) {
+        throw new Error(`Unexpected Supabase table query: ${table}`);
+      }
 
-      return new SupabaseQueryStub(nextResult);
+      return new SupabaseQueryStub(table, resolver);
     },
   } as unknown as AdminSupabaseClient;
+}
+
+function expectTenantScoped(query: SupabaseQueryState, tenantId: string): void {
+  expect(query.eqFilters.get("tenant_id")).toBe(tenantId);
+}
+
+function expectIncludesIds(
+  query: SupabaseQueryState,
+  expectedIds: string[],
+): void {
+  expect(new Set(query.inFilters.get("id") ?? [])).toEqual(
+    new Set(expectedIds),
+  );
+}
+
+function baseContributionTables() {
+  return {
+    staged_gifts: nullRow,
+    contribution_operation_audit_events: emptyRows,
+    contribution_corrections: emptyRows,
+    contribution_correction_requests: emptyRows,
+    donation_crm_links: emptyRows,
+  } satisfies Record<string, QueryResolver>;
 }
 
 describe("contribution operations store", () => {
@@ -76,6 +134,7 @@ describe("contribution operations store", () => {
     const tenantId = "00000000-0000-4000-8000-000000000001";
     const donationId = "00000000-0000-4000-8000-000000000002";
     const missionaryId = "00000000-0000-4000-8000-000000000003";
+    const queriedMissionaryIds: unknown[][] = [];
     const supabaseAdmin = createSupabaseStub({
       donations: {
         data: {
@@ -94,22 +153,12 @@ describe("contribution operations store", () => {
         },
         error: null,
       },
-      contribution_adjustments: { data: [], error: null },
-      missionaries: [
-        {
-          data: {
-            id: missionaryId,
-            profile: {
-              display_name: "",
-              full_name: "",
-              first_name: "",
-              last_name: "",
-              email: "worker@example.com",
-            },
-          },
-          error: null,
-        },
-        {
+      contribution_adjustments: emptyRows,
+      missionaries: (query) => {
+        queriedMissionaryIds.push(query.inFilters.get("id") ?? []);
+        expectTenantScoped(query, tenantId);
+        expectIncludesIds(query, [missionaryId]);
+        return {
           data: [
             {
               id: missionaryId,
@@ -123,13 +172,9 @@ describe("contribution operations store", () => {
             },
           ],
           error: null,
-        },
-      ],
-      staged_gifts: { data: null, error: null },
-      contribution_operation_audit_events: { data: [], error: null },
-      contribution_corrections: { data: [], error: null },
-      contribution_correction_requests: { data: [], error: null },
-      donation_crm_links: { data: [], error: null },
+        };
+      },
+      ...baseContributionTables(),
     });
 
     const detail = await loadContributionDetailFromSupabase({
@@ -138,12 +183,282 @@ describe("contribution operations store", () => {
       contributionId: donationId,
     });
 
+    expect(queriedMissionaryIds).toEqual([[missionaryId]]);
     expect(detail.designations.lines).toHaveLength(1);
     expect(detail.designations.lines[0]!.missionaryName).toBe(
       "worker@example.com",
     );
     expect(detail.shared.designationSummary.missionaryName).toBe(
       "worker@example.com",
+    );
+  });
+
+  it("hydrates donor, CRM, correction request, and recurring agreement detail", async () => {
+    const tenantId = "00000000-0000-4000-8000-000000000011";
+    const donationId = "00000000-0000-4000-8000-000000000012";
+    const donorId = "00000000-0000-4000-8000-000000000013";
+    const donationFundId = "00000000-0000-4000-8000-000000000014";
+    const pledgeId = "00000000-0000-4000-8000-000000000015";
+    const pledgeFundId = "00000000-0000-4000-8000-000000000016";
+    const stagedGiftId = "00000000-0000-4000-8000-000000000017";
+    const supabaseAdmin = createSupabaseStub({
+      donations: {
+        data: {
+          id: donationId,
+          tenant_id: tenantId,
+          donor_id: donorId,
+          fund_id: donationFundId,
+          pledge_id: pledgeId,
+          amount: 7500,
+          currency: "usd",
+          status: "completed",
+          donation_type: "recurring",
+          payment_method: "card",
+          is_recurring: true,
+          recurring_interval: "month",
+          refund_amount: 0,
+          gift_date: "2026-05-05T00:00:00.000Z",
+          created_at: "2026-05-05T00:00:00.000Z",
+          updated_at: "2026-05-05T00:00:00.000Z",
+        },
+        error: null,
+      },
+      contribution_adjustments: emptyRows,
+      donors: (query) => {
+        expectTenantScoped(query, tenantId);
+        expect(query.eqFilters.get("id")).toBe(donorId);
+        return {
+          data: {
+            id: donorId,
+            profile_id: "profile_donor",
+            name: "Jordan Donor",
+            email: "jordan@example.com",
+            phone: "555-0100",
+            mobile: "555-0101",
+            location: "Austin, TX",
+            organization: "Jordan Family",
+          },
+          error: null,
+        };
+      },
+      staged_gifts: {
+        data: {
+          id: stagedGiftId,
+          donation_id: donationId,
+          status: "posted",
+          receipt_status: "sent",
+          crm_post_status: "queued",
+          twenty_record_id: "twenty_staged",
+        },
+        error: null,
+      },
+      staged_gift_allocations: emptyRows,
+      contribution_operation_audit_events: emptyRows,
+      contribution_corrections: emptyRows,
+      contribution_correction_requests: {
+        data: [
+          {
+            id: "request_1",
+            action_type: "designation_correction",
+            status: "pending",
+            reason: "Needs review",
+            requested_by_profile_id: "profile_requester",
+            created_at: "2026-05-06T00:00:00.000Z",
+          },
+        ],
+        error: null,
+      },
+      donation_crm_links: {
+        data: [
+          {
+            id: "crm_parent",
+            scope: "parent",
+            allocation_id: null,
+            link_status: "active",
+            twenty_record_id: "twenty_parent",
+            last_error: null,
+          },
+          {
+            id: "crm_designation",
+            scope: "designation",
+            allocation_id: "allocation_1",
+            link_status: "failed",
+            twenty_record_id: null,
+            last_error: "Twenty rejected the child record.",
+          },
+        ],
+        error: null,
+      },
+      donor_pledges: (query) => {
+        expectTenantScoped(query, tenantId);
+        expect(query.eqFilters.get("id")).toBe(pledgeId);
+        return {
+          data: {
+            id: pledgeId,
+            status: "active",
+            frequency: "month",
+            amount: 7500,
+            currency: "usd",
+            fund_id: pledgeFundId,
+            missionary_id: null,
+            next_payment_date: "2026-06-05",
+            next_charge_at: "2026-06-05T12:00:00.000Z",
+            stripe_subscription_id: "sub_123",
+          },
+          error: null,
+        };
+      },
+      funds: (query) => {
+        expectTenantScoped(query, tenantId);
+        expectIncludesIds(query, [donationFundId, pledgeFundId]);
+        return {
+          data: [
+            {
+              id: donationFundId,
+              name: "General Fund",
+              missionary_id: null,
+              goal_amount: null,
+              start_date: null,
+              end_date: null,
+            },
+            {
+              id: pledgeFundId,
+              name: "Monthly Support",
+              missionary_id: null,
+              goal_amount: null,
+              start_date: null,
+              end_date: null,
+            },
+          ],
+          error: null,
+        };
+      },
+    });
+
+    const detail = await loadContributionDetailFromSupabase({
+      supabaseAdmin,
+      tenantId,
+      contributionId: donationId,
+    });
+
+    expect(detail.donor).toMatchObject({
+      id: donorId,
+      name: "Jordan Donor",
+      email: "jordan@example.com",
+      phoneNumbers: ["555-0100", "555-0101"],
+    });
+    expect(detail.correctionRequests).toEqual([
+      {
+        id: "request_1",
+        actionType: "designation_correction",
+        status: "pending",
+        reason: "Needs review",
+        requestedByProfileId: "profile_requester",
+        createdAt: "2026-05-06T00:00:00.000Z",
+      },
+    ]);
+    expect(detail.crm.parent.twentyRecordId).toBe("twenty_parent");
+    expect(detail.crm.designationRecords).toEqual([
+      {
+        allocationId: "allocation_1",
+        status: "failed",
+        twentyRecordId: null,
+        lastError: "Twenty rejected the child record.",
+      },
+    ]);
+    expect(detail.crm.failedScopes).toEqual([
+      { scope: "designation", allocationId: "allocation_1" },
+    ]);
+    expect(detail.recurring).toMatchObject({
+      isRecurring: true,
+      interval: "month",
+      pledgeId,
+      providerRecurrenceWithoutAgreement: false,
+      agreement: {
+        id: pledgeId,
+        fundId: pledgeFundId,
+        fundName: "Monthly Support",
+        stripeSubscriptionId: "sub_123",
+      },
+    });
+  });
+
+  it("hydrates summary labels from the effective missionary after corrections", async () => {
+    const tenantId = "00000000-0000-4000-8000-000000000021";
+    const donationId = "00000000-0000-4000-8000-000000000022";
+    const originalMissionaryId = "00000000-0000-4000-8000-000000000023";
+    const effectiveMissionaryId = "00000000-0000-4000-8000-000000000024";
+    const queriedMissionaryIds: unknown[][] = [];
+    const supabaseAdmin = createSupabaseStub({
+      donations: {
+        data: {
+          id: donationId,
+          tenant_id: tenantId,
+          missionary_id: originalMissionaryId,
+          amount: 5000,
+          currency: "usd",
+          status: "completed",
+          donation_type: "one_time",
+          payment_method: "card",
+          is_recurring: false,
+          refund_amount: 0,
+          created_at: "2026-05-01T00:00:00.000Z",
+          updated_at: "2026-05-01T00:00:00.000Z",
+        },
+        error: null,
+      },
+      contribution_adjustments: {
+        data: [
+          {
+            id: "adjustment_1",
+            adjustment_type: "allocation_correction",
+            status: "applied",
+            effective_values: { missionaryId: effectiveMissionaryId },
+            reason: "Correct missionary",
+            actor_profile_id: "profile_actor",
+            source_surface: "contribution_hub",
+            created_at: "2026-05-02T00:00:00.000Z",
+          },
+        ],
+        error: null,
+      },
+      missionaries: (query) => {
+        queriedMissionaryIds.push(query.inFilters.get("id") ?? []);
+        expectTenantScoped(query, tenantId);
+        expectIncludesIds(query, [effectiveMissionaryId]);
+        return {
+          data: [
+            {
+              id: effectiveMissionaryId,
+              profile: {
+                display_name: "Correct Worker",
+                full_name: null,
+                first_name: null,
+                last_name: null,
+                email: "correct@example.com",
+              },
+            },
+          ],
+          error: null,
+        };
+      },
+      ...baseContributionTables(),
+    });
+
+    const detail = await loadContributionDetailFromSupabase({
+      supabaseAdmin,
+      tenantId,
+      contributionId: donationId,
+    });
+
+    expect(queriedMissionaryIds).toEqual([[effectiveMissionaryId]]);
+    expect(detail.original.missionaryId).toBe(originalMissionaryId);
+    expect(detail.effective.missionaryId).toBe(effectiveMissionaryId);
+    expect(detail.designations.lines[0]!.missionaryId).toBe(
+      effectiveMissionaryId,
+    );
+    expect(detail.shared.designationSummary.missionaryName).toBe(
+      "Correct Worker",
     );
   });
 });

--- a/tests/unit/packages/api/admin/contribution-operations-store.test.ts
+++ b/tests/unit/packages/api/admin/contribution-operations-store.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { loadContributionDetailFromSupabase } from "../../../../../packages/api/src/admin/contribution-operations/store";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+
+type QueryResult = {
+  data: unknown;
+  error: null;
+};
+
+class SupabaseQueryStub {
+  constructor(private readonly result: QueryResult) {}
+
+  select(): this {
+    return this;
+  }
+
+  eq(): this {
+    return this;
+  }
+
+  in(): this {
+    return this;
+  }
+
+  order(): this {
+    return this;
+  }
+
+  limit(): Promise<QueryResult> {
+    return Promise.resolve(this.result);
+  }
+
+  maybeSingle(): Promise<QueryResult> {
+    return Promise.resolve(this.result);
+  }
+
+  single(): Promise<QueryResult> {
+    return Promise.resolve(this.result);
+  }
+
+  then<TResult1 = QueryResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: QueryResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.result).then(onfulfilled, onrejected);
+  }
+}
+
+function createSupabaseStub(
+  resultsByTable: Record<string, QueryResult | QueryResult[]>,
+): AdminSupabaseClient {
+  const remainingResults = new Map(
+    Object.entries(resultsByTable).map(([table, result]) => [
+      table,
+      Array.isArray(result) ? [...result] : [result],
+    ]),
+  );
+
+  return {
+    from(table: string) {
+      const tableResults = remainingResults.get(table) ?? [];
+      const nextResult = tableResults.shift() ?? { data: null, error: null };
+      remainingResults.set(table, tableResults);
+
+      return new SupabaseQueryStub(nextResult);
+    },
+  } as unknown as AdminSupabaseClient;
+}
+
+describe("contribution operations store", () => {
+  it("hydrates donation missionary labels from profile email when name fields are blank", async () => {
+    const tenantId = "00000000-0000-4000-8000-000000000001";
+    const donationId = "00000000-0000-4000-8000-000000000002";
+    const missionaryId = "00000000-0000-4000-8000-000000000003";
+    const supabaseAdmin = createSupabaseStub({
+      donations: {
+        data: {
+          id: donationId,
+          tenant_id: tenantId,
+          missionary_id: missionaryId,
+          amount: 5000,
+          currency: "usd",
+          status: "completed",
+          donation_type: "one_time",
+          payment_method: "card",
+          is_recurring: false,
+          refund_amount: 0,
+          created_at: "2026-05-01T00:00:00.000Z",
+          updated_at: "2026-05-01T00:00:00.000Z",
+        },
+        error: null,
+      },
+      contribution_adjustments: { data: [], error: null },
+      missionaries: [
+        {
+          data: {
+            id: missionaryId,
+            profile: {
+              display_name: "",
+              full_name: "",
+              first_name: "",
+              last_name: "",
+              email: "worker@example.com",
+            },
+          },
+          error: null,
+        },
+        {
+          data: [
+            {
+              id: missionaryId,
+              profile: {
+                display_name: "",
+                full_name: "",
+                first_name: "",
+                last_name: "",
+                email: "worker@example.com",
+              },
+            },
+          ],
+          error: null,
+        },
+      ],
+      staged_gifts: { data: null, error: null },
+      contribution_operation_audit_events: { data: [], error: null },
+      contribution_corrections: { data: [], error: null },
+      contribution_correction_requests: { data: [], error: null },
+      donation_crm_links: { data: [], error: null },
+    });
+
+    const detail = await loadContributionDetailFromSupabase({
+      supabaseAdmin,
+      tenantId,
+      contributionId: donationId,
+    });
+
+    expect(detail.designations.lines).toHaveLength(1);
+    expect(detail.designations.lines[0]!.missionaryName).toBe(
+      "worker@example.com",
+    );
+    expect(detail.shared.designationSummary.missionaryName).toBe(
+      "worker@example.com",
+    );
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-shared-filters.test.ts
+++ b/tests/unit/packages/api/admin/contribution-shared-filters.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterSharedContributions,
+  hasSharedContributionIssue,
+  matchesSharedContributionFilter,
+  SHARED_CONTRIBUTION_FILTERS,
+  type SharedContributionFilter,
+} from "../../../../../packages/api/src/admin/contribution-shared/filters";
+import { buildContributionGridRow } from "../../../../../packages/api/src/admin/contributions/model";
+import { buildCrmGiftHistoryRow } from "../../../../../packages/api/src/admin/crm/detail/gift-history";
+
+import type { SharedContributionRowFields } from "../../../../../packages/database/types/contribution-shared";
+
+function sharedFields(
+  overrides: Partial<SharedContributionRowFields> = {},
+): SharedContributionRowFields {
+  return {
+    donationId: "donation-1",
+    amountCents: 25_000,
+    currencyCode: "USD",
+    giftDate: "2026-05-01",
+    donorId: "donor-1",
+    donorName: "Alice Johnson",
+    designationSummary: {
+      fundId: "fund-1",
+      fundName: "Clean Water Initiative",
+      missionaryId: null,
+      missionaryName: null,
+      lineCount: 1,
+    },
+    paymentStatus: "completed",
+    receiptStatus: "sent",
+    crmPostStatus: "posted",
+    refundState: "none",
+    refundedAmountCents: 0,
+    correctionState: "none",
+    recurringLinkState: "none",
+    ...overrides,
+  };
+}
+
+describe("admin/contribution-shared/filters", () => {
+  it("registers one definition per shared filter id", () => {
+    expect(SHARED_CONTRIBUTION_FILTERS.map((filter) => filter.id)).toEqual([
+      "receipt_affected",
+      "pending_correction",
+      "approval_state",
+      "refund_state",
+      "crm_post_state",
+      "designation_issue",
+      "recurring_link",
+      "payment_status",
+    ]);
+  });
+
+  it("receipt affected means a sent receipt with correction activity", () => {
+    const affected = {
+      shared: sharedFields({
+        receiptStatus: "sent",
+        correctionState: "applied",
+      }),
+    };
+    const cleanSent = {
+      shared: sharedFields({ receiptStatus: "sent", correctionState: "none" }),
+    };
+    const neverSent = {
+      shared: sharedFields({
+        receiptStatus: "not_sent",
+        correctionState: "applied",
+      }),
+    };
+
+    const filter: SharedContributionFilter = { id: "receipt_affected" };
+    expect(matchesSharedContributionFilter(affected, filter)).toBe(true);
+    expect(matchesSharedContributionFilter(cleanSent, filter)).toBe(false);
+    expect(matchesSharedContributionFilter(neverSent, filter)).toBe(false);
+  });
+
+  it("evaluates parameterized state filters against shared fields", () => {
+    const row = {
+      shared: sharedFields({
+        paymentStatus: "refunded",
+        refundState: "refunded",
+        crmPostStatus: "failed",
+        correctionState: "pending",
+        recurringLinkState: "provider_only",
+      }),
+    };
+
+    expect(
+      matchesSharedContributionFilter(row, { id: "pending_correction" }),
+    ).toBe(true);
+    expect(
+      matchesSharedContributionFilter(row, {
+        id: "approval_state",
+        value: "pending",
+      }),
+    ).toBe(true);
+    expect(
+      matchesSharedContributionFilter(row, {
+        id: "refund_state",
+        value: "refunded",
+      }),
+    ).toBe(true);
+    expect(
+      matchesSharedContributionFilter(row, {
+        id: "crm_post_state",
+        value: "failed",
+      }),
+    ).toBe(true);
+    expect(
+      matchesSharedContributionFilter(row, {
+        id: "recurring_link",
+        value: "provider_only",
+      }),
+    ).toBe(true);
+    expect(
+      matchesSharedContributionFilter(row, {
+        id: "payment_status",
+        value: "refunded",
+      }),
+    ).toBe(true);
+    expect(
+      matchesSharedContributionFilter(row, {
+        id: "payment_status",
+        value: "completed",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a null CRM post status as not_required", () => {
+    const row = { shared: sharedFields({ crmPostStatus: null }) };
+
+    expect(
+      matchesSharedContributionFilter(row, {
+        id: "crm_post_state",
+        value: "not_required",
+      }),
+    ).toBe(true);
+  });
+
+  it("flags designation issues from designation set context", () => {
+    const withIssue = {
+      shared: sharedFields(),
+      designationIssues: ["Lines total $240.00 but the gift is $250.00."],
+    };
+    const clean = { shared: sharedFields(), designationIssues: [] };
+
+    expect(
+      matchesSharedContributionFilter(withIssue, { id: "designation_issue" }),
+    ).toBe(true);
+    expect(
+      matchesSharedContributionFilter(clean, { id: "designation_issue" }),
+    ).toBe(false);
+  });
+
+  it("composes compact issue filters from the shared definitions", () => {
+    expect(
+      hasSharedContributionIssue({
+        shared: sharedFields({ crmPostStatus: "failed" }),
+      }),
+    ).toBe(true);
+    expect(
+      hasSharedContributionIssue({
+        shared: sharedFields({ recurringLinkState: "provider_only" }),
+      }),
+    ).toBe(true);
+    expect(hasSharedContributionIssue({ shared: sharedFields() })).toBe(false);
+  });
+
+  it("returns the same gifts for Hub and CRM rows built from the same data", () => {
+    const donation = {
+      id: "donation-9",
+      donor_id: "donor-1",
+      missionary_id: null,
+      fund_id: "fund-1",
+      amount: 25_000,
+      currency: "usd",
+      status: "completed",
+      gift_date: "2026-05-01",
+      refund_amount: 25_000,
+      refunded_at: "2026-05-02T00:00:00.000Z",
+      created_at: "2026-05-01T00:00:00.000Z",
+      updated_at: "2026-05-02T00:00:00.000Z",
+    };
+    const donor = { id: "donor-1", name: "Alice", email: "a@example.com" };
+    const fund = { id: "fund-1", name: "Clean Water Initiative" };
+    const stagedGift = {
+      id: "staged-9",
+      status: "posted",
+      receipt_status: "sent",
+      crm_post_status: "failed",
+    };
+    const corrections = [{ status: "pending" }];
+
+    const crmRow = buildCrmGiftHistoryRow({
+      donation,
+      donor,
+      fund,
+      missionary: null,
+      stagedGift: { ...stagedGift, twenty_record_id: null },
+      corrections,
+    });
+    const hubRow = buildContributionGridRow({
+      donation: {
+        ...donation,
+        donation_type: "one_time",
+        payment_method: "card",
+        is_recurring: false,
+        recurring_interval: null,
+        notes: null,
+        stripe_payment_intent_id: "pi_9",
+        campaign_id: null,
+        pledge_id: null,
+        processed_at: null,
+        completed_at: null,
+        failed_at: null,
+        error_code: null,
+        error_message: null,
+        stripe_charge_id: "ch_9",
+        source: "online",
+      },
+      donor: {
+        ...donor,
+        phone: null,
+        type: null,
+        location: null,
+        organization: null,
+        notes: null,
+      },
+      profile: null,
+      fund,
+      missionary: null,
+      stagedGift: {
+        ...stagedGift,
+        review_reason: null,
+        receipt_send_log_id: null,
+      },
+      corrections,
+    });
+
+    const filters: SharedContributionFilter[][] = [
+      [{ id: "receipt_affected" }],
+      [{ id: "pending_correction" }],
+      [{ id: "refund_state", value: "refunded" }],
+      [{ id: "crm_post_state", value: "failed" }],
+      [{ id: "payment_status", value: "refunded" }],
+      [{ id: "crm_post_state", value: "failed" }, { id: "pending_correction" }],
+    ];
+
+    for (const filterSet of filters) {
+      const crmMatch = filterSharedContributions([crmRow], filterSet);
+      const hubMatch = filterSharedContributions([hubRow], filterSet);
+
+      expect(crmMatch.length).toBe(hubMatch.length);
+      expect(crmMatch.length).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- hydrate contribution detail reads with tenant-scoped donor, missionary, staged allocation, correction request, CRM link, and recurring agreement context
- preserve leftover effective-value and shared-filter coverage from the original #251 branch
- add a store-level regression for missionary label fallback from profile email

## Verification
- node scripts/run-with-ci-env.mjs -- bunx vitest run tests/unit/packages/api/admin/contribution-effective-values.test.ts tests/unit/packages/api/admin/contribution-effective-values-status.test.ts tests/unit/packages/api/admin/contribution-shared-filters.test.ts tests/unit/packages/api/admin/contribution-operations-store.test.ts tests/unit/packages/api/admin/contribution-operations-read-model.test.ts tests/unit/packages/api/admin/crm-gift-history-row.test.ts tests/unit/packages/api/admin/contributions-model.test.ts
- bunx turbo run typecheck --filter=@asym/api
- bunx turbo run lint --filter=@asym/api
- bun run format:check
- git diff --check
- pre-push: bun run ci:preflight

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hydrates the contribution detail loader with tenant-scoped donor, correction-request, CRM link, and recurring-agreement data that were previously returned as empty stubs. It also extracts missionary/donor display-name resolution into a shared `profile-label.ts` helper (adding email as a final fallback) and applies it consistently across four CRM and contribution services.

- `loadContributionOperationDetail` now runs 7 parallel queries (donor, staged gift, audit, corrections, correction requests, CRM links, pledge) and batches all fund/missionary lookups — including the pledge's fund — into a single `loadDesignationSetData` call.
- `resolveContributionProfileLabel` consolidates previously duplicated name-resolution chains across `contributions/service.ts`, `crm/service.ts`, `crm/detail/service.ts`, and `crm/reports/service.ts`, with `email` added as a fallback tier in each corresponding `profiles` query.
- New unit tests cover effective-value derivation, shared-filter parity between Hub and CRM rows, and store-level regression for missionary label fallback from profile email.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all new queries are tenant-scoped and the data model changes are purely additive.

The change fills in previously stubbed-out fields (donor, correction requests, CRM links, recurring agreement) with real DB reads, all correctly filtered by tenant_id. The adjustment load moving from parallel to sequential is a minor efficiency gap, not a correctness issue. Tests are thorough and cover the new hydration paths.

packages/api/src/admin/contribution-operations/operations.ts — sequential adjustment load before the 7-item Promise.all is worth revisiting for a small latency improvement.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-operations/operations.ts | Expands loadContributionOperationDetail with 7 parallel fetches (donor, staged gift, audit, corrections, correction requests, CRM links, pledge). Sequential adjustment load before the Promise.all is a minor perf regression; effectiveReferences derived from adjustments are only needed for loadDesignationSetData which runs after the Promise.all, so adjustments could move back into the parallel batch. |
| packages/api/src/admin/contribution-shared/profile-label.ts | New utility consolidating missionary/donor name resolution with email fallback; correctly handles null/undefined profile and all-empty-string fields. |
| tests/unit/packages/api/admin/contribution-operations-store.test.ts | New store-level tests covering donor hydration, CRM links, correction requests, recurring agreement, and missionary email-label fallback after corrections; stub faithfully implements chainable query builder. |
| tests/unit/packages/api/admin/contribution-effective-values.test.ts | New unit tests for deriveEffectiveContribution covering chronological ordering, reversed adjustment exclusion, and no-adjustment baseline. |
| tests/unit/packages/api/admin/contribution-shared-filters.test.ts | New filter parity tests verifying Hub rows and CRM gift-history rows match the same shared filter set; covers all filter IDs. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant O as operations.ts
    participant DB as Supabase (Admin)

    C->>O: loadContributionOperationDetail(tenantId, contributionId)
    O->>DB: donations.single()
    DB-->>O: donation row

    O->>DB: contribution_adjustments.order() [sequential]
    DB-->>O: adjustments[]

    O->>O: deriveEffectiveContribution(original, adjustments)
    O->>O: collectEffectiveReferenceIds(effective, lines)

    par Promise.all (7 queries)
        O->>DB: donors.maybeSingle()
        O->>DB: staged_gifts.maybeSingle()
        O->>DB: contribution_operation_audit_events.limit(50)
        O->>DB: contribution_corrections.limit(50)
        O->>DB: contribution_correction_requests.limit(50)
        O->>DB: donation_crm_links.order()
        O->>DB: donor_pledges.maybeSingle()
    end
    DB-->>O: donorRow, stagedGift, audit, corrections, requests, crmLinks, pledgeRow

    O->>DB: staged_gift_allocations.order() [sequential, needs stagedGiftId]
    par Promise.all (funds + missionaries)
        O->>DB: funds.in(fundIds)
        O->>DB: missionaries.in(missionaryIds)
    end
    DB-->>O: allocations, funds, missionaries

    O->>O: buildContributionDetail(...)
    O-->>C: ContributionDetail
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant O as operations.ts
    participant DB as Supabase (Admin)

    C->>O: loadContributionOperationDetail(tenantId, contributionId)
    O->>DB: donations.single()
    DB-->>O: donation row

    O->>DB: contribution_adjustments.order() [sequential]
    DB-->>O: adjustments[]

    O->>O: deriveEffectiveContribution(original, adjustments)
    O->>O: collectEffectiveReferenceIds(effective, lines)

    par Promise.all (7 queries)
        O->>DB: donors.maybeSingle()
        O->>DB: staged_gifts.maybeSingle()
        O->>DB: contribution_operation_audit_events.limit(50)
        O->>DB: contribution_corrections.limit(50)
        O->>DB: contribution_correction_requests.limit(50)
        O->>DB: donation_crm_links.order()
        O->>DB: donor_pledges.maybeSingle()
    end
    DB-->>O: donorRow, stagedGift, audit, corrections, requests, crmLinks, pledgeRow

    O->>DB: staged_gift_allocations.order() [sequential, needs stagedGiftId]
    par Promise.all (funds + missionaries)
        O->>DB: funds.in(fundIds)
        O->>DB: missionaries.in(missionaryIds)
    end
    DB-->>O: allocations, funds, missionaries

    O->>O: buildContributionDetail(...)
    O-->>C: ContributionDetail
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(contributions): harden detail loader..."](https://github.com/asymmetric-al/core/commit/24cb51a34dbaa8dc0c1bf58ad1b051a19cb77b99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38984039)</sub>

<!-- /greptile_comment -->