### PR TITLE
AL-268: Bring CRM freshness parity and prove shared query freshness

### DIFF
--- a/apps/admin/app/contributions/freshness-indicator.tsx
+++ b/apps/admin/app/contributions/freshness-indicator.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** How long the quiet freshness indicator stays visible (ADR-CD-022). */
+const FRESHNESS_VISIBLE_MS = 8000;
+
+/**
+ * Shared freshness state for contribution surfaces (ADR-CD-022).
+ *
+ * `markFreshness` shows the indicator and auto-hides it after eight seconds;
+ * repeated successes restart the timer instead of stacking indicators. The
+ * pending timer is cleared on unmount.
+ */
+export function useContributionFreshness() {
+  const [showFreshness, setShowFreshness] = useState(false);
+  const freshnessTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (freshnessTimerRef.current !== null) {
+        window.clearTimeout(freshnessTimerRef.current);
+      }
+    };
+  }, []);
+
+  const markFreshness = useCallback(() => {
+    setShowFreshness(true);
+    if (freshnessTimerRef.current !== null) {
+      window.clearTimeout(freshnessTimerRef.current);
+    }
+    freshnessTimerRef.current = window.setTimeout(() => {
+      setShowFreshness(false);
+    }, FRESHNESS_VISIBLE_MS);
+  }, []);
+
+  return { markFreshness, showFreshness };
+}
+
+/**
+ * Quiet, low-noise "Updated just now" indicator shown after shared row data
+ * refreshes (ADR-CD-022). The Contributions Hub and the CRM surface render
+ * this same component so freshness reads identically on both surfaces.
+ */
+export function ContributionFreshnessIndicator({
+  show,
+  testId,
+}: {
+  show: boolean;
+  testId: string;
+}) {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <p
+      role="status"
+      className="mb-2 text-xs text-muted-foreground"
+      data-testid={testId}
+    >
+      Updated just now
+    </p>
+  );
+}

--- a/apps/admin/app/contributions/page-client.tsx
+++ b/apps/admin/app/contributions/page-client.tsx
@@ -16,6 +16,10 @@ import {
   invalidateContributionOperationQueries,
 } from "./contribution-detail-overlay";
 import { boneyardContributionsFixture, mockContributions } from "./data";
+import {
+  ContributionFreshnessIndicator,
+  useContributionFreshness,
+} from "./freshness-indicator";
 import { ContributionsMainBody, ContributionsPageActions } from "./main-body";
 import { useAdminContributions } from "./use-admin-contributions";
 
@@ -44,31 +48,13 @@ export default function ContributionsPage() {
   const [selectedDonationId, setSelectedDonationId] = useState<string | null>(
     () => selectedGiftParam,
   );
-  const [showFreshness, setShowFreshness] = useState(false);
-  const freshnessTimerRef = useRef<number | null>(null);
+  // Quiet, low-noise freshness indicator after row data refreshes
+  // (ADR-CD-022); shared with the CRM surface.
+  const { markFreshness, showFreshness } = useContributionFreshness();
 
   useEffect(() => {
     setSelectedDonationId(selectedGiftParam);
   }, [selectedGiftParam]);
-
-  useEffect(() => {
-    return () => {
-      if (freshnessTimerRef.current !== null) {
-        window.clearTimeout(freshnessTimerRef.current);
-      }
-    };
-  }, []);
-
-  /** Quiet, low-noise freshness indicator after row data refreshes (ADR-CD-022). */
-  const markFreshness = useCallback(() => {
-    setShowFreshness(true);
-    if (freshnessTimerRef.current !== null) {
-      window.clearTimeout(freshnessTimerRef.current);
-    }
-    freshnessTimerRef.current = window.setTimeout(() => {
-      setShowFreshness(false);
-    }, 8000);
-  }, []);
 
   const openerElementRef = useRef<HTMLElement | null>(null);
 
@@ -155,15 +141,10 @@ export default function ContributionsPage() {
       actions={<ContributionsPageActions />}
     >
       <div data-testid="mc-contributions-live">
-        {showFreshness && (
-          <p
-            role="status"
-            className="mb-2 text-xs text-muted-foreground"
-            data-testid="contributions-freshness"
-          >
-            Updated just now
-          </p>
-        )}
+        <ContributionFreshnessIndicator
+          show={showFreshness}
+          testId="contributions-freshness"
+        />
         {isError ? (
           <div className="flex flex-col items-center justify-center rounded-lg border border-border bg-card py-20 text-center">
             <div className="mb-4 flex size-16 items-center justify-center rounded-lg border border-destructive/20 bg-destructive/10">

--- a/apps/admin/app/crm/detail-drawer.tsx
+++ b/apps/admin/app/crm/detail-drawer.tsx
@@ -95,10 +95,16 @@ export function DetailDrawer({
   contact,
   onClose,
   onOpenGift,
+  onRowRefresh,
 }: {
   contact: CrmRecord;
   onClose: () => void;
   onOpenGift: (donationId: string) => void;
+  /**
+   * Fires after an inline operation succeeds and shared row data refreshes,
+   * so the host surface can show its quiet freshness indicator (ADR-CD-022).
+   */
+  onRowRefresh?: () => void;
 }) {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [noteBody, setNoteBody] = useState("");
@@ -948,7 +954,10 @@ export function DetailDrawer({
           setInlineOperation(null);
           onOpenGift(donationId);
         }}
-        onRowRefresh={() => void detailQuery.refetch()}
+        onRowRefresh={() => {
+          void detailQuery.refetch();
+          onRowRefresh?.();
+        }}
       />
       {pendingReset && resetPreview ? (
         <Dialog open onOpenChange={(open) => !open && setPendingReset(null)}>

--- a/apps/admin/app/crm/page-client.tsx
+++ b/apps/admin/app/crm/page-client.tsx
@@ -49,6 +49,10 @@ import {
   ContributionDetailOverlay,
   isContributionGiftParam,
 } from "../contributions/contribution-detail-overlay";
+import {
+  ContributionFreshnessIndicator,
+  useContributionFreshness,
+} from "../contributions/freshness-indicator";
 
 import type { CrmGridRow, CrmRecord } from "./types";
 
@@ -67,6 +71,9 @@ export default function MissionControlCRM() {
   const [openGiftId, setOpenGiftId] = useState<string | null>(
     () => selectedGiftParam,
   );
+  // Quiet, low-noise freshness indicator after row data refreshes
+  // (ADR-CD-022); mirrors the Contributions Hub indicator.
+  const { markFreshness, showFreshness } = useContributionFreshness();
 
   useEffect(() => {
     setOpenGiftId(selectedGiftParam);
@@ -336,6 +343,10 @@ export default function MissionControlCRM() {
         }
       >
         <div className="flex flex-col min-h-[400px]">
+          <ContributionFreshnessIndicator
+            show={showFreshness}
+            testId="crm-freshness"
+          />
           <AnimatePresence mode="wait">
             {view === "table" ? (
               <motion.div
@@ -517,6 +528,7 @@ export default function MissionControlCRM() {
           contact={selectedRecord}
           onClose={() => selectRecord(null)}
           onOpenGift={openGift}
+          onRowRefresh={markFreshness}
         />
       )}
 
@@ -524,6 +536,7 @@ export default function MissionControlCRM() {
         donationId={openGiftId}
         sourceSurface="donor_crm_record"
         onClose={closeGift}
+        onActionSuccess={markFreshness}
       />
     </>
   );

--- a/tests/unit/apps/admin/app/contributions-page.test.tsx
+++ b/tests/unit/apps/admin/app/contributions-page.test.tsx
@@ -2,6 +2,7 @@
 
 import { QueryProvider } from "@asym/database/providers";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -224,6 +225,27 @@ function makeDetailPayload(donationId: string, donorName: string) {
         historyUpdatedImmediately: true,
         amount: 10000,
         currency: "USD",
+      },
+    },
+  };
+}
+
+/**
+ * Detail payload variant with a staged gift whose receipt is still pending,
+ * so the shared detail sheet renders an enabled "Send Receipt" action.
+ */
+function makeReceiptActionablePayload(donationId: string, donorName: string) {
+  const base = makeDetailPayload(donationId, donorName);
+  return {
+    contribution: {
+      ...base.contribution,
+      stagedGift: {
+        id: "staged_1",
+        status: "posted",
+        receiptStatus: "pending",
+        crmPostStatus: null,
+        reviewReason: null,
+        twentyRecordId: null,
       },
     },
   };
@@ -962,6 +984,134 @@ describe("apps/admin/app/contributions/page", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(opener);
     });
+  });
+
+  it("shows the freshness indicator after an overlay operation succeeds and auto-hides it", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000012c";
+    mockSearch = `gift=${donationId}`;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/actions")) {
+        return { ok: true, json: async () => ({ ok: true }) };
+      }
+      return {
+        ok: true,
+        json: async () =>
+          makeReceiptActionablePayload(donationId, "Freshness Donor"),
+      };
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = renderContributionsPage();
+    expect(await view.findByText("Freshness Donor")).toBeTruthy();
+    expect(view.queryByTestId("contributions-freshness")).toBeNull();
+
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    fireEvent.click(view.getByRole("button", { name: /send receipt/i }));
+
+    const indicator = await view.findByTestId("contributions-freshness");
+    expect(indicator.textContent).toBe("Updated just now");
+
+    // The indicator schedules an 8s auto-hide (ADR-CD-022). The harness runs
+    // real timers, so run the captured 8000ms callback instead of waiting.
+    const freshnessTimerCall = setTimeoutSpy.mock.calls.find(
+      ([, delay]) => delay === 8000,
+    );
+    expect(freshnessTimerCall).toBeTruthy();
+    act(() => {
+      (freshnessTimerCall![0] as () => void)();
+    });
+    expect(view.queryByTestId("contributions-freshness")).toBeNull();
+  });
+
+  it("keeps workspace filter and search params intact after operation-success invalidation", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000012d";
+    mockSearch = `status=completed&search=sarah&gift=${donationId}`;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/actions")) {
+        return { ok: true, json: async () => ({ ok: true }) };
+      }
+      return {
+        ok: true,
+        json: async () =>
+          makeReceiptActionablePayload(donationId, "Params Donor"),
+      };
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = renderContributionsPage();
+    expect(await view.findByText("Params Donor")).toBeTruthy();
+
+    fireEvent.click(view.getByRole("button", { name: /send receipt/i }));
+
+    // Success invalidates the shared queries and smart-closes the overlay:
+    // only the gift selection leaves the route; filters and search survive.
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith(
+        "/contributions?status=completed&search=sarah",
+        { scroll: false },
+      );
+    });
+    for (const [url] of routerReplaceMock.mock.calls) {
+      expect(String(url)).toContain("status=completed");
+      expect(String(url)).toContain("search=sarah");
+    }
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  it("recovers from a stale save by refetching detail and surfacing the recovery message", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000012e";
+    mockSearch = `gift=${donationId}`;
+    const staleMessage =
+      "This gift changed since you loaded it. Reload the latest detail, review the changes, and submit the correction again.";
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/actions")) {
+        return { ok: false, json: async () => ({ error: staleMessage }) };
+      }
+      return {
+        ok: true,
+        json: async () =>
+          makeReceiptActionablePayload(donationId, "Stale Donor"),
+      };
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = renderContributionsPage();
+    expect(await view.findByText("Stale Donor")).toBeTruthy();
+
+    const detailCallCount = () =>
+      fetchMock.mock.calls.filter(([url]) => !String(url).includes("/actions"))
+        .length;
+    expect(detailCallCount()).toBe(1);
+
+    fireEvent.click(view.getByRole("button", { name: /send receipt/i }));
+
+    // The rejected save surfaces the server's recovery messaging…
+    const { toast } = await import("sonner");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/changed since you loaded/i),
+      );
+    });
+
+    // …and recoverFromStaleSave refetches the canonical detail so staff can
+    // review current truth and retry (ADR-CD-022).
+    await waitFor(() => {
+      expect(detailCallCount()).toBeGreaterThan(1);
+    });
+
+    // Failure is not freshness: no indicator, and the overlay stays open
+    // for review-and-retry.
+    expect(view.queryByTestId("contributions-freshness")).toBeNull();
+    expect(view.getByRole("button", { name: /send receipt/i })).toBeTruthy();
   });
 
   it("invalidates every shared contribution surface after contribution mutations", async () => {

--- a/tests/unit/apps/admin/app/crm-gift-detail-entry.test.tsx
+++ b/tests/unit/apps/admin/app/crm-gift-detail-entry.test.tsx
@@ -2,6 +2,7 @@
 
 import { QueryProvider } from "@asym/database/providers";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -673,6 +674,129 @@ describe("apps/admin/app/crm gift detail entry", () => {
 
     // Shared row data refreshes in place after the operation.
     expect(detailRefetch).toHaveBeenCalled();
+
+    // The CRM surface shows the same quiet freshness indicator the Hub
+    // uses when inline row data refreshes (ADR-CD-022).
+    expect(view.getByTestId("crm-freshness").textContent).toBe(
+      "Updated just now",
+    );
+  });
+
+  it("shows the freshness indicator after an overlay operation succeeds and auto-hides it", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d00c";
+    mockSearch = `gift=${donationId}`;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        if (String(url).includes("/actions")) {
+          return {
+            ok: true,
+            init,
+            json: async () => ({
+              result: {
+                auditEventId: "audit-10",
+                approvalStatus: "applied",
+                taskIds: [],
+                canonicalContribution: {},
+              },
+            }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => contributionDetailPayloadFor(donationId),
+        };
+      });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    expect(view.queryByTestId("crm-freshness")).toBeNull();
+    const sendReceipt = await view.findByRole("button", {
+      name: /send receipt/i,
+    });
+
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    fireEvent.click(sendReceipt);
+
+    const indicator = await view.findByTestId("crm-freshness");
+    expect(indicator.textContent).toBe("Updated just now");
+
+    // Success smart-closes the overlay quietly: the gift param leaves the
+    // route without scrolling the CRM workspace.
+    await waitFor(() => {
+      expect(routerReplaceMock).toHaveBeenCalledWith("/crm", {
+        scroll: false,
+      });
+    });
+
+    // The indicator schedules an 8s auto-hide (ADR-CD-022). The harness runs
+    // real timers, so run the captured 8000ms callback instead of waiting.
+    const freshnessTimerCall = setTimeoutSpy.mock.calls.find(
+      ([, delay]) => delay === 8000,
+    );
+    expect(freshnessTimerCall).toBeTruthy();
+    act(() => {
+      (freshnessTimerCall![0] as () => void)();
+    });
+    expect(view.queryByTestId("crm-freshness")).toBeNull();
+  });
+
+  it("restores focus to the originating gift row after closing the gift detail overlay", async () => {
+    const donationId = "00000000-0000-4000-8000-00000000d00d";
+    mockSearch = `donor=${DONOR_RECORD_ID}`;
+    useAdminCrmRecordDetailMock.mockReturnValue(
+      mockQuery({ data: crmDonorDetailFor(donationId) }),
+    );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => contributionDetailPayloadFor(donationId),
+      }),
+    });
+
+    const view = render(
+      <QueryProvider>
+        <CrmPage />
+      </QueryProvider>,
+    );
+
+    const giftButton = await view.findByRole("button", {
+      name: /open gift detail for \$250\.00/i,
+    });
+    giftButton.focus();
+    fireEvent.click(giftButton);
+
+    // Opening the overlay keeps the workspace quiet ({ scroll: false }).
+    expect(routerPushMock).toHaveBeenCalledWith(
+      `/crm?donor=${DONOR_RECORD_ID}&gift=${donationId}`,
+      { scroll: false },
+    );
+
+    const closeButton = await view.findByRole("button", {
+      name: /close contribution details/i,
+    });
+    routerReplaceMock.mockClear();
+    fireEvent.click(closeButton);
+
+    // Smart close removes only the gift param, quietly, and preserves the
+    // donor drawer context (ADR-CD-023).
+    expect(routerReplaceMock).toHaveBeenCalledWith(
+      `/crm?donor=${DONOR_RECORD_ID}`,
+      { scroll: false },
+    );
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(giftButton);
+    });
   });
 
   it("strips malformed gift deep links while preserving donor context", async () => {


### PR DESCRIPTION
# Summary

Brings the CRM donor workspace to freshness parity with the Contributions Hub and locks in the shared query-freshness + smart-close acceptance criteria with tests. The Hub's "Updated just now" indicator (8-second auto-hide) is extracted into a shared hook/component and now renders on the CRM surface, wired to the same operation-success moments the Hub uses: detail-overlay operation success and inline operation shell row refresh.

# Issue

Closes #268

# Scope

- Extract the Hub freshness machinery into `apps/admin/app/contributions/freshness-indicator.tsx` (`useContributionFreshness()` + `ContributionFreshnessIndicator`); the Hub consumes it with unchanged behavior and test id.
- Render the indicator on the CRM workspace (`data-testid="crm-freshness"`), wired via `onActionSuccess` on the contribution detail overlay and a new optional `onRowRefresh` host callback on the CRM detail drawer (inline shell success also refetches the drawer detail as before).
- No changes to invalidation keys, smart-close behavior, or the operations contract — those were pre-landed and are now covered by acceptance tests.

# Data/API Changes

None. No new routes, no schema changes, no revision-fingerprint changes.

# UI Changes

- CRM donor workspace now shows "Updated just now" (`role="status"`, low-noise muted text) for 8 seconds after a successful gift operation, matching the Hub.
- Hub rendering unchanged (refactor only, net −24 lines).

# Testing

- `bunx turbo run typecheck --filter=@asym/admin` — pass.
- `VITEST_MAX_WORKERS=4 bunx vitest run tests/unit/apps/admin/` — 50 files / 275 tests green.
- New acceptance tests:
  - Hub freshness appears after overlay operation success and auto-hides on the 8s timer.
  - CRM freshness via the overlay deep-link path (appear + auto-hide + quiet close `{ scroll: false }`), and via inline operation success.
  - CRM focus restoration to the originating gift row after closing the gift overlay, with quiet open and `?donor=` preserved on smart close.
  - Stale-save recovery: a `/changed since you loaded/i` rejection triggers a second detail fetch (`recoverFromStaleSave`) with the recovery message surfaced and no false freshness signal.
  - Hub invalidation preserves `status=`/`search=` params across operation success (every `router.replace` retains them; no `push`).
- Auto-hide is asserted by spying on `window.setTimeout` (8000ms) and invoking the captured callback in `act()` — the test harness rebuilds JSDOM `window` per test, which `vi.useFakeTimers` cannot patch.

# Follow-ups

- Compare/reload/discard conflict UX from ADR-CD-022 remains deferred; the implemented reload-and-review recovery satisfies the "clear recovery path" acceptance criterion.

**Stacking note:** this PR is stacked on #455 (AL-267) → #454 (AL-266) → #453 (AL-265). Merge in chain order; only the AL-268 commit is new here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR shares the contribution freshness UI between the Contributions Hub and CRM. The main changes are:

- Adds a shared `useContributionFreshness` hook and `ContributionFreshnessIndicator` component.
- Refactors the Contributions Hub to use the shared freshness component without changing its behavior.
- Shows the CRM freshness indicator after overlay and inline gift operation success.
- Adds unit coverage for auto-hide timing, smart-close route preservation, focus restoration, and stale-save recovery.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge with minimal risk.

The changes are narrowly scoped client-side state and refactor work. Existing Contributions Hub behavior is preserved. New CRM parity paths are covered by targeted tests. No material correctness or security issues were found.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a baseline comparison showing the base source had contributions-freshness only and no crm-freshness, and then exercised the targeted Hub and CRM freshness tests on head; all targeted tests passed.
- After changes, the CRM workflows head run completed with 34/34 tests passing, including the freshness indicator after an overlay operation and related UI behaviors.
- The overlay success path tests showed the freshness UI updates to 'Updated just now', schedules an 8000ms hide, hides after the callback, preserves status and search on router.replace, and does not call router.push.

<a href="https://app.greptile.com/trex/runs/13067412/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/admin/app/contributions/freshness-indicator.tsx | Adds a shared client-side freshness hook and status indicator with timer cleanup; no material issues found. |
| apps/admin/app/contributions/page-client.tsx | Refactors the Contributions Hub to consume the shared freshness hook/component while preserving existing success wiring. |
| apps/admin/app/crm/detail-drawer.tsx | Adds an optional host callback after inline operation refresh so CRM can surface freshness alongside the existing detail refetch. |
| apps/admin/app/crm/page-client.tsx | Wires the shared freshness indicator into CRM overlay and inline operation success paths without changing route/state semantics. |
| tests/unit/apps/admin/app/contributions-page.test.tsx | Adds coverage for Hub freshness, preserved query params, stale-save recovery, and auto-hide behavior. |
| tests/unit/apps/admin/app/crm-gift-detail-entry.test.tsx | Adds CRM acceptance coverage for inline/overlay freshness, quiet smart close, and focus restoration. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Staff
participant Hub as Contributions Hub
participant CRM as CRM Workspace
participant Overlay as ContributionDetailOverlay
participant Inline as ContributionOperationShell
participant API as Contribution Operations API
participant Fresh as useContributionFreshness

Staff->>Overlay: Complete overlay gift operation
Overlay->>API: POST /actions
API-->>Overlay: Success
Overlay->>Overlay: Invalidate shared contribution queries
Overlay->>Fresh: markFreshness()
Fresh-->>Hub: Show Updated just now
Fresh-->>CRM: Show Updated just now
Fresh-->>Fresh: Auto-hide after 8000ms

Staff->>Inline: Complete CRM inline operation
Inline->>API: POST /actions
API-->>Inline: Success
Inline->>Inline: Invalidate shared contribution queries
Inline->>CRM: Refetch drawer detail
Inline->>Fresh: markFreshness()
Fresh-->>CRM: Show Updated just now
Fresh-->>Fresh: Auto-hide after 8000ms
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Staff
participant Hub as Contributions Hub
participant CRM as CRM Workspace
participant Overlay as ContributionDetailOverlay
participant Inline as ContributionOperationShell
participant API as Contribution Operations API
participant Fresh as useContributionFreshness

Staff->>Overlay: Complete overlay gift operation
Overlay->>API: POST /actions
API-->>Overlay: Success
Overlay->>Overlay: Invalidate shared contribution queries
Overlay->>Fresh: markFreshness()
Fresh-->>Hub: Show Updated just now
Fresh-->>CRM: Show Updated just now
Fresh-->>Fresh: Auto-hide after 8000ms

Staff->>Inline: Complete CRM inline operation
Inline->>API: POST /actions
API-->>Inline: Success
Inline->>Inline: Invalidate shared contribution queries
Inline->>CRM: Refetch drawer detail
Inline->>Fresh: markFreshness()
Fresh-->>CRM: Show Updated just now
Fresh-->>Fresh: Auto-hide after 8000ms
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;feature/AL-267-recurring-a..."](https://github.com/asymmetric-al/core/commit/40cbbd1614a00d5b9375fc468f771f50c5916879) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41382166)</sub>

<!-- /greptile_comment -->