### PR TITLE
Add ReUI agent skills and MCP tooling

### DIFF
--- a/.agents/skills/.repo-canonical-skills.json
+++ b/.agents/skills/.repo-canonical-skills.json
@@ -50,6 +50,7 @@
     "repo-entry",
     "request-refactor-plan",
     "resend-cli",
+    "reui",
     "setup-matt-pocock-skills",
     "setup-pre-commit",
     "supabase",

--- a/.agents/skills/reui/SKILL.md
+++ b/.agents/skills/reui/SKILL.md
@@ -5,6 +5,26 @@ user-invocable: false
 allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
 ---
 
+## This repository (Asymmetric-al/core)
+
+Subordinate to **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/moai-library-shadcn/SKILL.md`** (generic shadcn rules), and TanStack guides under `docs/guides/development/`.
+
+**Registry (`packages/ui/components.json`):**
+
+- Active style is **`base-maia`** (Base UI + Maia). Read the segment before the first `-` in `style` to detect the base (`base-maia` → Base UI).
+- **`@reui`** is the **plain-string** registry (free components and `c-*` examples). Premium blocks/icons need the authenticated object form plus `REUI_LICENSE_KEY` in git-ignored `.env.local` — see [rules/cli.md](./rules/cli.md). Switch back to the plain form when premium installs are not in progress so contributors without a key can install free items.
+
+**Tables:**
+
+- Prefer shared **`DataTableResponsive`** from `@asym/ui/components/shadcn/data-table` for standard app tables (see `docs/guides/development/tanstack-virtual-foundation.md`).
+- Use ReUI **`data-grid`** when you need ReUI-specific table composition after `get_component('data-grid')`.
+
+**Naming:** **ReUI** (`@reui`, this skill) is unrelated to shadcn-studio **`/rui`** (Refine UI) in `docs/ai/rules/shadcn-studio-mcp.md`.
+
+**MCP:** `reui` at `https://mcp.reui.io` in `.mcp.json`, `.cursor/mcp.json`, and `.codex/config.toml`. The MCP is free; only premium **installs** need a license key. Never commit `REUI_LICENSE_KEY`.
+
+Refresh: [references/upstream.md](./references/upstream.md).
+
 # ReUI for Agents
 
 ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
@@ -16,13 +36,13 @@ ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never
 
 The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
 
-Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on** [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../moai-library-shadcn/SKILL.md) for generic shadcn rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
 
 ## The core loop (MCP-native)
 
 1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
 2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
-3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (this repo uses `base-maia` → Base UI; `radix-nova` → Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
 4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
 
 If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
@@ -45,7 +65,7 @@ Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor
 | Need                                                                 | Reach for                                                                 |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
-| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
+| A data table with sorting/filtering/pagination/virtualization        | **`DataTableResponsive`** in this repo; ReUI **data-grid** when ReUI-specific composition is required |
 | A drag-and-drop board                                                | the **kanban** component                                                  |
 | Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
 | A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |

--- a/.agents/skills/reui/SKILL.md
+++ b/.agents/skills/reui/SKILL.md
@@ -62,13 +62,13 @@ Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor
 
 ## When to reach for ReUI vs plain shadcn
 
-| Need                                                                 | Reach for                                                                 |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
+| Need                                                                 | Reach for                                                                                             |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks**                             |
 | A data table with sorting/filtering/pagination/virtualization        | **`DataTableResponsive`** in this repo; ReUI **data-grid** when ReUI-specific composition is required |
-| A drag-and-drop board                                                | the **kanban** component                                                  |
-| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
-| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+| A drag-and-drop board                                                | the **kanban** component                                                                              |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                                                       |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                                                      |
 
 ## Detailed references
 

--- a/.agents/skills/reui/SKILL.md
+++ b/.agents/skills/reui/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: reui
+description: Use the ReUI registry from your AI agent - find, install, and correctly use ReUI components (the 17 free building blocks like data-grid, kanban, filters), their free examples, premium blocks, and Motion Icons. Applies in any project using ReUI, the @reui registry, REUI_LICENSE_KEY, or any shadcn project where the user asks for premium blocks, data grids, kanban boards, dashboards, or full pages. Pairs with the free ReUI MCP server for live, scored registry search and inline component APIs.
+user-invocable: false
+allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
+---
+
+# ReUI for Agents
+
+ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
+
+- **components** - the 17 ReUI building blocks with real APIs: `data-grid`, `kanban`, `filters`, `date-selector`, `tree`, `stepper`, ... (free)
+- **examples** - free `c-*` single-pattern use-cases of a component (`c-kanban-1`); install one and read it to see exact composition
+- **blocks** - premium full-page sections that compose components (`data-grid-2`, `pricing-page-1`); Pro or Ultimate license at install
+- **icons** - Motion Icons in 4 styles, static + hover-animated variants; Ultimate license at install
+
+The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
+
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+
+## The core loop (MCP-native)
+
+1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
+2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
+
+If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
+
+## Commands
+
+Run ReUI as explicit slash commands (via the ReUI MCP) **or** just ask in plain language - both run the same workflow.
+
+| Command     | Invoke                         | Does                                                                                                               |
+| ----------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| **build**   | `/mcp__reui__build <what>`     | Compose a page/section/feature from ReUI: plan → install → read API → adapt → craft → audit.                       |
+| **add**     | `/mcp__reui__add <item>`       | Find & install one component/example/block/icon and wire it in.                                                    |
+| **fix**     | `/mcp__reui__fix [target]`     | Diagnose & fix ReUI usage: wrong/undocumented props, base/radix mismatch, missing states, a11y/scroll.             |
+| **improve** | `/mcp__reui__improve [target]` | Refine + extend existing ReUI UI to a production-exceptional bar (hierarchy, density, states, responsive, motion). |
+
+Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor/Windsurf, `/mcp.reui.build` in VS Code). No command surface? Just describe what you want - this skill drives the identical loop.
+
+## When to reach for ReUI vs plain shadcn
+
+| Need                                                                 | Reach for                                                                 |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
+| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
+| A drag-and-drop board                                                | the **kanban** component                                                  |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+
+## Detailed references
+
+- [rules/registry.md](./rules/registry.md) - the four types, the @reui registry, base/radix, free vs premium + license
+- [rules/workflow.md](./rules/workflow.md) - the find -> install -> read-API -> adapt loop (most important)
+- [rules/components.md](./rules/components.md) - the 17 components, the data-grid contract, base vs radix
+- [rules/adapting.md](./rules/adapting.md) - reuse-first: preserve the design (no over-customizing), reuse examples + a block's own elements, real data, don't invent APIs
+- [rules/craft.md](./rules/craft.md) - make it exceptional: point of view, hierarchy, density, states, responsive, motion, the bar
+- [rules/quality.md](./rules/quality.md) - security, accessibility, and scroll gates (the done gate)
+- [rules/styling.md](./rules/styling.md) - ReUI extended tokens, theme adaptation, density
+- [rules/icons.md](./rules/icons.md) - portable icons, swapping imports, Motion Icons (static + animated)
+- [tools.md](./tools.md) - the ReUI MCP: golden path, the 19 tools, token rules, result shapes, errors

--- a/.agents/skills/reui/references/upstream.md
+++ b/.agents/skills/reui/references/upstream.md
@@ -1,0 +1,25 @@
+---
+source: https://reui.io/docs/agent-skills
+install_commands:
+  - bunx --bun shadcn@latest add @reui/skills-claude
+  - bunx --bun shadcn@latest add @reui/skills-codex
+  - bunx --bun shadcn@latest add @reui/skills-cursor
+last_refreshed: 2026-07-01
+---
+
+# ReUI agent skills upstream
+
+Canonical copy in this repo: `docs/ai/skills/reui/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, and Cursor. This repo uses the shared canonical-skill pattern instead of committing each tool's installer output as the source of truth.
+
+## Refresh workflow
+
+1. Run the current ReUI install commands in a clean working tree or scratch branch:
+   - `bunx --bun shadcn@latest add @reui/skills-claude`
+   - `bunx --bun shadcn@latest add @reui/skills-codex`
+   - `bunx --bun shadcn@latest add @reui/skills-cursor`
+2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+5. Commit canonical and generated mirror updates together.

--- a/.agents/skills/reui/references/upstream.md
+++ b/.agents/skills/reui/references/upstream.md
@@ -20,6 +20,6 @@ ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, a
    - `bunx --bun shadcn@latest add @reui/skills-codex`
    - `bunx --bun shadcn@latest add @reui/skills-cursor`
 2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
-3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file plus the **`## This repository (Asymmetric-al/core)`** overlay at the top of `SKILL.md` (registry defaults, `base-maia`, `DataTableResponsive`, `/rui` disambiguation).
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 5. Commit canonical and generated mirror updates together.

--- a/.agents/skills/reui/rules/adapting.md
+++ b/.agents/skills/reui/rules/adapting.md
@@ -1,0 +1,43 @@
+# Adapting installed ReUI code (reuse-first, no AI slop)
+
+ReUI items ship production-quality. Your job is to **adapt by reuse** - wire real data and fit the app - not to redesign or hand-roll. The output should look like ReUI built it for this product.
+
+## Preserve the design - don't over-customize
+
+The design IS the product. A ReUI block/component encodes senior-designer decisions: spacing, hierarchy, density, color treatment, and component choices. The fastest way to turn a premium block back into generic AI slop is to "improve" its look - so don't.
+
+- Change **data, copy, and props**; keep the **structure and styling** it ships with. Make the **smallest** change that wires the real data. If your diff touches `className` / JSX structure more than data / props, you are over-customizing - stop and reuse.
+- Don't swap ReUI components for hand-rolled ones, restructure the layout, re-skin spacing / radius / colors, or add decorative chrome. Let the installed components carry the default spacing, radius, sizing, icon rhythm, density, and state styling; add custom Tailwind only when a component genuinely lacks a contract you need.
+- Want a different look? `search` for a block whose design already fits and reuse that - don't restyle this one into a new design.
+
+## Reuse the parts: examples and the block's own elements
+
+- **Examples are building parts.** A free `c-*` example is a correct, single-pattern composition you can reuse. Before composing from scratch, `get_examples(component)`, install the closest one, and reuse its wiring - assemble UI from examples instead of hand-rolling what an example already shows.
+- **Reuse a block's own elements.** Need more rows, cards, items, or sections than ship by default? Repeat the block's **existing** element by mapping real data through the same markup - never invent parallel markup that drifts from its design. Need a variant (empty / loading / expanded)? Derive it from an element the block already has.
+
+## Don't invent (read, don't guess)
+
+- Never write a prop, variant value, import path, or `@reui/...` name you didn't read in a component's inline `api`, an installed example, or a `search` result. If you didn't see it, treat it as nonexistent - call `get_component` / `get_examples` / `search` first, or run the MCP `validate_usage` tool to check planned names + props against the docs before writing code.
+- If a getter returns `found: false` or `search` returns nothing, say so and fall back (plain shadcn, or ask) - never fabricate an install command or an API.
+
+## What to change vs leave alone
+
+- **Change:** the item's own data, copy, props, and layout to fit the app.
+- **Leave alone:** installed component files, hooks, and the shared theme - do not edit vendored ReUI internals; change behavior through props and the documented API.
+- Blocks are **portable React** - no `next/link`, `next/image`, or other framework-runtime imports inside them. Keep them portable.
+
+## Demo data -> real data
+
+- Replace every placeholder with the user's real data. Model it as **typed data structures** and **map over arrays** - never duplicate JSX per row/card. Keep small block-specific formatters next to the data.
+- Wire the real source (columns, fields, fetch). For `data-grid`, implement the server fetch contract if the user needs server-side data.
+- **Type from the component API, derive during render.** Type domain state through the component's own types - e.g. map status to `BadgeProps["variant"]` via a typed `Record<Status, …>` - instead of stringly-typed values. Compute view state during render; don't mirror derived data into `useState`/`useEffect`.
+- **Adapt on the right base.** Use the API for the project's base (Base UI vs Radix - see [components.md](./components.md)); the installed files are already base-correct, so reuse their shape rather than translating from memory.
+
+## Believable content (no AI tells)
+
+- Use realistic labels, counts, timestamps, and statuses that map to a real workflow.
+- No decorative buttons, fake tabs, meaningless toggles, equal-weight card walls, empty gradients, ornamental icons, or generic SaaS filler. Every element should do something.
+
+## Operational surfaces (settings / profile / admin)
+
+Pick ONE archetype and keep the family consistent: a vertical rail (3-6 sections), horizontal tabs (5-8), or a frame/stack. Prefer `frame` for tool-like surfaces, a card for profile-like ones. Don't mix archetypes in one surface.

--- a/.agents/skills/reui/rules/cli.md
+++ b/.agents/skills/reui/rules/cli.md
@@ -1,0 +1,58 @@
+# CLI: registry setup, license, non-interactive install
+
+## Registry setup (one-time, per project)
+
+Free items (the 17 components and all `c-*` examples) need only the plain string registry in `components.json`:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium items (blocks; Motion Icons and templates) require a ReUI license at install:
+
+1. Add the key to `.env.local`:
+
+```bash
+REUI_LICENSE_KEY=your-license-key
+```
+
+2. Switch `components.json` to the authenticated object form:
+
+```json
+{
+  "registries": {
+    "@reui": {
+      "url": "https://reui.io/r/{style}/{name}.json",
+      "headers": { "Authorization": "Bearer ${REUI_LICENSE_KEY}" }
+    }
+  }
+}
+```
+
+The MCP `get_project_context` tool returns the right config. Full guide: https://reui.io/docs/registry
+
+## Installing
+
+Use the project's package runner (check `packageManager`):
+
+```bash
+npx shadcn@latest add @reui/<name> --yes      # npm
+pnpm dlx shadcn@latest add @reui/<name> --yes  # pnpm
+bunx --bun shadcn@latest add @reui/<name> --yes # bun
+```
+
+`--yes` skips confirmation prompts. The CLI auto-detects the package manager from the lockfile (there is no `--package-manager` flag). It also resolves the correct base+style variant from `components.json`, so do not pass a style.
+
+## Handling prompts and conflicts
+
+- **Always pass `--yes`** so the CLI does not block on confirmation prompts.
+- **Do NOT pass `--overwrite` by default.** If the CLI reports an existing file, read the output and resolve deliberately: install under a different name, adjust the path, or ask the user. Only use `--overwrite` when the user explicitly wants to replace a file.
+- **Preview first when touching an existing project**: `npx shadcn@latest add @reui/<name> --dry-run` shows what would change; `--diff <file>` shows a specific file's diff. Use these before overwriting.
+- Run from the **project root** so `components.json` and `.env.local` are found.
+
+## Free vs premium boundary
+
+- Public, no key: `c-*` examples and the 17 components (`@reui/data-grid`, `@reui/badge`, ...) that those examples depend on.
+- Key required at install: blocks (`@reui/<category>-N`) need a Pro or Ultimate license; Motion Icons (`@reui/icons/...`) and templates need Ultimate.
+
+If an install 401/403s, the license key is missing, invalid, or the plan does not cover that resource (blocks: Pro or higher; icons and templates: Ultimate). Point the user to https://reui.io/account (their key) or https://reui.io/pricing (upgrade).

--- a/.agents/skills/reui/rules/components.md
+++ b/.agents/skills/reui/rules/components.md
@@ -9,7 +9,7 @@ The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `dat
 `data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
 
 - Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
-- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Pass that instance to `<DataGrid table={table} recordCount={total}>` (`total` is the full row count for pagination, not just the current page's `data.length`).
 - Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
 - Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
 
@@ -21,7 +21,7 @@ const table = useReactTable({
   // add sorting/pagination/selection models per the API
 })
 
-<DataGrid table={table} recordCount={data.length}>
+<DataGrid table={table} recordCount={totalRowCount}>
   <DataGridTable />
 </DataGrid>
 ```

--- a/.agents/skills/reui/rules/components.md
+++ b/.agents/skills/reui/rules/components.md
@@ -1,0 +1,349 @@
+# ReUI components
+
+The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `date-selector`, `filters`, `frame`, `icon-stack`, `kanban`, `number-field`, `phone-input`, `rating`, `scrollspy`, `sortable`, `stepper`, `timeline`, `tree`. Examples and blocks are composed from these.
+
+**Rule one: never guess a component's API. Read it first.** Call **`get_component(name)`** for its inline `api` (props + usage, no web fetch); the result's `docsUrl` and the `/llms.txt` index are the fallback. Then call **`get_examples(name)`** to install a worked example and copy real composition. The contracts below are first-try orientation (required props, composition shape, the one gotcha); the inline `api` is the full reference. No single block fits? Compose: search the components you need, read each `get_component`, install a `get_examples` example per component, and adapt.
+
+## data-grid (the flagship - read its API every time)
+
+`data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
+
+- Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
+- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
+- Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
+
+```tsx
+const table = useReactTable({
+  data,
+  columns,
+  getCoreRowModel: getCoreRowModel(),
+  // add sorting/pagination/selection models per the API
+})
+
+<DataGrid table={table} recordCount={data.length}>
+  <DataGridTable />
+</DataGrid>
+```
+
+Common mistakes:
+
+- **Incorrect:** `<DataGrid data={rows} columns={cols} />` - these props do not exist. **Correct:** build a `useReactTable` instance and pass `table={table}` + `recordCount`.
+- **Incorrect:** a raw `<table>` / hand-rolled pagination. **Correct:** use `data-grid`; read its API for sticky header, pagination, virtualization, row selection.
+- **Incorrect:** styling rows/cells with arbitrary classes. **Correct:** drive layout via `tableLayout` and the documented `ColumnMeta` (e.g. `cellClassName`, `headerTitle`).
+
+## kanban
+
+**Required:** `value` (`Record<string, T[]>`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Kanban value={cols} onValueChange={setCols} getItemValue={(i) => i.id}>
+  <KanbanBoard>
+    {Object.entries(cols).map(([id, items]) => (
+      <KanbanColumn key={id} value={id}>
+        <KanbanColumnHandle>
+          <h3>{id}</h3>
+        </KanbanColumnHandle>
+        <KanbanColumnContent value={id}>
+          {items.map((i) => (
+            <KanbanItem key={i.id} value={i.id}>
+              <KanbanItemHandle>{i.title}</KanbanItemHandle>
+            </KanbanItem>
+          ))}
+        </KanbanColumnContent>
+      </KanbanColumn>
+    ))}
+  </KanbanBoard>
+  <KanbanOverlay>
+    <div className="bg-muted size-full rounded-md" />
+  </KanbanOverlay>
+</Kanban>
+```
+
+**Gotcha:** state is `Record<columnId, T[]>`. Each `KanbanColumnContent value` must match its parent `KanbanColumn value`. Omit `KanbanOverlay` and the drag preview silently breaks.
+
+## sortable
+
+**Required:** `value` (`T[]`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Sortable value={items} onValueChange={setItems} getItemValue={(i) => i.id}>
+  {items.map((i) => (
+    <SortableItem key={i.id} value={i.id}>
+      <SortableItemHandle>
+        <GripVertical />
+      </SortableItemHandle>
+      {i.label}
+    </SortableItem>
+  ))}
+</Sortable>
+```
+
+**Gotcha:** a flat 1D reorder list (not columns - that is `kanban`). `getItemValue` must return a stable, unique string. Pass `layout="grid"` or `layout="nested"` for non-list layouts.
+
+## filters
+
+**Required:** `filters` (`Filter[]`), `fields` (`FilterFieldConfig[]`), `onChange`
+**Shape:**
+
+```tsx
+const [filters, setFilters] = useState<Filter[]>([
+  createFilter("priority", "is_any_of", ["low"]),
+])
+const fields: FilterFieldConfig[] = [
+  { key: "priority", label: "Priority", type: "multiselect",
+    options: [{ value: "low", label: "Low" }, { value: "high", label: "High" }] },
+]
+
+<Filters filters={filters} fields={fields} onChange={setFilters} />
+```
+
+**Gotcha:** always build initial filters with `createFilter(field, operator, values)` - it generates the required `id`. Never hand-construct a `Filter` object. Pairs naturally with `data-grid`.
+
+## date-selector
+
+**Required:** none, but wire `onChange` to capture the value.
+**Shape:**
+
+```tsx
+const [value, setValue] = useState<DateSelectorValue | undefined>()
+
+<DateSelector value={value} onChange={setValue} label="Due date" />
+```
+
+**Gotcha:** the value is a structured `DateSelectorValue` (period / operator / start+end dates), NOT a `Date` - never pass a raw `Date`. Use `allowRange={false}` to lock single-date picking. Read `get_component("date-selector")` for the value shape.
+
+## tree
+
+**Required:** `tree` (a `@headless-tree/core` instance you construct)
+**Shape:**
+
+```tsx
+<Tree tree={tree}>
+  {tree.getItems().map((item) => (
+    <TreeItem key={item.getId()} item={item}>
+      <TreeItemLabel />
+    </TreeItem>
+  ))}
+</Tree>
+```
+
+**Gotcha:** `Tree` is a styled shell - it takes a headless-tree instance via `tree`, NOT `data`/`items` props. Build the instance with `@headless-tree/react`. External API: https://headless-tree.lukasbach.com/
+
+## stepper
+
+**Required:** `StepperItem step` (number), `StepperContent value` (number)
+**Shape:**
+
+```tsx
+<Stepper defaultValue={1}>
+  <StepperNav>
+    <StepperItem step={1}>
+      <StepperTrigger>
+        <StepperIndicator>1</StepperIndicator>
+      </StepperTrigger>
+      <StepperSeparator />
+    </StepperItem>
+    <StepperItem step={2}>
+      <StepperTrigger>
+        <StepperIndicator>2</StepperIndicator>
+      </StepperTrigger>
+    </StepperItem>
+  </StepperNav>
+  <StepperPanel>
+    <StepperContent value={1}>Step 1 content</StepperContent>
+    <StepperContent value={2}>Step 2 content</StepperContent>
+  </StepperPanel>
+</Stepper>
+```
+
+**Gotcha:** steps are 1-indexed. Without `StepperPanel` + `StepperContent` you render the nav trail but no body. Put `StepperSeparator` in every `StepperItem` except the last.
+
+## timeline
+
+**Required:** `TimelineItem step` (number)
+**Shape:**
+
+```tsx
+<Timeline>
+  <TimelineItem step={1}>
+    <TimelineHeader>
+      <TimelineDate>March 2024</TimelineDate>
+      <TimelineTitle>Project initialized</TimelineTitle>
+    </TimelineHeader>
+    <TimelineIndicator />
+    <TimelineSeparator />
+    <TimelineContent>Repo and architecture set up.</TimelineContent>
+  </TimelineItem>
+</Timeline>
+```
+
+**Gotcha:** each item needs a unique `step`. `orientation` is `"vertical"` (default) or `"horizontal"`. This is a static event display, not interactive like `stepper`.
+
+## autocomplete
+
+**Required:** `items` (array; each item has at least `value`)
+**Shape:**
+
+```tsx
+<Autocomplete items={items}>
+  <AutocompleteInput placeholder="Search..." />
+  <AutocompleteContent>
+    <AutocompleteEmpty>No results found.</AutocompleteEmpty>
+    <AutocompleteList>
+      {(item) => (
+        <AutocompleteItem key={item.value} value={item}>
+          {item.label}
+        </AutocompleteItem>
+      )}
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>
+```
+
+**Gotcha:** `AutocompleteList` takes a render-prop `(item) => ReactNode`, NOT a mapped array of children. External API: https://base-ui.com/react/components/autocomplete
+
+## phone-input
+
+**Required:** none, but wire `onChange`.
+**Shape:**
+
+```tsx
+<PhoneInput
+  placeholder="Enter phone number"
+  defaultCountry="US"
+  value={value}
+  onChange={setValue}
+/>
+```
+
+**Gotcha:** `value`/`onChange` use an E.164 string (e.g. `"+14155551234"`), not a display-formatted string; `onChange` can fire `undefined`. `defaultCountry` is a 2-letter ISO code. Wraps `react-phone-number-input`.
+
+## number-field
+
+**Required:** wrap the controls in `NumberFieldGroup`.
+**Shape:**
+
+```tsx
+<NumberField defaultValue={0}>
+  <NumberFieldScrubArea label="Quantity" />
+  <NumberFieldGroup>
+    <NumberFieldDecrement />
+    <NumberFieldInput />
+    <NumberFieldIncrement />
+  </NumberFieldGroup>
+</NumberField>
+```
+
+**Gotcha:** import from `@/components/ui/number-field`. The accessible label goes on `NumberFieldScrubArea`, not `NumberField`. External API: https://base-ui.com/react/components/number-field
+
+## rating
+
+**Required:** `rating` (number)
+**Shape:**
+
+```tsx
+<Rating rating={4.5} showValue editable onRatingChange={setRating} />
+```
+
+**Gotcha:** supports decimals (partial stars). Pass `editable` + `onRatingChange` for interactive input; omit both for a read-only display.
+
+## scrollspy
+
+**Required:** `targetRef` (the scroll container ref)
+**Shape:**
+
+```tsx
+<Scrollspy targetRef={containerRef}>
+  <a href="#s1" data-scrollspy-anchor="s1">Section 1</a>
+  <a href="#s2" data-scrollspy-anchor="s2">Section 2</a>
+</Scrollspy>
+<div ref={containerRef}>
+  <div id="s1">...</div>
+  <div id="s2">...</div>
+</div>
+```
+
+**Gotcha:** each link's `data-scrollspy-anchor` must match a section `id`. `targetRef` is the scrollable container (defaults to the window).
+
+## frame
+
+**Required:** `Frame` > `FramePanel`
+**Shape:**
+
+```tsx
+<Frame>
+  <FramePanel>
+    <FrameHeader>
+      <FrameTitle>Title</FrameTitle>
+      <FrameDescription>Description</FrameDescription>
+    </FrameHeader>
+    <div className="p-5">Content</div>
+    <FrameFooter>Footer</FrameFooter>
+  </FramePanel>
+</Frame>
+```
+
+**Gotcha:** a structured card shell for tool-like surfaces. `stacked` connects multiple panels with shared borders; `dense` removes panel padding; radius via the `--frame-radius` CSS variable.
+
+## icon-stack
+
+**Required:** one child icon
+**Shape:**
+
+```tsx
+<IconStack aria-hidden="true">
+  <InboxIcon className="size-4" />
+</IconStack>
+```
+
+**Gotcha:** isometric layered artwork for empty states and illustrations; style the inner icon via its own `className`. Mark purely decorative stacks `aria-hidden="true"` and keep the real label in surrounding copy.
+
+## alert
+
+**Required:** `Alert` > `AlertTitle`
+**Shape:**
+
+```tsx
+<Alert variant="success">
+  <ShieldCheckIcon />
+  <AlertTitle>Security update</AlertTitle>
+  <AlertDescription>Enable two-factor authentication.</AlertDescription>
+  <AlertAction>
+    <Button size="xs">Update</Button>
+  </AlertAction>
+</Alert>
+```
+
+**Gotcha:** shadcn-compatible API. `variant`: `default | destructive | info | success | warning | invert`. The non-default variants use ReUI extended color tokens (`--success`/`--info`/`--warning`/`--invert`), which the install adds. Defer generic alert rules to the shadcn skill.
+
+## badge
+
+**Required:** none (text child).
+**Shape:**
+
+```tsx
+<Badge variant="success-light" size="sm">Success</Badge>
+<Badge variant="outline" radius="full">Pill</Badge>
+```
+
+**Gotcha:** shadcn-compatible. Rich `variant` set (solid, `-outline`, `-light` per color), `size` `xs..xl`, `radius` `default | full`. Like `alert`, the color variants rely on ReUI extended tokens. Prefer `Badge` variants over raw color classes for statuses.
+
+## base vs radix - write for the project's base
+
+ReUI ships every component in two builds: `base` (Base UI) and `radix` (Radix UI). The install command and name are identical, and the CLI installs the build matching the project. But you must write/adapt code against the **right base**, because their APIs differ.
+
+**Detect the base first.** Read `components.json` -> `style` and take the segment before the first `-`:
+
+- `"style": "base-nova"` -> **Base UI**
+- `"style": "radix-nova"` -> **Radix UI**
+
+**Then use that base's API.** The deltas mirror shadcn's base-vs-radix split:
+
+- Slot/composition: Base UI `render={<… />}` vs Radix `asChild`.
+- `Select`: Base UI takes `items`; Radix uses `<SelectItem>` children.
+- `ToggleGroup`: Base UI `multiple` boolean vs Radix `type="single" | "multiple"`.
+
+The safest path is to **read the installed files and `c-*` examples** - they're already in your base, so reuse their wiring instead of guessing. When `get_component`'s inline `api` or an example shows the other base's shape, translate it to your base (or `validate_usage` to confirm). Defer the generic base/radix mechanics to the shadcn skill.

--- a/.agents/skills/reui/rules/craft.md
+++ b/.agents/skills/reui/rules/craft.md
@@ -1,0 +1,45 @@
+# Craft: make ReUI UI exceptional, not generic
+
+ReUI items ship senior-designer quality. Your adaptation has to hold that bar, so the result reads like a real product surface a team would keep - not a wireframe an AI generated. Use these alongside the reuse rules in [adapting.md](./adapting.md).
+
+## Have a point of view
+
+Pick an emotional register before you compose - calm, operational, premium, editorial, dense, energetic - and let layout, spacing, surface treatment, and icon behavior all reinforce it. One or two memorable decisions and restraint everywhere else beats ten generic ones. UI with no point of view reads as generated.
+
+## Brutally clear hierarchy
+
+One focal point per card or panel: the dominant metric or task first, its label second, supporting detail third. The first thing the eye lands on should be the right thing; secondary text must read as secondary. Borders, separators, and surfaces do real work to create 2-3 information bands - don't flatten everything to equal weight.
+
+## Spacing rhythm and deliberate density
+
+Gaps are a signal, not a default. Keep them intentional and consistent within a family (`gap-1`/`gap-2` for tight operational rows, larger gaps for section breaks), and smaller within a group than between groups. Match the surrounding ReUI density; don't pad an operational surface like a marketing page, and don't drift density mid-section. The composition should still feel authored in grayscale.
+
+## Cover the real states (the usual miss)
+
+A surface isn't done at the happy path. Compose, and wire:
+
+- **Empty** - a purposeful empty state (short message + the primary action), never a blank panel.
+- **Loading** - a **skeleton** that matches the real layout, not a centered spinner.
+- **Error** - an inline, recoverable error with a retry, announced via `role="status"`/`aria-live`.
+
+Derive these from an element the block already has (don't invent parallel markup), or `get_examples` for a state-specific example.
+
+## Responsive by default
+
+Mobile-first, not mobile-afterthought. In constrained rows/cards/sidebars, put `min-w-0` on the shrinking container and `truncate` long single-line labels; protect the primary label's width and let secondary content compress. Reflow layouts (multi-column -> single column) rather than just shrinking them. Desktop and mobile should both look designed.
+
+## Motion, subtly
+
+Motion should clarify, not decorate. Use ReUI Motion Icons on primary actions for a subtle hover cue; keep transitions short (~200-300ms) with calm easing; prefer a skeleton pulse over a spinner. No bouncing, no gratuitous entrance animations on every element.
+
+## Real, activated content
+
+Use believable, typed data (realistic labels, counts, timestamps, statuses that map to a real workflow) - never lorem or abstract filler. Every visible control does something: no decorative buttons, fake tabs, meaningless toggles, or stats with no job. It must still hold with long names, empty values, and crowded data.
+
+## Avoid the AI tells
+
+These instantly read as generated - don't ship them: equal-weight card walls, empty gradients, repetitive padding everywhere, generic enterprise copy, ornamental icons, and number tiles that don't earn their place.
+
+## The bar
+
+Before you finish, ask: **would a product team keep this instead of replacing it? Does it still feel strong after swapping in real content?** If not, reuse the shipped ReUI design harder - don't restyle it into something new - then run the [quality.md](./quality.md) gates.

--- a/.agents/skills/reui/rules/icons.md
+++ b/.agents/skills/reui/rules/icons.md
@@ -1,0 +1,38 @@
+# Icons (ReUI delta over shadcn)
+
+Follow the shadcn icon rules (use the project's configured `iconLibrary`, `data-icon` on icons inside `Button`, no sizing classes on icons inside components, pass icons as component objects not string keys). ReUI adds the following.
+
+## Portable icons (library-agnostic)
+
+ReUI components, examples, and blocks are authored to be icon-library-agnostic. When `iconLibrary` is set in `components.json`, the shadcn CLI installs each item's icons in **your** library automatically - you swap nothing. If an installed item's icons don't match your project (for example `iconLibrary` isn't set, so they came in from the item's demo library), change the **import source and component name** to your library, keeping the same icon-name semantics:
+
+- `lucide` -> `lucide-react`
+- `tabler` -> `@tabler/icons-react`
+- `phosphor` -> `@phosphor-icons/react`
+- `remix` -> `@remixicon/react`
+- `hugeicons` -> `@hugeicons/react`
+
+Don't assume `lucide-react`; read `iconLibrary` from `components.json`.
+
+## Keep icons purposeful
+
+Icons support the hierarchy, they don't replace it: keep them small, matched to the surrounding density, and decorative ones `aria-hidden="true"` (an icon-only control still needs an accessible label on the control). Don't add ornamental icons that do no job.
+
+## Motion Icons (the `@reui/icons/...` set)
+
+ReUI ships its own icon set in 4 styles (outline, solid, duotone, filled), each icon in two variants:
+
+```bash
+npx shadcn@latest add @reui/icons/default/<style>/<name> --yes    # static
+npx shadcn@latest add @reui/icons/animated/<style>/<name> --yes   # hover-animated (motion/react)
+```
+
+Finding them via the MCP is free; installing requires an Ultimate license (`REUI_LICENSE_KEY`, see [cli.md](./cli.md)). Reach for a Motion Icon on a primary action when a subtle hover cue helps; keep motion restrained.
+
+Finding icons:
+
+- Several icons (the common case): **`search_icons(concepts[])`** - up to 24 concepts in one call, the best icons per concept with install commands. Pass `animated: true` to get only icons with a hover-animated Motion variant.
+- One icon: `search` with `type: "icon"`.
+- Icon results and `get_icon` carry `animated: true` and `installAnimated` when an animated variant exists - use those install strings, do not construct paths by hand.
+
+The `icon-stack` component composes multiple icons into a stacked display.

--- a/.agents/skills/reui/rules/quality.md
+++ b/.agents/skills/reui/rules/quality.md
@@ -1,0 +1,22 @@
+# Quality gates (security, accessibility, scroll)
+
+These are the **done gate**, not a nice-to-have: before you call any ReUI work finished, call the MCP `get_audit_checklist` tool and pass every item below (plus the craft bar in [craft.md](./craft.md)). Then typecheck and lint.
+
+## Security
+
+- Never `dangerouslySetInnerHTML`. Render data as text/components.
+- External links (`target="_blank"`) must always pair `rel="noopener noreferrer"`.
+- No real PII, secrets, or tokens in demo or committed code. Remote media only from sources the project already allows.
+
+## Accessibility
+
+- Implicit list/card items that navigate get real anchors with a standard hover affordance.
+- Icon-only or numeric buttons need an `aria-label`; decorative icons get `aria-hidden`.
+- Every non-submit button is `type="button"`.
+- Keyboard + focus: everything interactive is reachable in a sensible Tab order with a visible focus ring; layers (dialogs/sheets/menus) trap focus and close on `Escape`. ReUI components ship standard keyboard behavior - read each component's inline `api` rather than re-implementing it.
+- Announce async UI: loading and error messages use `role="status"` / `aria-live` so they're not silent to screen readers.
+
+## Scroll mechanics
+
+- Make scroll regions with a parent-owned height: a `min-h-0` + flex chain down to the scroll container. Never guess a `max-h`.
+- The scroll container owns `overflow-auto`; ancestors stay `min-h-0` so the height resolves.

--- a/.agents/skills/reui/rules/registry.md
+++ b/.agents/skills/reui/rules/registry.md
@@ -1,0 +1,31 @@
+# ReUI registry structure
+
+ReUI is a shadcn-compatible registry with four entity types. **Examples and blocks are built FROM components** - reuse them, don't rebuild.
+
+- **component** - one of the 17 ReUI building blocks with a real API (`data-grid`, `kanban`, `filters`, `date-selector`, `tree`, ...). Install directly (`@reui/data-grid`) or let it come in as a dependency of an example/block. Free. Read its API with `get_component(name)`.
+- **example** - a free `c-*` single-pattern use-case of a component (`c-kanban-1`, `c-data-grid-3`). Install one and read it to copy real composition. Find a component's examples with `get_examples(name)`.
+- **block** - a premium, full-page section that composes several components (`data-grid-2`, `pricing-page-1`). Pro or Ultimate license at install. Adapts to your active theme via semantic tokens.
+- **icon** - Motion Icons in 4 styles (outline, solid, duotone, filled), static (`@reui/icons/default/<style>/<name>`) and hover-animated (`@reui/icons/animated/<style>/<name>`). Ultimate license at install. See [icons.md](./icons.md).
+
+## The @reui registry
+
+Install everything through the shadcn CLI: `npx shadcn@latest add @reui/<name> --yes`. The CLI reads the `@reui` registry from the project's `components.json`. Free items need only the plain string form:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium installs need the authenticated form + `REUI_LICENSE_KEY` in `.env.local` - see [cli.md](./cli.md). The MCP `get_project_context` tool returns the right config.
+
+## Know your base: base or radix
+
+ReUI ships every item in two builds - `base` (Base UI) and `radix` (Radix UI) - with mirrored names. The CLI installs the build matching your project automatically, but **you must write code against the right base's API**. Detect it from `components.json` -> `style`: the segment before the first `-` is the base (`base-nova` -> Base UI, `radix-nova` -> Radix UI). The installed files and `c-*` examples are already in your base - read them and adapt on that base. See [components.md](./components.md) for the API deltas. Blocks adapt to your active theme through semantic tokens and CSS variables - change the theme and every block follows.
+
+## Free vs premium
+
+- **Free, no key:** the 17 components, all `c-*` examples, the ReUI MCP, and this skill.
+- **Premium, license required at install:** blocks (Pro or Ultimate), Motion Icons and templates (Ultimate). Set `REUI_LICENSE_KEY` (see [cli.md](./cli.md)).
+
+## Component API index
+
+The canonical index of every component's API docs is **https://reui.io/llms.txt** (returned as `componentsApiUrl` in MCP results). Prefer the inline `api` from `get_component`; use the index/docs as the fallback.

--- a/.agents/skills/reui/rules/styling.md
+++ b/.agents/skills/reui/rules/styling.md
@@ -1,0 +1,26 @@
+# Styling (ReUI delta over shadcn)
+
+Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+
+## ReUI extended semantic tokens
+
+ReUI adds semantic tokens beyond shadcn's base set. Use these instead of raw colors for status and emphasis:
+
+- `--success` / `--success-foreground`
+- `--info` / `--info-foreground`
+- `--warning` / `--warning-foreground`
+- `--destructive-foreground` (paired with shadcn's `--destructive`)
+- `--invert` / `--invert-foreground` (inverted surfaces)
+
+Use them as Tailwind utilities (`bg-success text-success-foreground`, `text-warning`, ...). They are defined in the project's global CSS and registered with Tailwind (`@theme inline` on v4). If a token is missing in the project, add it to the global CSS file (never a new file) following the same `name` / `name-foreground` convention, exactly as the shadcn customization rules describe.
+
+**Incorrect:** `<span className="text-green-600">Active</span>`
+**Correct:** `<Badge variant="success">Active</Badge>` or `<span className="text-success">Active</span>`
+
+## Blocks follow your theme
+
+When you install a block it adapts to your active theme through the semantic tokens above and the project's CSS variables. Don't hardcode style-specific values into installed block code and don't fork it to "restyle" - change the theme via the CSS variables / a preset and every block follows. Want a different look? `search` for a block whose design already fits instead of re-skinning one.
+
+## Density and typography rhythm
+
+ReUI operational UI usually feels dense, not airy. Keep the gap between a title and its supporting description tight by default (`gap-0.5`, `space-y-1`, or `space-y-px`), and smaller than the gap between sections. Match the surrounding ReUI density when you add rows or fields; do not pad operational surfaces like a marketing page.

--- a/.agents/skills/reui/rules/styling.md
+++ b/.agents/skills/reui/rules/styling.md
@@ -1,6 +1,6 @@
 # Styling (ReUI delta over shadcn)
 
-Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+Follow [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../../moai-library-shadcn/SKILL.md) for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
 
 ## ReUI extended semantic tokens
 

--- a/.agents/skills/reui/rules/workflow.md
+++ b/.agents/skills/reui/rules/workflow.md
@@ -1,0 +1,52 @@
+# Workflow: find -> install -> read API -> adapt
+
+The core ReUI loop. The MCP tells you what to install and gives you the API; the shadcn CLI installs it; you turn the installed files into correct, themed, data-wired code by **reuse**, not redesign.
+
+## 1. Find (ReUI MCP `search` / `compose_page`)
+
+**Full multi-section page ask?** Call `compose_page(intent, sections?)` FIRST, before searching block-by-block. It returns ordered sections, each with the best block for the intent (top pick + alternates); sections listed in `unavailableSections` have no real inventory - compose those from components, do not force a bad block.
+
+For everything else, call `search` with the user's intent. Pass structured hints whenever you can infer them - you are an LLM, so do the parsing the server cannot:
+
+- `type`: `"component"` (one of the 17 building blocks), `"example"` (a c-\* use-case), `"block"` (a full page/section), `"icon"`.
+- `component`: the ReUI component the request implies (`"data-grid"`, `"kanban"`, ...).
+- `category`, `features` (e.g. `["sortable","pagination"]`), `free`.
+
+Example: "build a users management page with filters" -> `search({ query: "users management page with filters", type: "block", component: "data-grid", features: ["filters"] })`.
+
+Each result has `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `termCoverage`, and `whyMatch`. `score` is relative to the top hit (the top is ~100 by construction), not an absolute quality - compare results to each other, and show the user the top options if several score closely; do not silently guess. A low `termCoverage` means a weak match even with a high score - rephrase or widen.
+
+## 2. Install (shadcn CLI)
+
+Run the result's `install` command from the project root, non-interactively:
+
+```bash
+npx shadcn@latest add @reui/<name> --yes
+```
+
+The CLI reads `components.json`, installs the correct base+style variant, resolves `registryDependencies` (a block pulls in its components), installs npm deps, and rewrites aliases. Do not pass the base/style. See [cli.md](./cli.md).
+
+## 3. Read the API (do not guess props)
+
+Before writing code against any component an item uses:
+
+1. The item's `componentDigests` already give a 1-line contract per component - often enough to wire it. For the full API, call **`get_component(names)`** with ALL of `componentsUsed` in ONE call (it accepts an array) and read each inline `api` - no web fetch. `docsUrl` and the `/llms.txt` index are the fallback.
+2. Call **`get_examples(name)`** for the free `c-*` examples of that component; install one and **read the added files** to copy the exact composition. This is the fastest correct path - the example shows real wiring you adapt, not invent.
+3. About to write a prop you did not see in an `api` or installed file? Run **`validate_usage`** BEFORE writing the code - per-prop documented / notDocumented verdicts plus did-you-mean suggestions. notDocumented means read the API, not push on.
+
+## 4. Adapt (reuse-first) - do not skip
+
+Installing files is not the end, and redesigning them defeats the point. First note the project's **base** so you write the right API - read `components.json` -> `style` and take the segment before the first `-` (`base-nova` -> Base UI, `radix-nova` -> Radix UI), see [components.md](./components.md). After `add`:
+
+1. **Read the added files**; keep the composition intact. For a block, verify the components are wired correctly (for `data-grid`: a `useReactTable` instance passed as `table`, `recordCount` set - see [components.md](./components.md)).
+2. **Replace demo data with the user's real data** via typed structures (see [adapting.md](./adapting.md)).
+3. **Fix icon imports** to the project's icon library (see [icons.md](./icons.md)).
+4. **Align styling** to semantic tokens and the active theme - no raw colors (see [styling.md](./styling.md)).
+5. **Validate before finalizing**: if your adaptation introduced components or props you did not read in an `api` or example, run `validate_usage` on them.
+6. **Hit the craft bar** - clear hierarchy, deliberate density, the empty / loading / error states, subtle motion, and mobile-first responsiveness (see [craft.md](./craft.md)). Generic-looking output means you under-reused the design, not that it needs restyling.
+7. **Pass the quality gates** (security, a11y, scroll) - call the MCP `get_audit_checklist` tool and clear every item (see [quality.md](./quality.md)).
+8. **Typecheck / lint**.
+
+## If no single block fits
+
+Compose from components (`compose_page` tells you which sections have no block inventory via `unavailableSections`). `search` the components you need, read each `get_component` API, install a worked `get_examples` example for each, and assemble by adapting those examples. A block in the same category is a useful reference - install it and read its files to see how ReUI composes those components, then adapt.

--- a/.agents/skills/reui/tools.md
+++ b/.agents/skills/reui/tools.md
@@ -1,0 +1,57 @@
+# ReUI MCP: full reference
+
+The ReUI MCP (`https://mcp.reui.io`, Streamable HTTP) is free - it needs no license and no auth header at all. It does **discovery + guidance** (search, inline APIs, page planning, validation) and never serves source code; the shadcn CLI does **installation**, and the license key lives only there (the `@reui` entry in `components.json`, backed by `.env.local`). In this repo it is configured as `reui` for Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), and Codex (`.codex/config.toml`). Goal: from the user's intent to correct, themed, data-wired ReUI code in the **fewest tokens and calls**, with **no guessing**.
+
+## Golden path (token-optimal - follow this order)
+
+Most tasks need 2-4 MCP calls and ZERO web fetches:
+
+1. **`search(query, ...hints)`** -> pick the top 1-3 results. Each result already carries `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `whyMatch`. The payload is complete - do not call another tool just to "confirm" a result.
+2. **`get_component([...componentsUsed])`** in ONE batched call (one name or an array of up to 20) -> read each inline `api`. This **replaces** fetching docs pages. Often skippable: search responses carry `componentDigests`, a compact API contract per referenced component.
+3. **`get_examples(component)`** -> install ONE returned `c-*` example, read the added files, copy the composition.
+4. **`get_install_command(item)`** only to validate a name you are unsure of (results already include `install`). Run the install with the shadcn CLI (`--yes`).
+5. **`get_audit_checklist()`** before declaring done.
+
+If you already know the exact item name, skip `search`. Everything else is situational.
+
+## The 5 task-specific tools (when to reach for each)
+
+- **`compose_page`** - BEFORE building any full page (dashboard, settings, billing, landing). Pass the intent (and optionally the sections you want); it returns ordered sections, each with the best premium block for the intent (top pick + alternates). Sections with no real inventory are listed honestly in `unavailableSections` - compose those from components instead of forcing a bad block.
+- **`search_icons`** - whenever you need icons, especially several. Batch up to 24 concepts in one call; each concept returns its best icons with install commands. Pass `animated: true` to get only icons that have a hover-animated Motion variant.
+- **`validate_usage`** - BEFORE writing code with component names or props you have not read in an inline `api` or an installed example. It checks planned names + props against the indexed API docs and registry item names; returns did-you-mean suggestions and per-prop documented / notDocumented verdicts. Deterministic, no inference - a notDocumented prop means stop and read the API, not push on.
+- **`whats_new`** - when your registry knowledge might be stale (a name 404s, the user mentions an item you don't know). Returns items added/removed per build, newest first.
+- **`report_issue`** - when an installed item is actually broken (bad source, wrong dependency, broken preview). Goes straight to the ReUI team; rate-limited 5/hour. Not for usage questions.
+
+## All 19 tools
+
+`search`, `get_block`, `get_example`, `get_icon`, `list_block_groups`, `list_block_categories`, `list_example_categories`, `list_icon_categories`, `list_components`, `get_component`, `get_examples`, `search_icons`, `compose_page`, `validate_usage`, `whats_new`, `report_issue`, `get_install_command`, `get_project_context`, `get_audit_checklist`. The MCP serves the full parameter schemas; do not guess parameters beyond them.
+
+## Token + speed rules
+
+- **Batch `get_component`** - ONE call with the whole `componentsUsed` array, never N calls. Skip it entirely when `componentDigests` already answers the question.
+- **Read source by installing** - the MCP serves no source. To read or analyze an item's real code, install it with the shadcn CLI and open the local files. Learn an API from the inline `api` / `componentDigests`, never by reading raw source.
+- **Infer `search` hints yourself** (`type`, `component`, `category`, `features`, `free`) - hints shrink the result set and the tokens. Keep `limit` low; one right result beats ten.
+- Run independent calls (and the shadcn install) concurrently in one turn - serial tool calls are the main source of slowness.
+- Don't repeat a search for the same intent; don't call `list_*` to "see everything" - `search` is the entry point, `list_*` is only for browsing a taxonomy the user explicitly wants to explore.
+- Prefer `get_component`'s inline `api` over `docsUrl` / `/llms.txt`. Fetch a web page only as a last resort.
+
+## Result shapes (so you don't re-fetch)
+
+- `score` is 0-100 RELATIVE to the top hit (the top is ~100 by construction), not absolute - compare results to each other.
+- `termCoverage` (0-1) is the share of the query the item matched - low means a weak match even if the score looks high; rephrase or widen the search.
+- Each result carries `whyMatch`, `install`, docs/preview URLs, and a `free` flag; premium items carry `requiredPlan` (`"pro"` for blocks, `"ultimate"` for icons).
+- `componentDigests` is a top-level map: a compact API contract per referenced component - often enough to wire an item without a `get_component` call.
+- Icon results and `get_icon` include `animated: true` and `installAnimated` when a hover-animated Motion variant exists (animated: `@reui/icons/animated/<style>/<name>`; static: `@reui/icons/default/<style>/<name>`).
+
+## Error playbook
+
+- **401 / 403** - install-time only: a premium install without a valid `REUI_LICENSE_KEY`, or a plan that does not cover the item (blocks Pro+, icons/templates Ultimate). Point to https://reui.io/account (key) or https://reui.io/pricing (upgrade). The MCP itself never authenticates - connecting and every tool are free.
+- **429** - rate limited (120 requests/min per IP); back off, honor `Retry-After`.
+- **not found** (`found: false`) - use the returned `suggestions`, or `search`; check `whats_new` if you suspect a stale name. Never run a fabricated install command.
+
+## Fallbacks
+
+- No ReUI MCP: `npx shadcn@latest search @reui -q "..."` then `add` (generic, no scoring / inline API).
+- The shadcn project's own MCP also works over the `@reui` registry: https://ui.shadcn.com/docs/mcp.
+
+Per-agent MCP setup: https://reui.io/docs/mcp

--- a/.claude/skills/.repo-canonical-skills.json
+++ b/.claude/skills/.repo-canonical-skills.json
@@ -50,6 +50,7 @@
     "repo-entry",
     "request-refactor-plan",
     "resend-cli",
+    "reui",
     "setup-matt-pocock-skills",
     "setup-pre-commit",
     "supabase",

--- a/.claude/skills/reui/SKILL.md
+++ b/.claude/skills/reui/SKILL.md
@@ -5,6 +5,26 @@ user-invocable: false
 allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
 ---
 
+## This repository (Asymmetric-al/core)
+
+Subordinate to **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/moai-library-shadcn/SKILL.md`** (generic shadcn rules), and TanStack guides under `docs/guides/development/`.
+
+**Registry (`packages/ui/components.json`):**
+
+- Active style is **`base-maia`** (Base UI + Maia). Read the segment before the first `-` in `style` to detect the base (`base-maia` → Base UI).
+- **`@reui`** is the **plain-string** registry (free components and `c-*` examples). Premium blocks/icons need the authenticated object form plus `REUI_LICENSE_KEY` in git-ignored `.env.local` — see [rules/cli.md](./rules/cli.md). Switch back to the plain form when premium installs are not in progress so contributors without a key can install free items.
+
+**Tables:**
+
+- Prefer shared **`DataTableResponsive`** from `@asym/ui/components/shadcn/data-table` for standard app tables (see `docs/guides/development/tanstack-virtual-foundation.md`).
+- Use ReUI **`data-grid`** when you need ReUI-specific table composition after `get_component('data-grid')`.
+
+**Naming:** **ReUI** (`@reui`, this skill) is unrelated to shadcn-studio **`/rui`** (Refine UI) in `docs/ai/rules/shadcn-studio-mcp.md`.
+
+**MCP:** `reui` at `https://mcp.reui.io` in `.mcp.json`, `.cursor/mcp.json`, and `.codex/config.toml`. The MCP is free; only premium **installs** need a license key. Never commit `REUI_LICENSE_KEY`.
+
+Refresh: [references/upstream.md](./references/upstream.md).
+
 # ReUI for Agents
 
 ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
@@ -16,13 +36,13 @@ ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never
 
 The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
 
-Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on** [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../moai-library-shadcn/SKILL.md) for generic shadcn rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
 
 ## The core loop (MCP-native)
 
 1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
 2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
-3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (this repo uses `base-maia` → Base UI; `radix-nova` → Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
 4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
 
 If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
@@ -45,7 +65,7 @@ Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor
 | Need                                                                 | Reach for                                                                 |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
-| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
+| A data table with sorting/filtering/pagination/virtualization        | **`DataTableResponsive`** in this repo; ReUI **data-grid** when ReUI-specific composition is required |
 | A drag-and-drop board                                                | the **kanban** component                                                  |
 | Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
 | A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |

--- a/.claude/skills/reui/SKILL.md
+++ b/.claude/skills/reui/SKILL.md
@@ -62,13 +62,13 @@ Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor
 
 ## When to reach for ReUI vs plain shadcn
 
-| Need                                                                 | Reach for                                                                 |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
+| Need                                                                 | Reach for                                                                                             |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks**                             |
 | A data table with sorting/filtering/pagination/virtualization        | **`DataTableResponsive`** in this repo; ReUI **data-grid** when ReUI-specific composition is required |
-| A drag-and-drop board                                                | the **kanban** component                                                  |
-| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
-| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+| A drag-and-drop board                                                | the **kanban** component                                                                              |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                                                       |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                                                      |
 
 ## Detailed references
 

--- a/.claude/skills/reui/SKILL.md
+++ b/.claude/skills/reui/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: reui
+description: Use the ReUI registry from your AI agent - find, install, and correctly use ReUI components (the 17 free building blocks like data-grid, kanban, filters), their free examples, premium blocks, and Motion Icons. Applies in any project using ReUI, the @reui registry, REUI_LICENSE_KEY, or any shadcn project where the user asks for premium blocks, data grids, kanban boards, dashboards, or full pages. Pairs with the free ReUI MCP server for live, scored registry search and inline component APIs.
+user-invocable: false
+allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
+---
+
+# ReUI for Agents
+
+ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
+
+- **components** - the 17 ReUI building blocks with real APIs: `data-grid`, `kanban`, `filters`, `date-selector`, `tree`, `stepper`, ... (free)
+- **examples** - free `c-*` single-pattern use-cases of a component (`c-kanban-1`); install one and read it to see exact composition
+- **blocks** - premium full-page sections that compose components (`data-grid-2`, `pricing-page-1`); Pro or Ultimate license at install
+- **icons** - Motion Icons in 4 styles, static + hover-animated variants; Ultimate license at install
+
+The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
+
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+
+## The core loop (MCP-native)
+
+1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
+2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
+
+If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
+
+## Commands
+
+Run ReUI as explicit slash commands (via the ReUI MCP) **or** just ask in plain language - both run the same workflow.
+
+| Command     | Invoke                         | Does                                                                                                               |
+| ----------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| **build**   | `/mcp__reui__build <what>`     | Compose a page/section/feature from ReUI: plan → install → read API → adapt → craft → audit.                       |
+| **add**     | `/mcp__reui__add <item>`       | Find & install one component/example/block/icon and wire it in.                                                    |
+| **fix**     | `/mcp__reui__fix [target]`     | Diagnose & fix ReUI usage: wrong/undocumented props, base/radix mismatch, missing states, a11y/scroll.             |
+| **improve** | `/mcp__reui__improve [target]` | Refine + extend existing ReUI UI to a production-exceptional bar (hierarchy, density, states, responsive, motion). |
+
+Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor/Windsurf, `/mcp.reui.build` in VS Code). No command surface? Just describe what you want - this skill drives the identical loop.
+
+## When to reach for ReUI vs plain shadcn
+
+| Need                                                                 | Reach for                                                                 |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
+| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
+| A drag-and-drop board                                                | the **kanban** component                                                  |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+
+## Detailed references
+
+- [rules/registry.md](./rules/registry.md) - the four types, the @reui registry, base/radix, free vs premium + license
+- [rules/workflow.md](./rules/workflow.md) - the find -> install -> read-API -> adapt loop (most important)
+- [rules/components.md](./rules/components.md) - the 17 components, the data-grid contract, base vs radix
+- [rules/adapting.md](./rules/adapting.md) - reuse-first: preserve the design (no over-customizing), reuse examples + a block's own elements, real data, don't invent APIs
+- [rules/craft.md](./rules/craft.md) - make it exceptional: point of view, hierarchy, density, states, responsive, motion, the bar
+- [rules/quality.md](./rules/quality.md) - security, accessibility, and scroll gates (the done gate)
+- [rules/styling.md](./rules/styling.md) - ReUI extended tokens, theme adaptation, density
+- [rules/icons.md](./rules/icons.md) - portable icons, swapping imports, Motion Icons (static + animated)
+- [tools.md](./tools.md) - the ReUI MCP: golden path, the 19 tools, token rules, result shapes, errors

--- a/.claude/skills/reui/references/upstream.md
+++ b/.claude/skills/reui/references/upstream.md
@@ -1,0 +1,25 @@
+---
+source: https://reui.io/docs/agent-skills
+install_commands:
+  - bunx --bun shadcn@latest add @reui/skills-claude
+  - bunx --bun shadcn@latest add @reui/skills-codex
+  - bunx --bun shadcn@latest add @reui/skills-cursor
+last_refreshed: 2026-07-01
+---
+
+# ReUI agent skills upstream
+
+Canonical copy in this repo: `docs/ai/skills/reui/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, and Cursor. This repo uses the shared canonical-skill pattern instead of committing each tool's installer output as the source of truth.
+
+## Refresh workflow
+
+1. Run the current ReUI install commands in a clean working tree or scratch branch:
+   - `bunx --bun shadcn@latest add @reui/skills-claude`
+   - `bunx --bun shadcn@latest add @reui/skills-codex`
+   - `bunx --bun shadcn@latest add @reui/skills-cursor`
+2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+5. Commit canonical and generated mirror updates together.

--- a/.claude/skills/reui/references/upstream.md
+++ b/.claude/skills/reui/references/upstream.md
@@ -20,6 +20,6 @@ ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, a
    - `bunx --bun shadcn@latest add @reui/skills-codex`
    - `bunx --bun shadcn@latest add @reui/skills-cursor`
 2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
-3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file plus the **`## This repository (Asymmetric-al/core)`** overlay at the top of `SKILL.md` (registry defaults, `base-maia`, `DataTableResponsive`, `/rui` disambiguation).
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 5. Commit canonical and generated mirror updates together.

--- a/.claude/skills/reui/rules/adapting.md
+++ b/.claude/skills/reui/rules/adapting.md
@@ -1,0 +1,43 @@
+# Adapting installed ReUI code (reuse-first, no AI slop)
+
+ReUI items ship production-quality. Your job is to **adapt by reuse** - wire real data and fit the app - not to redesign or hand-roll. The output should look like ReUI built it for this product.
+
+## Preserve the design - don't over-customize
+
+The design IS the product. A ReUI block/component encodes senior-designer decisions: spacing, hierarchy, density, color treatment, and component choices. The fastest way to turn a premium block back into generic AI slop is to "improve" its look - so don't.
+
+- Change **data, copy, and props**; keep the **structure and styling** it ships with. Make the **smallest** change that wires the real data. If your diff touches `className` / JSX structure more than data / props, you are over-customizing - stop and reuse.
+- Don't swap ReUI components for hand-rolled ones, restructure the layout, re-skin spacing / radius / colors, or add decorative chrome. Let the installed components carry the default spacing, radius, sizing, icon rhythm, density, and state styling; add custom Tailwind only when a component genuinely lacks a contract you need.
+- Want a different look? `search` for a block whose design already fits and reuse that - don't restyle this one into a new design.
+
+## Reuse the parts: examples and the block's own elements
+
+- **Examples are building parts.** A free `c-*` example is a correct, single-pattern composition you can reuse. Before composing from scratch, `get_examples(component)`, install the closest one, and reuse its wiring - assemble UI from examples instead of hand-rolling what an example already shows.
+- **Reuse a block's own elements.** Need more rows, cards, items, or sections than ship by default? Repeat the block's **existing** element by mapping real data through the same markup - never invent parallel markup that drifts from its design. Need a variant (empty / loading / expanded)? Derive it from an element the block already has.
+
+## Don't invent (read, don't guess)
+
+- Never write a prop, variant value, import path, or `@reui/...` name you didn't read in a component's inline `api`, an installed example, or a `search` result. If you didn't see it, treat it as nonexistent - call `get_component` / `get_examples` / `search` first, or run the MCP `validate_usage` tool to check planned names + props against the docs before writing code.
+- If a getter returns `found: false` or `search` returns nothing, say so and fall back (plain shadcn, or ask) - never fabricate an install command or an API.
+
+## What to change vs leave alone
+
+- **Change:** the item's own data, copy, props, and layout to fit the app.
+- **Leave alone:** installed component files, hooks, and the shared theme - do not edit vendored ReUI internals; change behavior through props and the documented API.
+- Blocks are **portable React** - no `next/link`, `next/image`, or other framework-runtime imports inside them. Keep them portable.
+
+## Demo data -> real data
+
+- Replace every placeholder with the user's real data. Model it as **typed data structures** and **map over arrays** - never duplicate JSX per row/card. Keep small block-specific formatters next to the data.
+- Wire the real source (columns, fields, fetch). For `data-grid`, implement the server fetch contract if the user needs server-side data.
+- **Type from the component API, derive during render.** Type domain state through the component's own types - e.g. map status to `BadgeProps["variant"]` via a typed `Record<Status, …>` - instead of stringly-typed values. Compute view state during render; don't mirror derived data into `useState`/`useEffect`.
+- **Adapt on the right base.** Use the API for the project's base (Base UI vs Radix - see [components.md](./components.md)); the installed files are already base-correct, so reuse their shape rather than translating from memory.
+
+## Believable content (no AI tells)
+
+- Use realistic labels, counts, timestamps, and statuses that map to a real workflow.
+- No decorative buttons, fake tabs, meaningless toggles, equal-weight card walls, empty gradients, ornamental icons, or generic SaaS filler. Every element should do something.
+
+## Operational surfaces (settings / profile / admin)
+
+Pick ONE archetype and keep the family consistent: a vertical rail (3-6 sections), horizontal tabs (5-8), or a frame/stack. Prefer `frame` for tool-like surfaces, a card for profile-like ones. Don't mix archetypes in one surface.

--- a/.claude/skills/reui/rules/cli.md
+++ b/.claude/skills/reui/rules/cli.md
@@ -1,0 +1,58 @@
+# CLI: registry setup, license, non-interactive install
+
+## Registry setup (one-time, per project)
+
+Free items (the 17 components and all `c-*` examples) need only the plain string registry in `components.json`:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium items (blocks; Motion Icons and templates) require a ReUI license at install:
+
+1. Add the key to `.env.local`:
+
+```bash
+REUI_LICENSE_KEY=your-license-key
+```
+
+2. Switch `components.json` to the authenticated object form:
+
+```json
+{
+  "registries": {
+    "@reui": {
+      "url": "https://reui.io/r/{style}/{name}.json",
+      "headers": { "Authorization": "Bearer ${REUI_LICENSE_KEY}" }
+    }
+  }
+}
+```
+
+The MCP `get_project_context` tool returns the right config. Full guide: https://reui.io/docs/registry
+
+## Installing
+
+Use the project's package runner (check `packageManager`):
+
+```bash
+npx shadcn@latest add @reui/<name> --yes      # npm
+pnpm dlx shadcn@latest add @reui/<name> --yes  # pnpm
+bunx --bun shadcn@latest add @reui/<name> --yes # bun
+```
+
+`--yes` skips confirmation prompts. The CLI auto-detects the package manager from the lockfile (there is no `--package-manager` flag). It also resolves the correct base+style variant from `components.json`, so do not pass a style.
+
+## Handling prompts and conflicts
+
+- **Always pass `--yes`** so the CLI does not block on confirmation prompts.
+- **Do NOT pass `--overwrite` by default.** If the CLI reports an existing file, read the output and resolve deliberately: install under a different name, adjust the path, or ask the user. Only use `--overwrite` when the user explicitly wants to replace a file.
+- **Preview first when touching an existing project**: `npx shadcn@latest add @reui/<name> --dry-run` shows what would change; `--diff <file>` shows a specific file's diff. Use these before overwriting.
+- Run from the **project root** so `components.json` and `.env.local` are found.
+
+## Free vs premium boundary
+
+- Public, no key: `c-*` examples and the 17 components (`@reui/data-grid`, `@reui/badge`, ...) that those examples depend on.
+- Key required at install: blocks (`@reui/<category>-N`) need a Pro or Ultimate license; Motion Icons (`@reui/icons/...`) and templates need Ultimate.
+
+If an install 401/403s, the license key is missing, invalid, or the plan does not cover that resource (blocks: Pro or higher; icons and templates: Ultimate). Point the user to https://reui.io/account (their key) or https://reui.io/pricing (upgrade).

--- a/.claude/skills/reui/rules/components.md
+++ b/.claude/skills/reui/rules/components.md
@@ -9,7 +9,7 @@ The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `dat
 `data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
 
 - Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
-- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Pass that instance to `<DataGrid table={table} recordCount={total}>` (`total` is the full row count for pagination, not just the current page's `data.length`).
 - Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
 - Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
 
@@ -21,7 +21,7 @@ const table = useReactTable({
   // add sorting/pagination/selection models per the API
 })
 
-<DataGrid table={table} recordCount={data.length}>
+<DataGrid table={table} recordCount={totalRowCount}>
   <DataGridTable />
 </DataGrid>
 ```

--- a/.claude/skills/reui/rules/components.md
+++ b/.claude/skills/reui/rules/components.md
@@ -1,0 +1,349 @@
+# ReUI components
+
+The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `date-selector`, `filters`, `frame`, `icon-stack`, `kanban`, `number-field`, `phone-input`, `rating`, `scrollspy`, `sortable`, `stepper`, `timeline`, `tree`. Examples and blocks are composed from these.
+
+**Rule one: never guess a component's API. Read it first.** Call **`get_component(name)`** for its inline `api` (props + usage, no web fetch); the result's `docsUrl` and the `/llms.txt` index are the fallback. Then call **`get_examples(name)`** to install a worked example and copy real composition. The contracts below are first-try orientation (required props, composition shape, the one gotcha); the inline `api` is the full reference. No single block fits? Compose: search the components you need, read each `get_component`, install a `get_examples` example per component, and adapt.
+
+## data-grid (the flagship - read its API every time)
+
+`data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
+
+- Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
+- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
+- Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
+
+```tsx
+const table = useReactTable({
+  data,
+  columns,
+  getCoreRowModel: getCoreRowModel(),
+  // add sorting/pagination/selection models per the API
+})
+
+<DataGrid table={table} recordCount={data.length}>
+  <DataGridTable />
+</DataGrid>
+```
+
+Common mistakes:
+
+- **Incorrect:** `<DataGrid data={rows} columns={cols} />` - these props do not exist. **Correct:** build a `useReactTable` instance and pass `table={table}` + `recordCount`.
+- **Incorrect:** a raw `<table>` / hand-rolled pagination. **Correct:** use `data-grid`; read its API for sticky header, pagination, virtualization, row selection.
+- **Incorrect:** styling rows/cells with arbitrary classes. **Correct:** drive layout via `tableLayout` and the documented `ColumnMeta` (e.g. `cellClassName`, `headerTitle`).
+
+## kanban
+
+**Required:** `value` (`Record<string, T[]>`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Kanban value={cols} onValueChange={setCols} getItemValue={(i) => i.id}>
+  <KanbanBoard>
+    {Object.entries(cols).map(([id, items]) => (
+      <KanbanColumn key={id} value={id}>
+        <KanbanColumnHandle>
+          <h3>{id}</h3>
+        </KanbanColumnHandle>
+        <KanbanColumnContent value={id}>
+          {items.map((i) => (
+            <KanbanItem key={i.id} value={i.id}>
+              <KanbanItemHandle>{i.title}</KanbanItemHandle>
+            </KanbanItem>
+          ))}
+        </KanbanColumnContent>
+      </KanbanColumn>
+    ))}
+  </KanbanBoard>
+  <KanbanOverlay>
+    <div className="bg-muted size-full rounded-md" />
+  </KanbanOverlay>
+</Kanban>
+```
+
+**Gotcha:** state is `Record<columnId, T[]>`. Each `KanbanColumnContent value` must match its parent `KanbanColumn value`. Omit `KanbanOverlay` and the drag preview silently breaks.
+
+## sortable
+
+**Required:** `value` (`T[]`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Sortable value={items} onValueChange={setItems} getItemValue={(i) => i.id}>
+  {items.map((i) => (
+    <SortableItem key={i.id} value={i.id}>
+      <SortableItemHandle>
+        <GripVertical />
+      </SortableItemHandle>
+      {i.label}
+    </SortableItem>
+  ))}
+</Sortable>
+```
+
+**Gotcha:** a flat 1D reorder list (not columns - that is `kanban`). `getItemValue` must return a stable, unique string. Pass `layout="grid"` or `layout="nested"` for non-list layouts.
+
+## filters
+
+**Required:** `filters` (`Filter[]`), `fields` (`FilterFieldConfig[]`), `onChange`
+**Shape:**
+
+```tsx
+const [filters, setFilters] = useState<Filter[]>([
+  createFilter("priority", "is_any_of", ["low"]),
+])
+const fields: FilterFieldConfig[] = [
+  { key: "priority", label: "Priority", type: "multiselect",
+    options: [{ value: "low", label: "Low" }, { value: "high", label: "High" }] },
+]
+
+<Filters filters={filters} fields={fields} onChange={setFilters} />
+```
+
+**Gotcha:** always build initial filters with `createFilter(field, operator, values)` - it generates the required `id`. Never hand-construct a `Filter` object. Pairs naturally with `data-grid`.
+
+## date-selector
+
+**Required:** none, but wire `onChange` to capture the value.
+**Shape:**
+
+```tsx
+const [value, setValue] = useState<DateSelectorValue | undefined>()
+
+<DateSelector value={value} onChange={setValue} label="Due date" />
+```
+
+**Gotcha:** the value is a structured `DateSelectorValue` (period / operator / start+end dates), NOT a `Date` - never pass a raw `Date`. Use `allowRange={false}` to lock single-date picking. Read `get_component("date-selector")` for the value shape.
+
+## tree
+
+**Required:** `tree` (a `@headless-tree/core` instance you construct)
+**Shape:**
+
+```tsx
+<Tree tree={tree}>
+  {tree.getItems().map((item) => (
+    <TreeItem key={item.getId()} item={item}>
+      <TreeItemLabel />
+    </TreeItem>
+  ))}
+</Tree>
+```
+
+**Gotcha:** `Tree` is a styled shell - it takes a headless-tree instance via `tree`, NOT `data`/`items` props. Build the instance with `@headless-tree/react`. External API: https://headless-tree.lukasbach.com/
+
+## stepper
+
+**Required:** `StepperItem step` (number), `StepperContent value` (number)
+**Shape:**
+
+```tsx
+<Stepper defaultValue={1}>
+  <StepperNav>
+    <StepperItem step={1}>
+      <StepperTrigger>
+        <StepperIndicator>1</StepperIndicator>
+      </StepperTrigger>
+      <StepperSeparator />
+    </StepperItem>
+    <StepperItem step={2}>
+      <StepperTrigger>
+        <StepperIndicator>2</StepperIndicator>
+      </StepperTrigger>
+    </StepperItem>
+  </StepperNav>
+  <StepperPanel>
+    <StepperContent value={1}>Step 1 content</StepperContent>
+    <StepperContent value={2}>Step 2 content</StepperContent>
+  </StepperPanel>
+</Stepper>
+```
+
+**Gotcha:** steps are 1-indexed. Without `StepperPanel` + `StepperContent` you render the nav trail but no body. Put `StepperSeparator` in every `StepperItem` except the last.
+
+## timeline
+
+**Required:** `TimelineItem step` (number)
+**Shape:**
+
+```tsx
+<Timeline>
+  <TimelineItem step={1}>
+    <TimelineHeader>
+      <TimelineDate>March 2024</TimelineDate>
+      <TimelineTitle>Project initialized</TimelineTitle>
+    </TimelineHeader>
+    <TimelineIndicator />
+    <TimelineSeparator />
+    <TimelineContent>Repo and architecture set up.</TimelineContent>
+  </TimelineItem>
+</Timeline>
+```
+
+**Gotcha:** each item needs a unique `step`. `orientation` is `"vertical"` (default) or `"horizontal"`. This is a static event display, not interactive like `stepper`.
+
+## autocomplete
+
+**Required:** `items` (array; each item has at least `value`)
+**Shape:**
+
+```tsx
+<Autocomplete items={items}>
+  <AutocompleteInput placeholder="Search..." />
+  <AutocompleteContent>
+    <AutocompleteEmpty>No results found.</AutocompleteEmpty>
+    <AutocompleteList>
+      {(item) => (
+        <AutocompleteItem key={item.value} value={item}>
+          {item.label}
+        </AutocompleteItem>
+      )}
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>
+```
+
+**Gotcha:** `AutocompleteList` takes a render-prop `(item) => ReactNode`, NOT a mapped array of children. External API: https://base-ui.com/react/components/autocomplete
+
+## phone-input
+
+**Required:** none, but wire `onChange`.
+**Shape:**
+
+```tsx
+<PhoneInput
+  placeholder="Enter phone number"
+  defaultCountry="US"
+  value={value}
+  onChange={setValue}
+/>
+```
+
+**Gotcha:** `value`/`onChange` use an E.164 string (e.g. `"+14155551234"`), not a display-formatted string; `onChange` can fire `undefined`. `defaultCountry` is a 2-letter ISO code. Wraps `react-phone-number-input`.
+
+## number-field
+
+**Required:** wrap the controls in `NumberFieldGroup`.
+**Shape:**
+
+```tsx
+<NumberField defaultValue={0}>
+  <NumberFieldScrubArea label="Quantity" />
+  <NumberFieldGroup>
+    <NumberFieldDecrement />
+    <NumberFieldInput />
+    <NumberFieldIncrement />
+  </NumberFieldGroup>
+</NumberField>
+```
+
+**Gotcha:** import from `@/components/ui/number-field`. The accessible label goes on `NumberFieldScrubArea`, not `NumberField`. External API: https://base-ui.com/react/components/number-field
+
+## rating
+
+**Required:** `rating` (number)
+**Shape:**
+
+```tsx
+<Rating rating={4.5} showValue editable onRatingChange={setRating} />
+```
+
+**Gotcha:** supports decimals (partial stars). Pass `editable` + `onRatingChange` for interactive input; omit both for a read-only display.
+
+## scrollspy
+
+**Required:** `targetRef` (the scroll container ref)
+**Shape:**
+
+```tsx
+<Scrollspy targetRef={containerRef}>
+  <a href="#s1" data-scrollspy-anchor="s1">Section 1</a>
+  <a href="#s2" data-scrollspy-anchor="s2">Section 2</a>
+</Scrollspy>
+<div ref={containerRef}>
+  <div id="s1">...</div>
+  <div id="s2">...</div>
+</div>
+```
+
+**Gotcha:** each link's `data-scrollspy-anchor` must match a section `id`. `targetRef` is the scrollable container (defaults to the window).
+
+## frame
+
+**Required:** `Frame` > `FramePanel`
+**Shape:**
+
+```tsx
+<Frame>
+  <FramePanel>
+    <FrameHeader>
+      <FrameTitle>Title</FrameTitle>
+      <FrameDescription>Description</FrameDescription>
+    </FrameHeader>
+    <div className="p-5">Content</div>
+    <FrameFooter>Footer</FrameFooter>
+  </FramePanel>
+</Frame>
+```
+
+**Gotcha:** a structured card shell for tool-like surfaces. `stacked` connects multiple panels with shared borders; `dense` removes panel padding; radius via the `--frame-radius` CSS variable.
+
+## icon-stack
+
+**Required:** one child icon
+**Shape:**
+
+```tsx
+<IconStack aria-hidden="true">
+  <InboxIcon className="size-4" />
+</IconStack>
+```
+
+**Gotcha:** isometric layered artwork for empty states and illustrations; style the inner icon via its own `className`. Mark purely decorative stacks `aria-hidden="true"` and keep the real label in surrounding copy.
+
+## alert
+
+**Required:** `Alert` > `AlertTitle`
+**Shape:**
+
+```tsx
+<Alert variant="success">
+  <ShieldCheckIcon />
+  <AlertTitle>Security update</AlertTitle>
+  <AlertDescription>Enable two-factor authentication.</AlertDescription>
+  <AlertAction>
+    <Button size="xs">Update</Button>
+  </AlertAction>
+</Alert>
+```
+
+**Gotcha:** shadcn-compatible API. `variant`: `default | destructive | info | success | warning | invert`. The non-default variants use ReUI extended color tokens (`--success`/`--info`/`--warning`/`--invert`), which the install adds. Defer generic alert rules to the shadcn skill.
+
+## badge
+
+**Required:** none (text child).
+**Shape:**
+
+```tsx
+<Badge variant="success-light" size="sm">Success</Badge>
+<Badge variant="outline" radius="full">Pill</Badge>
+```
+
+**Gotcha:** shadcn-compatible. Rich `variant` set (solid, `-outline`, `-light` per color), `size` `xs..xl`, `radius` `default | full`. Like `alert`, the color variants rely on ReUI extended tokens. Prefer `Badge` variants over raw color classes for statuses.
+
+## base vs radix - write for the project's base
+
+ReUI ships every component in two builds: `base` (Base UI) and `radix` (Radix UI). The install command and name are identical, and the CLI installs the build matching the project. But you must write/adapt code against the **right base**, because their APIs differ.
+
+**Detect the base first.** Read `components.json` -> `style` and take the segment before the first `-`:
+
+- `"style": "base-nova"` -> **Base UI**
+- `"style": "radix-nova"` -> **Radix UI**
+
+**Then use that base's API.** The deltas mirror shadcn's base-vs-radix split:
+
+- Slot/composition: Base UI `render={<… />}` vs Radix `asChild`.
+- `Select`: Base UI takes `items`; Radix uses `<SelectItem>` children.
+- `ToggleGroup`: Base UI `multiple` boolean vs Radix `type="single" | "multiple"`.
+
+The safest path is to **read the installed files and `c-*` examples** - they're already in your base, so reuse their wiring instead of guessing. When `get_component`'s inline `api` or an example shows the other base's shape, translate it to your base (or `validate_usage` to confirm). Defer the generic base/radix mechanics to the shadcn skill.

--- a/.claude/skills/reui/rules/craft.md
+++ b/.claude/skills/reui/rules/craft.md
@@ -1,0 +1,45 @@
+# Craft: make ReUI UI exceptional, not generic
+
+ReUI items ship senior-designer quality. Your adaptation has to hold that bar, so the result reads like a real product surface a team would keep - not a wireframe an AI generated. Use these alongside the reuse rules in [adapting.md](./adapting.md).
+
+## Have a point of view
+
+Pick an emotional register before you compose - calm, operational, premium, editorial, dense, energetic - and let layout, spacing, surface treatment, and icon behavior all reinforce it. One or two memorable decisions and restraint everywhere else beats ten generic ones. UI with no point of view reads as generated.
+
+## Brutally clear hierarchy
+
+One focal point per card or panel: the dominant metric or task first, its label second, supporting detail third. The first thing the eye lands on should be the right thing; secondary text must read as secondary. Borders, separators, and surfaces do real work to create 2-3 information bands - don't flatten everything to equal weight.
+
+## Spacing rhythm and deliberate density
+
+Gaps are a signal, not a default. Keep them intentional and consistent within a family (`gap-1`/`gap-2` for tight operational rows, larger gaps for section breaks), and smaller within a group than between groups. Match the surrounding ReUI density; don't pad an operational surface like a marketing page, and don't drift density mid-section. The composition should still feel authored in grayscale.
+
+## Cover the real states (the usual miss)
+
+A surface isn't done at the happy path. Compose, and wire:
+
+- **Empty** - a purposeful empty state (short message + the primary action), never a blank panel.
+- **Loading** - a **skeleton** that matches the real layout, not a centered spinner.
+- **Error** - an inline, recoverable error with a retry, announced via `role="status"`/`aria-live`.
+
+Derive these from an element the block already has (don't invent parallel markup), or `get_examples` for a state-specific example.
+
+## Responsive by default
+
+Mobile-first, not mobile-afterthought. In constrained rows/cards/sidebars, put `min-w-0` on the shrinking container and `truncate` long single-line labels; protect the primary label's width and let secondary content compress. Reflow layouts (multi-column -> single column) rather than just shrinking them. Desktop and mobile should both look designed.
+
+## Motion, subtly
+
+Motion should clarify, not decorate. Use ReUI Motion Icons on primary actions for a subtle hover cue; keep transitions short (~200-300ms) with calm easing; prefer a skeleton pulse over a spinner. No bouncing, no gratuitous entrance animations on every element.
+
+## Real, activated content
+
+Use believable, typed data (realistic labels, counts, timestamps, statuses that map to a real workflow) - never lorem or abstract filler. Every visible control does something: no decorative buttons, fake tabs, meaningless toggles, or stats with no job. It must still hold with long names, empty values, and crowded data.
+
+## Avoid the AI tells
+
+These instantly read as generated - don't ship them: equal-weight card walls, empty gradients, repetitive padding everywhere, generic enterprise copy, ornamental icons, and number tiles that don't earn their place.
+
+## The bar
+
+Before you finish, ask: **would a product team keep this instead of replacing it? Does it still feel strong after swapping in real content?** If not, reuse the shipped ReUI design harder - don't restyle it into something new - then run the [quality.md](./quality.md) gates.

--- a/.claude/skills/reui/rules/icons.md
+++ b/.claude/skills/reui/rules/icons.md
@@ -1,0 +1,38 @@
+# Icons (ReUI delta over shadcn)
+
+Follow the shadcn icon rules (use the project's configured `iconLibrary`, `data-icon` on icons inside `Button`, no sizing classes on icons inside components, pass icons as component objects not string keys). ReUI adds the following.
+
+## Portable icons (library-agnostic)
+
+ReUI components, examples, and blocks are authored to be icon-library-agnostic. When `iconLibrary` is set in `components.json`, the shadcn CLI installs each item's icons in **your** library automatically - you swap nothing. If an installed item's icons don't match your project (for example `iconLibrary` isn't set, so they came in from the item's demo library), change the **import source and component name** to your library, keeping the same icon-name semantics:
+
+- `lucide` -> `lucide-react`
+- `tabler` -> `@tabler/icons-react`
+- `phosphor` -> `@phosphor-icons/react`
+- `remix` -> `@remixicon/react`
+- `hugeicons` -> `@hugeicons/react`
+
+Don't assume `lucide-react`; read `iconLibrary` from `components.json`.
+
+## Keep icons purposeful
+
+Icons support the hierarchy, they don't replace it: keep them small, matched to the surrounding density, and decorative ones `aria-hidden="true"` (an icon-only control still needs an accessible label on the control). Don't add ornamental icons that do no job.
+
+## Motion Icons (the `@reui/icons/...` set)
+
+ReUI ships its own icon set in 4 styles (outline, solid, duotone, filled), each icon in two variants:
+
+```bash
+npx shadcn@latest add @reui/icons/default/<style>/<name> --yes    # static
+npx shadcn@latest add @reui/icons/animated/<style>/<name> --yes   # hover-animated (motion/react)
+```
+
+Finding them via the MCP is free; installing requires an Ultimate license (`REUI_LICENSE_KEY`, see [cli.md](./cli.md)). Reach for a Motion Icon on a primary action when a subtle hover cue helps; keep motion restrained.
+
+Finding icons:
+
+- Several icons (the common case): **`search_icons(concepts[])`** - up to 24 concepts in one call, the best icons per concept with install commands. Pass `animated: true` to get only icons with a hover-animated Motion variant.
+- One icon: `search` with `type: "icon"`.
+- Icon results and `get_icon` carry `animated: true` and `installAnimated` when an animated variant exists - use those install strings, do not construct paths by hand.
+
+The `icon-stack` component composes multiple icons into a stacked display.

--- a/.claude/skills/reui/rules/quality.md
+++ b/.claude/skills/reui/rules/quality.md
@@ -1,0 +1,22 @@
+# Quality gates (security, accessibility, scroll)
+
+These are the **done gate**, not a nice-to-have: before you call any ReUI work finished, call the MCP `get_audit_checklist` tool and pass every item below (plus the craft bar in [craft.md](./craft.md)). Then typecheck and lint.
+
+## Security
+
+- Never `dangerouslySetInnerHTML`. Render data as text/components.
+- External links (`target="_blank"`) must always pair `rel="noopener noreferrer"`.
+- No real PII, secrets, or tokens in demo or committed code. Remote media only from sources the project already allows.
+
+## Accessibility
+
+- Implicit list/card items that navigate get real anchors with a standard hover affordance.
+- Icon-only or numeric buttons need an `aria-label`; decorative icons get `aria-hidden`.
+- Every non-submit button is `type="button"`.
+- Keyboard + focus: everything interactive is reachable in a sensible Tab order with a visible focus ring; layers (dialogs/sheets/menus) trap focus and close on `Escape`. ReUI components ship standard keyboard behavior - read each component's inline `api` rather than re-implementing it.
+- Announce async UI: loading and error messages use `role="status"` / `aria-live` so they're not silent to screen readers.
+
+## Scroll mechanics
+
+- Make scroll regions with a parent-owned height: a `min-h-0` + flex chain down to the scroll container. Never guess a `max-h`.
+- The scroll container owns `overflow-auto`; ancestors stay `min-h-0` so the height resolves.

--- a/.claude/skills/reui/rules/registry.md
+++ b/.claude/skills/reui/rules/registry.md
@@ -1,0 +1,31 @@
+# ReUI registry structure
+
+ReUI is a shadcn-compatible registry with four entity types. **Examples and blocks are built FROM components** - reuse them, don't rebuild.
+
+- **component** - one of the 17 ReUI building blocks with a real API (`data-grid`, `kanban`, `filters`, `date-selector`, `tree`, ...). Install directly (`@reui/data-grid`) or let it come in as a dependency of an example/block. Free. Read its API with `get_component(name)`.
+- **example** - a free `c-*` single-pattern use-case of a component (`c-kanban-1`, `c-data-grid-3`). Install one and read it to copy real composition. Find a component's examples with `get_examples(name)`.
+- **block** - a premium, full-page section that composes several components (`data-grid-2`, `pricing-page-1`). Pro or Ultimate license at install. Adapts to your active theme via semantic tokens.
+- **icon** - Motion Icons in 4 styles (outline, solid, duotone, filled), static (`@reui/icons/default/<style>/<name>`) and hover-animated (`@reui/icons/animated/<style>/<name>`). Ultimate license at install. See [icons.md](./icons.md).
+
+## The @reui registry
+
+Install everything through the shadcn CLI: `npx shadcn@latest add @reui/<name> --yes`. The CLI reads the `@reui` registry from the project's `components.json`. Free items need only the plain string form:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium installs need the authenticated form + `REUI_LICENSE_KEY` in `.env.local` - see [cli.md](./cli.md). The MCP `get_project_context` tool returns the right config.
+
+## Know your base: base or radix
+
+ReUI ships every item in two builds - `base` (Base UI) and `radix` (Radix UI) - with mirrored names. The CLI installs the build matching your project automatically, but **you must write code against the right base's API**. Detect it from `components.json` -> `style`: the segment before the first `-` is the base (`base-nova` -> Base UI, `radix-nova` -> Radix UI). The installed files and `c-*` examples are already in your base - read them and adapt on that base. See [components.md](./components.md) for the API deltas. Blocks adapt to your active theme through semantic tokens and CSS variables - change the theme and every block follows.
+
+## Free vs premium
+
+- **Free, no key:** the 17 components, all `c-*` examples, the ReUI MCP, and this skill.
+- **Premium, license required at install:** blocks (Pro or Ultimate), Motion Icons and templates (Ultimate). Set `REUI_LICENSE_KEY` (see [cli.md](./cli.md)).
+
+## Component API index
+
+The canonical index of every component's API docs is **https://reui.io/llms.txt** (returned as `componentsApiUrl` in MCP results). Prefer the inline `api` from `get_component`; use the index/docs as the fallback.

--- a/.claude/skills/reui/rules/styling.md
+++ b/.claude/skills/reui/rules/styling.md
@@ -1,0 +1,26 @@
+# Styling (ReUI delta over shadcn)
+
+Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+
+## ReUI extended semantic tokens
+
+ReUI adds semantic tokens beyond shadcn's base set. Use these instead of raw colors for status and emphasis:
+
+- `--success` / `--success-foreground`
+- `--info` / `--info-foreground`
+- `--warning` / `--warning-foreground`
+- `--destructive-foreground` (paired with shadcn's `--destructive`)
+- `--invert` / `--invert-foreground` (inverted surfaces)
+
+Use them as Tailwind utilities (`bg-success text-success-foreground`, `text-warning`, ...). They are defined in the project's global CSS and registered with Tailwind (`@theme inline` on v4). If a token is missing in the project, add it to the global CSS file (never a new file) following the same `name` / `name-foreground` convention, exactly as the shadcn customization rules describe.
+
+**Incorrect:** `<span className="text-green-600">Active</span>`
+**Correct:** `<Badge variant="success">Active</Badge>` or `<span className="text-success">Active</span>`
+
+## Blocks follow your theme
+
+When you install a block it adapts to your active theme through the semantic tokens above and the project's CSS variables. Don't hardcode style-specific values into installed block code and don't fork it to "restyle" - change the theme via the CSS variables / a preset and every block follows. Want a different look? `search` for a block whose design already fits instead of re-skinning one.
+
+## Density and typography rhythm
+
+ReUI operational UI usually feels dense, not airy. Keep the gap between a title and its supporting description tight by default (`gap-0.5`, `space-y-1`, or `space-y-px`), and smaller than the gap between sections. Match the surrounding ReUI density when you add rows or fields; do not pad operational surfaces like a marketing page.

--- a/.claude/skills/reui/rules/styling.md
+++ b/.claude/skills/reui/rules/styling.md
@@ -1,6 +1,6 @@
 # Styling (ReUI delta over shadcn)
 
-Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+Follow [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../../moai-library-shadcn/SKILL.md) for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
 
 ## ReUI extended semantic tokens
 

--- a/.claude/skills/reui/rules/workflow.md
+++ b/.claude/skills/reui/rules/workflow.md
@@ -1,0 +1,52 @@
+# Workflow: find -> install -> read API -> adapt
+
+The core ReUI loop. The MCP tells you what to install and gives you the API; the shadcn CLI installs it; you turn the installed files into correct, themed, data-wired code by **reuse**, not redesign.
+
+## 1. Find (ReUI MCP `search` / `compose_page`)
+
+**Full multi-section page ask?** Call `compose_page(intent, sections?)` FIRST, before searching block-by-block. It returns ordered sections, each with the best block for the intent (top pick + alternates); sections listed in `unavailableSections` have no real inventory - compose those from components, do not force a bad block.
+
+For everything else, call `search` with the user's intent. Pass structured hints whenever you can infer them - you are an LLM, so do the parsing the server cannot:
+
+- `type`: `"component"` (one of the 17 building blocks), `"example"` (a c-\* use-case), `"block"` (a full page/section), `"icon"`.
+- `component`: the ReUI component the request implies (`"data-grid"`, `"kanban"`, ...).
+- `category`, `features` (e.g. `["sortable","pagination"]`), `free`.
+
+Example: "build a users management page with filters" -> `search({ query: "users management page with filters", type: "block", component: "data-grid", features: ["filters"] })`.
+
+Each result has `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `termCoverage`, and `whyMatch`. `score` is relative to the top hit (the top is ~100 by construction), not an absolute quality - compare results to each other, and show the user the top options if several score closely; do not silently guess. A low `termCoverage` means a weak match even with a high score - rephrase or widen.
+
+## 2. Install (shadcn CLI)
+
+Run the result's `install` command from the project root, non-interactively:
+
+```bash
+npx shadcn@latest add @reui/<name> --yes
+```
+
+The CLI reads `components.json`, installs the correct base+style variant, resolves `registryDependencies` (a block pulls in its components), installs npm deps, and rewrites aliases. Do not pass the base/style. See [cli.md](./cli.md).
+
+## 3. Read the API (do not guess props)
+
+Before writing code against any component an item uses:
+
+1. The item's `componentDigests` already give a 1-line contract per component - often enough to wire it. For the full API, call **`get_component(names)`** with ALL of `componentsUsed` in ONE call (it accepts an array) and read each inline `api` - no web fetch. `docsUrl` and the `/llms.txt` index are the fallback.
+2. Call **`get_examples(name)`** for the free `c-*` examples of that component; install one and **read the added files** to copy the exact composition. This is the fastest correct path - the example shows real wiring you adapt, not invent.
+3. About to write a prop you did not see in an `api` or installed file? Run **`validate_usage`** BEFORE writing the code - per-prop documented / notDocumented verdicts plus did-you-mean suggestions. notDocumented means read the API, not push on.
+
+## 4. Adapt (reuse-first) - do not skip
+
+Installing files is not the end, and redesigning them defeats the point. First note the project's **base** so you write the right API - read `components.json` -> `style` and take the segment before the first `-` (`base-nova` -> Base UI, `radix-nova` -> Radix UI), see [components.md](./components.md). After `add`:
+
+1. **Read the added files**; keep the composition intact. For a block, verify the components are wired correctly (for `data-grid`: a `useReactTable` instance passed as `table`, `recordCount` set - see [components.md](./components.md)).
+2. **Replace demo data with the user's real data** via typed structures (see [adapting.md](./adapting.md)).
+3. **Fix icon imports** to the project's icon library (see [icons.md](./icons.md)).
+4. **Align styling** to semantic tokens and the active theme - no raw colors (see [styling.md](./styling.md)).
+5. **Validate before finalizing**: if your adaptation introduced components or props you did not read in an `api` or example, run `validate_usage` on them.
+6. **Hit the craft bar** - clear hierarchy, deliberate density, the empty / loading / error states, subtle motion, and mobile-first responsiveness (see [craft.md](./craft.md)). Generic-looking output means you under-reused the design, not that it needs restyling.
+7. **Pass the quality gates** (security, a11y, scroll) - call the MCP `get_audit_checklist` tool and clear every item (see [quality.md](./quality.md)).
+8. **Typecheck / lint**.
+
+## If no single block fits
+
+Compose from components (`compose_page` tells you which sections have no block inventory via `unavailableSections`). `search` the components you need, read each `get_component` API, install a worked `get_examples` example for each, and assemble by adapting those examples. A block in the same category is a useful reference - install it and read its files to see how ReUI composes those components, then adapt.

--- a/.claude/skills/reui/tools.md
+++ b/.claude/skills/reui/tools.md
@@ -1,0 +1,57 @@
+# ReUI MCP: full reference
+
+The ReUI MCP (`https://mcp.reui.io`, Streamable HTTP) is free - it needs no license and no auth header at all. It does **discovery + guidance** (search, inline APIs, page planning, validation) and never serves source code; the shadcn CLI does **installation**, and the license key lives only there (the `@reui` entry in `components.json`, backed by `.env.local`). In this repo it is configured as `reui` for Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), and Codex (`.codex/config.toml`). Goal: from the user's intent to correct, themed, data-wired ReUI code in the **fewest tokens and calls**, with **no guessing**.
+
+## Golden path (token-optimal - follow this order)
+
+Most tasks need 2-4 MCP calls and ZERO web fetches:
+
+1. **`search(query, ...hints)`** -> pick the top 1-3 results. Each result already carries `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `whyMatch`. The payload is complete - do not call another tool just to "confirm" a result.
+2. **`get_component([...componentsUsed])`** in ONE batched call (one name or an array of up to 20) -> read each inline `api`. This **replaces** fetching docs pages. Often skippable: search responses carry `componentDigests`, a compact API contract per referenced component.
+3. **`get_examples(component)`** -> install ONE returned `c-*` example, read the added files, copy the composition.
+4. **`get_install_command(item)`** only to validate a name you are unsure of (results already include `install`). Run the install with the shadcn CLI (`--yes`).
+5. **`get_audit_checklist()`** before declaring done.
+
+If you already know the exact item name, skip `search`. Everything else is situational.
+
+## The 5 task-specific tools (when to reach for each)
+
+- **`compose_page`** - BEFORE building any full page (dashboard, settings, billing, landing). Pass the intent (and optionally the sections you want); it returns ordered sections, each with the best premium block for the intent (top pick + alternates). Sections with no real inventory are listed honestly in `unavailableSections` - compose those from components instead of forcing a bad block.
+- **`search_icons`** - whenever you need icons, especially several. Batch up to 24 concepts in one call; each concept returns its best icons with install commands. Pass `animated: true` to get only icons that have a hover-animated Motion variant.
+- **`validate_usage`** - BEFORE writing code with component names or props you have not read in an inline `api` or an installed example. It checks planned names + props against the indexed API docs and registry item names; returns did-you-mean suggestions and per-prop documented / notDocumented verdicts. Deterministic, no inference - a notDocumented prop means stop and read the API, not push on.
+- **`whats_new`** - when your registry knowledge might be stale (a name 404s, the user mentions an item you don't know). Returns items added/removed per build, newest first.
+- **`report_issue`** - when an installed item is actually broken (bad source, wrong dependency, broken preview). Goes straight to the ReUI team; rate-limited 5/hour. Not for usage questions.
+
+## All 19 tools
+
+`search`, `get_block`, `get_example`, `get_icon`, `list_block_groups`, `list_block_categories`, `list_example_categories`, `list_icon_categories`, `list_components`, `get_component`, `get_examples`, `search_icons`, `compose_page`, `validate_usage`, `whats_new`, `report_issue`, `get_install_command`, `get_project_context`, `get_audit_checklist`. The MCP serves the full parameter schemas; do not guess parameters beyond them.
+
+## Token + speed rules
+
+- **Batch `get_component`** - ONE call with the whole `componentsUsed` array, never N calls. Skip it entirely when `componentDigests` already answers the question.
+- **Read source by installing** - the MCP serves no source. To read or analyze an item's real code, install it with the shadcn CLI and open the local files. Learn an API from the inline `api` / `componentDigests`, never by reading raw source.
+- **Infer `search` hints yourself** (`type`, `component`, `category`, `features`, `free`) - hints shrink the result set and the tokens. Keep `limit` low; one right result beats ten.
+- Run independent calls (and the shadcn install) concurrently in one turn - serial tool calls are the main source of slowness.
+- Don't repeat a search for the same intent; don't call `list_*` to "see everything" - `search` is the entry point, `list_*` is only for browsing a taxonomy the user explicitly wants to explore.
+- Prefer `get_component`'s inline `api` over `docsUrl` / `/llms.txt`. Fetch a web page only as a last resort.
+
+## Result shapes (so you don't re-fetch)
+
+- `score` is 0-100 RELATIVE to the top hit (the top is ~100 by construction), not absolute - compare results to each other.
+- `termCoverage` (0-1) is the share of the query the item matched - low means a weak match even if the score looks high; rephrase or widen the search.
+- Each result carries `whyMatch`, `install`, docs/preview URLs, and a `free` flag; premium items carry `requiredPlan` (`"pro"` for blocks, `"ultimate"` for icons).
+- `componentDigests` is a top-level map: a compact API contract per referenced component - often enough to wire an item without a `get_component` call.
+- Icon results and `get_icon` include `animated: true` and `installAnimated` when a hover-animated Motion variant exists (animated: `@reui/icons/animated/<style>/<name>`; static: `@reui/icons/default/<style>/<name>`).
+
+## Error playbook
+
+- **401 / 403** - install-time only: a premium install without a valid `REUI_LICENSE_KEY`, or a plan that does not cover the item (blocks Pro+, icons/templates Ultimate). Point to https://reui.io/account (key) or https://reui.io/pricing (upgrade). The MCP itself never authenticates - connecting and every tool are free.
+- **429** - rate limited (120 requests/min per IP); back off, honor `Retry-After`.
+- **not found** (`found: false`) - use the returned `suggestions`, or `search`; check `whats_new` if you suspect a stale name. Never run a fabricated install command.
+
+## Fallbacks
+
+- No ReUI MCP: `npx shadcn@latest search @reui -q "..."` then `add` (generic, no scoring / inline API).
+- The shadcn project's own MCP also works over the `@reui` registry: https://ui.shadcn.com/docs/mcp.
+
+Per-agent MCP setup: https://reui.io/docs/mcp

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -12,3 +12,6 @@ args = [
     "shadcn@latest",
     "mcp",
 ]
+
+[mcp_servers.reui]
+url = "https://mcp.reui.io"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -18,6 +18,10 @@
     "inngest-dev": {
       "type": "http",
       "url": "http://127.0.0.1:8288/mcp"
+    },
+    "reui": {
+      "type": "http",
+      "url": "https://mcp.reui.io"
     }
   }
 }

--- a/.cursor/skills/.repo-canonical-skills.json
+++ b/.cursor/skills/.repo-canonical-skills.json
@@ -50,6 +50,7 @@
     "repo-entry",
     "request-refactor-plan",
     "resend-cli",
+    "reui",
     "setup-matt-pocock-skills",
     "setup-pre-commit",
     "supabase",

--- a/.cursor/skills/reui/SKILL.md
+++ b/.cursor/skills/reui/SKILL.md
@@ -5,6 +5,26 @@ user-invocable: false
 allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
 ---
 
+## This repository (Asymmetric-al/core)
+
+Subordinate to **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/moai-library-shadcn/SKILL.md`** (generic shadcn rules), and TanStack guides under `docs/guides/development/`.
+
+**Registry (`packages/ui/components.json`):**
+
+- Active style is **`base-maia`** (Base UI + Maia). Read the segment before the first `-` in `style` to detect the base (`base-maia` → Base UI).
+- **`@reui`** is the **plain-string** registry (free components and `c-*` examples). Premium blocks/icons need the authenticated object form plus `REUI_LICENSE_KEY` in git-ignored `.env.local` — see [rules/cli.md](./rules/cli.md). Switch back to the plain form when premium installs are not in progress so contributors without a key can install free items.
+
+**Tables:**
+
+- Prefer shared **`DataTableResponsive`** from `@asym/ui/components/shadcn/data-table` for standard app tables (see `docs/guides/development/tanstack-virtual-foundation.md`).
+- Use ReUI **`data-grid`** when you need ReUI-specific table composition after `get_component('data-grid')`.
+
+**Naming:** **ReUI** (`@reui`, this skill) is unrelated to shadcn-studio **`/rui`** (Refine UI) in `docs/ai/rules/shadcn-studio-mcp.md`.
+
+**MCP:** `reui` at `https://mcp.reui.io` in `.mcp.json`, `.cursor/mcp.json`, and `.codex/config.toml`. The MCP is free; only premium **installs** need a license key. Never commit `REUI_LICENSE_KEY`.
+
+Refresh: [references/upstream.md](./references/upstream.md).
+
 # ReUI for Agents
 
 ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
@@ -16,13 +36,13 @@ ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never
 
 The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
 
-Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on** [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../moai-library-shadcn/SKILL.md) for generic shadcn rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
 
 ## The core loop (MCP-native)
 
 1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
 2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
-3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (this repo uses `base-maia` → Base UI; `radix-nova` → Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
 4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
 
 If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
@@ -45,7 +65,7 @@ Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor
 | Need                                                                 | Reach for                                                                 |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
-| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
+| A data table with sorting/filtering/pagination/virtualization        | **`DataTableResponsive`** in this repo; ReUI **data-grid** when ReUI-specific composition is required |
 | A drag-and-drop board                                                | the **kanban** component                                                  |
 | Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
 | A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |

--- a/.cursor/skills/reui/SKILL.md
+++ b/.cursor/skills/reui/SKILL.md
@@ -62,13 +62,13 @@ Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor
 
 ## When to reach for ReUI vs plain shadcn
 
-| Need                                                                 | Reach for                                                                 |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
+| Need                                                                 | Reach for                                                                                             |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks**                             |
 | A data table with sorting/filtering/pagination/virtualization        | **`DataTableResponsive`** in this repo; ReUI **data-grid** when ReUI-specific composition is required |
-| A drag-and-drop board                                                | the **kanban** component                                                  |
-| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
-| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+| A drag-and-drop board                                                | the **kanban** component                                                                              |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                                                       |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                                                      |
 
 ## Detailed references
 

--- a/.cursor/skills/reui/SKILL.md
+++ b/.cursor/skills/reui/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: reui
+description: Use the ReUI registry from your AI agent - find, install, and correctly use ReUI components (the 17 free building blocks like data-grid, kanban, filters), their free examples, premium blocks, and Motion Icons. Applies in any project using ReUI, the @reui registry, REUI_LICENSE_KEY, or any shadcn project where the user asks for premium blocks, data grids, kanban boards, dashboards, or full pages. Pairs with the free ReUI MCP server for live, scored registry search and inline component APIs.
+user-invocable: false
+allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
+---
+
+# ReUI for Agents
+
+ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
+
+- **components** - the 17 ReUI building blocks with real APIs: `data-grid`, `kanban`, `filters`, `date-selector`, `tree`, `stepper`, ... (free)
+- **examples** - free `c-*` single-pattern use-cases of a component (`c-kanban-1`); install one and read it to see exact composition
+- **blocks** - premium full-page sections that compose components (`data-grid-2`, `pricing-page-1`); Pro or Ultimate license at install
+- **icons** - Motion Icons in 4 styles, static + hover-animated variants; Ultimate license at install
+
+The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
+
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+
+## The core loop (MCP-native)
+
+1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
+2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
+
+If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
+
+## Commands
+
+Run ReUI as explicit slash commands (via the ReUI MCP) **or** just ask in plain language - both run the same workflow.
+
+| Command     | Invoke                         | Does                                                                                                               |
+| ----------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| **build**   | `/mcp__reui__build <what>`     | Compose a page/section/feature from ReUI: plan → install → read API → adapt → craft → audit.                       |
+| **add**     | `/mcp__reui__add <item>`       | Find & install one component/example/block/icon and wire it in.                                                    |
+| **fix**     | `/mcp__reui__fix [target]`     | Diagnose & fix ReUI usage: wrong/undocumented props, base/radix mismatch, missing states, a11y/scroll.             |
+| **improve** | `/mcp__reui__improve [target]` | Refine + extend existing ReUI UI to a production-exceptional bar (hierarchy, density, states, responsive, motion). |
+
+Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor/Windsurf, `/mcp.reui.build` in VS Code). No command surface? Just describe what you want - this skill drives the identical loop.
+
+## When to reach for ReUI vs plain shadcn
+
+| Need                                                                 | Reach for                                                                 |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
+| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
+| A drag-and-drop board                                                | the **kanban** component                                                  |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+
+## Detailed references
+
+- [rules/registry.md](./rules/registry.md) - the four types, the @reui registry, base/radix, free vs premium + license
+- [rules/workflow.md](./rules/workflow.md) - the find -> install -> read-API -> adapt loop (most important)
+- [rules/components.md](./rules/components.md) - the 17 components, the data-grid contract, base vs radix
+- [rules/adapting.md](./rules/adapting.md) - reuse-first: preserve the design (no over-customizing), reuse examples + a block's own elements, real data, don't invent APIs
+- [rules/craft.md](./rules/craft.md) - make it exceptional: point of view, hierarchy, density, states, responsive, motion, the bar
+- [rules/quality.md](./rules/quality.md) - security, accessibility, and scroll gates (the done gate)
+- [rules/styling.md](./rules/styling.md) - ReUI extended tokens, theme adaptation, density
+- [rules/icons.md](./rules/icons.md) - portable icons, swapping imports, Motion Icons (static + animated)
+- [tools.md](./tools.md) - the ReUI MCP: golden path, the 19 tools, token rules, result shapes, errors

--- a/.cursor/skills/reui/references/upstream.md
+++ b/.cursor/skills/reui/references/upstream.md
@@ -1,0 +1,25 @@
+---
+source: https://reui.io/docs/agent-skills
+install_commands:
+  - bunx --bun shadcn@latest add @reui/skills-claude
+  - bunx --bun shadcn@latest add @reui/skills-codex
+  - bunx --bun shadcn@latest add @reui/skills-cursor
+last_refreshed: 2026-07-01
+---
+
+# ReUI agent skills upstream
+
+Canonical copy in this repo: `docs/ai/skills/reui/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, and Cursor. This repo uses the shared canonical-skill pattern instead of committing each tool's installer output as the source of truth.
+
+## Refresh workflow
+
+1. Run the current ReUI install commands in a clean working tree or scratch branch:
+   - `bunx --bun shadcn@latest add @reui/skills-claude`
+   - `bunx --bun shadcn@latest add @reui/skills-codex`
+   - `bunx --bun shadcn@latest add @reui/skills-cursor`
+2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+5. Commit canonical and generated mirror updates together.

--- a/.cursor/skills/reui/references/upstream.md
+++ b/.cursor/skills/reui/references/upstream.md
@@ -20,6 +20,6 @@ ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, a
    - `bunx --bun shadcn@latest add @reui/skills-codex`
    - `bunx --bun shadcn@latest add @reui/skills-cursor`
 2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
-3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file plus the **`## This repository (Asymmetric-al/core)`** overlay at the top of `SKILL.md` (registry defaults, `base-maia`, `DataTableResponsive`, `/rui` disambiguation).
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 5. Commit canonical and generated mirror updates together.

--- a/.cursor/skills/reui/rules/adapting.md
+++ b/.cursor/skills/reui/rules/adapting.md
@@ -1,0 +1,43 @@
+# Adapting installed ReUI code (reuse-first, no AI slop)
+
+ReUI items ship production-quality. Your job is to **adapt by reuse** - wire real data and fit the app - not to redesign or hand-roll. The output should look like ReUI built it for this product.
+
+## Preserve the design - don't over-customize
+
+The design IS the product. A ReUI block/component encodes senior-designer decisions: spacing, hierarchy, density, color treatment, and component choices. The fastest way to turn a premium block back into generic AI slop is to "improve" its look - so don't.
+
+- Change **data, copy, and props**; keep the **structure and styling** it ships with. Make the **smallest** change that wires the real data. If your diff touches `className` / JSX structure more than data / props, you are over-customizing - stop and reuse.
+- Don't swap ReUI components for hand-rolled ones, restructure the layout, re-skin spacing / radius / colors, or add decorative chrome. Let the installed components carry the default spacing, radius, sizing, icon rhythm, density, and state styling; add custom Tailwind only when a component genuinely lacks a contract you need.
+- Want a different look? `search` for a block whose design already fits and reuse that - don't restyle this one into a new design.
+
+## Reuse the parts: examples and the block's own elements
+
+- **Examples are building parts.** A free `c-*` example is a correct, single-pattern composition you can reuse. Before composing from scratch, `get_examples(component)`, install the closest one, and reuse its wiring - assemble UI from examples instead of hand-rolling what an example already shows.
+- **Reuse a block's own elements.** Need more rows, cards, items, or sections than ship by default? Repeat the block's **existing** element by mapping real data through the same markup - never invent parallel markup that drifts from its design. Need a variant (empty / loading / expanded)? Derive it from an element the block already has.
+
+## Don't invent (read, don't guess)
+
+- Never write a prop, variant value, import path, or `@reui/...` name you didn't read in a component's inline `api`, an installed example, or a `search` result. If you didn't see it, treat it as nonexistent - call `get_component` / `get_examples` / `search` first, or run the MCP `validate_usage` tool to check planned names + props against the docs before writing code.
+- If a getter returns `found: false` or `search` returns nothing, say so and fall back (plain shadcn, or ask) - never fabricate an install command or an API.
+
+## What to change vs leave alone
+
+- **Change:** the item's own data, copy, props, and layout to fit the app.
+- **Leave alone:** installed component files, hooks, and the shared theme - do not edit vendored ReUI internals; change behavior through props and the documented API.
+- Blocks are **portable React** - no `next/link`, `next/image`, or other framework-runtime imports inside them. Keep them portable.
+
+## Demo data -> real data
+
+- Replace every placeholder with the user's real data. Model it as **typed data structures** and **map over arrays** - never duplicate JSX per row/card. Keep small block-specific formatters next to the data.
+- Wire the real source (columns, fields, fetch). For `data-grid`, implement the server fetch contract if the user needs server-side data.
+- **Type from the component API, derive during render.** Type domain state through the component's own types - e.g. map status to `BadgeProps["variant"]` via a typed `Record<Status, …>` - instead of stringly-typed values. Compute view state during render; don't mirror derived data into `useState`/`useEffect`.
+- **Adapt on the right base.** Use the API for the project's base (Base UI vs Radix - see [components.md](./components.md)); the installed files are already base-correct, so reuse their shape rather than translating from memory.
+
+## Believable content (no AI tells)
+
+- Use realistic labels, counts, timestamps, and statuses that map to a real workflow.
+- No decorative buttons, fake tabs, meaningless toggles, equal-weight card walls, empty gradients, ornamental icons, or generic SaaS filler. Every element should do something.
+
+## Operational surfaces (settings / profile / admin)
+
+Pick ONE archetype and keep the family consistent: a vertical rail (3-6 sections), horizontal tabs (5-8), or a frame/stack. Prefer `frame` for tool-like surfaces, a card for profile-like ones. Don't mix archetypes in one surface.

--- a/.cursor/skills/reui/rules/cli.md
+++ b/.cursor/skills/reui/rules/cli.md
@@ -1,0 +1,58 @@
+# CLI: registry setup, license, non-interactive install
+
+## Registry setup (one-time, per project)
+
+Free items (the 17 components and all `c-*` examples) need only the plain string registry in `components.json`:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium items (blocks; Motion Icons and templates) require a ReUI license at install:
+
+1. Add the key to `.env.local`:
+
+```bash
+REUI_LICENSE_KEY=your-license-key
+```
+
+2. Switch `components.json` to the authenticated object form:
+
+```json
+{
+  "registries": {
+    "@reui": {
+      "url": "https://reui.io/r/{style}/{name}.json",
+      "headers": { "Authorization": "Bearer ${REUI_LICENSE_KEY}" }
+    }
+  }
+}
+```
+
+The MCP `get_project_context` tool returns the right config. Full guide: https://reui.io/docs/registry
+
+## Installing
+
+Use the project's package runner (check `packageManager`):
+
+```bash
+npx shadcn@latest add @reui/<name> --yes      # npm
+pnpm dlx shadcn@latest add @reui/<name> --yes  # pnpm
+bunx --bun shadcn@latest add @reui/<name> --yes # bun
+```
+
+`--yes` skips confirmation prompts. The CLI auto-detects the package manager from the lockfile (there is no `--package-manager` flag). It also resolves the correct base+style variant from `components.json`, so do not pass a style.
+
+## Handling prompts and conflicts
+
+- **Always pass `--yes`** so the CLI does not block on confirmation prompts.
+- **Do NOT pass `--overwrite` by default.** If the CLI reports an existing file, read the output and resolve deliberately: install under a different name, adjust the path, or ask the user. Only use `--overwrite` when the user explicitly wants to replace a file.
+- **Preview first when touching an existing project**: `npx shadcn@latest add @reui/<name> --dry-run` shows what would change; `--diff <file>` shows a specific file's diff. Use these before overwriting.
+- Run from the **project root** so `components.json` and `.env.local` are found.
+
+## Free vs premium boundary
+
+- Public, no key: `c-*` examples and the 17 components (`@reui/data-grid`, `@reui/badge`, ...) that those examples depend on.
+- Key required at install: blocks (`@reui/<category>-N`) need a Pro or Ultimate license; Motion Icons (`@reui/icons/...`) and templates need Ultimate.
+
+If an install 401/403s, the license key is missing, invalid, or the plan does not cover that resource (blocks: Pro or higher; icons and templates: Ultimate). Point the user to https://reui.io/account (their key) or https://reui.io/pricing (upgrade).

--- a/.cursor/skills/reui/rules/components.md
+++ b/.cursor/skills/reui/rules/components.md
@@ -9,7 +9,7 @@ The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `dat
 `data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
 
 - Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
-- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Pass that instance to `<DataGrid table={table} recordCount={total}>` (`total` is the full row count for pagination, not just the current page's `data.length`).
 - Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
 - Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
 
@@ -21,7 +21,7 @@ const table = useReactTable({
   // add sorting/pagination/selection models per the API
 })
 
-<DataGrid table={table} recordCount={data.length}>
+<DataGrid table={table} recordCount={totalRowCount}>
   <DataGridTable />
 </DataGrid>
 ```

--- a/.cursor/skills/reui/rules/components.md
+++ b/.cursor/skills/reui/rules/components.md
@@ -1,0 +1,349 @@
+# ReUI components
+
+The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `date-selector`, `filters`, `frame`, `icon-stack`, `kanban`, `number-field`, `phone-input`, `rating`, `scrollspy`, `sortable`, `stepper`, `timeline`, `tree`. Examples and blocks are composed from these.
+
+**Rule one: never guess a component's API. Read it first.** Call **`get_component(name)`** for its inline `api` (props + usage, no web fetch); the result's `docsUrl` and the `/llms.txt` index are the fallback. Then call **`get_examples(name)`** to install a worked example and copy real composition. The contracts below are first-try orientation (required props, composition shape, the one gotcha); the inline `api` is the full reference. No single block fits? Compose: search the components you need, read each `get_component`, install a `get_examples` example per component, and adapt.
+
+## data-grid (the flagship - read its API every time)
+
+`data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
+
+- Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
+- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
+- Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
+
+```tsx
+const table = useReactTable({
+  data,
+  columns,
+  getCoreRowModel: getCoreRowModel(),
+  // add sorting/pagination/selection models per the API
+})
+
+<DataGrid table={table} recordCount={data.length}>
+  <DataGridTable />
+</DataGrid>
+```
+
+Common mistakes:
+
+- **Incorrect:** `<DataGrid data={rows} columns={cols} />` - these props do not exist. **Correct:** build a `useReactTable` instance and pass `table={table}` + `recordCount`.
+- **Incorrect:** a raw `<table>` / hand-rolled pagination. **Correct:** use `data-grid`; read its API for sticky header, pagination, virtualization, row selection.
+- **Incorrect:** styling rows/cells with arbitrary classes. **Correct:** drive layout via `tableLayout` and the documented `ColumnMeta` (e.g. `cellClassName`, `headerTitle`).
+
+## kanban
+
+**Required:** `value` (`Record<string, T[]>`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Kanban value={cols} onValueChange={setCols} getItemValue={(i) => i.id}>
+  <KanbanBoard>
+    {Object.entries(cols).map(([id, items]) => (
+      <KanbanColumn key={id} value={id}>
+        <KanbanColumnHandle>
+          <h3>{id}</h3>
+        </KanbanColumnHandle>
+        <KanbanColumnContent value={id}>
+          {items.map((i) => (
+            <KanbanItem key={i.id} value={i.id}>
+              <KanbanItemHandle>{i.title}</KanbanItemHandle>
+            </KanbanItem>
+          ))}
+        </KanbanColumnContent>
+      </KanbanColumn>
+    ))}
+  </KanbanBoard>
+  <KanbanOverlay>
+    <div className="bg-muted size-full rounded-md" />
+  </KanbanOverlay>
+</Kanban>
+```
+
+**Gotcha:** state is `Record<columnId, T[]>`. Each `KanbanColumnContent value` must match its parent `KanbanColumn value`. Omit `KanbanOverlay` and the drag preview silently breaks.
+
+## sortable
+
+**Required:** `value` (`T[]`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Sortable value={items} onValueChange={setItems} getItemValue={(i) => i.id}>
+  {items.map((i) => (
+    <SortableItem key={i.id} value={i.id}>
+      <SortableItemHandle>
+        <GripVertical />
+      </SortableItemHandle>
+      {i.label}
+    </SortableItem>
+  ))}
+</Sortable>
+```
+
+**Gotcha:** a flat 1D reorder list (not columns - that is `kanban`). `getItemValue` must return a stable, unique string. Pass `layout="grid"` or `layout="nested"` for non-list layouts.
+
+## filters
+
+**Required:** `filters` (`Filter[]`), `fields` (`FilterFieldConfig[]`), `onChange`
+**Shape:**
+
+```tsx
+const [filters, setFilters] = useState<Filter[]>([
+  createFilter("priority", "is_any_of", ["low"]),
+])
+const fields: FilterFieldConfig[] = [
+  { key: "priority", label: "Priority", type: "multiselect",
+    options: [{ value: "low", label: "Low" }, { value: "high", label: "High" }] },
+]
+
+<Filters filters={filters} fields={fields} onChange={setFilters} />
+```
+
+**Gotcha:** always build initial filters with `createFilter(field, operator, values)` - it generates the required `id`. Never hand-construct a `Filter` object. Pairs naturally with `data-grid`.
+
+## date-selector
+
+**Required:** none, but wire `onChange` to capture the value.
+**Shape:**
+
+```tsx
+const [value, setValue] = useState<DateSelectorValue | undefined>()
+
+<DateSelector value={value} onChange={setValue} label="Due date" />
+```
+
+**Gotcha:** the value is a structured `DateSelectorValue` (period / operator / start+end dates), NOT a `Date` - never pass a raw `Date`. Use `allowRange={false}` to lock single-date picking. Read `get_component("date-selector")` for the value shape.
+
+## tree
+
+**Required:** `tree` (a `@headless-tree/core` instance you construct)
+**Shape:**
+
+```tsx
+<Tree tree={tree}>
+  {tree.getItems().map((item) => (
+    <TreeItem key={item.getId()} item={item}>
+      <TreeItemLabel />
+    </TreeItem>
+  ))}
+</Tree>
+```
+
+**Gotcha:** `Tree` is a styled shell - it takes a headless-tree instance via `tree`, NOT `data`/`items` props. Build the instance with `@headless-tree/react`. External API: https://headless-tree.lukasbach.com/
+
+## stepper
+
+**Required:** `StepperItem step` (number), `StepperContent value` (number)
+**Shape:**
+
+```tsx
+<Stepper defaultValue={1}>
+  <StepperNav>
+    <StepperItem step={1}>
+      <StepperTrigger>
+        <StepperIndicator>1</StepperIndicator>
+      </StepperTrigger>
+      <StepperSeparator />
+    </StepperItem>
+    <StepperItem step={2}>
+      <StepperTrigger>
+        <StepperIndicator>2</StepperIndicator>
+      </StepperTrigger>
+    </StepperItem>
+  </StepperNav>
+  <StepperPanel>
+    <StepperContent value={1}>Step 1 content</StepperContent>
+    <StepperContent value={2}>Step 2 content</StepperContent>
+  </StepperPanel>
+</Stepper>
+```
+
+**Gotcha:** steps are 1-indexed. Without `StepperPanel` + `StepperContent` you render the nav trail but no body. Put `StepperSeparator` in every `StepperItem` except the last.
+
+## timeline
+
+**Required:** `TimelineItem step` (number)
+**Shape:**
+
+```tsx
+<Timeline>
+  <TimelineItem step={1}>
+    <TimelineHeader>
+      <TimelineDate>March 2024</TimelineDate>
+      <TimelineTitle>Project initialized</TimelineTitle>
+    </TimelineHeader>
+    <TimelineIndicator />
+    <TimelineSeparator />
+    <TimelineContent>Repo and architecture set up.</TimelineContent>
+  </TimelineItem>
+</Timeline>
+```
+
+**Gotcha:** each item needs a unique `step`. `orientation` is `"vertical"` (default) or `"horizontal"`. This is a static event display, not interactive like `stepper`.
+
+## autocomplete
+
+**Required:** `items` (array; each item has at least `value`)
+**Shape:**
+
+```tsx
+<Autocomplete items={items}>
+  <AutocompleteInput placeholder="Search..." />
+  <AutocompleteContent>
+    <AutocompleteEmpty>No results found.</AutocompleteEmpty>
+    <AutocompleteList>
+      {(item) => (
+        <AutocompleteItem key={item.value} value={item}>
+          {item.label}
+        </AutocompleteItem>
+      )}
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>
+```
+
+**Gotcha:** `AutocompleteList` takes a render-prop `(item) => ReactNode`, NOT a mapped array of children. External API: https://base-ui.com/react/components/autocomplete
+
+## phone-input
+
+**Required:** none, but wire `onChange`.
+**Shape:**
+
+```tsx
+<PhoneInput
+  placeholder="Enter phone number"
+  defaultCountry="US"
+  value={value}
+  onChange={setValue}
+/>
+```
+
+**Gotcha:** `value`/`onChange` use an E.164 string (e.g. `"+14155551234"`), not a display-formatted string; `onChange` can fire `undefined`. `defaultCountry` is a 2-letter ISO code. Wraps `react-phone-number-input`.
+
+## number-field
+
+**Required:** wrap the controls in `NumberFieldGroup`.
+**Shape:**
+
+```tsx
+<NumberField defaultValue={0}>
+  <NumberFieldScrubArea label="Quantity" />
+  <NumberFieldGroup>
+    <NumberFieldDecrement />
+    <NumberFieldInput />
+    <NumberFieldIncrement />
+  </NumberFieldGroup>
+</NumberField>
+```
+
+**Gotcha:** import from `@/components/ui/number-field`. The accessible label goes on `NumberFieldScrubArea`, not `NumberField`. External API: https://base-ui.com/react/components/number-field
+
+## rating
+
+**Required:** `rating` (number)
+**Shape:**
+
+```tsx
+<Rating rating={4.5} showValue editable onRatingChange={setRating} />
+```
+
+**Gotcha:** supports decimals (partial stars). Pass `editable` + `onRatingChange` for interactive input; omit both for a read-only display.
+
+## scrollspy
+
+**Required:** `targetRef` (the scroll container ref)
+**Shape:**
+
+```tsx
+<Scrollspy targetRef={containerRef}>
+  <a href="#s1" data-scrollspy-anchor="s1">Section 1</a>
+  <a href="#s2" data-scrollspy-anchor="s2">Section 2</a>
+</Scrollspy>
+<div ref={containerRef}>
+  <div id="s1">...</div>
+  <div id="s2">...</div>
+</div>
+```
+
+**Gotcha:** each link's `data-scrollspy-anchor` must match a section `id`. `targetRef` is the scrollable container (defaults to the window).
+
+## frame
+
+**Required:** `Frame` > `FramePanel`
+**Shape:**
+
+```tsx
+<Frame>
+  <FramePanel>
+    <FrameHeader>
+      <FrameTitle>Title</FrameTitle>
+      <FrameDescription>Description</FrameDescription>
+    </FrameHeader>
+    <div className="p-5">Content</div>
+    <FrameFooter>Footer</FrameFooter>
+  </FramePanel>
+</Frame>
+```
+
+**Gotcha:** a structured card shell for tool-like surfaces. `stacked` connects multiple panels with shared borders; `dense` removes panel padding; radius via the `--frame-radius` CSS variable.
+
+## icon-stack
+
+**Required:** one child icon
+**Shape:**
+
+```tsx
+<IconStack aria-hidden="true">
+  <InboxIcon className="size-4" />
+</IconStack>
+```
+
+**Gotcha:** isometric layered artwork for empty states and illustrations; style the inner icon via its own `className`. Mark purely decorative stacks `aria-hidden="true"` and keep the real label in surrounding copy.
+
+## alert
+
+**Required:** `Alert` > `AlertTitle`
+**Shape:**
+
+```tsx
+<Alert variant="success">
+  <ShieldCheckIcon />
+  <AlertTitle>Security update</AlertTitle>
+  <AlertDescription>Enable two-factor authentication.</AlertDescription>
+  <AlertAction>
+    <Button size="xs">Update</Button>
+  </AlertAction>
+</Alert>
+```
+
+**Gotcha:** shadcn-compatible API. `variant`: `default | destructive | info | success | warning | invert`. The non-default variants use ReUI extended color tokens (`--success`/`--info`/`--warning`/`--invert`), which the install adds. Defer generic alert rules to the shadcn skill.
+
+## badge
+
+**Required:** none (text child).
+**Shape:**
+
+```tsx
+<Badge variant="success-light" size="sm">Success</Badge>
+<Badge variant="outline" radius="full">Pill</Badge>
+```
+
+**Gotcha:** shadcn-compatible. Rich `variant` set (solid, `-outline`, `-light` per color), `size` `xs..xl`, `radius` `default | full`. Like `alert`, the color variants rely on ReUI extended tokens. Prefer `Badge` variants over raw color classes for statuses.
+
+## base vs radix - write for the project's base
+
+ReUI ships every component in two builds: `base` (Base UI) and `radix` (Radix UI). The install command and name are identical, and the CLI installs the build matching the project. But you must write/adapt code against the **right base**, because their APIs differ.
+
+**Detect the base first.** Read `components.json` -> `style` and take the segment before the first `-`:
+
+- `"style": "base-nova"` -> **Base UI**
+- `"style": "radix-nova"` -> **Radix UI**
+
+**Then use that base's API.** The deltas mirror shadcn's base-vs-radix split:
+
+- Slot/composition: Base UI `render={<… />}` vs Radix `asChild`.
+- `Select`: Base UI takes `items`; Radix uses `<SelectItem>` children.
+- `ToggleGroup`: Base UI `multiple` boolean vs Radix `type="single" | "multiple"`.
+
+The safest path is to **read the installed files and `c-*` examples** - they're already in your base, so reuse their wiring instead of guessing. When `get_component`'s inline `api` or an example shows the other base's shape, translate it to your base (or `validate_usage` to confirm). Defer the generic base/radix mechanics to the shadcn skill.

--- a/.cursor/skills/reui/rules/craft.md
+++ b/.cursor/skills/reui/rules/craft.md
@@ -1,0 +1,45 @@
+# Craft: make ReUI UI exceptional, not generic
+
+ReUI items ship senior-designer quality. Your adaptation has to hold that bar, so the result reads like a real product surface a team would keep - not a wireframe an AI generated. Use these alongside the reuse rules in [adapting.md](./adapting.md).
+
+## Have a point of view
+
+Pick an emotional register before you compose - calm, operational, premium, editorial, dense, energetic - and let layout, spacing, surface treatment, and icon behavior all reinforce it. One or two memorable decisions and restraint everywhere else beats ten generic ones. UI with no point of view reads as generated.
+
+## Brutally clear hierarchy
+
+One focal point per card or panel: the dominant metric or task first, its label second, supporting detail third. The first thing the eye lands on should be the right thing; secondary text must read as secondary. Borders, separators, and surfaces do real work to create 2-3 information bands - don't flatten everything to equal weight.
+
+## Spacing rhythm and deliberate density
+
+Gaps are a signal, not a default. Keep them intentional and consistent within a family (`gap-1`/`gap-2` for tight operational rows, larger gaps for section breaks), and smaller within a group than between groups. Match the surrounding ReUI density; don't pad an operational surface like a marketing page, and don't drift density mid-section. The composition should still feel authored in grayscale.
+
+## Cover the real states (the usual miss)
+
+A surface isn't done at the happy path. Compose, and wire:
+
+- **Empty** - a purposeful empty state (short message + the primary action), never a blank panel.
+- **Loading** - a **skeleton** that matches the real layout, not a centered spinner.
+- **Error** - an inline, recoverable error with a retry, announced via `role="status"`/`aria-live`.
+
+Derive these from an element the block already has (don't invent parallel markup), or `get_examples` for a state-specific example.
+
+## Responsive by default
+
+Mobile-first, not mobile-afterthought. In constrained rows/cards/sidebars, put `min-w-0` on the shrinking container and `truncate` long single-line labels; protect the primary label's width and let secondary content compress. Reflow layouts (multi-column -> single column) rather than just shrinking them. Desktop and mobile should both look designed.
+
+## Motion, subtly
+
+Motion should clarify, not decorate. Use ReUI Motion Icons on primary actions for a subtle hover cue; keep transitions short (~200-300ms) with calm easing; prefer a skeleton pulse over a spinner. No bouncing, no gratuitous entrance animations on every element.
+
+## Real, activated content
+
+Use believable, typed data (realistic labels, counts, timestamps, statuses that map to a real workflow) - never lorem or abstract filler. Every visible control does something: no decorative buttons, fake tabs, meaningless toggles, or stats with no job. It must still hold with long names, empty values, and crowded data.
+
+## Avoid the AI tells
+
+These instantly read as generated - don't ship them: equal-weight card walls, empty gradients, repetitive padding everywhere, generic enterprise copy, ornamental icons, and number tiles that don't earn their place.
+
+## The bar
+
+Before you finish, ask: **would a product team keep this instead of replacing it? Does it still feel strong after swapping in real content?** If not, reuse the shipped ReUI design harder - don't restyle it into something new - then run the [quality.md](./quality.md) gates.

--- a/.cursor/skills/reui/rules/icons.md
+++ b/.cursor/skills/reui/rules/icons.md
@@ -1,0 +1,38 @@
+# Icons (ReUI delta over shadcn)
+
+Follow the shadcn icon rules (use the project's configured `iconLibrary`, `data-icon` on icons inside `Button`, no sizing classes on icons inside components, pass icons as component objects not string keys). ReUI adds the following.
+
+## Portable icons (library-agnostic)
+
+ReUI components, examples, and blocks are authored to be icon-library-agnostic. When `iconLibrary` is set in `components.json`, the shadcn CLI installs each item's icons in **your** library automatically - you swap nothing. If an installed item's icons don't match your project (for example `iconLibrary` isn't set, so they came in from the item's demo library), change the **import source and component name** to your library, keeping the same icon-name semantics:
+
+- `lucide` -> `lucide-react`
+- `tabler` -> `@tabler/icons-react`
+- `phosphor` -> `@phosphor-icons/react`
+- `remix` -> `@remixicon/react`
+- `hugeicons` -> `@hugeicons/react`
+
+Don't assume `lucide-react`; read `iconLibrary` from `components.json`.
+
+## Keep icons purposeful
+
+Icons support the hierarchy, they don't replace it: keep them small, matched to the surrounding density, and decorative ones `aria-hidden="true"` (an icon-only control still needs an accessible label on the control). Don't add ornamental icons that do no job.
+
+## Motion Icons (the `@reui/icons/...` set)
+
+ReUI ships its own icon set in 4 styles (outline, solid, duotone, filled), each icon in two variants:
+
+```bash
+npx shadcn@latest add @reui/icons/default/<style>/<name> --yes    # static
+npx shadcn@latest add @reui/icons/animated/<style>/<name> --yes   # hover-animated (motion/react)
+```
+
+Finding them via the MCP is free; installing requires an Ultimate license (`REUI_LICENSE_KEY`, see [cli.md](./cli.md)). Reach for a Motion Icon on a primary action when a subtle hover cue helps; keep motion restrained.
+
+Finding icons:
+
+- Several icons (the common case): **`search_icons(concepts[])`** - up to 24 concepts in one call, the best icons per concept with install commands. Pass `animated: true` to get only icons with a hover-animated Motion variant.
+- One icon: `search` with `type: "icon"`.
+- Icon results and `get_icon` carry `animated: true` and `installAnimated` when an animated variant exists - use those install strings, do not construct paths by hand.
+
+The `icon-stack` component composes multiple icons into a stacked display.

--- a/.cursor/skills/reui/rules/quality.md
+++ b/.cursor/skills/reui/rules/quality.md
@@ -1,0 +1,22 @@
+# Quality gates (security, accessibility, scroll)
+
+These are the **done gate**, not a nice-to-have: before you call any ReUI work finished, call the MCP `get_audit_checklist` tool and pass every item below (plus the craft bar in [craft.md](./craft.md)). Then typecheck and lint.
+
+## Security
+
+- Never `dangerouslySetInnerHTML`. Render data as text/components.
+- External links (`target="_blank"`) must always pair `rel="noopener noreferrer"`.
+- No real PII, secrets, or tokens in demo or committed code. Remote media only from sources the project already allows.
+
+## Accessibility
+
+- Implicit list/card items that navigate get real anchors with a standard hover affordance.
+- Icon-only or numeric buttons need an `aria-label`; decorative icons get `aria-hidden`.
+- Every non-submit button is `type="button"`.
+- Keyboard + focus: everything interactive is reachable in a sensible Tab order with a visible focus ring; layers (dialogs/sheets/menus) trap focus and close on `Escape`. ReUI components ship standard keyboard behavior - read each component's inline `api` rather than re-implementing it.
+- Announce async UI: loading and error messages use `role="status"` / `aria-live` so they're not silent to screen readers.
+
+## Scroll mechanics
+
+- Make scroll regions with a parent-owned height: a `min-h-0` + flex chain down to the scroll container. Never guess a `max-h`.
+- The scroll container owns `overflow-auto`; ancestors stay `min-h-0` so the height resolves.

--- a/.cursor/skills/reui/rules/registry.md
+++ b/.cursor/skills/reui/rules/registry.md
@@ -1,0 +1,31 @@
+# ReUI registry structure
+
+ReUI is a shadcn-compatible registry with four entity types. **Examples and blocks are built FROM components** - reuse them, don't rebuild.
+
+- **component** - one of the 17 ReUI building blocks with a real API (`data-grid`, `kanban`, `filters`, `date-selector`, `tree`, ...). Install directly (`@reui/data-grid`) or let it come in as a dependency of an example/block. Free. Read its API with `get_component(name)`.
+- **example** - a free `c-*` single-pattern use-case of a component (`c-kanban-1`, `c-data-grid-3`). Install one and read it to copy real composition. Find a component's examples with `get_examples(name)`.
+- **block** - a premium, full-page section that composes several components (`data-grid-2`, `pricing-page-1`). Pro or Ultimate license at install. Adapts to your active theme via semantic tokens.
+- **icon** - Motion Icons in 4 styles (outline, solid, duotone, filled), static (`@reui/icons/default/<style>/<name>`) and hover-animated (`@reui/icons/animated/<style>/<name>`). Ultimate license at install. See [icons.md](./icons.md).
+
+## The @reui registry
+
+Install everything through the shadcn CLI: `npx shadcn@latest add @reui/<name> --yes`. The CLI reads the `@reui` registry from the project's `components.json`. Free items need only the plain string form:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium installs need the authenticated form + `REUI_LICENSE_KEY` in `.env.local` - see [cli.md](./cli.md). The MCP `get_project_context` tool returns the right config.
+
+## Know your base: base or radix
+
+ReUI ships every item in two builds - `base` (Base UI) and `radix` (Radix UI) - with mirrored names. The CLI installs the build matching your project automatically, but **you must write code against the right base's API**. Detect it from `components.json` -> `style`: the segment before the first `-` is the base (`base-nova` -> Base UI, `radix-nova` -> Radix UI). The installed files and `c-*` examples are already in your base - read them and adapt on that base. See [components.md](./components.md) for the API deltas. Blocks adapt to your active theme through semantic tokens and CSS variables - change the theme and every block follows.
+
+## Free vs premium
+
+- **Free, no key:** the 17 components, all `c-*` examples, the ReUI MCP, and this skill.
+- **Premium, license required at install:** blocks (Pro or Ultimate), Motion Icons and templates (Ultimate). Set `REUI_LICENSE_KEY` (see [cli.md](./cli.md)).
+
+## Component API index
+
+The canonical index of every component's API docs is **https://reui.io/llms.txt** (returned as `componentsApiUrl` in MCP results). Prefer the inline `api` from `get_component`; use the index/docs as the fallback.

--- a/.cursor/skills/reui/rules/styling.md
+++ b/.cursor/skills/reui/rules/styling.md
@@ -1,0 +1,26 @@
+# Styling (ReUI delta over shadcn)
+
+Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+
+## ReUI extended semantic tokens
+
+ReUI adds semantic tokens beyond shadcn's base set. Use these instead of raw colors for status and emphasis:
+
+- `--success` / `--success-foreground`
+- `--info` / `--info-foreground`
+- `--warning` / `--warning-foreground`
+- `--destructive-foreground` (paired with shadcn's `--destructive`)
+- `--invert` / `--invert-foreground` (inverted surfaces)
+
+Use them as Tailwind utilities (`bg-success text-success-foreground`, `text-warning`, ...). They are defined in the project's global CSS and registered with Tailwind (`@theme inline` on v4). If a token is missing in the project, add it to the global CSS file (never a new file) following the same `name` / `name-foreground` convention, exactly as the shadcn customization rules describe.
+
+**Incorrect:** `<span className="text-green-600">Active</span>`
+**Correct:** `<Badge variant="success">Active</Badge>` or `<span className="text-success">Active</span>`
+
+## Blocks follow your theme
+
+When you install a block it adapts to your active theme through the semantic tokens above and the project's CSS variables. Don't hardcode style-specific values into installed block code and don't fork it to "restyle" - change the theme via the CSS variables / a preset and every block follows. Want a different look? `search` for a block whose design already fits instead of re-skinning one.
+
+## Density and typography rhythm
+
+ReUI operational UI usually feels dense, not airy. Keep the gap between a title and its supporting description tight by default (`gap-0.5`, `space-y-1`, or `space-y-px`), and smaller than the gap between sections. Match the surrounding ReUI density when you add rows or fields; do not pad operational surfaces like a marketing page.

--- a/.cursor/skills/reui/rules/styling.md
+++ b/.cursor/skills/reui/rules/styling.md
@@ -1,6 +1,6 @@
 # Styling (ReUI delta over shadcn)
 
-Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+Follow [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../../moai-library-shadcn/SKILL.md) for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
 
 ## ReUI extended semantic tokens
 

--- a/.cursor/skills/reui/rules/workflow.md
+++ b/.cursor/skills/reui/rules/workflow.md
@@ -1,0 +1,52 @@
+# Workflow: find -> install -> read API -> adapt
+
+The core ReUI loop. The MCP tells you what to install and gives you the API; the shadcn CLI installs it; you turn the installed files into correct, themed, data-wired code by **reuse**, not redesign.
+
+## 1. Find (ReUI MCP `search` / `compose_page`)
+
+**Full multi-section page ask?** Call `compose_page(intent, sections?)` FIRST, before searching block-by-block. It returns ordered sections, each with the best block for the intent (top pick + alternates); sections listed in `unavailableSections` have no real inventory - compose those from components, do not force a bad block.
+
+For everything else, call `search` with the user's intent. Pass structured hints whenever you can infer them - you are an LLM, so do the parsing the server cannot:
+
+- `type`: `"component"` (one of the 17 building blocks), `"example"` (a c-\* use-case), `"block"` (a full page/section), `"icon"`.
+- `component`: the ReUI component the request implies (`"data-grid"`, `"kanban"`, ...).
+- `category`, `features` (e.g. `["sortable","pagination"]`), `free`.
+
+Example: "build a users management page with filters" -> `search({ query: "users management page with filters", type: "block", component: "data-grid", features: ["filters"] })`.
+
+Each result has `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `termCoverage`, and `whyMatch`. `score` is relative to the top hit (the top is ~100 by construction), not an absolute quality - compare results to each other, and show the user the top options if several score closely; do not silently guess. A low `termCoverage` means a weak match even with a high score - rephrase or widen.
+
+## 2. Install (shadcn CLI)
+
+Run the result's `install` command from the project root, non-interactively:
+
+```bash
+npx shadcn@latest add @reui/<name> --yes
+```
+
+The CLI reads `components.json`, installs the correct base+style variant, resolves `registryDependencies` (a block pulls in its components), installs npm deps, and rewrites aliases. Do not pass the base/style. See [cli.md](./cli.md).
+
+## 3. Read the API (do not guess props)
+
+Before writing code against any component an item uses:
+
+1. The item's `componentDigests` already give a 1-line contract per component - often enough to wire it. For the full API, call **`get_component(names)`** with ALL of `componentsUsed` in ONE call (it accepts an array) and read each inline `api` - no web fetch. `docsUrl` and the `/llms.txt` index are the fallback.
+2. Call **`get_examples(name)`** for the free `c-*` examples of that component; install one and **read the added files** to copy the exact composition. This is the fastest correct path - the example shows real wiring you adapt, not invent.
+3. About to write a prop you did not see in an `api` or installed file? Run **`validate_usage`** BEFORE writing the code - per-prop documented / notDocumented verdicts plus did-you-mean suggestions. notDocumented means read the API, not push on.
+
+## 4. Adapt (reuse-first) - do not skip
+
+Installing files is not the end, and redesigning them defeats the point. First note the project's **base** so you write the right API - read `components.json` -> `style` and take the segment before the first `-` (`base-nova` -> Base UI, `radix-nova` -> Radix UI), see [components.md](./components.md). After `add`:
+
+1. **Read the added files**; keep the composition intact. For a block, verify the components are wired correctly (for `data-grid`: a `useReactTable` instance passed as `table`, `recordCount` set - see [components.md](./components.md)).
+2. **Replace demo data with the user's real data** via typed structures (see [adapting.md](./adapting.md)).
+3. **Fix icon imports** to the project's icon library (see [icons.md](./icons.md)).
+4. **Align styling** to semantic tokens and the active theme - no raw colors (see [styling.md](./styling.md)).
+5. **Validate before finalizing**: if your adaptation introduced components or props you did not read in an `api` or example, run `validate_usage` on them.
+6. **Hit the craft bar** - clear hierarchy, deliberate density, the empty / loading / error states, subtle motion, and mobile-first responsiveness (see [craft.md](./craft.md)). Generic-looking output means you under-reused the design, not that it needs restyling.
+7. **Pass the quality gates** (security, a11y, scroll) - call the MCP `get_audit_checklist` tool and clear every item (see [quality.md](./quality.md)).
+8. **Typecheck / lint**.
+
+## If no single block fits
+
+Compose from components (`compose_page` tells you which sections have no block inventory via `unavailableSections`). `search` the components you need, read each `get_component` API, install a worked `get_examples` example for each, and assemble by adapting those examples. A block in the same category is a useful reference - install it and read its files to see how ReUI composes those components, then adapt.

--- a/.cursor/skills/reui/tools.md
+++ b/.cursor/skills/reui/tools.md
@@ -1,0 +1,57 @@
+# ReUI MCP: full reference
+
+The ReUI MCP (`https://mcp.reui.io`, Streamable HTTP) is free - it needs no license and no auth header at all. It does **discovery + guidance** (search, inline APIs, page planning, validation) and never serves source code; the shadcn CLI does **installation**, and the license key lives only there (the `@reui` entry in `components.json`, backed by `.env.local`). In this repo it is configured as `reui` for Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), and Codex (`.codex/config.toml`). Goal: from the user's intent to correct, themed, data-wired ReUI code in the **fewest tokens and calls**, with **no guessing**.
+
+## Golden path (token-optimal - follow this order)
+
+Most tasks need 2-4 MCP calls and ZERO web fetches:
+
+1. **`search(query, ...hints)`** -> pick the top 1-3 results. Each result already carries `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `whyMatch`. The payload is complete - do not call another tool just to "confirm" a result.
+2. **`get_component([...componentsUsed])`** in ONE batched call (one name or an array of up to 20) -> read each inline `api`. This **replaces** fetching docs pages. Often skippable: search responses carry `componentDigests`, a compact API contract per referenced component.
+3. **`get_examples(component)`** -> install ONE returned `c-*` example, read the added files, copy the composition.
+4. **`get_install_command(item)`** only to validate a name you are unsure of (results already include `install`). Run the install with the shadcn CLI (`--yes`).
+5. **`get_audit_checklist()`** before declaring done.
+
+If you already know the exact item name, skip `search`. Everything else is situational.
+
+## The 5 task-specific tools (when to reach for each)
+
+- **`compose_page`** - BEFORE building any full page (dashboard, settings, billing, landing). Pass the intent (and optionally the sections you want); it returns ordered sections, each with the best premium block for the intent (top pick + alternates). Sections with no real inventory are listed honestly in `unavailableSections` - compose those from components instead of forcing a bad block.
+- **`search_icons`** - whenever you need icons, especially several. Batch up to 24 concepts in one call; each concept returns its best icons with install commands. Pass `animated: true` to get only icons that have a hover-animated Motion variant.
+- **`validate_usage`** - BEFORE writing code with component names or props you have not read in an inline `api` or an installed example. It checks planned names + props against the indexed API docs and registry item names; returns did-you-mean suggestions and per-prop documented / notDocumented verdicts. Deterministic, no inference - a notDocumented prop means stop and read the API, not push on.
+- **`whats_new`** - when your registry knowledge might be stale (a name 404s, the user mentions an item you don't know). Returns items added/removed per build, newest first.
+- **`report_issue`** - when an installed item is actually broken (bad source, wrong dependency, broken preview). Goes straight to the ReUI team; rate-limited 5/hour. Not for usage questions.
+
+## All 19 tools
+
+`search`, `get_block`, `get_example`, `get_icon`, `list_block_groups`, `list_block_categories`, `list_example_categories`, `list_icon_categories`, `list_components`, `get_component`, `get_examples`, `search_icons`, `compose_page`, `validate_usage`, `whats_new`, `report_issue`, `get_install_command`, `get_project_context`, `get_audit_checklist`. The MCP serves the full parameter schemas; do not guess parameters beyond them.
+
+## Token + speed rules
+
+- **Batch `get_component`** - ONE call with the whole `componentsUsed` array, never N calls. Skip it entirely when `componentDigests` already answers the question.
+- **Read source by installing** - the MCP serves no source. To read or analyze an item's real code, install it with the shadcn CLI and open the local files. Learn an API from the inline `api` / `componentDigests`, never by reading raw source.
+- **Infer `search` hints yourself** (`type`, `component`, `category`, `features`, `free`) - hints shrink the result set and the tokens. Keep `limit` low; one right result beats ten.
+- Run independent calls (and the shadcn install) concurrently in one turn - serial tool calls are the main source of slowness.
+- Don't repeat a search for the same intent; don't call `list_*` to "see everything" - `search` is the entry point, `list_*` is only for browsing a taxonomy the user explicitly wants to explore.
+- Prefer `get_component`'s inline `api` over `docsUrl` / `/llms.txt`. Fetch a web page only as a last resort.
+
+## Result shapes (so you don't re-fetch)
+
+- `score` is 0-100 RELATIVE to the top hit (the top is ~100 by construction), not absolute - compare results to each other.
+- `termCoverage` (0-1) is the share of the query the item matched - low means a weak match even if the score looks high; rephrase or widen the search.
+- Each result carries `whyMatch`, `install`, docs/preview URLs, and a `free` flag; premium items carry `requiredPlan` (`"pro"` for blocks, `"ultimate"` for icons).
+- `componentDigests` is a top-level map: a compact API contract per referenced component - often enough to wire an item without a `get_component` call.
+- Icon results and `get_icon` include `animated: true` and `installAnimated` when a hover-animated Motion variant exists (animated: `@reui/icons/animated/<style>/<name>`; static: `@reui/icons/default/<style>/<name>`).
+
+## Error playbook
+
+- **401 / 403** - install-time only: a premium install without a valid `REUI_LICENSE_KEY`, or a plan that does not cover the item (blocks Pro+, icons/templates Ultimate). Point to https://reui.io/account (key) or https://reui.io/pricing (upgrade). The MCP itself never authenticates - connecting and every tool are free.
+- **429** - rate limited (120 requests/min per IP); back off, honor `Retry-After`.
+- **not found** (`found: false`) - use the returned `suggestions`, or `search`; check `whats_new` if you suspect a stale name. Never run a fabricated install command.
+
+## Fallbacks
+
+- No ReUI MCP: `npx shadcn@latest search @reui -q "..."` then `add` (generic, no scoring / inline API).
+- The shadcn project's own MCP also works over the `@reui` registry: https://ui.shadcn.com/docs/mcp.
+
+Per-agent MCP setup: https://reui.io/docs/mcp

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,6 +11,10 @@
     "inngest-dev": {
       "type": "http",
       "url": "http://127.0.0.1:8288/mcp"
+    },
+    "reui": {
+      "type": "http",
+      "url": "https://mcp.reui.io"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,17 @@ This repo configures the official Inngest dev-server MCP endpoint in root `.mcp.
 - **Scope:** This is agent tooling only. It does not mean this repo has adopted Inngest product runtime code, dependencies, or env vars.
 - **Claude Code:** The official Claude Code plugin can provide its own Inngest tooling and MCP wiring; repo MCP config is available when the client reads `.mcp.json`.
 
+## ReUI MCP (agent tooling)
+
+This repo configures the free ReUI MCP endpoint as `reui` in root `.mcp.json`, `.cursor/mcp.json`, and `.codex/config.toml`.
+
+- **Endpoint:** `https://mcp.reui.io` (Streamable HTTP).
+- **Scope:** Use it for ReUI registry discovery, scored search, inline component APIs, page planning, and usage validation.
+- **License:** The MCP server does not use a license key. Premium installs use the authenticated `@reui` registry in `packages/ui/components.json`, which reads `REUI_LICENSE_KEY` from a local, git-ignored `.env.local`.
+- **Claude Code:** Claude Code reads the repo-root `.mcp.json`.
+- **Cursor:** Cursor reads `.cursor/mcp.json`, which mirrors the repo-root MCP server definitions.
+- **Codex:** Codex reads `.codex/config.toml` for repo-local MCP server definitions.
+
 ### TanStack CLI and Intent
 
 For any TanStack work (Query, Router, Table, DB, Form, Virtual, Start, CLI, Intent, Devtools, or related integrations), use the official TanStack CLI and official TanStack Intent skills when they exist for the installed packages. Do not use repo-local or unofficial TanStack skills.
@@ -314,6 +325,7 @@ To **pull newer upstream** content for Supabase: `npx skills add supabase/agent-
 - **Tasteful UI animation (timing, easing, CSS/Motion patterns):** `docs/ai/skills/anim/SKILL.md`
 - **Additional Emil design-engineering notes / companion reference:** `docs/ai/skills/emil-design-eng/SKILL.md`
 - **Recharts:** `docs/ai/skills/rechart/SKILL.md`
+- **ReUI registry components, examples, blocks, Motion Icons, or ReUI MCP workflows:** `docs/ai/skills/reui/SKILL.md` (vendored from ReUI agent skills; mirrored into `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
 - **TanStack work:** use the official TanStack CLI plus current official Intent skills when `npx --yes @tanstack/intent@latest list` returns a matching package; otherwise use `tanstack doc` / `tanstack search-docs` and the repo-specific TanStack guides linked in **TanStack CLI and Intent** above.
 - **Tiptap rich text editor (`@tiptap/*`, shared editor in `@asym/ui`):** `docs/ai/skills/tiptap/SKILL.md`
 - **npm / pnpm / Yarn / Bun dependency footprint cleanup (unused deps, dedupe, lockfile closure, e18e):** `docs/ai/skills/npm-deps-cleanup/SKILL.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,8 @@ This repo configures the free ReUI MCP endpoint as `reui` in root `.mcp.json`, `
 
 - **Endpoint:** `https://mcp.reui.io` (Streamable HTTP).
 - **Scope:** Use it for ReUI registry discovery, scored search, inline component APIs, page planning, and usage validation.
-- **License:** The MCP server does not use a license key. Premium installs use the authenticated `@reui` registry in `packages/ui/components.json`, which reads `REUI_LICENSE_KEY` from a local, git-ignored `.env.local`.
+- **License:** The MCP server does not use a license key. Free `@reui` installs use the plain-string registry in `packages/ui/components.json`. Premium installs temporarily need the authenticated `@reui` object form plus `REUI_LICENSE_KEY` in git-ignored `.env.local` (see `docs/ai/skills/reui/rules/cli.md`).
+- **Not shadcn-studio `/rui`:** ReUI (`@reui`) is separate from shadcn-studio Refine UI (`/rui` in `docs/ai/rules/shadcn-studio-mcp.md`).
 - **Claude Code:** Claude Code reads the repo-root `.mcp.json`.
 - **Cursor:** Cursor reads `.cursor/mcp.json`, which mirrors the repo-root MCP server definitions.
 - **Codex:** Codex reads `.codex/config.toml` for repo-local MCP server definitions.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Agent-oriented docs live under `docs/ai/`:
 
 **Canonical source:** `docs/ai/`. Root `rules/` and `skills/` contain **deprecation pointers** to `docs/ai/` (not full duplicates).
 
-**Repo-owned skills (how it fits together):** Edit and review skills under `docs/ai/skills/<name>/SKILL.md`. `AGENTS.md` points agents at those paths for routing. The same content is copied into **committed mirrors** at `.agents/skills/` (Codex-style discovery) and `.cursor/skills/` (Cursor) by the sync script so tools can surface them without a personal global install. CI runs `bun run skills:verify` to ensure mirrors match the canonical tree.
+**Repo-owned skills (how it fits together):** Edit and review skills under `docs/ai/skills/<name>/SKILL.md`. `AGENTS.md` points agents at those paths for routing. The same content is copied into **committed mirrors** at `.agents/skills/` (Codex-style discovery), `.cursor/skills/` (Cursor), and `.claude/skills/` (Claude Code) by the sync script so tools can surface them without a personal global install. CI runs `bun run skills:verify` to ensure mirrors match the canonical tree.
 
 **Skill scripts (root `package.json`):**
 
@@ -166,7 +166,7 @@ Agent-oriented docs live under `docs/ai/`:
 | `bun run skills:verify`           | Fails if mirrors drift from canonical sources or the git tree is dirty after sync (same check used in CI and in `bun run setup` / `scripts/setup.ps1`).                                                                                                                                                                                                                                              |
 | `bun run skills:refresh-upstream` | Vendors the pinned set into `docs/ai/skills/`: `supabase`, `supabase-postgres-best-practices`, and `npm-deps-cleanup` from repo-local `.agents/skills/` (after targeted Skills CLI refreshes); `emil-design-engineering` from `$HOME/.cursor/skills/` (after the animations.dev installer). Use the matching upstream workflow for each skill, then run `skills:sync` / `skills:verify` (see below). |
 
-**Manual-vendored skills:** `docs/ai/skills/resend-cli/`, `docs/ai/skills/bendc-frontend-guidelines/`, `docs/ai/skills/payloadcms-payload/`, and `docs/ai/skills/payloadcms-cms-migration/` are not part of `skills:refresh-upstream`. Refresh them from the source documented in each `references/upstream.md`, then run `bun run skills:sync` and `bun run skills:verify`.
+**Manual-vendored skills:** `docs/ai/skills/resend-cli/`, `docs/ai/skills/bendc-frontend-guidelines/`, `docs/ai/skills/payloadcms-payload/`, `docs/ai/skills/payloadcms-cms-migration/`, and `docs/ai/skills/reui/` are not part of `skills:refresh-upstream`. Refresh them from the source documented in each `references/upstream.md`, then run `bun run skills:sync` and `bun run skills:verify`.
 
 When you add or change a skill **only** under `docs/ai/skills/`:
 

--- a/cursor.md
+++ b/cursor.md
@@ -4,5 +4,6 @@
 - **Animation routing:** For animation work, transitions, micro-interactions, or motion polish, load `docs/ai/skills/emil-design-engineering/SKILL.md` first; pair `docs/ai/skills/motion/SKILL.md` only when Motion API details matter.
 - **TanStack routing:** Follow the root `AGENTS.md` TanStack CLI and Intent section. In short: use the official TanStack CLI, run `npx --yes @tanstack/intent@latest list`, load Intent skills only for packages returned by that current command, and use `tanstack doc` / `tanstack search-docs` plus repo TanStack guides for packages not returned by Intent. Do not use repo-local or unofficial TanStack skills.
 - **Inngest routing:** Official Inngest agent skills are routed from root `AGENTS.md`, mirrored to `.cursor/skills/`, and paired with the `inngest-dev` MCP server in `.cursor/mcp.json` when the Inngest dev server is running.
+- **ReUI routing:** ReUI agent skills are routed from root `AGENTS.md`, mirrored to `.cursor/skills/`, and paired with the `reui` MCP server in `.cursor/mcp.json` for registry search, planning, inline APIs, and validation.
 - **Cursor project rules:** `.cursor/rules/` (scoped behavior; optional `*.mdc` with frontmatter).
 - **MCP (Cursor):** `.cursor/mcp.json` mirrors root `.mcp.json` for the same server definitions.

--- a/docs/AI_AGENT_PLAYBOOK.md
+++ b/docs/AI_AGENT_PLAYBOOK.md
@@ -10,7 +10,7 @@
 ## Repo-owned skills and mirrors
 
 - Repo-owned skills are authored canonically under `docs/ai/skills/*/SKILL.md`.
-- Runtime mirrors are committed under `.agents/skills/*` and `.cursor/skills/*`.
+- Runtime mirrors are committed under `.agents/skills/*`, `.cursor/skills/*`, and `.claude/skills/*`.
 - Keep `AGENTS.md` as the routing layer. It should point at canonical files in `docs/ai/skills/*`, not at tool-specific mirrors.
 - For Codex desktop, `.agents/skills/*` is the closest repo-level match to Codex's documented skill discovery behavior.
 - For Cursor Agent Window, committed `.cursor/skills/*` improves visible availability, while `AGENTS.md` still provides the strongest always-on routing contract.
@@ -41,6 +41,20 @@
 - Codex users can use the generated `.agents/skills/inngest-*` mirrors. If they
   need the full upstream plugin, clone `inngest/inngest-codex-plugin` outside
   the repo and run `/plugin install <path>/plugins/inngest`.
+
+## ReUI agent tooling
+
+- The ReUI MCP is configured as `reui` in root `.mcp.json`,
+  `.cursor/mcp.json`, and `.codex/config.toml`.
+- Claude Code reads the repo-root `.mcp.json`; Cursor reads `.cursor/mcp.json`;
+  Codex reads `.codex/config.toml`.
+- The MCP endpoint is `https://mcp.reui.io` and does not need auth headers or a
+  license key. It is for ReUI search, planning, inline APIs, and validation.
+- Premium ReUI installs use the `@reui` registry entry in
+  `packages/ui/components.json`, which reads `REUI_LICENSE_KEY` from local,
+  git-ignored `.env.local` files.
+- The canonical ReUI skill remains `docs/ai/skills/reui/SKILL.md`; keep mirrors
+  fresh with `bun run skills:sync` and `bun run skills:verify`.
 
 ## Monorepo scoping (pick the right app first)
 

--- a/docs/AI_AGENT_PLAYBOOK.md
+++ b/docs/AI_AGENT_PLAYBOOK.md
@@ -50,9 +50,11 @@
   Codex reads `.codex/config.toml`.
 - The MCP endpoint is `https://mcp.reui.io` and does not need auth headers or a
   license key. It is for ReUI search, planning, inline APIs, and validation.
-- Premium ReUI installs use the `@reui` registry entry in
-  `packages/ui/components.json`, which reads `REUI_LICENSE_KEY` from local,
-  git-ignored `.env.local` files.
+- Free `@reui` installs use the plain-string registry in
+  `packages/ui/components.json`. Premium installs temporarily need the
+  authenticated `@reui` object form plus `REUI_LICENSE_KEY` in git-ignored
+  `.env.local` (see `docs/ai/skills/reui/rules/cli.md`). ReUI is not
+  shadcn-studio `/rui` (Refine UI).
 - The canonical ReUI skill remains `docs/ai/skills/reui/SKILL.md`; keep mirrors
   fresh with `bun run skills:sync` and `bun run skills:verify`.
 

--- a/docs/ai/skills/reui/SKILL.md
+++ b/docs/ai/skills/reui/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: reui
+description: Use the ReUI registry from your AI agent - find, install, and correctly use ReUI components (the 17 free building blocks like data-grid, kanban, filters), their free examples, premium blocks, and Motion Icons. Applies in any project using ReUI, the @reui registry, REUI_LICENSE_KEY, or any shadcn project where the user asks for premium blocks, data grids, kanban boards, dashboards, or full pages. Pairs with the free ReUI MCP server for live, scored registry search and inline component APIs.
+user-invocable: false
+allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
+---
+
+# ReUI for Agents
+
+ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
+
+- **components** - the 17 ReUI building blocks with real APIs: `data-grid`, `kanban`, `filters`, `date-selector`, `tree`, `stepper`, ... (free)
+- **examples** - free `c-*` single-pattern use-cases of a component (`c-kanban-1`); install one and read it to see exact composition
+- **blocks** - premium full-page sections that compose components (`data-grid-2`, `pricing-page-1`); Pro or Ultimate license at install
+- **icons** - Motion Icons in 4 styles, static + hover-animated variants; Ultimate license at install
+
+The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
+
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+
+## The core loop (MCP-native)
+
+1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
+2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
+
+If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
+
+## Commands
+
+Run ReUI as explicit slash commands (via the ReUI MCP) **or** just ask in plain language - both run the same workflow.
+
+| Command     | Invoke                         | Does                                                                                                               |
+| ----------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| **build**   | `/mcp__reui__build <what>`     | Compose a page/section/feature from ReUI: plan → install → read API → adapt → craft → audit.                       |
+| **add**     | `/mcp__reui__add <item>`       | Find & install one component/example/block/icon and wire it in.                                                    |
+| **fix**     | `/mcp__reui__fix [target]`     | Diagnose & fix ReUI usage: wrong/undocumented props, base/radix mismatch, missing states, a11y/scroll.             |
+| **improve** | `/mcp__reui__improve [target]` | Refine + extend existing ReUI UI to a production-exceptional bar (hierarchy, density, states, responsive, motion). |
+
+Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor/Windsurf, `/mcp.reui.build` in VS Code). No command surface? Just describe what you want - this skill drives the identical loop.
+
+## When to reach for ReUI vs plain shadcn
+
+| Need                                                                 | Reach for                                                                 |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
+| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
+| A drag-and-drop board                                                | the **kanban** component                                                  |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+
+## Detailed references
+
+- [rules/registry.md](./rules/registry.md) - the four types, the @reui registry, base/radix, free vs premium + license
+- [rules/workflow.md](./rules/workflow.md) - the find -> install -> read-API -> adapt loop (most important)
+- [rules/components.md](./rules/components.md) - the 17 components, the data-grid contract, base vs radix
+- [rules/adapting.md](./rules/adapting.md) - reuse-first: preserve the design (no over-customizing), reuse examples + a block's own elements, real data, don't invent APIs
+- [rules/craft.md](./rules/craft.md) - make it exceptional: point of view, hierarchy, density, states, responsive, motion, the bar
+- [rules/quality.md](./rules/quality.md) - security, accessibility, and scroll gates (the done gate)
+- [rules/styling.md](./rules/styling.md) - ReUI extended tokens, theme adaptation, density
+- [rules/icons.md](./rules/icons.md) - portable icons, swapping imports, Motion Icons (static + animated)
+- [tools.md](./tools.md) - the ReUI MCP: golden path, the 19 tools, token rules, result shapes, errors

--- a/docs/ai/skills/reui/SKILL.md
+++ b/docs/ai/skills/reui/SKILL.md
@@ -5,6 +5,26 @@ user-invocable: false
 allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
 ---
 
+## This repository (Asymmetric-al/core)
+
+Subordinate to **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/moai-library-shadcn/SKILL.md`** (generic shadcn rules), and TanStack guides under `docs/guides/development/`.
+
+**Registry (`packages/ui/components.json`):**
+
+- Active style is **`base-maia`** (Base UI + Maia). Read the segment before the first `-` in `style` to detect the base (`base-maia` → Base UI).
+- **`@reui`** is the **plain-string** registry (free components and `c-*` examples). Premium blocks/icons need the authenticated object form plus `REUI_LICENSE_KEY` in git-ignored `.env.local` — see [rules/cli.md](./rules/cli.md). Switch back to the plain form when premium installs are not in progress so contributors without a key can install free items.
+
+**Tables:**
+
+- Prefer shared **`DataTableResponsive`** from `@asym/ui/components/shadcn/data-table` for standard app tables (see `docs/guides/development/tanstack-virtual-foundation.md`).
+- Use ReUI **`data-grid`** when you need ReUI-specific table composition after `get_component('data-grid')`.
+
+**Naming:** **ReUI** (`@reui`, this skill) is unrelated to shadcn-studio **`/rui`** (Refine UI) in `docs/ai/rules/shadcn-studio-mcp.md`.
+
+**MCP:** `reui` at `https://mcp.reui.io` in `.mcp.json`, `.cursor/mcp.json`, and `.codex/config.toml`. The MCP is free; only premium **installs** need a license key. Never commit `REUI_LICENSE_KEY`.
+
+Refresh: [references/upstream.md](./references/upstream.md).
+
 # ReUI for Agents
 
 ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never redesign:
@@ -16,13 +36,13 @@ ReUI is a shadcn-compatible registry. It ships four things you **reuse** - never
 
 The MCP and this skill are free; only installing premium content needs a license (see [rules/registry.md](./rules/registry.md)).
 
-Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on the shadcn skill**: follow that for generic rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
+Your job: find the right item, install it with the shadcn CLI, read its real API, and **adapt by reuse** - wire real data and theme it; do not hand-roll or restyle what ReUI already provides. This skill **layers on** [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../moai-library-shadcn/SKILL.md) for generic shadcn rules (spacing, `cn()`, semantic colors, forms); follow this for everything ReUI-specific.
 
 ## The core loop (MCP-native)
 
 1. **Find** - call the ReUI MCP `search` tool with the user's intent. It returns a ranked, scored list across components/examples/blocks/icons, each with an `install` command, `previewUrl`, `docsUrl`, and `componentsUsed`. Pass hints (`type`, `component`, `category`, `features`, `free`) when you can infer them.
 2. **Install** - run the returned command non-interactively (`npx shadcn@latest add @reui/<name> --yes`). The CLI resolves deps, aliases, and the base/style from `components.json`. See [cli.md](./rules/cli.md).
-3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (`base-nova` -> Base UI, `radix-nova` -> Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
+3. **Read the API (on your base)** - first note your base from `components.json` -> `style` (this repo uses `base-maia` → Base UI; `radix-nova` → Radix UI). For each component an item uses, call `get_component(name)` and read its **inline `api`** (no web fetch); then `get_examples(name)` to install a worked example and copy its composition - the installed files are already in your base. See [components.md](./rules/components.md).
 4. **Adapt (reuse-first)** - swap demo data for real data, fix icon imports, align tokens. Do not redesign. See [adapting.md](./rules/adapting.md).
 
 If the ReUI MCP is not configured, fall back to `npx shadcn@latest search @reui -q "..."` then `add` - but the MCP gives scored matches + inline APIs; prefer it.
@@ -42,13 +62,13 @@ Invocation differs slightly per agent (`/mcp__reui__build` in Claude Code/Cursor
 
 ## When to reach for ReUI vs plain shadcn
 
-| Need                                                                 | Reach for                                                                 |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks** |
-| A data table with sorting/filtering/pagination/virtualization        | the **data-grid** component (never hand-roll a `<table>`)                 |
-| A drag-and-drop board                                                | the **kanban** component                                                  |
-| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                           |
-| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                          |
+| Need                                                                 | Reach for                                                                                             |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| A full page or section (dashboard, billing, auth, pricing, settings) | `compose_page` first (plans sections + best blocks), then ReUI **blocks**                             |
+| A data table with sorting/filtering/pagination/virtualization        | **`DataTableResponsive`** in this repo; ReUI **data-grid** when ReUI-specific composition is required |
+| A drag-and-drop board                                                | the **kanban** component                                                                              |
+| Advanced column filtering, date range, tree, stepper, ...            | the matching ReUI **component**                                                                       |
+| A single generic control already in shadcn (Button, Dialog, Select)  | plain **shadcn**                                                                                      |
 
 ## Detailed references
 

--- a/docs/ai/skills/reui/references/upstream.md
+++ b/docs/ai/skills/reui/references/upstream.md
@@ -1,0 +1,25 @@
+---
+source: https://reui.io/docs/agent-skills
+install_commands:
+  - bunx --bun shadcn@latest add @reui/skills-claude
+  - bunx --bun shadcn@latest add @reui/skills-codex
+  - bunx --bun shadcn@latest add @reui/skills-cursor
+last_refreshed: 2026-07-01
+---
+
+# ReUI agent skills upstream
+
+Canonical copy in this repo: `docs/ai/skills/reui/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, and Cursor. This repo uses the shared canonical-skill pattern instead of committing each tool's installer output as the source of truth.
+
+## Refresh workflow
+
+1. Run the current ReUI install commands in a clean working tree or scratch branch:
+   - `bunx --bun shadcn@latest add @reui/skills-claude`
+   - `bunx --bun shadcn@latest add @reui/skills-codex`
+   - `bunx --bun shadcn@latest add @reui/skills-cursor`
+2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+5. Commit canonical and generated mirror updates together.

--- a/docs/ai/skills/reui/references/upstream.md
+++ b/docs/ai/skills/reui/references/upstream.md
@@ -20,6 +20,6 @@ ReUI publishes agent-specific shadcn registry packages for Claude Code, Codex, a
    - `bunx --bun shadcn@latest add @reui/skills-codex`
    - `bunx --bun shadcn@latest add @reui/skills-cursor`
 2. Compare the generated `reui/` skill payloads. They should be equivalent except for destination paths.
-3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file.
+3. Copy the selected `reui/` payload into `docs/ai/skills/reui/` and preserve this `references/upstream.md` file plus the **`## This repository (Asymmetric-al/core)`** overlay at the top of `SKILL.md` (registry defaults, `base-maia`, `DataTableResponsive`, `/rui` disambiguation).
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 5. Commit canonical and generated mirror updates together.

--- a/docs/ai/skills/reui/rules/adapting.md
+++ b/docs/ai/skills/reui/rules/adapting.md
@@ -1,0 +1,43 @@
+# Adapting installed ReUI code (reuse-first, no AI slop)
+
+ReUI items ship production-quality. Your job is to **adapt by reuse** - wire real data and fit the app - not to redesign or hand-roll. The output should look like ReUI built it for this product.
+
+## Preserve the design - don't over-customize
+
+The design IS the product. A ReUI block/component encodes senior-designer decisions: spacing, hierarchy, density, color treatment, and component choices. The fastest way to turn a premium block back into generic AI slop is to "improve" its look - so don't.
+
+- Change **data, copy, and props**; keep the **structure and styling** it ships with. Make the **smallest** change that wires the real data. If your diff touches `className` / JSX structure more than data / props, you are over-customizing - stop and reuse.
+- Don't swap ReUI components for hand-rolled ones, restructure the layout, re-skin spacing / radius / colors, or add decorative chrome. Let the installed components carry the default spacing, radius, sizing, icon rhythm, density, and state styling; add custom Tailwind only when a component genuinely lacks a contract you need.
+- Want a different look? `search` for a block whose design already fits and reuse that - don't restyle this one into a new design.
+
+## Reuse the parts: examples and the block's own elements
+
+- **Examples are building parts.** A free `c-*` example is a correct, single-pattern composition you can reuse. Before composing from scratch, `get_examples(component)`, install the closest one, and reuse its wiring - assemble UI from examples instead of hand-rolling what an example already shows.
+- **Reuse a block's own elements.** Need more rows, cards, items, or sections than ship by default? Repeat the block's **existing** element by mapping real data through the same markup - never invent parallel markup that drifts from its design. Need a variant (empty / loading / expanded)? Derive it from an element the block already has.
+
+## Don't invent (read, don't guess)
+
+- Never write a prop, variant value, import path, or `@reui/...` name you didn't read in a component's inline `api`, an installed example, or a `search` result. If you didn't see it, treat it as nonexistent - call `get_component` / `get_examples` / `search` first, or run the MCP `validate_usage` tool to check planned names + props against the docs before writing code.
+- If a getter returns `found: false` or `search` returns nothing, say so and fall back (plain shadcn, or ask) - never fabricate an install command or an API.
+
+## What to change vs leave alone
+
+- **Change:** the item's own data, copy, props, and layout to fit the app.
+- **Leave alone:** installed component files, hooks, and the shared theme - do not edit vendored ReUI internals; change behavior through props and the documented API.
+- Blocks are **portable React** - no `next/link`, `next/image`, or other framework-runtime imports inside them. Keep them portable.
+
+## Demo data -> real data
+
+- Replace every placeholder with the user's real data. Model it as **typed data structures** and **map over arrays** - never duplicate JSX per row/card. Keep small block-specific formatters next to the data.
+- Wire the real source (columns, fields, fetch). For `data-grid`, implement the server fetch contract if the user needs server-side data.
+- **Type from the component API, derive during render.** Type domain state through the component's own types - e.g. map status to `BadgeProps["variant"]` via a typed `Record<Status, …>` - instead of stringly-typed values. Compute view state during render; don't mirror derived data into `useState`/`useEffect`.
+- **Adapt on the right base.** Use the API for the project's base (Base UI vs Radix - see [components.md](./components.md)); the installed files are already base-correct, so reuse their shape rather than translating from memory.
+
+## Believable content (no AI tells)
+
+- Use realistic labels, counts, timestamps, and statuses that map to a real workflow.
+- No decorative buttons, fake tabs, meaningless toggles, equal-weight card walls, empty gradients, ornamental icons, or generic SaaS filler. Every element should do something.
+
+## Operational surfaces (settings / profile / admin)
+
+Pick ONE archetype and keep the family consistent: a vertical rail (3-6 sections), horizontal tabs (5-8), or a frame/stack. Prefer `frame` for tool-like surfaces, a card for profile-like ones. Don't mix archetypes in one surface.

--- a/docs/ai/skills/reui/rules/cli.md
+++ b/docs/ai/skills/reui/rules/cli.md
@@ -1,0 +1,58 @@
+# CLI: registry setup, license, non-interactive install
+
+## Registry setup (one-time, per project)
+
+Free items (the 17 components and all `c-*` examples) need only the plain string registry in `components.json`:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium items (blocks; Motion Icons and templates) require a ReUI license at install:
+
+1. Add the key to `.env.local`:
+
+```bash
+REUI_LICENSE_KEY=your-license-key
+```
+
+2. Switch `components.json` to the authenticated object form:
+
+```json
+{
+  "registries": {
+    "@reui": {
+      "url": "https://reui.io/r/{style}/{name}.json",
+      "headers": { "Authorization": "Bearer ${REUI_LICENSE_KEY}" }
+    }
+  }
+}
+```
+
+The MCP `get_project_context` tool returns the right config. Full guide: https://reui.io/docs/registry
+
+## Installing
+
+Use the project's package runner (check `packageManager`):
+
+```bash
+npx shadcn@latest add @reui/<name> --yes      # npm
+pnpm dlx shadcn@latest add @reui/<name> --yes  # pnpm
+bunx --bun shadcn@latest add @reui/<name> --yes # bun
+```
+
+`--yes` skips confirmation prompts. The CLI auto-detects the package manager from the lockfile (there is no `--package-manager` flag). It also resolves the correct base+style variant from `components.json`, so do not pass a style.
+
+## Handling prompts and conflicts
+
+- **Always pass `--yes`** so the CLI does not block on confirmation prompts.
+- **Do NOT pass `--overwrite` by default.** If the CLI reports an existing file, read the output and resolve deliberately: install under a different name, adjust the path, or ask the user. Only use `--overwrite` when the user explicitly wants to replace a file.
+- **Preview first when touching an existing project**: `npx shadcn@latest add @reui/<name> --dry-run` shows what would change; `--diff <file>` shows a specific file's diff. Use these before overwriting.
+- Run from the **project root** so `components.json` and `.env.local` are found.
+
+## Free vs premium boundary
+
+- Public, no key: `c-*` examples and the 17 components (`@reui/data-grid`, `@reui/badge`, ...) that those examples depend on.
+- Key required at install: blocks (`@reui/<category>-N`) need a Pro or Ultimate license; Motion Icons (`@reui/icons/...`) and templates need Ultimate.
+
+If an install 401/403s, the license key is missing, invalid, or the plan does not cover that resource (blocks: Pro or higher; icons and templates: Ultimate). Point the user to https://reui.io/account (their key) or https://reui.io/pricing (upgrade).

--- a/docs/ai/skills/reui/rules/components.md
+++ b/docs/ai/skills/reui/rules/components.md
@@ -9,7 +9,7 @@ The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `dat
 `data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
 
 - Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
-- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Pass that instance to `<DataGrid table={table} recordCount={total}>` (`total` is the full row count for pagination, not just the current page's `data.length`).
 - Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
 - Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
 
@@ -21,7 +21,7 @@ const table = useReactTable({
   // add sorting/pagination/selection models per the API
 })
 
-<DataGrid table={table} recordCount={data.length}>
+<DataGrid table={table} recordCount={totalRowCount}>
   <DataGridTable />
 </DataGrid>
 ```

--- a/docs/ai/skills/reui/rules/components.md
+++ b/docs/ai/skills/reui/rules/components.md
@@ -1,0 +1,349 @@
+# ReUI components
+
+The 17 ReUI building blocks: `alert`, `autocomplete`, `badge`, `data-grid`, `date-selector`, `filters`, `frame`, `icon-stack`, `kanban`, `number-field`, `phone-input`, `rating`, `scrollspy`, `sortable`, `stepper`, `timeline`, `tree`. Examples and blocks are composed from these.
+
+**Rule one: never guess a component's API. Read it first.** Call **`get_component(name)`** for its inline `api` (props + usage, no web fetch); the result's `docsUrl` and the `/llms.txt` index are the fallback. Then call **`get_examples(name)`** to install a worked example and copy real composition. The contracts below are first-try orientation (required props, composition shape, the one gotcha); the inline `api` is the full reference. No single block fits? Compose: search the components you need, read each `get_component`, install a `get_examples` example per component, and adapt.
+
+## data-grid (the flagship - read its API every time)
+
+`data-grid` wraps TanStack Table v8. It is NOT a styled `<table>` and does NOT take `data`/`columns` props directly. The contract:
+
+- Build a TanStack table instance with `useReactTable(...)` (columns, data, the feature models you need: sorting, pagination, row selection).
+- Pass that instance to `<DataGrid table={table} recordCount={total}>`.
+- Compose the body with `DataGridTable` inside `DataGrid`, and enable features through `tableLayout` (e.g. `{ headerSticky: true, columnsResizable: true }`), not ad-hoc classes.
+- Server-side data uses the documented fetch shape (`recordCount` is the total for pagination).
+
+```tsx
+const table = useReactTable({
+  data,
+  columns,
+  getCoreRowModel: getCoreRowModel(),
+  // add sorting/pagination/selection models per the API
+})
+
+<DataGrid table={table} recordCount={data.length}>
+  <DataGridTable />
+</DataGrid>
+```
+
+Common mistakes:
+
+- **Incorrect:** `<DataGrid data={rows} columns={cols} />` - these props do not exist. **Correct:** build a `useReactTable` instance and pass `table={table}` + `recordCount`.
+- **Incorrect:** a raw `<table>` / hand-rolled pagination. **Correct:** use `data-grid`; read its API for sticky header, pagination, virtualization, row selection.
+- **Incorrect:** styling rows/cells with arbitrary classes. **Correct:** drive layout via `tableLayout` and the documented `ColumnMeta` (e.g. `cellClassName`, `headerTitle`).
+
+## kanban
+
+**Required:** `value` (`Record<string, T[]>`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Kanban value={cols} onValueChange={setCols} getItemValue={(i) => i.id}>
+  <KanbanBoard>
+    {Object.entries(cols).map(([id, items]) => (
+      <KanbanColumn key={id} value={id}>
+        <KanbanColumnHandle>
+          <h3>{id}</h3>
+        </KanbanColumnHandle>
+        <KanbanColumnContent value={id}>
+          {items.map((i) => (
+            <KanbanItem key={i.id} value={i.id}>
+              <KanbanItemHandle>{i.title}</KanbanItemHandle>
+            </KanbanItem>
+          ))}
+        </KanbanColumnContent>
+      </KanbanColumn>
+    ))}
+  </KanbanBoard>
+  <KanbanOverlay>
+    <div className="bg-muted size-full rounded-md" />
+  </KanbanOverlay>
+</Kanban>
+```
+
+**Gotcha:** state is `Record<columnId, T[]>`. Each `KanbanColumnContent value` must match its parent `KanbanColumn value`. Omit `KanbanOverlay` and the drag preview silently breaks.
+
+## sortable
+
+**Required:** `value` (`T[]`), `onValueChange`, `getItemValue`
+**Shape:**
+
+```tsx
+<Sortable value={items} onValueChange={setItems} getItemValue={(i) => i.id}>
+  {items.map((i) => (
+    <SortableItem key={i.id} value={i.id}>
+      <SortableItemHandle>
+        <GripVertical />
+      </SortableItemHandle>
+      {i.label}
+    </SortableItem>
+  ))}
+</Sortable>
+```
+
+**Gotcha:** a flat 1D reorder list (not columns - that is `kanban`). `getItemValue` must return a stable, unique string. Pass `layout="grid"` or `layout="nested"` for non-list layouts.
+
+## filters
+
+**Required:** `filters` (`Filter[]`), `fields` (`FilterFieldConfig[]`), `onChange`
+**Shape:**
+
+```tsx
+const [filters, setFilters] = useState<Filter[]>([
+  createFilter("priority", "is_any_of", ["low"]),
+])
+const fields: FilterFieldConfig[] = [
+  { key: "priority", label: "Priority", type: "multiselect",
+    options: [{ value: "low", label: "Low" }, { value: "high", label: "High" }] },
+]
+
+<Filters filters={filters} fields={fields} onChange={setFilters} />
+```
+
+**Gotcha:** always build initial filters with `createFilter(field, operator, values)` - it generates the required `id`. Never hand-construct a `Filter` object. Pairs naturally with `data-grid`.
+
+## date-selector
+
+**Required:** none, but wire `onChange` to capture the value.
+**Shape:**
+
+```tsx
+const [value, setValue] = useState<DateSelectorValue | undefined>()
+
+<DateSelector value={value} onChange={setValue} label="Due date" />
+```
+
+**Gotcha:** the value is a structured `DateSelectorValue` (period / operator / start+end dates), NOT a `Date` - never pass a raw `Date`. Use `allowRange={false}` to lock single-date picking. Read `get_component("date-selector")` for the value shape.
+
+## tree
+
+**Required:** `tree` (a `@headless-tree/core` instance you construct)
+**Shape:**
+
+```tsx
+<Tree tree={tree}>
+  {tree.getItems().map((item) => (
+    <TreeItem key={item.getId()} item={item}>
+      <TreeItemLabel />
+    </TreeItem>
+  ))}
+</Tree>
+```
+
+**Gotcha:** `Tree` is a styled shell - it takes a headless-tree instance via `tree`, NOT `data`/`items` props. Build the instance with `@headless-tree/react`. External API: https://headless-tree.lukasbach.com/
+
+## stepper
+
+**Required:** `StepperItem step` (number), `StepperContent value` (number)
+**Shape:**
+
+```tsx
+<Stepper defaultValue={1}>
+  <StepperNav>
+    <StepperItem step={1}>
+      <StepperTrigger>
+        <StepperIndicator>1</StepperIndicator>
+      </StepperTrigger>
+      <StepperSeparator />
+    </StepperItem>
+    <StepperItem step={2}>
+      <StepperTrigger>
+        <StepperIndicator>2</StepperIndicator>
+      </StepperTrigger>
+    </StepperItem>
+  </StepperNav>
+  <StepperPanel>
+    <StepperContent value={1}>Step 1 content</StepperContent>
+    <StepperContent value={2}>Step 2 content</StepperContent>
+  </StepperPanel>
+</Stepper>
+```
+
+**Gotcha:** steps are 1-indexed. Without `StepperPanel` + `StepperContent` you render the nav trail but no body. Put `StepperSeparator` in every `StepperItem` except the last.
+
+## timeline
+
+**Required:** `TimelineItem step` (number)
+**Shape:**
+
+```tsx
+<Timeline>
+  <TimelineItem step={1}>
+    <TimelineHeader>
+      <TimelineDate>March 2024</TimelineDate>
+      <TimelineTitle>Project initialized</TimelineTitle>
+    </TimelineHeader>
+    <TimelineIndicator />
+    <TimelineSeparator />
+    <TimelineContent>Repo and architecture set up.</TimelineContent>
+  </TimelineItem>
+</Timeline>
+```
+
+**Gotcha:** each item needs a unique `step`. `orientation` is `"vertical"` (default) or `"horizontal"`. This is a static event display, not interactive like `stepper`.
+
+## autocomplete
+
+**Required:** `items` (array; each item has at least `value`)
+**Shape:**
+
+```tsx
+<Autocomplete items={items}>
+  <AutocompleteInput placeholder="Search..." />
+  <AutocompleteContent>
+    <AutocompleteEmpty>No results found.</AutocompleteEmpty>
+    <AutocompleteList>
+      {(item) => (
+        <AutocompleteItem key={item.value} value={item}>
+          {item.label}
+        </AutocompleteItem>
+      )}
+    </AutocompleteList>
+  </AutocompleteContent>
+</Autocomplete>
+```
+
+**Gotcha:** `AutocompleteList` takes a render-prop `(item) => ReactNode`, NOT a mapped array of children. External API: https://base-ui.com/react/components/autocomplete
+
+## phone-input
+
+**Required:** none, but wire `onChange`.
+**Shape:**
+
+```tsx
+<PhoneInput
+  placeholder="Enter phone number"
+  defaultCountry="US"
+  value={value}
+  onChange={setValue}
+/>
+```
+
+**Gotcha:** `value`/`onChange` use an E.164 string (e.g. `"+14155551234"`), not a display-formatted string; `onChange` can fire `undefined`. `defaultCountry` is a 2-letter ISO code. Wraps `react-phone-number-input`.
+
+## number-field
+
+**Required:** wrap the controls in `NumberFieldGroup`.
+**Shape:**
+
+```tsx
+<NumberField defaultValue={0}>
+  <NumberFieldScrubArea label="Quantity" />
+  <NumberFieldGroup>
+    <NumberFieldDecrement />
+    <NumberFieldInput />
+    <NumberFieldIncrement />
+  </NumberFieldGroup>
+</NumberField>
+```
+
+**Gotcha:** import from `@/components/ui/number-field`. The accessible label goes on `NumberFieldScrubArea`, not `NumberField`. External API: https://base-ui.com/react/components/number-field
+
+## rating
+
+**Required:** `rating` (number)
+**Shape:**
+
+```tsx
+<Rating rating={4.5} showValue editable onRatingChange={setRating} />
+```
+
+**Gotcha:** supports decimals (partial stars). Pass `editable` + `onRatingChange` for interactive input; omit both for a read-only display.
+
+## scrollspy
+
+**Required:** `targetRef` (the scroll container ref)
+**Shape:**
+
+```tsx
+<Scrollspy targetRef={containerRef}>
+  <a href="#s1" data-scrollspy-anchor="s1">Section 1</a>
+  <a href="#s2" data-scrollspy-anchor="s2">Section 2</a>
+</Scrollspy>
+<div ref={containerRef}>
+  <div id="s1">...</div>
+  <div id="s2">...</div>
+</div>
+```
+
+**Gotcha:** each link's `data-scrollspy-anchor` must match a section `id`. `targetRef` is the scrollable container (defaults to the window).
+
+## frame
+
+**Required:** `Frame` > `FramePanel`
+**Shape:**
+
+```tsx
+<Frame>
+  <FramePanel>
+    <FrameHeader>
+      <FrameTitle>Title</FrameTitle>
+      <FrameDescription>Description</FrameDescription>
+    </FrameHeader>
+    <div className="p-5">Content</div>
+    <FrameFooter>Footer</FrameFooter>
+  </FramePanel>
+</Frame>
+```
+
+**Gotcha:** a structured card shell for tool-like surfaces. `stacked` connects multiple panels with shared borders; `dense` removes panel padding; radius via the `--frame-radius` CSS variable.
+
+## icon-stack
+
+**Required:** one child icon
+**Shape:**
+
+```tsx
+<IconStack aria-hidden="true">
+  <InboxIcon className="size-4" />
+</IconStack>
+```
+
+**Gotcha:** isometric layered artwork for empty states and illustrations; style the inner icon via its own `className`. Mark purely decorative stacks `aria-hidden="true"` and keep the real label in surrounding copy.
+
+## alert
+
+**Required:** `Alert` > `AlertTitle`
+**Shape:**
+
+```tsx
+<Alert variant="success">
+  <ShieldCheckIcon />
+  <AlertTitle>Security update</AlertTitle>
+  <AlertDescription>Enable two-factor authentication.</AlertDescription>
+  <AlertAction>
+    <Button size="xs">Update</Button>
+  </AlertAction>
+</Alert>
+```
+
+**Gotcha:** shadcn-compatible API. `variant`: `default | destructive | info | success | warning | invert`. The non-default variants use ReUI extended color tokens (`--success`/`--info`/`--warning`/`--invert`), which the install adds. Defer generic alert rules to the shadcn skill.
+
+## badge
+
+**Required:** none (text child).
+**Shape:**
+
+```tsx
+<Badge variant="success-light" size="sm">Success</Badge>
+<Badge variant="outline" radius="full">Pill</Badge>
+```
+
+**Gotcha:** shadcn-compatible. Rich `variant` set (solid, `-outline`, `-light` per color), `size` `xs..xl`, `radius` `default | full`. Like `alert`, the color variants rely on ReUI extended tokens. Prefer `Badge` variants over raw color classes for statuses.
+
+## base vs radix - write for the project's base
+
+ReUI ships every component in two builds: `base` (Base UI) and `radix` (Radix UI). The install command and name are identical, and the CLI installs the build matching the project. But you must write/adapt code against the **right base**, because their APIs differ.
+
+**Detect the base first.** Read `components.json` -> `style` and take the segment before the first `-`:
+
+- `"style": "base-nova"` -> **Base UI**
+- `"style": "radix-nova"` -> **Radix UI**
+
+**Then use that base's API.** The deltas mirror shadcn's base-vs-radix split:
+
+- Slot/composition: Base UI `render={<… />}` vs Radix `asChild`.
+- `Select`: Base UI takes `items`; Radix uses `<SelectItem>` children.
+- `ToggleGroup`: Base UI `multiple` boolean vs Radix `type="single" | "multiple"`.
+
+The safest path is to **read the installed files and `c-*` examples** - they're already in your base, so reuse their wiring instead of guessing. When `get_component`'s inline `api` or an example shows the other base's shape, translate it to your base (or `validate_usage` to confirm). Defer the generic base/radix mechanics to the shadcn skill.

--- a/docs/ai/skills/reui/rules/craft.md
+++ b/docs/ai/skills/reui/rules/craft.md
@@ -1,0 +1,45 @@
+# Craft: make ReUI UI exceptional, not generic
+
+ReUI items ship senior-designer quality. Your adaptation has to hold that bar, so the result reads like a real product surface a team would keep - not a wireframe an AI generated. Use these alongside the reuse rules in [adapting.md](./adapting.md).
+
+## Have a point of view
+
+Pick an emotional register before you compose - calm, operational, premium, editorial, dense, energetic - and let layout, spacing, surface treatment, and icon behavior all reinforce it. One or two memorable decisions and restraint everywhere else beats ten generic ones. UI with no point of view reads as generated.
+
+## Brutally clear hierarchy
+
+One focal point per card or panel: the dominant metric or task first, its label second, supporting detail third. The first thing the eye lands on should be the right thing; secondary text must read as secondary. Borders, separators, and surfaces do real work to create 2-3 information bands - don't flatten everything to equal weight.
+
+## Spacing rhythm and deliberate density
+
+Gaps are a signal, not a default. Keep them intentional and consistent within a family (`gap-1`/`gap-2` for tight operational rows, larger gaps for section breaks), and smaller within a group than between groups. Match the surrounding ReUI density; don't pad an operational surface like a marketing page, and don't drift density mid-section. The composition should still feel authored in grayscale.
+
+## Cover the real states (the usual miss)
+
+A surface isn't done at the happy path. Compose, and wire:
+
+- **Empty** - a purposeful empty state (short message + the primary action), never a blank panel.
+- **Loading** - a **skeleton** that matches the real layout, not a centered spinner.
+- **Error** - an inline, recoverable error with a retry, announced via `role="status"`/`aria-live`.
+
+Derive these from an element the block already has (don't invent parallel markup), or `get_examples` for a state-specific example.
+
+## Responsive by default
+
+Mobile-first, not mobile-afterthought. In constrained rows/cards/sidebars, put `min-w-0` on the shrinking container and `truncate` long single-line labels; protect the primary label's width and let secondary content compress. Reflow layouts (multi-column -> single column) rather than just shrinking them. Desktop and mobile should both look designed.
+
+## Motion, subtly
+
+Motion should clarify, not decorate. Use ReUI Motion Icons on primary actions for a subtle hover cue; keep transitions short (~200-300ms) with calm easing; prefer a skeleton pulse over a spinner. No bouncing, no gratuitous entrance animations on every element.
+
+## Real, activated content
+
+Use believable, typed data (realistic labels, counts, timestamps, statuses that map to a real workflow) - never lorem or abstract filler. Every visible control does something: no decorative buttons, fake tabs, meaningless toggles, or stats with no job. It must still hold with long names, empty values, and crowded data.
+
+## Avoid the AI tells
+
+These instantly read as generated - don't ship them: equal-weight card walls, empty gradients, repetitive padding everywhere, generic enterprise copy, ornamental icons, and number tiles that don't earn their place.
+
+## The bar
+
+Before you finish, ask: **would a product team keep this instead of replacing it? Does it still feel strong after swapping in real content?** If not, reuse the shipped ReUI design harder - don't restyle it into something new - then run the [quality.md](./quality.md) gates.

--- a/docs/ai/skills/reui/rules/icons.md
+++ b/docs/ai/skills/reui/rules/icons.md
@@ -1,0 +1,38 @@
+# Icons (ReUI delta over shadcn)
+
+Follow the shadcn icon rules (use the project's configured `iconLibrary`, `data-icon` on icons inside `Button`, no sizing classes on icons inside components, pass icons as component objects not string keys). ReUI adds the following.
+
+## Portable icons (library-agnostic)
+
+ReUI components, examples, and blocks are authored to be icon-library-agnostic. When `iconLibrary` is set in `components.json`, the shadcn CLI installs each item's icons in **your** library automatically - you swap nothing. If an installed item's icons don't match your project (for example `iconLibrary` isn't set, so they came in from the item's demo library), change the **import source and component name** to your library, keeping the same icon-name semantics:
+
+- `lucide` -> `lucide-react`
+- `tabler` -> `@tabler/icons-react`
+- `phosphor` -> `@phosphor-icons/react`
+- `remix` -> `@remixicon/react`
+- `hugeicons` -> `@hugeicons/react`
+
+Don't assume `lucide-react`; read `iconLibrary` from `components.json`.
+
+## Keep icons purposeful
+
+Icons support the hierarchy, they don't replace it: keep them small, matched to the surrounding density, and decorative ones `aria-hidden="true"` (an icon-only control still needs an accessible label on the control). Don't add ornamental icons that do no job.
+
+## Motion Icons (the `@reui/icons/...` set)
+
+ReUI ships its own icon set in 4 styles (outline, solid, duotone, filled), each icon in two variants:
+
+```bash
+npx shadcn@latest add @reui/icons/default/<style>/<name> --yes    # static
+npx shadcn@latest add @reui/icons/animated/<style>/<name> --yes   # hover-animated (motion/react)
+```
+
+Finding them via the MCP is free; installing requires an Ultimate license (`REUI_LICENSE_KEY`, see [cli.md](./cli.md)). Reach for a Motion Icon on a primary action when a subtle hover cue helps; keep motion restrained.
+
+Finding icons:
+
+- Several icons (the common case): **`search_icons(concepts[])`** - up to 24 concepts in one call, the best icons per concept with install commands. Pass `animated: true` to get only icons with a hover-animated Motion variant.
+- One icon: `search` with `type: "icon"`.
+- Icon results and `get_icon` carry `animated: true` and `installAnimated` when an animated variant exists - use those install strings, do not construct paths by hand.
+
+The `icon-stack` component composes multiple icons into a stacked display.

--- a/docs/ai/skills/reui/rules/quality.md
+++ b/docs/ai/skills/reui/rules/quality.md
@@ -1,0 +1,22 @@
+# Quality gates (security, accessibility, scroll)
+
+These are the **done gate**, not a nice-to-have: before you call any ReUI work finished, call the MCP `get_audit_checklist` tool and pass every item below (plus the craft bar in [craft.md](./craft.md)). Then typecheck and lint.
+
+## Security
+
+- Never `dangerouslySetInnerHTML`. Render data as text/components.
+- External links (`target="_blank"`) must always pair `rel="noopener noreferrer"`.
+- No real PII, secrets, or tokens in demo or committed code. Remote media only from sources the project already allows.
+
+## Accessibility
+
+- Implicit list/card items that navigate get real anchors with a standard hover affordance.
+- Icon-only or numeric buttons need an `aria-label`; decorative icons get `aria-hidden`.
+- Every non-submit button is `type="button"`.
+- Keyboard + focus: everything interactive is reachable in a sensible Tab order with a visible focus ring; layers (dialogs/sheets/menus) trap focus and close on `Escape`. ReUI components ship standard keyboard behavior - read each component's inline `api` rather than re-implementing it.
+- Announce async UI: loading and error messages use `role="status"` / `aria-live` so they're not silent to screen readers.
+
+## Scroll mechanics
+
+- Make scroll regions with a parent-owned height: a `min-h-0` + flex chain down to the scroll container. Never guess a `max-h`.
+- The scroll container owns `overflow-auto`; ancestors stay `min-h-0` so the height resolves.

--- a/docs/ai/skills/reui/rules/registry.md
+++ b/docs/ai/skills/reui/rules/registry.md
@@ -1,0 +1,31 @@
+# ReUI registry structure
+
+ReUI is a shadcn-compatible registry with four entity types. **Examples and blocks are built FROM components** - reuse them, don't rebuild.
+
+- **component** - one of the 17 ReUI building blocks with a real API (`data-grid`, `kanban`, `filters`, `date-selector`, `tree`, ...). Install directly (`@reui/data-grid`) or let it come in as a dependency of an example/block. Free. Read its API with `get_component(name)`.
+- **example** - a free `c-*` single-pattern use-case of a component (`c-kanban-1`, `c-data-grid-3`). Install one and read it to copy real composition. Find a component's examples with `get_examples(name)`.
+- **block** - a premium, full-page section that composes several components (`data-grid-2`, `pricing-page-1`). Pro or Ultimate license at install. Adapts to your active theme via semantic tokens.
+- **icon** - Motion Icons in 4 styles (outline, solid, duotone, filled), static (`@reui/icons/default/<style>/<name>`) and hover-animated (`@reui/icons/animated/<style>/<name>`). Ultimate license at install. See [icons.md](./icons.md).
+
+## The @reui registry
+
+Install everything through the shadcn CLI: `npx shadcn@latest add @reui/<name> --yes`. The CLI reads the `@reui` registry from the project's `components.json`. Free items need only the plain string form:
+
+```json
+{ "registries": { "@reui": "https://reui.io/r/{style}/{name}.json" } }
+```
+
+Premium installs need the authenticated form + `REUI_LICENSE_KEY` in `.env.local` - see [cli.md](./cli.md). The MCP `get_project_context` tool returns the right config.
+
+## Know your base: base or radix
+
+ReUI ships every item in two builds - `base` (Base UI) and `radix` (Radix UI) - with mirrored names. The CLI installs the build matching your project automatically, but **you must write code against the right base's API**. Detect it from `components.json` -> `style`: the segment before the first `-` is the base (`base-nova` -> Base UI, `radix-nova` -> Radix UI). The installed files and `c-*` examples are already in your base - read them and adapt on that base. See [components.md](./components.md) for the API deltas. Blocks adapt to your active theme through semantic tokens and CSS variables - change the theme and every block follows.
+
+## Free vs premium
+
+- **Free, no key:** the 17 components, all `c-*` examples, the ReUI MCP, and this skill.
+- **Premium, license required at install:** blocks (Pro or Ultimate), Motion Icons and templates (Ultimate). Set `REUI_LICENSE_KEY` (see [cli.md](./cli.md)).
+
+## Component API index
+
+The canonical index of every component's API docs is **https://reui.io/llms.txt** (returned as `componentsApiUrl` in MCP results). Prefer the inline `api` from `get_component`; use the index/docs as the fallback.

--- a/docs/ai/skills/reui/rules/styling.md
+++ b/docs/ai/skills/reui/rules/styling.md
@@ -1,0 +1,26 @@
+# Styling (ReUI delta over shadcn)
+
+Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+
+## ReUI extended semantic tokens
+
+ReUI adds semantic tokens beyond shadcn's base set. Use these instead of raw colors for status and emphasis:
+
+- `--success` / `--success-foreground`
+- `--info` / `--info-foreground`
+- `--warning` / `--warning-foreground`
+- `--destructive-foreground` (paired with shadcn's `--destructive`)
+- `--invert` / `--invert-foreground` (inverted surfaces)
+
+Use them as Tailwind utilities (`bg-success text-success-foreground`, `text-warning`, ...). They are defined in the project's global CSS and registered with Tailwind (`@theme inline` on v4). If a token is missing in the project, add it to the global CSS file (never a new file) following the same `name` / `name-foreground` convention, exactly as the shadcn customization rules describe.
+
+**Incorrect:** `<span className="text-green-600">Active</span>`
+**Correct:** `<Badge variant="success">Active</Badge>` or `<span className="text-success">Active</span>`
+
+## Blocks follow your theme
+
+When you install a block it adapts to your active theme through the semantic tokens above and the project's CSS variables. Don't hardcode style-specific values into installed block code and don't fork it to "restyle" - change the theme via the CSS variables / a preset and every block follows. Want a different look? `search` for a block whose design already fits instead of re-skinning one.
+
+## Density and typography rhythm
+
+ReUI operational UI usually feels dense, not airy. Keep the gap between a title and its supporting description tight by default (`gap-0.5`, `space-y-1`, or `space-y-px`), and smaller than the gap between sections. Match the surrounding ReUI density when you add rows or fields; do not pad operational surfaces like a marketing page.

--- a/docs/ai/skills/reui/rules/styling.md
+++ b/docs/ai/skills/reui/rules/styling.md
@@ -1,6 +1,6 @@
 # Styling (ReUI delta over shadcn)
 
-Follow the shadcn skill for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
+Follow [`docs/ai/skills/moai-library-shadcn/SKILL.md`](../../moai-library-shadcn/SKILL.md) for the generic rules (semantic colors not raw values, `gap-*` not `space-y-*`, `size-*`, `cn()`, no manual `dark:` overrides, no overlay `z-index`). This file is only the ReUI-specific additions.
 
 ## ReUI extended semantic tokens
 

--- a/docs/ai/skills/reui/rules/workflow.md
+++ b/docs/ai/skills/reui/rules/workflow.md
@@ -1,0 +1,52 @@
+# Workflow: find -> install -> read API -> adapt
+
+The core ReUI loop. The MCP tells you what to install and gives you the API; the shadcn CLI installs it; you turn the installed files into correct, themed, data-wired code by **reuse**, not redesign.
+
+## 1. Find (ReUI MCP `search` / `compose_page`)
+
+**Full multi-section page ask?** Call `compose_page(intent, sections?)` FIRST, before searching block-by-block. It returns ordered sections, each with the best block for the intent (top pick + alternates); sections listed in `unavailableSections` have no real inventory - compose those from components, do not force a bad block.
+
+For everything else, call `search` with the user's intent. Pass structured hints whenever you can infer them - you are an LLM, so do the parsing the server cannot:
+
+- `type`: `"component"` (one of the 17 building blocks), `"example"` (a c-\* use-case), `"block"` (a full page/section), `"icon"`.
+- `component`: the ReUI component the request implies (`"data-grid"`, `"kanban"`, ...).
+- `category`, `features` (e.g. `["sortable","pagination"]`), `free`.
+
+Example: "build a users management page with filters" -> `search({ query: "users management page with filters", type: "block", component: "data-grid", features: ["filters"] })`.
+
+Each result has `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `termCoverage`, and `whyMatch`. `score` is relative to the top hit (the top is ~100 by construction), not an absolute quality - compare results to each other, and show the user the top options if several score closely; do not silently guess. A low `termCoverage` means a weak match even with a high score - rephrase or widen.
+
+## 2. Install (shadcn CLI)
+
+Run the result's `install` command from the project root, non-interactively:
+
+```bash
+npx shadcn@latest add @reui/<name> --yes
+```
+
+The CLI reads `components.json`, installs the correct base+style variant, resolves `registryDependencies` (a block pulls in its components), installs npm deps, and rewrites aliases. Do not pass the base/style. See [cli.md](./cli.md).
+
+## 3. Read the API (do not guess props)
+
+Before writing code against any component an item uses:
+
+1. The item's `componentDigests` already give a 1-line contract per component - often enough to wire it. For the full API, call **`get_component(names)`** with ALL of `componentsUsed` in ONE call (it accepts an array) and read each inline `api` - no web fetch. `docsUrl` and the `/llms.txt` index are the fallback.
+2. Call **`get_examples(name)`** for the free `c-*` examples of that component; install one and **read the added files** to copy the exact composition. This is the fastest correct path - the example shows real wiring you adapt, not invent.
+3. About to write a prop you did not see in an `api` or installed file? Run **`validate_usage`** BEFORE writing the code - per-prop documented / notDocumented verdicts plus did-you-mean suggestions. notDocumented means read the API, not push on.
+
+## 4. Adapt (reuse-first) - do not skip
+
+Installing files is not the end, and redesigning them defeats the point. First note the project's **base** so you write the right API - read `components.json` -> `style` and take the segment before the first `-` (`base-nova` -> Base UI, `radix-nova` -> Radix UI), see [components.md](./components.md). After `add`:
+
+1. **Read the added files**; keep the composition intact. For a block, verify the components are wired correctly (for `data-grid`: a `useReactTable` instance passed as `table`, `recordCount` set - see [components.md](./components.md)).
+2. **Replace demo data with the user's real data** via typed structures (see [adapting.md](./adapting.md)).
+3. **Fix icon imports** to the project's icon library (see [icons.md](./icons.md)).
+4. **Align styling** to semantic tokens and the active theme - no raw colors (see [styling.md](./styling.md)).
+5. **Validate before finalizing**: if your adaptation introduced components or props you did not read in an `api` or example, run `validate_usage` on them.
+6. **Hit the craft bar** - clear hierarchy, deliberate density, the empty / loading / error states, subtle motion, and mobile-first responsiveness (see [craft.md](./craft.md)). Generic-looking output means you under-reused the design, not that it needs restyling.
+7. **Pass the quality gates** (security, a11y, scroll) - call the MCP `get_audit_checklist` tool and clear every item (see [quality.md](./quality.md)).
+8. **Typecheck / lint**.
+
+## If no single block fits
+
+Compose from components (`compose_page` tells you which sections have no block inventory via `unavailableSections`). `search` the components you need, read each `get_component` API, install a worked `get_examples` example for each, and assemble by adapting those examples. A block in the same category is a useful reference - install it and read its files to see how ReUI composes those components, then adapt.

--- a/docs/ai/skills/reui/tools.md
+++ b/docs/ai/skills/reui/tools.md
@@ -1,0 +1,57 @@
+# ReUI MCP: full reference
+
+The ReUI MCP (`https://mcp.reui.io`, Streamable HTTP) is free - it needs no license and no auth header at all. It does **discovery + guidance** (search, inline APIs, page planning, validation) and never serves source code; the shadcn CLI does **installation**, and the license key lives only there (the `@reui` entry in `components.json`, backed by `.env.local`). In this repo it is configured as `reui` for Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), and Codex (`.codex/config.toml`). Goal: from the user's intent to correct, themed, data-wired ReUI code in the **fewest tokens and calls**, with **no guessing**.
+
+## Golden path (token-optimal - follow this order)
+
+Most tasks need 2-4 MCP calls and ZERO web fetches:
+
+1. **`search(query, ...hints)`** -> pick the top 1-3 results. Each result already carries `install`, `previewUrl`, `docsUrl`, `componentsUsed`, `score`, `whyMatch`. The payload is complete - do not call another tool just to "confirm" a result.
+2. **`get_component([...componentsUsed])`** in ONE batched call (one name or an array of up to 20) -> read each inline `api`. This **replaces** fetching docs pages. Often skippable: search responses carry `componentDigests`, a compact API contract per referenced component.
+3. **`get_examples(component)`** -> install ONE returned `c-*` example, read the added files, copy the composition.
+4. **`get_install_command(item)`** only to validate a name you are unsure of (results already include `install`). Run the install with the shadcn CLI (`--yes`).
+5. **`get_audit_checklist()`** before declaring done.
+
+If you already know the exact item name, skip `search`. Everything else is situational.
+
+## The 5 task-specific tools (when to reach for each)
+
+- **`compose_page`** - BEFORE building any full page (dashboard, settings, billing, landing). Pass the intent (and optionally the sections you want); it returns ordered sections, each with the best premium block for the intent (top pick + alternates). Sections with no real inventory are listed honestly in `unavailableSections` - compose those from components instead of forcing a bad block.
+- **`search_icons`** - whenever you need icons, especially several. Batch up to 24 concepts in one call; each concept returns its best icons with install commands. Pass `animated: true` to get only icons that have a hover-animated Motion variant.
+- **`validate_usage`** - BEFORE writing code with component names or props you have not read in an inline `api` or an installed example. It checks planned names + props against the indexed API docs and registry item names; returns did-you-mean suggestions and per-prop documented / notDocumented verdicts. Deterministic, no inference - a notDocumented prop means stop and read the API, not push on.
+- **`whats_new`** - when your registry knowledge might be stale (a name 404s, the user mentions an item you don't know). Returns items added/removed per build, newest first.
+- **`report_issue`** - when an installed item is actually broken (bad source, wrong dependency, broken preview). Goes straight to the ReUI team; rate-limited 5/hour. Not for usage questions.
+
+## All 19 tools
+
+`search`, `get_block`, `get_example`, `get_icon`, `list_block_groups`, `list_block_categories`, `list_example_categories`, `list_icon_categories`, `list_components`, `get_component`, `get_examples`, `search_icons`, `compose_page`, `validate_usage`, `whats_new`, `report_issue`, `get_install_command`, `get_project_context`, `get_audit_checklist`. The MCP serves the full parameter schemas; do not guess parameters beyond them.
+
+## Token + speed rules
+
+- **Batch `get_component`** - ONE call with the whole `componentsUsed` array, never N calls. Skip it entirely when `componentDigests` already answers the question.
+- **Read source by installing** - the MCP serves no source. To read or analyze an item's real code, install it with the shadcn CLI and open the local files. Learn an API from the inline `api` / `componentDigests`, never by reading raw source.
+- **Infer `search` hints yourself** (`type`, `component`, `category`, `features`, `free`) - hints shrink the result set and the tokens. Keep `limit` low; one right result beats ten.
+- Run independent calls (and the shadcn install) concurrently in one turn - serial tool calls are the main source of slowness.
+- Don't repeat a search for the same intent; don't call `list_*` to "see everything" - `search` is the entry point, `list_*` is only for browsing a taxonomy the user explicitly wants to explore.
+- Prefer `get_component`'s inline `api` over `docsUrl` / `/llms.txt`. Fetch a web page only as a last resort.
+
+## Result shapes (so you don't re-fetch)
+
+- `score` is 0-100 RELATIVE to the top hit (the top is ~100 by construction), not absolute - compare results to each other.
+- `termCoverage` (0-1) is the share of the query the item matched - low means a weak match even if the score looks high; rephrase or widen the search.
+- Each result carries `whyMatch`, `install`, docs/preview URLs, and a `free` flag; premium items carry `requiredPlan` (`"pro"` for blocks, `"ultimate"` for icons).
+- `componentDigests` is a top-level map: a compact API contract per referenced component - often enough to wire an item without a `get_component` call.
+- Icon results and `get_icon` include `animated: true` and `installAnimated` when a hover-animated Motion variant exists (animated: `@reui/icons/animated/<style>/<name>`; static: `@reui/icons/default/<style>/<name>`).
+
+## Error playbook
+
+- **401 / 403** - install-time only: a premium install without a valid `REUI_LICENSE_KEY`, or a plan that does not cover the item (blocks Pro+, icons/templates Ultimate). Point to https://reui.io/account (key) or https://reui.io/pricing (upgrade). The MCP itself never authenticates - connecting and every tool are free.
+- **429** - rate limited (120 requests/min per IP); back off, honor `Retry-After`.
+- **not found** (`found: false`) - use the returned `suggestions`, or `search`; check `whats_new` if you suspect a stale name. Never run a fabricated install command.
+
+## Fallbacks
+
+- No ReUI MCP: `npx shadcn@latest search @reui -q "..."` then `add` (generic, no scoring / inline API).
+- The shadcn project's own MCP also works over the `@reui` registry: https://ui.shadcn.com/docs/mcp.
+
+Per-agent MCP setup: https://reui.io/docs/mcp

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -63,6 +63,12 @@
       "headers": {
         "Authorization": "Bearer ${REGISTRY_TOKEN}"
       }
+    },
+    "@reui": {
+      "url": "https://reui.io/r/{style}/{name}.json",
+      "headers": {
+        "Authorization": "Bearer ${REUI_LICENSE_KEY}"
+      }
     }
   }
 }

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -64,11 +64,6 @@
         "Authorization": "Bearer ${REGISTRY_TOKEN}"
       }
     },
-    "@reui": {
-      "url": "https://reui.io/r/{style}/{name}.json",
-      "headers": {
-        "Authorization": "Bearer ${REUI_LICENSE_KEY}"
-      }
-    }
+    "@reui": "https://reui.io/r/{style}/{name}.json"
   }
 }


### PR DESCRIPTION
## Summary

Adds ReUI agent tooling to the repo instruction system and MCP configuration.

- Adds the canonical `docs/ai/skills/reui/` skill and syncs committed mirrors under `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/`.
- Configures the free ReUI MCP endpoint as `reui` for Claude Code, Cursor, and Codex via `.mcp.json`, `.cursor/mcp.json`, and `.codex/config.toml`.
- Documents ReUI routing and adds the premium `@reui` registry entry in `packages/ui/components.json`, using `REUI_LICENSE_KEY` from local env.

## Validation

- `bun run skills:verify`
- `bun run --filter @asym/ui typecheck`
- `git push -u origin codex/add-reui-agent-tooling` ran the full pre-push `ci:preflight` successfully: format, skills verify, lint, data-boundary, workspace-contract, eslint config, shadcn config/diff, typecheck, build, and unit tests.

## Notes

This PR was split from the existing `claude/gifted-ishizaka-823597` branch so it does not stack on the open TanStack migration PR #370.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds ReUI agent tooling and registry support. The main changes are:

- Adds the canonical `docs/ai/skills/reui/` skill and generated mirrors for agent clients.
- Configures the free ReUI MCP endpoint for Claude Code, Cursor, and Codex.
- Adds the plain-string `@reui` shadcn registry entry in `packages/ui/components.json`.
- Updates repo agent docs to route ReUI work through the new skill and MCP workflow.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

Changes are limited to agent documentation, skill mirrors, MCP endpoint configuration, and a shadcn registry entry. No material correctness, security, or deployment issues were found in the reviewed changes.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the reui-skills scenario using trex-artifacts/reui-skills-script.sh to capture the baseline (before) state and the head (after) state.
- Compared the before and after states to verify 12 ReUI files exist in canonical and all mirrors, manifests report contains\_reui: yes, mirrors match: yes, and routing lines are present.
- Confirmed skills\_verify\_exit remains 0 in both the before and after states.
- Recorded artifacts for the reui-skills run, including the before and after parse logs and the script used for the scenario.
- Parsed and inspected REUI MCP/registry data; after-state parse shows MCP config URL https://mcp.reui.io and registry URL patterns https://reui.io/r/{style}/{name}.json, with REUI\_LICENSE\_KEY present only in documentation excerpts, not in MCP/registry values.
- Recorded artifacts for the REUI MCP/registry run, including the before and after parse logs.

<a href="https://app.greptile.com/trex/runs/13003851/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/ai/skills/reui/SKILL.md | Adds the canonical ReUI skill entrypoint with repo-specific routing, registry, table, and MCP guidance. |
| docs/ai/skills/reui/rules/cli.md | Documents free versus premium ReUI registry setup and non-interactive shadcn install behavior. |
| docs/ai/skills/reui/tools.md | Documents the ReUI MCP tool surface and token-efficient workflow for agents. |
| packages/ui/components.json | Adds the plain-string `@reui` registry for free ReUI installs under the UI package shadcn config. |
| .mcp.json | Adds the ReUI Streamable HTTP MCP endpoint for Claude Code at the repo root. |
| .cursor/mcp.json | Mirrors the ReUI MCP endpoint for Cursor. |
| .codex/config.toml | Adds the ReUI MCP endpoint to Codex configuration. |
| AGENTS.md | Routes agents to the new ReUI MCP and canonical ReUI skill documentation. |
| README.md | Updates repo skill mirror documentation to include Claude and ReUI manual vendoring. |
| docs/AI_AGENT_PLAYBOOK.md | Adds ReUI agent tooling guidance and updates mirror documentation. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Agent as Repo agent
participant MCP as ReUI MCP (reui)
participant Skill as docs/ai/skills/reui
participant CLI as shadcn CLI
participant Registry as packages/ui components.json

Agent->>Skill: Load ReUI routing and workflow
Agent->>MCP: search / compose_page / get_component
MCP-->>Agent: Ranked results, install command, inline APIs
Agent->>CLI: "shadcn add @reui/<name> --yes"
CLI->>Registry: "Read @reui registry and style base-maia"
Registry-->>CLI: "https://reui.io/r/{style}/{name}.json"
CLI-->>Agent: Install Base UI themed ReUI files
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Agent as Repo agent
participant MCP as ReUI MCP (reui)
participant Skill as docs/ai/skills/reui
participant CLI as shadcn CLI
participant Registry as packages/ui components.json

Agent->>Skill: Load ReUI routing and workflow
Agent->>MCP: search / compose_page / get_component
MCP-->>Agent: Ranked results, install command, inline APIs
Agent->>CLI: "shadcn add @reui/<name> --yes"
CLI->>Registry: "Read @reui registry and style base-maia"
Registry-->>CLI: "https://reui.io/r/{style}/{name}.json"
CLI-->>Agent: Install Base UI themed ReUI files
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(reui): sync skill mirror table for..."](https://github.com/asymmetric-al/core/commit/0d415c719e285bf448d73fd27c8c79c12be3a545) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41256579)</sub>

<!-- /greptile_comment -->