### PR TITLE
AL-256: Add shared contribution row contract

### DIFF
--- a/packages/api/src/admin/contribution-shared/index.ts
+++ b/packages/api/src/admin/contribution-shared/index.ts
@@ -21,6 +21,20 @@ export {
   type ContributionProfileLabelInput,
 } from "./profile-label";
 export {
+  applyEffectiveContributionToDonation,
+  assembleSharedContributionEffectiveState,
+  buildSharedContributionDesignationSets,
+  collectSharedContributionLookupIds,
+  loadSharedContributionRowInputs,
+  toContributionCents,
+  type SharedContributionEffectiveState,
+  type SharedContributionRowInputs,
+  type SharedRowAllocationSource,
+  type SharedRowCorrectionSource,
+  type SharedRowDonationSource,
+  type SharedRowStagedGiftSource,
+} from "./row-inputs";
+export {
   buildContributionDesignationSet,
   deriveFundType,
   summarizeContributionDesignationSet,

--- a/packages/api/src/admin/contribution-shared/row-inputs.ts
+++ b/packages/api/src/admin/contribution-shared/row-inputs.ts
@@ -1,0 +1,513 @@
+import {
+  buildContributionDesignationSet,
+  type DesignationAllocationInput,
+  type DesignationFundInput,
+} from "./designation-set";
+import {
+  deriveEffectiveContribution,
+  mapContributionAdjustmentRow,
+  type EffectiveContributionResult,
+} from "./effective-values";
+import { resolveContributionProfileLabel } from "./profile-label";
+import { ApiHttpError } from "../../shared/http-errors";
+
+import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
+import type { ContributionDesignationSet } from "@asym/database/types";
+
+/**
+ * Shared contribution row input assembly (ADR-CD-032, issue #256).
+ *
+ * `buildSharedContributionRowFields` only guarantees display parity when both
+ * surfaces feed it the same inputs. CRM donor gift history and the
+ * Contributions Hub therefore assemble corrections, adjustment-derived
+ * effective values, and designation sets through this one module instead of
+ * re-implementing the load per surface.
+ */
+
+export interface SharedRowDonationSource {
+  id: string;
+  /** BIGINT cents; Postgres can deliver this as a string. */
+  amount: number | string | null;
+  currency: string | null;
+  fund_id: string | null;
+  missionary_id: string | null;
+  status: string | null;
+}
+
+export interface SharedRowStagedGiftSource {
+  id: string;
+  donation_id: string;
+  fund_id?: string | null;
+  missionary_id?: string | null;
+}
+
+export interface SharedRowCorrectionSource {
+  donation_id: string;
+  status: string;
+}
+
+export interface SharedRowAllocationSource {
+  id: string;
+  staged_gift_id: string;
+  /** Allocation amount in cents (normalize with `toContributionCents` first). */
+  amount: number;
+  fund_id: string | null;
+  missionary_id: string | null;
+  memo: string | null;
+}
+
+/**
+ * Postgres BIGINT columns can arrive as strings; every shared row input must
+ * normalize amounts through this before derivation.
+ */
+export function toContributionCents(
+  value: number | string | null | undefined,
+): number {
+  if (value == null) {
+    return 0;
+  }
+
+  const numberValue = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numberValue) ? Math.round(numberValue) : 0;
+}
+
+export interface SharedContributionEffectiveState {
+  correctionsByDonationId: Map<string, Array<{ status: string }>>;
+  effectiveByDonationId: Map<string, EffectiveContributionResult>;
+}
+
+/**
+ * Groups correction records and derives adjustment-based effective values per
+ * donation. Corrections and pending correction requests share one correction
+ * list because `deriveSharedCorrectionState` treats them identically.
+ */
+export function assembleSharedContributionEffectiveState(input: {
+  donations: SharedRowDonationSource[];
+  corrections: SharedRowCorrectionSource[];
+  correctionRequests: SharedRowCorrectionSource[];
+  adjustments: Array<Record<string, unknown>>;
+}): SharedContributionEffectiveState {
+  const correctionsByDonationId = new Map<string, Array<{ status: string }>>();
+  for (const correction of [
+    ...input.corrections,
+    ...input.correctionRequests,
+  ]) {
+    const existing = correctionsByDonationId.get(correction.donation_id) ?? [];
+    existing.push({ status: correction.status });
+    correctionsByDonationId.set(correction.donation_id, existing);
+  }
+
+  const adjustmentsByDonationId = new Map<
+    string,
+    ReturnType<typeof mapContributionAdjustmentRow>[]
+  >();
+  for (const row of input.adjustments) {
+    const donationId =
+      typeof row.donation_id === "string" ? row.donation_id : "";
+    const existing = adjustmentsByDonationId.get(donationId) ?? [];
+    existing.push(mapContributionAdjustmentRow(row));
+    adjustmentsByDonationId.set(donationId, existing);
+  }
+
+  const effectiveByDonationId = new Map<string, EffectiveContributionResult>(
+    input.donations.map((donation) => [
+      donation.id,
+      deriveEffectiveContribution({
+        original: {
+          amountCents: toContributionCents(donation.amount),
+          fundId: donation.fund_id,
+          missionaryId: donation.missionary_id,
+          paymentStatus: donation.status ?? "pending",
+        },
+        adjustments: adjustmentsByDonationId.get(donation.id) ?? [],
+      }),
+    ]),
+  );
+
+  return { correctionsByDonationId, effectiveByDonationId };
+}
+
+/**
+ * Collects every fund and missionary id a page of shared rows can reference:
+ * original donation targets, staged gift targets, allocation lines, and
+ * adjustment-derived effective targets (including replacement designation
+ * lines). Surfaces append their own extra ids (pledges, donor context).
+ */
+export function collectSharedContributionLookupIds(input: {
+  donations: SharedRowDonationSource[];
+  stagedGifts: SharedRowStagedGiftSource[];
+  allocations: SharedRowAllocationSource[];
+  effectiveByDonationId: Map<string, EffectiveContributionResult>;
+  extraFundIds?: Array<string | null | undefined>;
+  extraMissionaryIds?: Array<string | null | undefined>;
+}): { fundIds: string[]; missionaryIds: string[] } {
+  const effectiveResults = Array.from(input.effectiveByDonationId.values());
+
+  const fundIds = mergeUniqueIds([
+    ...input.donations.map((donation) => donation.fund_id),
+    ...input.stagedGifts.map((gift) => gift.fund_id),
+    ...input.allocations.map((allocation) => allocation.fund_id),
+    ...effectiveResults.map((result) => result.effective.fundId),
+    ...effectiveResults.flatMap(
+      (result) =>
+        result.effectiveDesignationLines?.map((line) => line.fundId) ?? [],
+    ),
+    ...(input.extraFundIds ?? []),
+  ]);
+
+  const missionaryIds = mergeUniqueIds([
+    ...input.donations.map((donation) => donation.missionary_id),
+    ...input.stagedGifts.map((gift) => gift.missionary_id),
+    ...input.allocations.map((allocation) => allocation.missionary_id),
+    ...effectiveResults.map((result) => result.effective.missionaryId),
+    ...effectiveResults.flatMap(
+      (result) =>
+        result.effectiveDesignationLines?.map((line) => line.missionaryId) ??
+        [],
+    ),
+    ...(input.extraMissionaryIds ?? []),
+  ]);
+
+  return { fundIds, missionaryIds };
+}
+
+/**
+ * Builds the designation set for every donation from the same precedence CRM
+ * detail established: replacement lines from the latest applied allocation
+ * adjustment win, then staged gift allocation lines, then the single-line
+ * donation fallback — always reconciled against the effective gift amount.
+ */
+export function buildSharedContributionDesignationSets(input: {
+  donations: SharedRowDonationSource[];
+  stagedGifts: SharedRowStagedGiftSource[];
+  allocationsByStagedGiftId: Map<string, DesignationAllocationInput[]>;
+  effectiveByDonationId: Map<string, EffectiveContributionResult>;
+  funds: Map<string, DesignationFundInput>;
+  missionaries: Map<string, string | null>;
+}): Map<string, ContributionDesignationSet> {
+  const stagedGiftIdByDonationId = new Map(
+    input.stagedGifts.map((gift) => [gift.donation_id, gift.id]),
+  );
+
+  const sets = new Map<string, ContributionDesignationSet>();
+  for (const donation of input.donations) {
+    const effectiveResult = input.effectiveByDonationId.get(donation.id);
+    const effective = effectiveResult?.effective ?? {
+      amountCents: toContributionCents(donation.amount),
+      fundId: donation.fund_id,
+      missionaryId: donation.missionary_id,
+      paymentStatus: donation.status ?? "pending",
+    };
+
+    const stagedGiftId = stagedGiftIdByDonationId.get(donation.id);
+    const allocations = effectiveResult?.effectiveDesignationLines
+      ? effectiveResult.effectiveDesignationLines.map((line) => ({
+          id: line.id,
+          amount: line.amountCents,
+          fund_id: line.fundId,
+          missionary_id: line.missionaryId,
+          memo: line.memo,
+        }))
+      : stagedGiftId
+        ? (input.allocationsByStagedGiftId.get(stagedGiftId) ?? [])
+        : [];
+
+    sets.set(
+      donation.id,
+      buildContributionDesignationSet({
+        donation: {
+          id: donation.id,
+          amount: effective.amountCents,
+          currency: donation.currency ?? "usd",
+          fund_id: effective.fundId,
+          missionary_id: effective.missionaryId,
+        },
+        effectiveAmountCents: effective.amountCents,
+        allocations,
+        funds: input.funds,
+        missionaries: input.missionaries,
+      }),
+    );
+  }
+
+  return sets;
+}
+
+/**
+ * Applies adjustment-derived effective values onto a donation row so shared
+ * row derivation (amount, designation target, payment status) reads corrected
+ * financial truth on every surface.
+ */
+export function applyEffectiveContributionToDonation<
+  T extends SharedRowDonationSource,
+>(
+  donation: T,
+  effectiveByDonationId: Map<string, EffectiveContributionResult>,
+): T {
+  const effectiveResult = effectiveByDonationId.get(donation.id);
+  if (!effectiveResult) {
+    return donation;
+  }
+
+  const withEffectiveValues = {
+    ...donation,
+    amount: effectiveResult.effective.amountCents,
+    fund_id: effectiveResult.effective.fundId,
+    missionary_id: effectiveResult.effective.missionaryId,
+    status: effectiveResult.effective.paymentStatus,
+  };
+  return withEffectiveValues as T;
+}
+
+export interface SharedContributionRowInputs extends SharedContributionEffectiveState {
+  designationSetByDonationId: Map<string, ContributionDesignationSet>;
+  allocationsByStagedGiftId: Map<string, DesignationAllocationInput[]>;
+  fundsById: Map<string, DesignationFundInput>;
+  fundNamesById: Map<string, string | null>;
+  missionaryLabelsById: Map<string, string | null>;
+}
+
+type SupabaseErrorShape = { message?: string | null } | null;
+
+function assertNoRowInputError(
+  error: SupabaseErrorShape,
+  fallback: string,
+): void {
+  if (error) {
+    throw new ApiHttpError(500, error.message ?? fallback);
+  }
+}
+
+function mergeUniqueIds(ids: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(ids.filter((id): id is string => Boolean(id))));
+}
+
+type MissionaryLabelRow = {
+  id: string;
+  profile: {
+    display_name: string | null;
+    full_name: string | null;
+    first_name: string | null;
+    last_name: string | null;
+    email: string | null;
+  } | null;
+};
+
+type FundMetaRow = {
+  id: string;
+  name: string | null;
+  missionary_id: string | null;
+  goal_amount: number | string | null;
+  start_date: string | null;
+  end_date: string | null;
+};
+
+type AllocationRow = {
+  id: string;
+  staged_gift_id: string;
+  amount: number | string | null;
+  fund_id: string | null;
+  missionary_id: string | null;
+  memo: string | null;
+};
+
+/**
+ * Loads and assembles every shared row input for one page of donations. Both
+ * the Contributions Hub list and CRM donor gift history call this, so the
+ * same gift always derives the same shared fields regardless of surface.
+ */
+export async function loadSharedContributionRowInputs(
+  supabaseAdmin: AdminSupabaseClient,
+  input: {
+    tenantId: string;
+    donations: SharedRowDonationSource[];
+    stagedGifts: SharedRowStagedGiftSource[];
+    extraFundIds?: Array<string | null | undefined>;
+    extraMissionaryIds?: Array<string | null | undefined>;
+  },
+): Promise<SharedContributionRowInputs> {
+  const donationIds = mergeUniqueIds(
+    input.donations.map((donation) => donation.id),
+  );
+  const stagedGiftIds = mergeUniqueIds(
+    input.stagedGifts.map((gift) => gift.id),
+  );
+
+  const [
+    correctionsResult,
+    correctionRequestsResult,
+    adjustmentsResult,
+    allocationsResult,
+  ] = await Promise.all([
+    donationIds.length > 0
+      ? supabaseAdmin
+          .from("contribution_corrections")
+          .select("donation_id, status")
+          .eq("tenant_id", input.tenantId)
+          .in("donation_id", donationIds)
+      : Promise.resolve({ data: [], error: null }),
+    donationIds.length > 0
+      ? supabaseAdmin
+          .from("contribution_correction_requests")
+          .select("donation_id, status")
+          .eq("tenant_id", input.tenantId)
+          .in("donation_id", donationIds)
+          .eq("status", "pending")
+      : Promise.resolve({ data: [], error: null }),
+    donationIds.length > 0
+      ? supabaseAdmin
+          .from("contribution_adjustments")
+          .select(
+            "id, donation_id, adjustment_type, status, effective_values, reason, actor_profile_id, source_surface, created_at",
+          )
+          .eq("tenant_id", input.tenantId)
+          .in("donation_id", donationIds)
+          .order("created_at", { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+    stagedGiftIds.length > 0
+      ? supabaseAdmin
+          .from("staged_gift_allocations")
+          .select("id, staged_gift_id, amount, fund_id, missionary_id, memo")
+          .eq("tenant_id", input.tenantId)
+          .in("staged_gift_id", stagedGiftIds)
+          .order("created_at", { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  assertNoRowInputError(
+    correctionsResult.error,
+    "Failed to load gift corrections.",
+  );
+  assertNoRowInputError(
+    correctionRequestsResult.error,
+    "Failed to load correction requests.",
+  );
+  assertNoRowInputError(
+    adjustmentsResult.error,
+    "Failed to load gift adjustments.",
+  );
+  assertNoRowInputError(
+    allocationsResult.error,
+    "Failed to load designation lines.",
+  );
+
+  const allocations: SharedRowAllocationSource[] = (
+    (allocationsResult.data ?? []) as AllocationRow[]
+  ).map((allocation) => ({
+    id: allocation.id,
+    staged_gift_id: allocation.staged_gift_id,
+    amount: toContributionCents(allocation.amount),
+    fund_id: allocation.fund_id,
+    missionary_id: allocation.missionary_id,
+    memo: allocation.memo,
+  }));
+
+  const { correctionsByDonationId, effectiveByDonationId } =
+    assembleSharedContributionEffectiveState({
+      donations: input.donations,
+      corrections: (correctionsResult.data ??
+        []) as SharedRowCorrectionSource[],
+      correctionRequests: (correctionRequestsResult.data ??
+        []) as SharedRowCorrectionSource[],
+      adjustments: (adjustmentsResult.data ?? []) as Array<
+        Record<string, unknown>
+      >,
+    });
+
+  const { fundIds, missionaryIds } = collectSharedContributionLookupIds({
+    donations: input.donations,
+    stagedGifts: input.stagedGifts,
+    allocations,
+    effectiveByDonationId,
+    extraFundIds: input.extraFundIds,
+    extraMissionaryIds: input.extraMissionaryIds,
+  });
+
+  // Tenant-scope the label lookups even though ids come from tenant rows:
+  // adjustment effective_values ids predate server-side reference validation,
+  // and this loader runs on the service-role client where RLS cannot backstop
+  // a foreign id (matches contribution-operations/operations.ts).
+  const [fundsResult, missionariesResult] = await Promise.all([
+    fundIds.length > 0
+      ? supabaseAdmin
+          .from("funds")
+          .select("id, name, missionary_id, goal_amount, start_date, end_date")
+          .eq("tenant_id", input.tenantId)
+          .in("id", fundIds)
+      : Promise.resolve({ data: [], error: null }),
+    missionaryIds.length > 0
+      ? supabaseAdmin
+          .from("missionaries")
+          .select(
+            "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)",
+          )
+          .eq("tenant_id", input.tenantId)
+          .in("id", missionaryIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  assertNoRowInputError(fundsResult.error, "Failed to load fund metadata.");
+  assertNoRowInputError(
+    missionariesResult.error,
+    "Failed to load missionary labels.",
+  );
+
+  const fundsById = new Map<string, DesignationFundInput>(
+    ((fundsResult.data ?? []) as FundMetaRow[]).map((fund) => [
+      fund.id,
+      {
+        id: fund.id,
+        name: fund.name,
+        missionary_id: fund.missionary_id,
+        goal_amount:
+          fund.goal_amount == null
+            ? null
+            : toContributionCents(fund.goal_amount),
+        start_date: fund.start_date,
+        end_date: fund.end_date,
+      },
+    ]),
+  );
+  const fundNamesById = new Map<string, string | null>(
+    Array.from(fundsById.values()).map((fund) => [fund.id, fund.name]),
+  );
+  const missionaryLabelsById = new Map<string, string | null>(
+    ((missionariesResult.data ?? []) as unknown as MissionaryLabelRow[]).map(
+      (row) => [row.id, resolveContributionProfileLabel(row.profile, null)],
+    ),
+  );
+
+  const allocationsByStagedGiftId = new Map<
+    string,
+    DesignationAllocationInput[]
+  >();
+  for (const allocation of allocations) {
+    const existing =
+      allocationsByStagedGiftId.get(allocation.staged_gift_id) ?? [];
+    existing.push({
+      id: allocation.id,
+      amount: allocation.amount,
+      fund_id: allocation.fund_id,
+      missionary_id: allocation.missionary_id,
+      memo: allocation.memo,
+    });
+    allocationsByStagedGiftId.set(allocation.staged_gift_id, existing);
+  }
+
+  const designationSetByDonationId = buildSharedContributionDesignationSets({
+    donations: input.donations,
+    stagedGifts: input.stagedGifts,
+    allocationsByStagedGiftId,
+    effectiveByDonationId,
+    funds: fundsById,
+    missionaries: missionaryLabelsById,
+  });
+
+  return {
+    correctionsByDonationId,
+    effectiveByDonationId,
+    designationSetByDonationId,
+    allocationsByStagedGiftId,
+    fundsById,
+    fundNamesById,
+    missionaryLabelsById,
+  };
+}

--- a/packages/api/src/admin/contribution-shared/row-inputs.ts
+++ b/packages/api/src/admin/contribution-shared/row-inputs.ts
@@ -426,29 +426,15 @@ export async function loadSharedContributionRowInputs(
   // adjustment effective_values ids predate server-side reference validation,
   // and this loader runs on the service-role client where RLS cannot backstop
   // a foreign id (matches contribution-operations/operations.ts).
-  const [fundsResult, missionariesResult] = await Promise.all([
+  const fundsResult =
     fundIds.length > 0
-      ? supabaseAdmin
+      ? await supabaseAdmin
           .from("funds")
           .select("id, name, missionary_id, goal_amount, start_date, end_date")
           .eq("tenant_id", input.tenantId)
           .in("id", fundIds)
-      : Promise.resolve({ data: [], error: null }),
-    missionaryIds.length > 0
-      ? supabaseAdmin
-          .from("missionaries")
-          .select(
-            "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)",
-          )
-          .eq("tenant_id", input.tenantId)
-          .in("id", missionaryIds)
-      : Promise.resolve({ data: [], error: null }),
-  ]);
+      : { data: [], error: null };
   assertNoRowInputError(fundsResult.error, "Failed to load fund metadata.");
-  assertNoRowInputError(
-    missionariesResult.error,
-    "Failed to load missionary labels.",
-  );
 
   const fundsById = new Map<string, DesignationFundInput>(
     ((fundsResult.data ?? []) as FundMetaRow[]).map((fund) => [
@@ -469,6 +455,29 @@ export async function loadSharedContributionRowInputs(
   const fundNamesById = new Map<string, string | null>(
     Array.from(fundsById.values()).map((fund) => [fund.id, fund.name]),
   );
+
+  // Designation lines fall back to fund.missionary_id when an allocation
+  // leaves missionary_id null, so missionaries owned by looked-up funds need
+  // labels too — the funds fetch must complete before this lookup.
+  const missionaryLookupIds = mergeUniqueIds([
+    ...missionaryIds,
+    ...Array.from(fundsById.values()).map((fund) => fund.missionary_id),
+  ]);
+  const missionariesResult =
+    missionaryLookupIds.length > 0
+      ? await supabaseAdmin
+          .from("missionaries")
+          .select(
+            "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)",
+          )
+          .eq("tenant_id", input.tenantId)
+          .in("id", missionaryLookupIds)
+      : { data: [], error: null };
+  assertNoRowInputError(
+    missionariesResult.error,
+    "Failed to load missionary labels.",
+  );
+
   const missionaryLabelsById = new Map<string, string | null>(
     ((missionariesResult.data ?? []) as unknown as MissionaryLabelRow[]).map(
       (row) => [row.id, resolveContributionProfileLabel(row.profile, null)],

--- a/packages/api/src/admin/contributions/service.ts
+++ b/packages/api/src/admin/contributions/service.ts
@@ -5,7 +5,10 @@ import {
   type ContributionSortField,
 } from "./query";
 import { ApiHttpError } from "../../shared/http-errors";
-import { resolveContributionProfileLabel } from "../contribution-shared/profile-label";
+import {
+  applyEffectiveContributionToDonation,
+  loadSharedContributionRowInputs,
+} from "../contribution-shared/row-inputs";
 
 import type {
   AdminContributionsListResponse,
@@ -73,19 +76,11 @@ type ProfileRow = {
   avatar_url: string | null;
 };
 
-type FundRow = {
-  id: string;
-  name: string | null;
-};
-
-type MissionaryRow = {
-  id: string;
-  profile_id: string | null;
-};
-
 type StagedGiftRow = {
   id: string;
   donation_id: string;
+  fund_id: string | null;
+  missionary_id: string | null;
   status: string | null;
   review_reason: string | null;
   receipt_status: string | null;
@@ -323,59 +318,37 @@ async function fetchContributionRelations(
 ) {
   const donorIds = normalizeSearchIds(rows.map((row) => row.donor_id || ""));
   const donationIds = normalizeSearchIds(rows.map((row) => row.id));
-  const fundIds = normalizeSearchIds(rows.map((row) => row.fund_id || ""));
-  const missionaryIds = normalizeSearchIds(
-    rows.map((row) => row.missionary_id || ""),
-  );
 
-  const [donorsResult, fundsResult, missionariesResult, stagedGiftsResult] =
-    await Promise.all([
-      donorIds.length > 0
-        ? supabaseAdmin
-            .from("donors")
-            .select(
-              "id, profile_id, name, email, phone, type, location, organization, notes",
-            )
-            .in("id", donorIds)
-        : Promise.resolve({ data: [], error: null }),
-      fundIds.length > 0
-        ? supabaseAdmin.from("funds").select("id, name").in("id", fundIds)
-        : Promise.resolve({ data: [], error: null }),
-      missionaryIds.length > 0
-        ? supabaseAdmin
-            .from("missionaries")
-            .select("id, profile_id")
-            .in("id", missionaryIds)
-        : Promise.resolve({ data: [], error: null }),
-      donationIds.length > 0
-        ? supabaseAdmin
-            .from("staged_gifts")
-            .select(
-              "id, donation_id, status, review_reason, receipt_status, receipt_send_log_id, crm_post_status",
-            )
-            .in("donation_id", donationIds)
-        : Promise.resolve({ data: [], error: null }),
-    ]);
+  const [donorsResult, stagedGiftsResult] = await Promise.all([
+    donorIds.length > 0
+      ? supabaseAdmin
+          .from("donors")
+          .select(
+            "id, profile_id, name, email, phone, type, location, organization, notes",
+          )
+          .in("id", donorIds)
+      : Promise.resolve({ data: [], error: null }),
+    donationIds.length > 0
+      ? supabaseAdmin
+          .from("staged_gifts")
+          .select(
+            "id, donation_id, fund_id, missionary_id, status, review_reason, receipt_status, receipt_send_log_id, crm_post_status",
+          )
+          .in("donation_id", donationIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
 
   if (donorsResult.error) {
     throw new ApiHttpError(500, donorsResult.error.message);
-  }
-  if (fundsResult.error) {
-    throw new ApiHttpError(500, fundsResult.error.message);
-  }
-  if (missionariesResult.error) {
-    throw new ApiHttpError(500, missionariesResult.error.message);
   }
   if (stagedGiftsResult.error) {
     throw new ApiHttpError(500, stagedGiftsResult.error.message);
   }
 
   const donorRows = (donorsResult.data ?? []) as DonorRow[];
-  const missionaryRows = (missionariesResult.data ?? []) as MissionaryRow[];
-  const profileIds = normalizeSearchIds([
-    ...donorRows.map((donor) => donor.profile_id || ""),
-    ...missionaryRows.map((missionary) => missionary.profile_id || ""),
-  ]);
+  const profileIds = normalizeSearchIds(
+    donorRows.map((donor) => donor.profile_id || ""),
+  );
 
   const profilesResult =
     profileIds.length > 0
@@ -391,23 +364,19 @@ async function fetchContributionRelations(
     throw new ApiHttpError(500, profilesResult.error.message);
   }
 
+  const stagedGiftRows = (stagedGiftsResult.data ?? []) as StagedGiftRow[];
+
   return {
     donorsById: new Map(donorRows.map((donor) => [donor.id, donor])),
-    fundsById: new Map(
-      ((fundsResult.data ?? []) as FundRow[]).map((fund) => [fund.id, fund]),
-    ),
-    missionariesById: new Map(missionaryRows.map((row) => [row.id, row])),
     profilesById: new Map(
       ((profilesResult.data ?? []) as ProfileRow[]).map((profile) => [
         profile.id,
         profile,
       ]),
     ),
+    stagedGiftRows,
     stagedGiftsByDonationId: new Map(
-      ((stagedGiftsResult.data ?? []) as StagedGiftRow[]).map((gift) => [
-        gift.donation_id,
-        gift,
-      ]),
+      stagedGiftRows.map((gift) => [gift.donation_id, gift]),
     ),
   };
 }
@@ -478,7 +447,20 @@ export async function listAdminContributions(
     pageRows,
   );
 
-  const gridRows = pageRows.map((donation) => {
+  // Corrections, adjustment-derived effective values, and designation sets
+  // come from the same shared loader CRM gift history uses, so both surfaces
+  // display identical shared row fields for the same gift (ADR-CD-032, #256).
+  const sharedInputs = await loadSharedContributionRowInputs(supabaseAdmin, {
+    tenantId,
+    donations: pageRows,
+    stagedGifts: relationData.stagedGiftRows,
+  });
+
+  const gridRows = pageRows.map((donationRow) => {
+    const donation = applyEffectiveContributionToDonation(
+      donationRow,
+      sharedInputs.effectiveByDonationId,
+    );
     const donor = donation.donor_id
       ? (relationData.donorsById.get(donation.donor_id) ?? null)
       : null;
@@ -488,15 +470,19 @@ export async function listAdminContributions(
         : null;
     const fund =
       donation.fund_id != null
-        ? (relationData.fundsById.get(donation.fund_id) ?? null)
+        ? {
+            id: donation.fund_id,
+            name: sharedInputs.fundNamesById.get(donation.fund_id) ?? null,
+          }
         : null;
     const missionary =
       donation.missionary_id != null
-        ? (relationData.missionariesById.get(donation.missionary_id) ?? null)
-        : null;
-    const missionaryProfile =
-      missionary?.profile_id != null
-        ? (relationData.profilesById.get(missionary.profile_id) ?? null)
+        ? {
+            id: donation.missionary_id,
+            display_name:
+              sharedInputs.missionaryLabelsById.get(donation.missionary_id) ??
+              null,
+          }
         : null;
     const stagedGift = relationData.stagedGiftsByDonationId.get(donation.id);
 
@@ -505,13 +491,10 @@ export async function listAdminContributions(
       donor,
       profile: donorProfile,
       fund,
-      missionary: missionaryProfile
-        ? {
-            id: missionary?.id ?? donation.missionary_id ?? "",
-            display_name: resolveContributionProfileLabel(missionaryProfile),
-          }
-        : null,
+      missionary,
       stagedGift: stagedGift ?? null,
+      corrections: sharedInputs.correctionsByDonationId.get(donation.id),
+      designationSet: sharedInputs.designationSetByDonationId.get(donation.id),
     });
   });
 

--- a/packages/api/src/admin/contributions/service.ts
+++ b/packages/api/src/admin/contributions/service.ts
@@ -314,11 +314,14 @@ function getCursorValue(row: DonationRow, field: ContributionSortField) {
 
 async function fetchContributionRelations(
   supabaseAdmin: AdminSupabase,
+  tenantId: string,
   rows: DonationRow[],
 ) {
   const donorIds = normalizeSearchIds(rows.map((row) => row.donor_id || ""));
   const donationIds = normalizeSearchIds(rows.map((row) => row.id));
 
+  // Tenant-scope even though ids come from tenant-filtered donations: these
+  // run on the service-role client where RLS cannot backstop a foreign id.
   const [donorsResult, stagedGiftsResult] = await Promise.all([
     donorIds.length > 0
       ? supabaseAdmin
@@ -326,6 +329,7 @@ async function fetchContributionRelations(
           .select(
             "id, profile_id, name, email, phone, type, location, organization, notes",
           )
+          .eq("tenant_id", tenantId)
           .in("id", donorIds)
       : Promise.resolve({ data: [], error: null }),
     donationIds.length > 0
@@ -334,6 +338,7 @@ async function fetchContributionRelations(
           .select(
             "id, donation_id, fund_id, missionary_id, status, review_reason, receipt_status, receipt_send_log_id, crm_post_status",
           )
+          .eq("tenant_id", tenantId)
           .in("donation_id", donationIds)
       : Promise.resolve({ data: [], error: null }),
   ]);
@@ -444,6 +449,7 @@ export async function listAdminContributions(
   const hasMore = rows.length > params.limit;
   const relationData = await fetchContributionRelations(
     supabaseAdmin,
+    tenantId,
     pageRows,
   );
 

--- a/packages/api/src/admin/crm/detail/service.ts
+++ b/packages/api/src/admin/crm/detail/service.ts
@@ -1,13 +1,6 @@
 import { buildCrmGiftHistoryRow } from "./gift-history";
 import { ApiHttpError } from "../../../shared/http-errors";
-import { buildContributionDesignationSet } from "../../contribution-shared/designation-set";
-import {
-  deriveEffectiveContribution,
-  mapContributionAdjustmentRow,
-  type ContributionAdjustmentRecord,
-  type EffectiveContributionResult,
-} from "../../contribution-shared/effective-values";
-import { resolveContributionProfileLabel } from "../../contribution-shared/profile-label";
+import { loadSharedContributionRowInputs } from "../../contribution-shared/row-inputs";
 
 import type { AdminSupabaseClient } from "@asym/database/supabase/admin";
 import type { CrmDonorDetailResponse, UserRole } from "@asym/database/types";
@@ -58,29 +51,6 @@ interface DonationRow {
   updated_at: string | null;
 }
 
-interface CorrectionRow {
-  donation_id: string;
-  status: string;
-}
-
-interface AllocationRow {
-  id: string;
-  staged_gift_id: string;
-  amount: number | string | null;
-  fund_id: string | null;
-  missionary_id: string | null;
-  memo: string | null;
-}
-
-interface FundMetaRow {
-  id: string;
-  name: string | null;
-  missionary_id: string | null;
-  goal_amount: number | string | null;
-  start_date: string | null;
-  end_date: string | null;
-}
-
 interface StagedGiftRow {
   id: string;
   donation_id: string;
@@ -100,19 +70,6 @@ interface DonationCrmLinkRow {
   staged_gift_id: string | null;
   link_status: string | null;
   twenty_record_id: string | null;
-}
-
-interface LabelRow {
-  id: string;
-  name?: string | null;
-  profile_id?: string | null;
-  profile?: {
-    display_name?: string | null;
-    full_name?: string | null;
-    first_name?: string | null;
-    last_name?: string | null;
-    email?: string | null;
-  } | null;
 }
 
 interface DonorActivityRow {
@@ -171,10 +128,6 @@ function previewNotes(notes: string | null): string | null {
   return trimmed.length <= 160 ? trimmed : `${trimmed.slice(0, 157)}...`;
 }
 
-function profileName(row: LabelRow): string | null {
-  return resolveContributionProfileLabel(row.profile, row.name ?? null);
-}
-
 function getLabel(
   map: Map<string, string | null>,
   id: string | null,
@@ -185,33 +138,6 @@ function getLabel(
 
 function mergeUniqueIds(ids: Array<string | null | undefined>): string[] {
   return Array.from(new Set(ids.filter((id): id is string => Boolean(id))));
-}
-
-async function fetchLabels(
-  supabaseAdmin: SupabaseAdmin,
-  table: "funds" | "missionaries",
-  ids: string[],
-): Promise<Map<string, string | null>> {
-  if (ids.length === 0) {
-    return new Map();
-  }
-
-  const select =
-    table === "missionaries"
-      ? "id, profile:profiles!missionaries_profile_id_fkey(display_name, full_name, first_name, last_name, email)"
-      : "id, name";
-  const { data, error } = await supabaseAdmin
-    .from(table)
-    .select(select)
-    .in("id", ids);
-  assertNoError(error, `Failed to load ${table} labels.`);
-
-  return new Map(
-    ((data ?? []) as LabelRow[]).map((row) => [
-      row.id,
-      table === "missionaries" ? profileName(row) : (row.name ?? null),
-    ]),
-  );
 }
 
 function buildSupportSummary(input: {
@@ -329,89 +255,52 @@ export async function getAdminCrmDonorDetail(input: {
   const donations = donationRows.slice(0, GIFT_HISTORY_LIMIT);
 
   const donationIds = mergeUniqueIds(donations.map((donation) => donation.id));
-  const [
-    stagedGiftResult,
-    correctionsResult,
-    correctionRequestsResult,
-    adjustmentsResult,
-    activityResult,
-    pledgeResult,
-    duplicateResult,
-  ] = await Promise.all([
-    donationIds.length > 0
-      ? input.supabaseAdmin
-          .from("staged_gifts")
-          .select(
-            "id, donation_id, fund_id, missionary_id, receipt_status, crm_post_status, status, twenty_record_id, posted_at, created_at",
-          )
-          .eq("tenant_id", input.tenantId)
-          .in("donation_id", donationIds)
-      : Promise.resolve({ data: [], error: null }),
-    donationIds.length > 0
-      ? input.supabaseAdmin
-          .from("contribution_corrections")
-          .select("donation_id, status")
-          .eq("tenant_id", input.tenantId)
-          .in("donation_id", donationIds)
-      : Promise.resolve({ data: [], error: null }),
-    donationIds.length > 0
-      ? input.supabaseAdmin
-          .from("contribution_correction_requests")
-          .select("donation_id, status")
-          .eq("tenant_id", input.tenantId)
-          .in("donation_id", donationIds)
-          .eq("status", "pending")
-      : Promise.resolve({ data: [], error: null }),
-    donationIds.length > 0
-      ? input.supabaseAdmin
-          .from("contribution_adjustments")
-          .select(
-            "id, donation_id, adjustment_type, status, effective_values, reason, actor_profile_id, source_surface, created_at",
-          )
-          .eq("tenant_id", input.tenantId)
-          .in("donation_id", donationIds)
-          .order("created_at", { ascending: true })
-      : Promise.resolve({ data: [], error: null }),
-    input.supabaseAdmin
-      .from("donor_activities")
-      .select("id, type, title, description, amount, date, created_at")
-      .eq("donor_id", donor.id)
-      .order("date", { ascending: false })
-      .limit(50),
-    input.supabaseAdmin
-      .from("donor_pledges")
-      .select(
-        "id, amount, frequency, status, missionary_id, fund_id, next_payment_date, updated_at",
-      )
-      .eq("donor_id", donor.id)
-      .order("updated_at", { ascending: false })
-      .limit(50),
-    input.supabaseAdmin
-      .from("crm_merge_candidates")
-      .select(
-        "id, candidate_twenty_record_id, confidence, score, match_reasons",
-      )
-      .eq("tenant_id", input.tenantId)
-      .eq("source_entity_type", "donor_profile")
-      .eq("source_entity_id", donor.id)
-      .eq("status", "pending")
-      .order("score", { ascending: false })
-      .limit(10),
-  ]);
+  const [stagedGiftResult, activityResult, pledgeResult, duplicateResult] =
+    await Promise.all([
+      donationIds.length > 0
+        ? input.supabaseAdmin
+            .from("staged_gifts")
+            .select(
+              "id, donation_id, fund_id, missionary_id, receipt_status, crm_post_status, status, twenty_record_id, posted_at, created_at",
+            )
+            .eq("tenant_id", input.tenantId)
+            .in("donation_id", donationIds)
+        : Promise.resolve({ data: [], error: null }),
+      input.supabaseAdmin
+        .from("donor_activities")
+        .select("id, type, title, description, amount, date, created_at")
+        .eq("donor_id", donor.id)
+        .order("date", { ascending: false })
+        .limit(50),
+      input.supabaseAdmin
+        .from("donor_pledges")
+        .select(
+          "id, amount, frequency, status, missionary_id, fund_id, next_payment_date, updated_at",
+        )
+        .eq("donor_id", donor.id)
+        .order("updated_at", { ascending: false })
+        .limit(50),
+      input.supabaseAdmin
+        .from("crm_merge_candidates")
+        .select(
+          "id, candidate_twenty_record_id, confidence, score, match_reasons",
+        )
+        .eq("tenant_id", input.tenantId)
+        .eq("source_entity_type", "donor_profile")
+        .eq("source_entity_id", donor.id)
+        .eq("status", "pending")
+        .order("score", { ascending: false })
+        .limit(10),
+    ]);
   assertNoError(stagedGiftResult.error, "Failed to load staged gift links.");
-  assertNoError(correctionsResult.error, "Failed to load gift corrections.");
-  assertNoError(
-    correctionRequestsResult.error,
-    "Failed to load correction requests.",
-  );
-  assertNoError(adjustmentsResult.error, "Failed to load gift adjustments.");
   assertNoError(activityResult.error, "Failed to load donor activities.");
   assertNoError(pledgeResult.error, "Failed to load donor commitments.");
   assertNoError(duplicateResult.error, "Failed to load duplicate warnings.");
   const stagedGifts = (stagedGiftResult.data ?? []) as StagedGiftRow[];
+  const pledges = (pledgeResult.data ?? []) as PledgeRow[];
 
   const stagedGiftIds = mergeUniqueIds(stagedGifts.map((gift) => gift.id));
-  const [linkResult, allocationsResult] = await Promise.all([
+  const [linkResult, sharedInputs] = await Promise.all([
     stagedGiftIds.length > 0
       ? input.supabaseAdmin
           .from("donation_crm_links")
@@ -422,136 +311,29 @@ export async function getAdminCrmDonorDetail(input: {
           .eq("scope", "parent")
           .in("staged_gift_id", stagedGiftIds)
       : Promise.resolve({ data: [], error: null }),
-    stagedGiftIds.length > 0
-      ? input.supabaseAdmin
-          .from("staged_gift_allocations")
-          .select("id, staged_gift_id, amount, fund_id, missionary_id, memo")
-          .eq("tenant_id", input.tenantId)
-          .in("staged_gift_id", stagedGiftIds)
-          .order("created_at", { ascending: true })
-      : Promise.resolve({ data: [], error: null }),
+    // Corrections, effective values, and designation sets come from the same
+    // shared loader the Contributions Hub uses (ADR-CD-032, #256).
+    loadSharedContributionRowInputs(input.supabaseAdmin, {
+      tenantId: input.tenantId,
+      donations,
+      stagedGifts,
+      extraFundIds: pledges.map((pledge) => pledge.fund_id),
+      extraMissionaryIds: [
+        ...pledges.map((pledge) => pledge.missionary_id),
+        donor.missionary_id,
+      ],
+    }),
   ]);
   assertNoError(linkResult.error, "Failed to load donation CRM links.");
-  assertNoError(allocationsResult.error, "Failed to load designation lines.");
   const links = (linkResult.data ?? []) as DonationCrmLinkRow[];
 
-  const correctionsByDonationId = new Map<string, Array<{ status: string }>>();
-  for (const correction of [
-    ...((correctionsResult.data ?? []) as CorrectionRow[]),
-    ...((correctionRequestsResult.data ?? []) as CorrectionRow[]),
-  ]) {
-    const existing = correctionsByDonationId.get(correction.donation_id) ?? [];
-    existing.push({ status: correction.status });
-    correctionsByDonationId.set(correction.donation_id, existing);
-  }
-
-  const adjustmentsByDonationId = new Map<
-    string,
-    ContributionAdjustmentRecord[]
-  >();
-  for (const row of (adjustmentsResult.data ?? []) as Array<
-    Record<string, unknown>
-  >) {
-    const donationId =
-      typeof row.donation_id === "string" ? row.donation_id : "";
-    const existing = adjustmentsByDonationId.get(donationId) ?? [];
-    existing.push(mapContributionAdjustmentRow(row));
-    adjustmentsByDonationId.set(donationId, existing);
-  }
-
-  const effectiveByDonationId = new Map<string, EffectiveContributionResult>(
-    donations.map((donation) => [
-      donation.id,
-      deriveEffectiveContribution({
-        original: {
-          amountCents: toCents(donation.amount),
-          fundId: donation.fund_id,
-          missionaryId: donation.missionary_id,
-          paymentStatus: donation.status ?? "pending",
-        },
-        adjustments: adjustmentsByDonationId.get(donation.id) ?? [],
-      }),
-    ]),
-  );
-
-  const allocationRows = (allocationsResult.data ?? []) as AllocationRow[];
-  const allocationsByStagedGiftId = new Map<
-    string,
-    Array<{
-      id: string;
-      amount: number;
-      fund_id: string | null;
-      missionary_id: string | null;
-      memo: string | null;
-    }>
-  >();
-  for (const allocation of allocationRows) {
-    const existing =
-      allocationsByStagedGiftId.get(allocation.staged_gift_id) ?? [];
-    existing.push({
-      id: allocation.id,
-      amount: toCents(allocation.amount),
-      fund_id: allocation.fund_id,
-      missionary_id: allocation.missionary_id,
-      memo: allocation.memo,
-    });
-    allocationsByStagedGiftId.set(allocation.staged_gift_id, existing);
-  }
-
-  const pledges = (pledgeResult.data ?? []) as PledgeRow[];
-
-  const effectiveResults = Array.from(effectiveByDonationId.values());
-  const fundIds = mergeUniqueIds([
-    ...donations.map((donation) => donation.fund_id),
-    ...stagedGifts.map((gift) => gift.fund_id),
-    ...pledges.map((pledge) => pledge.fund_id),
-    ...allocationRows.map((allocation) => allocation.fund_id),
-    ...effectiveResults.map((result) => result.effective.fundId),
-    ...effectiveResults.flatMap(
-      (result) =>
-        result.effectiveDesignationLines?.map((line) => line.fundId) ?? [],
-    ),
-  ]);
-  const missionaryIds = mergeUniqueIds([
-    ...donations.map((donation) => donation.missionary_id),
-    ...stagedGifts.map((gift) => gift.missionary_id),
-    ...pledges.map((pledge) => pledge.missionary_id),
-    ...allocationRows.map((allocation) => allocation.missionary_id),
-    ...effectiveResults.map((result) => result.effective.missionaryId),
-    ...effectiveResults.flatMap(
-      (result) =>
-        result.effectiveDesignationLines?.map((line) => line.missionaryId) ??
-        [],
-    ),
-    donor.missionary_id,
-  ]);
-  const [fundsMetaResult, missionariesById] = await Promise.all([
-    fundIds.length > 0
-      ? input.supabaseAdmin
-          .from("funds")
-          .select("id, name, missionary_id, goal_amount, start_date, end_date")
-          .in("id", fundIds)
-      : Promise.resolve({ data: [], error: null }),
-    fetchLabels(input.supabaseAdmin, "missionaries", missionaryIds),
-  ]);
-  assertNoError(fundsMetaResult.error, "Failed to load fund metadata.");
-  const fundsMetaById = new Map(
-    ((fundsMetaResult.data ?? []) as FundMetaRow[]).map((fund) => [
-      fund.id,
-      {
-        id: fund.id,
-        name: fund.name,
-        missionary_id: fund.missionary_id,
-        goal_amount:
-          fund.goal_amount == null ? null : toCents(fund.goal_amount),
-        start_date: fund.start_date,
-        end_date: fund.end_date,
-      },
-    ]),
-  );
-  const fundsById = new Map<string, string | null>(
-    Array.from(fundsMetaById.values()).map((fund) => [fund.id, fund.name]),
-  );
+  const {
+    correctionsByDonationId,
+    effectiveByDonationId,
+    designationSetByDonationId,
+    fundNamesById: fundsById,
+    missionaryLabelsById: missionariesById,
+  } = sharedInputs;
 
   const stagedByDonationId = new Map(
     stagedGifts.map((gift) => [gift.donation_id, gift]),
@@ -572,33 +354,9 @@ export async function getAdminCrmDonorDetail(input: {
       missionaryId: donation.missionary_id,
       paymentStatus: donation.status ?? "pending",
     };
-    const allocations = effectiveResult?.effectiveDesignationLines
-      ? effectiveResult.effectiveDesignationLines.map((line) => ({
-          id: line.id,
-          amount: line.amountCents,
-          fund_id: line.fundId,
-          missionary_id: line.missionaryId,
-          memo: line.memo,
-        }))
-      : stagedGift
-        ? (allocationsByStagedGiftId.get(stagedGift.id) ?? [])
-        : [];
-    const designationSet = buildContributionDesignationSet({
-      donation: {
-        id: donation.id,
-        amount: effective.amountCents,
-        currency: donation.currency ?? "usd",
-        fund_id: effective.fundId,
-        missionary_id: effective.missionaryId,
-      },
-      effectiveAmountCents: effective.amountCents,
-      allocations,
-      funds: fundsMetaById,
-      missionaries: missionariesById,
-    });
 
     return buildCrmGiftHistoryRow({
-      designationSet,
+      designationSet: designationSetByDonationId.get(donation.id),
       donation: {
         id: donation.id,
         donor_id: donation.donor_id,

--- a/packages/api/src/admin/crm/detail/service.ts
+++ b/packages/api/src/admin/crm/detail/service.ts
@@ -277,6 +277,7 @@ export async function getAdminCrmDonorDetail(input: {
         .select(
           "id, amount, frequency, status, missionary_id, fund_id, next_payment_date, updated_at",
         )
+        .eq("tenant_id", input.tenantId)
         .eq("donor_id", donor.id)
         .order("updated_at", { ascending: false })
         .limit(50),

--- a/tests/unit/packages/api/admin-crm-detail-report.test.ts
+++ b/tests/unit/packages/api/admin-crm-detail-report.test.ts
@@ -164,6 +164,7 @@ const baseTables: Record<string, Row[]> = {
       missionary_id: "missionary-1",
       next_payment_date: "2026-01-01",
       status: "active",
+      tenant_id: "tenant-1",
       updated_at: "2026-05-11T00:00:00.000Z",
     },
   ],

--- a/tests/unit/packages/api/admin/contribution-shared-row-inputs.test.ts
+++ b/tests/unit/packages/api/admin/contribution-shared-row-inputs.test.ts
@@ -1,0 +1,567 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyEffectiveContributionToDonation,
+  assembleSharedContributionEffectiveState,
+  buildSharedContributionDesignationSets,
+  collectSharedContributionLookupIds,
+  loadSharedContributionRowInputs,
+  toContributionCents,
+} from "../../../../../packages/api/src/admin/contribution-shared/row-inputs";
+import { buildContributionGridRow } from "../../../../../packages/api/src/admin/contributions/model";
+import { buildCrmGiftHistoryRow } from "../../../../../packages/api/src/admin/crm/detail/gift-history";
+
+import type {
+  DesignationAllocationInput,
+  DesignationFundInput,
+} from "../../../../../packages/api/src/admin/contribution-shared/designation-set";
+
+const donation = {
+  id: "donation-1",
+  donor_id: "donor-1",
+  missionary_id: "missionary-1",
+  fund_id: "fund-1",
+  amount: 25_000,
+  currency: "usd",
+  status: "completed",
+  gift_date: "2026-04-08",
+  refund_amount: 0,
+  refunded_at: null,
+  created_at: "2026-04-08T10:00:00.000Z",
+  updated_at: "2026-04-08T12:00:00.000Z",
+};
+
+const donor = {
+  id: "donor-1",
+  name: "Alice Johnson",
+  email: "alice@example.com",
+};
+
+const funds = new Map<string, DesignationFundInput>([
+  [
+    "fund-1",
+    {
+      id: "fund-1",
+      name: "Clean Water Initiative",
+      missionary_id: null,
+      goal_amount: 100_000,
+      start_date: null,
+      end_date: null,
+    },
+  ],
+  [
+    "fund-2",
+    {
+      id: "fund-2",
+      name: "Martinez Family Support",
+      missionary_id: "missionary-1",
+      goal_amount: null,
+      start_date: null,
+      end_date: null,
+    },
+  ],
+]);
+
+const missionaries = new Map<string, string | null>([
+  ["missionary-1", "John Martinez"],
+]);
+
+const appliedAmountAdjustment = {
+  id: "adjustment-1",
+  donation_id: "donation-1",
+  adjustment_type: "amount_correction",
+  status: "applied",
+  effective_values: { amountCents: 30_000, fundId: "fund-2" },
+  reason: "Donor intended a larger split gift.",
+  actor_profile_id: "profile-1",
+  source_surface: "contributions_hub",
+  created_at: "2026-04-10T09:00:00.000Z",
+};
+
+describe("admin/contribution-shared/row-inputs", () => {
+  it("normalizes BIGINT amounts that arrive as strings", () => {
+    expect(toContributionCents("25000")).toBe(25_000);
+    expect(toContributionCents(25_000.4)).toBe(25_000);
+    expect(toContributionCents(null)).toBe(0);
+    expect(toContributionCents("not-a-number")).toBe(0);
+  });
+
+  it("merges corrections and pending requests into one correction list", () => {
+    const { correctionsByDonationId } =
+      assembleSharedContributionEffectiveState({
+        donations: [donation],
+        corrections: [{ donation_id: "donation-1", status: "applied" }],
+        correctionRequests: [{ donation_id: "donation-1", status: "pending" }],
+        adjustments: [],
+      });
+
+    expect(correctionsByDonationId.get("donation-1")).toEqual([
+      { status: "applied" },
+      { status: "pending" },
+    ]);
+  });
+
+  it("derives effective values from applied adjustments only", () => {
+    const { effectiveByDonationId } = assembleSharedContributionEffectiveState({
+      donations: [donation],
+      corrections: [],
+      correctionRequests: [],
+      adjustments: [
+        appliedAmountAdjustment,
+        {
+          ...appliedAmountAdjustment,
+          id: "adjustment-2",
+          status: "reversed",
+          effective_values: { amountCents: 1 },
+          created_at: "2026-04-11T09:00:00.000Z",
+        },
+      ],
+    });
+
+    const effective = effectiveByDonationId.get("donation-1")?.effective;
+    expect(effective).toEqual({
+      amountCents: 30_000,
+      fundId: "fund-2",
+      missionaryId: "missionary-1",
+      paymentStatus: "completed",
+    });
+  });
+
+  it("applies effective values onto the donation row for grid derivation", () => {
+    const { effectiveByDonationId } = assembleSharedContributionEffectiveState({
+      donations: [donation],
+      corrections: [],
+      correctionRequests: [],
+      adjustments: [appliedAmountAdjustment],
+    });
+
+    const effectiveDonation = applyEffectiveContributionToDonation(
+      donation,
+      effectiveByDonationId,
+    );
+    expect(effectiveDonation.amount).toBe(30_000);
+    expect(effectiveDonation.fund_id).toBe("fund-2");
+
+    const untouched = applyEffectiveContributionToDonation(
+      { ...donation, id: "donation-unknown" },
+      effectiveByDonationId,
+    );
+    expect(untouched.amount).toBe(25_000);
+  });
+
+  it("collects lookup ids from donations, staged gifts, allocations, effective values, and extras", () => {
+    const { effectiveByDonationId } = assembleSharedContributionEffectiveState({
+      donations: [donation],
+      corrections: [],
+      correctionRequests: [],
+      adjustments: [appliedAmountAdjustment],
+    });
+
+    const { fundIds, missionaryIds } = collectSharedContributionLookupIds({
+      donations: [donation],
+      stagedGifts: [
+        {
+          id: "staged-1",
+          donation_id: "donation-1",
+          fund_id: "fund-3",
+          missionary_id: null,
+        },
+      ],
+      allocations: [
+        {
+          id: "alloc-1",
+          staged_gift_id: "staged-1",
+          amount: 10_000,
+          fund_id: "fund-4",
+          missionary_id: "missionary-2",
+          memo: null,
+        },
+      ],
+      effectiveByDonationId,
+      extraFundIds: ["fund-5", null],
+      extraMissionaryIds: ["missionary-3", undefined],
+    });
+
+    expect(fundIds.sort()).toEqual([
+      "fund-1",
+      "fund-2",
+      "fund-3",
+      "fund-4",
+      "fund-5",
+    ]);
+    expect(missionaryIds.sort()).toEqual([
+      "missionary-1",
+      "missionary-2",
+      "missionary-3",
+    ]);
+  });
+
+  it("builds designation sets that reconcile to the effective gift amount", () => {
+    const { effectiveByDonationId } = assembleSharedContributionEffectiveState({
+      donations: [donation],
+      corrections: [],
+      correctionRequests: [],
+      adjustments: [appliedAmountAdjustment],
+    });
+
+    const allocationsByStagedGiftId = new Map<
+      string,
+      DesignationAllocationInput[]
+    >([
+      [
+        "staged-1",
+        [
+          {
+            id: "alloc-1",
+            amount: 10_000,
+            fund_id: "fund-1",
+            missionary_id: null,
+            memo: null,
+          },
+          {
+            id: "alloc-2",
+            amount: 20_000,
+            fund_id: "fund-2",
+            missionary_id: "missionary-1",
+            memo: null,
+          },
+        ],
+      ],
+    ]);
+
+    const sets = buildSharedContributionDesignationSets({
+      donations: [donation],
+      stagedGifts: [{ id: "staged-1", donation_id: "donation-1" }],
+      allocationsByStagedGiftId,
+      effectiveByDonationId,
+      funds,
+      missionaries,
+    });
+
+    const set = sets.get("donation-1");
+    expect(set?.lines).toHaveLength(2);
+    expect(set?.totalAmountCents).toBe(30_000);
+    expect(set?.reconcilesToGiftAmount).toBe(true);
+  });
+
+  it("falls back to a single effective-amount line when no allocations exist", () => {
+    const { effectiveByDonationId } = assembleSharedContributionEffectiveState({
+      donations: [donation],
+      corrections: [],
+      correctionRequests: [],
+      adjustments: [appliedAmountAdjustment],
+    });
+
+    const sets = buildSharedContributionDesignationSets({
+      donations: [donation],
+      stagedGifts: [],
+      allocationsByStagedGiftId: new Map(),
+      effectiveByDonationId,
+      funds,
+      missionaries,
+    });
+
+    const set = sets.get("donation-1");
+    expect(set?.lines).toHaveLength(1);
+    expect(set?.lines[0]?.fundId).toBe("fund-2");
+    expect(set?.lines[0]?.amountCents).toBe(30_000);
+    expect(set?.reconcilesToGiftAmount).toBe(true);
+  });
+
+  it("prefers replacement designation lines from applied allocation adjustments", () => {
+    const { effectiveByDonationId } = assembleSharedContributionEffectiveState({
+      donations: [donation],
+      corrections: [],
+      correctionRequests: [],
+      adjustments: [
+        {
+          ...appliedAmountAdjustment,
+          effective_values: {
+            amountCents: 30_000,
+            designationLines: [
+              {
+                id: "line-1",
+                amountCents: 30_000,
+                fundId: "fund-2",
+                missionaryId: "missionary-1",
+                memo: "Reassigned by correction",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const sets = buildSharedContributionDesignationSets({
+      donations: [donation],
+      stagedGifts: [{ id: "staged-1", donation_id: "donation-1" }],
+      allocationsByStagedGiftId: new Map([
+        [
+          "staged-1",
+          [
+            {
+              id: "alloc-1",
+              amount: 25_000,
+              fund_id: "fund-1",
+              missionary_id: null,
+              memo: null,
+            },
+          ],
+        ],
+      ]),
+      effectiveByDonationId,
+      funds,
+      missionaries,
+    });
+
+    const set = sets.get("donation-1");
+    expect(set?.lines).toHaveLength(1);
+    expect(set?.lines[0]?.id).toBe("line-1");
+    expect(set?.lines[0]?.memo).toBe("Reassigned by correction");
+    expect(set?.reconcilesToGiftAmount).toBe(true);
+  });
+
+  it("tenant-scopes every loader query, including fund and missionary lookups", async () => {
+    type ChainCall = [method: string, args: unknown[]];
+    const chainsByTable = new Map<string, ChainCall[][]>();
+
+    function createQueryStub(table: string) {
+      const calls: ChainCall[] = [];
+      const existing = chainsByTable.get(table) ?? [];
+      existing.push(calls);
+      chainsByTable.set(table, existing);
+
+      const builder = {
+        select: (...args: unknown[]) => {
+          calls.push(["select", args]);
+          return builder;
+        },
+        eq: (...args: unknown[]) => {
+          calls.push(["eq", args]);
+          return builder;
+        },
+        in: (...args: unknown[]) => {
+          calls.push(["in", args]);
+          return builder;
+        },
+        order: (...args: unknown[]) => {
+          calls.push(["order", args]);
+          return builder;
+        },
+        then: (
+          resolve: (value: { data: unknown[]; error: null }) => unknown,
+          reject?: (reason: unknown) => unknown,
+        ) => Promise.resolve({ data: [], error: null }).then(resolve, reject),
+      };
+      return builder;
+    }
+
+    const supabaseStub = {
+      from: (table: string) => createQueryStub(table),
+    } as unknown as Parameters<typeof loadSharedContributionRowInputs>[0];
+
+    await loadSharedContributionRowInputs(supabaseStub, {
+      tenantId: "tenant-1",
+      donations: [donation],
+      stagedGifts: [{ id: "staged-1", donation_id: "donation-1" }],
+    });
+
+    const expectTenantScoped = (table: string) => {
+      const chains = chainsByTable.get(table);
+      expect(chains, `expected a query against ${table}`).toBeDefined();
+      for (const calls of chains ?? []) {
+        expect(
+          calls.some(
+            ([method, args]) =>
+              method === "eq" &&
+              args[0] === "tenant_id" &&
+              args[1] === "tenant-1",
+          ),
+          `expected the ${table} query to filter on tenant_id`,
+        ).toBe(true);
+      }
+    };
+
+    expectTenantScoped("contribution_corrections");
+    expectTenantScoped("contribution_correction_requests");
+    expectTenantScoped("contribution_adjustments");
+    expectTenantScoped("staged_gift_allocations");
+    expectTenantScoped("funds");
+    expectTenantScoped("missionaries");
+  });
+});
+
+describe("CRM and Hub display parity through the shared assembly path (#256)", () => {
+  it("derives identical shared fields for a corrected split gift on both surfaces", () => {
+    const stagedGift = {
+      id: "staged-1",
+      donation_id: "donation-1",
+      fund_id: null,
+      missionary_id: null,
+      status: "posted",
+      receipt_status: "sent",
+      crm_post_status: "posted",
+    };
+    const allocationsByStagedGiftId = new Map<
+      string,
+      DesignationAllocationInput[]
+    >([
+      [
+        "staged-1",
+        [
+          {
+            id: "alloc-1",
+            amount: 10_000,
+            fund_id: "fund-1",
+            missionary_id: null,
+            memo: null,
+          },
+          {
+            id: "alloc-2",
+            amount: 20_000,
+            fund_id: "fund-2",
+            missionary_id: "missionary-1",
+            memo: null,
+          },
+        ],
+      ],
+    ]);
+
+    // One shared assembly, exactly like loadSharedContributionRowInputs.
+    const { correctionsByDonationId, effectiveByDonationId } =
+      assembleSharedContributionEffectiveState({
+        donations: [donation],
+        corrections: [{ donation_id: "donation-1", status: "applied" }],
+        correctionRequests: [{ donation_id: "donation-1", status: "pending" }],
+        adjustments: [appliedAmountAdjustment],
+      });
+    const designationSetByDonationId = buildSharedContributionDesignationSets({
+      donations: [donation],
+      stagedGifts: [stagedGift],
+      allocationsByStagedGiftId,
+      effectiveByDonationId,
+      funds,
+      missionaries,
+    });
+    const fundNamesById = new Map(
+      Array.from(funds.values()).map((fund) => [fund.id, fund.name]),
+    );
+
+    // Contributions Hub assembly (mirrors listAdminContributions).
+    const hubDonation = applyEffectiveContributionToDonation(
+      {
+        ...donation,
+        donation_type: "one_time",
+        payment_method: "card",
+        is_recurring: false,
+        recurring_interval: null,
+        notes: null,
+        stripe_payment_intent_id: "pi_1",
+        campaign_id: null,
+        pledge_id: null,
+        processed_at: null,
+        completed_at: null,
+        failed_at: null,
+        error_code: null,
+        error_message: null,
+        stripe_charge_id: null,
+        source: "online",
+      },
+      effectiveByDonationId,
+    );
+    const hubRow = buildContributionGridRow({
+      donation: hubDonation,
+      donor: {
+        ...donor,
+        phone: null,
+        type: null,
+        location: null,
+        organization: null,
+        notes: null,
+      },
+      profile: null,
+      fund: hubDonation.fund_id
+        ? {
+            id: hubDonation.fund_id,
+            name: fundNamesById.get(hubDonation.fund_id) ?? null,
+          }
+        : null,
+      missionary: hubDonation.missionary_id
+        ? {
+            id: hubDonation.missionary_id,
+            display_name: missionaries.get(hubDonation.missionary_id) ?? null,
+          }
+        : null,
+      stagedGift: {
+        id: stagedGift.id,
+        status: stagedGift.status,
+        review_reason: null,
+        receipt_status: stagedGift.receipt_status,
+        receipt_send_log_id: null,
+        crm_post_status: stagedGift.crm_post_status,
+      },
+      corrections: correctionsByDonationId.get("donation-1"),
+      designationSet: designationSetByDonationId.get("donation-1"),
+    });
+
+    // CRM gift history assembly (mirrors getAdminCrmDonorDetail).
+    const effective = effectiveByDonationId.get("donation-1")!.effective;
+    const crmRow = buildCrmGiftHistoryRow({
+      designationSet: designationSetByDonationId.get("donation-1"),
+      donation: {
+        id: donation.id,
+        donor_id: donation.donor_id,
+        missionary_id: effective.missionaryId,
+        fund_id: effective.fundId,
+        amount: effective.amountCents,
+        currency: donation.currency,
+        status: effective.paymentStatus,
+        gift_date: donation.gift_date,
+        refund_amount: donation.refund_amount,
+        refunded_at: donation.refunded_at,
+        created_at: donation.created_at,
+        updated_at: donation.updated_at,
+        is_recurring: false,
+        recurring_interval: null,
+        pledge_id: null,
+      },
+      donor,
+      fund: effective.fundId
+        ? {
+            id: effective.fundId,
+            name: fundNamesById.get(effective.fundId) ?? null,
+          }
+        : null,
+      missionary: effective.missionaryId
+        ? {
+            id: effective.missionaryId,
+            display_name: missionaries.get(effective.missionaryId) ?? null,
+          }
+        : null,
+      stagedGift: {
+        id: stagedGift.id,
+        status: stagedGift.status,
+        receipt_status: stagedGift.receipt_status,
+        crm_post_status: stagedGift.crm_post_status,
+        twenty_record_id: null,
+      },
+      corrections: correctionsByDonationId.get("donation-1"),
+      provider: { stripePaymentIntentId: "pi_1", stripeChargeId: null },
+    });
+
+    // The acceptance criterion: same gift, same shared field values.
+    expect(crmRow.shared).toEqual(hubRow.shared);
+
+    // The corrected effective truth shows on both surfaces.
+    expect(hubRow.shared.amountCents).toBe(30_000);
+    expect(hubRow.shared.correctionState).toBe("pending");
+    expect(hubRow.shared.paymentStatus).toBe("completed");
+    expect(hubRow.shared.designationSummary).toEqual({
+      fundId: null,
+      fundName: "2 designations",
+      missionaryId: null,
+      missionaryName: null,
+      lineCount: 2,
+    });
+  });
+});

--- a/tests/unit/packages/api/admin/contribution-shared-row-inputs.test.ts
+++ b/tests/unit/packages/api/admin/contribution-shared-row-inputs.test.ts
@@ -321,9 +321,24 @@ describe("admin/contribution-shared/row-inputs", () => {
     expect(set?.reconcilesToGiftAmount).toBe(true);
   });
 
-  it("tenant-scopes every loader query, including fund and missionary lookups", async () => {
+  it("tenant-scopes every loader query and resolves fund-owned missionary labels", async () => {
     type ChainCall = [method: string, args: unknown[]];
     const chainsByTable = new Map<string, ChainCall[][]>();
+    const resultsByTable = new Map<string, unknown[]>([
+      [
+        "funds",
+        [
+          {
+            id: "fund-1",
+            name: "Martinez Family Support",
+            missionary_id: "missionary-9",
+            goal_amount: null,
+            start_date: null,
+            end_date: null,
+          },
+        ],
+      ],
+    ]);
 
     function createQueryStub(table: string) {
       const calls: ChainCall[] = [];
@@ -351,7 +366,11 @@ describe("admin/contribution-shared/row-inputs", () => {
         then: (
           resolve: (value: { data: unknown[]; error: null }) => unknown,
           reject?: (reason: unknown) => unknown,
-        ) => Promise.resolve({ data: [], error: null }).then(resolve, reject),
+        ) =>
+          Promise.resolve({
+            data: resultsByTable.get(table) ?? [],
+            error: null,
+          }).then(resolve, reject),
       };
       return builder;
     }
@@ -384,10 +403,32 @@ describe("admin/contribution-shared/row-inputs", () => {
 
     expectTenantScoped("contribution_corrections");
     expectTenantScoped("contribution_correction_requests");
+    const correctionRequestChains =
+      chainsByTable.get("contribution_correction_requests") ?? [];
+    for (const calls of correctionRequestChains) {
+      expect(
+        calls.some(
+          ([method, args]) =>
+            method === "eq" && args[0] === "status" && args[1] === "pending",
+        ),
+        "expected correction requests to filter pending status only",
+      ).toBe(true);
+    }
     expectTenantScoped("contribution_adjustments");
     expectTenantScoped("staged_gift_allocations");
     expectTenantScoped("funds");
     expectTenantScoped("missionaries");
+
+    // Missionaries owned by looked-up funds are labeled too: designation
+    // lines fall back to fund.missionary_id, so the missionary query must
+    // include ids discovered through the funds fetch.
+    const missionaryChains = chainsByTable.get("missionaries") ?? [];
+    const missionaryInIds = missionaryChains.flatMap((calls) =>
+      calls
+        .filter(([method]) => method === "in")
+        .flatMap(([, args]) => args[1] as string[]),
+    );
+    expect(missionaryInIds).toContain("missionary-9");
   });
 });
 

--- a/tests/unit/packages/api/crm-link-scope-contract.test.ts
+++ b/tests/unit/packages/api/crm-link-scope-contract.test.ts
@@ -110,7 +110,7 @@ describe("CRM donation link parent-scope contract", () => {
   it("keeps CRM detail and report readers scoped to parent links", () => {
     const detail = sourceSection(
       crmDetailSource,
-      "const [linkResult, allocationsResult] =",
+      "const [linkResult, sharedInputs] =",
       "assertNoError(linkResult.error",
     );
     const report = sourceSection(


### PR DESCRIPTION
## Summary

- The shared contribution row contract (ADR-CD-032) already guaranteed parity at the *builder* layer (`buildSharedContributionRowFields`), but the two staff surfaces fed it different inputs. CRM donor gift history loaded corrections, adjustment-derived effective values, and staged-gift-allocation designation sets; the Contributions Hub list loaded none of them. The same corrected gift therefore displayed a different amount, designation summary, payment status, and correction state depending on the surface.
- This PR adds one shared input loader/assembler, `packages/api/src/admin/contribution-shared/row-inputs.ts`, and wires **both** `listAdminContributions` (Hub) and `getAdminCrmDonorDetail` (CRM) through it, so shared row fields derive from identical inputs on both surfaces.
- Surfaces touched: Contributions Hub list read model and CRM donor gift history read model. No UI component changes were needed — Hub columns and CRM components already render from `shared.*` with the shared label maps.
- This satisfies the issue because overlapping fields (amount, gift date, donor, designation summary, receipt state, correction/approval state, refund state, CRM/Twenty post state, payment status) now share value derivation end-to-end (inputs + builders + labels), CRM-only fields remain isolated in `CrmGiftHistoryRow` (`twentyRecordId`, `inlineActions`), and a parity test proves both assembly paths derive identical shared fields for the same gift.

## Issue

Closes #256

## Scope

- In scope: shared row-input assembly (corrections, correction requests, adjustments → effective values, staged gift allocations → designation sets, fund metadata, missionary labels); Hub list service wiring; CRM detail service refactor onto the loader (behavior-preserving); tests.
- Out of scope (later issues): detail navigation (#257), no-staged-gift detail (#258), full multi-designation detail (#259), adjustment record workflow (#260–#262), receipts (#263), refunds (#265), query freshness (#268), Hub adoption of shared filter UI (#274), personalization (#271–#273), any visual redesign or ReUI work.

## Data/API Changes

- New module `packages/api/src/admin/contribution-shared/row-inputs.ts` (pure assemblers + `loadSharedContributionRowInputs`). Every query is tenant-scoped, including the fund/missionary label lookups (matching `contribution-operations/operations.ts`); an adversarial review pass flagged that the label lookups run on the service-role client where RLS cannot backstop a foreign id, so the tenant filters are load-bearing and covered by a regression test.
- `packages/api/src/admin/contributions/service.ts`: Hub rows now derive from effective values with corrections + designation sets; its relations fetch no longer queries funds/missionaries itself (the loader covers them, including adjustment-derived ids); staged-gifts select adds `fund_id, missionary_id`.
- `packages/api/src/admin/crm/detail/service.ts`: inline corrections/adjustments/allocations/designation logic replaced by the shared loader; pledge/donor fund + missionary ids pass through as extras so support summary/timeline labels are unchanged.
- No schema changes, no migrations. API response shapes unchanged (row values become correct for corrected gifts).
- Known/pre-existing consequences documented rather than changed here: Hub SQL sorting/cursoring still uses original DB values (unchanged; corrected rows can sort by original amount), and `summarizeAdminContributions` still aggregates original amounts — both belong to the adjustment-record follow-ups (#259/#260).

## UI Changes

- None. `/contributions` and `/crm` render through existing components; table/grid behavior, row identity, query keys, and invalidation are untouched. Corrected gifts now show identical values on both surfaces.

## Testing

- ✅ `bunx vitest run tests/unit/packages/api/` — 127 files, 806 tests passed (includes new `tests/unit/packages/api/admin/contribution-shared-row-inputs.test.ts`: assembler units, a service-assembly-path CRM↔Hub parity test for a corrected split gift, and a tenant-scoping regression test over every loader query)
- ✅ `VITEST_MAX_WORKERS=4 bunx vitest run tests/unit/packages/database/ tests/unit/apps/admin/` — 52 files, 261 tests passed
- ✅ `bunx tsc --noEmit -p packages/api` and `bunx turbo run typecheck --filter=@asym/admin`
- ✅ `bunx eslint` on touched files, `bun run format:check`
- ✅ Full pre-push `ci:preflight` passed locally on push
- ⚠️ Environment note: full `bun run check` on this Windows machine has 3 pre-existing `tests/unit/scripts` failures unrelated to this change (turbo.cmd path mock / bun-version.sh); Linux CI is authoritative.
- One existing test updated: `tests/unit/packages/api/crm-link-scope-contract.test.ts` source marker follows the CRM service destructure rename (the parent-scope contract assertion itself is unchanged and still enforced).

## Follow-ups

- Next issue unblocked: #257 (canonical contribution detail entry from CRM + Contributions Hub).
- Intentionally deferred: effective-value-aware Hub sorting/summary (#259/#260 territory), shared filter definitions surfaced in Hub UI (#274), shared query freshness/invalidation behavior (#268).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes shared contribution row input assembly for CRM and Contributions Hub. The main changes are:

- Added `loadSharedContributionRowInputs` for corrections, adjustment-derived effective values, allocation lines, fund metadata, and missionary labels.
- Routed Contributions Hub rows through the shared loader and effective donation values.
- Refactored CRM donor gift history to use the same shared row inputs.
- Added tests for assembler behavior, CRM and Hub shared-field parity, and tenant-scoped loader queries.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The updated code centralizes existing row assembly behavior, preserves response shapes, tenant-scopes service-role lookups, and includes focused parity and regression tests.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base worktree command completed with Exit code 0 and httpStatus 200 OK.
- The head worktree command completed with Exit code 0 and httpStatus 200 OK.
- CRM and hub shared fields matched exactly for overlapping fields, including amountCents 30000, correctionState pending, paymentStatus completed, receiptStatus sent, crmPostStatus posted, and designationSummary lineCount 2 with fundName 2 designations.
- The before-state shows the base contribution relations resolving TENANT 2 LEAK FUND and TENANT 2 LEAK MISSIONARY from tenant-2 ids, with no tenant\_id filters in the relation queries.
- The after-state shows funds and missionaries queries include tenant\_id filter and empty results, with eq('tenant\_id','tenant-1') before in('id', \['fund-t2', 'missionary-t2'\]), and empty fundNames/missionaryLabels.

<a href="https://app.greptile.com/trex/runs/13013894/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/admin/contribution-shared/row-inputs.ts | Adds tenant-scoped shared loading and assembly for corrections, adjustments, allocations, fund metadata, and missionary labels. |
| packages/api/src/admin/contributions/service.ts | Routes Contributions Hub rows through the shared loader and effective-value application while preserving pagination and response shape. |
| packages/api/src/admin/crm/detail/service.ts | Refactors CRM donor detail gift-history assembly onto the shared row input loader and adds tenant scoping for pledges. |
| tests/unit/packages/api/admin/contribution-shared-row-inputs.test.ts | Adds unit and parity coverage for shared row input assembly, effective values, designation sets, and tenant-scoped loader queries. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Hub as Contributions Hub list
participant CRM as CRM donor detail
participant Loader as loadSharedContributionRowInputs
participant DB as Supabase tables
participant Builder as Shared row builders

Hub->>Loader: donations + staged gifts + tenantId
CRM->>Loader: donations + staged gifts + tenantId + pledge/donor extras
Loader->>DB: tenant-scoped corrections, requests, adjustments, allocations
Loader->>DB: tenant-scoped funds and missionaries
Loader-->>Hub: effective values, corrections, designation sets, labels
Loader-->>CRM: effective values, corrections, designation sets, labels
Hub->>Builder: buildContributionGridRow(shared inputs)
CRM->>Builder: buildCrmGiftHistoryRow(shared inputs)
Builder-->>Hub: shared row fields
Builder-->>CRM: shared row fields
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Hub as Contributions Hub list
participant CRM as CRM donor detail
participant Loader as loadSharedContributionRowInputs
participant DB as Supabase tables
participant Builder as Shared row builders

Hub->>Loader: donations + staged gifts + tenantId
CRM->>Loader: donations + staged gifts + tenantId + pledge/donor extras
Loader->>DB: tenant-scoped corrections, requests, adjustments, allocations
Loader->>DB: tenant-scoped funds and missionaries
Loader-->>Hub: effective values, corrections, designation sets, labels
Loader-->>CRM: effective values, corrections, designation sets, labels
Hub->>Builder: buildContributionGridRow(shared inputs)
CRM->>Builder: buildCrmGiftHistoryRow(shared inputs)
Builder-->>Hub: shared row fields
Builder-->>CRM: shared row fields
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["AL-256: tenant-scope relation queries an..."](https://github.com/asymmetric-al/core/commit/13617f64edf21e48a3078399760535f8a90f2575) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41271746)</sub>

<!-- /greptile_comment -->