### PR TITLE
chore: allow Eve bot git attribution

### DIFF
--- a/docs/ops/git-attribution.md
+++ b/docs/ops/git-attribution.md
@@ -10,9 +10,14 @@ older `abiatarprado` account that GitHub associates with `codex@example.com`.
 
 - Future commits must use author and committer name `Blake`.
 - Future commits must use either `blake@risencode.org` after GitHub email
-  verification, or `116130409+II-ricky-bobby-II@users.noreply.github.com`.
+  verification, `116130409+II-ricky-bobby-II@users.noreply.github.com`, or
+  `299239962+asymmetric-core-eve[bot]@users.noreply.github.com` for Asymmetric
+  Core Eve automation commits.
 - Future GitHub and Vercel deployment metadata must resolve to
-  `II-ricky-bobby-II`.
+  `II-ricky-bobby-II` or `asymmetric-core-eve[bot]`.
+- Commit email and GitHub actor metadata must match the same identity: Blake's
+  human emails resolve to `II-ricky-bobby-II`, and Eve's bot email resolves to
+  `asymmetric-core-eve[bot]`.
 - Do not use `Codex <codex@example.com>` in this repository.
 - Do not invite or rely on `abiatarprado` for deployments. That account is an
   external historical attribution path caused by older `codex@example.com`
@@ -20,12 +25,12 @@ older `abiatarprado` account that GitHub associates with `codex@example.com`.
 
 ## Automation Identity
 
-The long-term target is a team-owned GitHub/Vercel automation identity for
-Codex-assisted deploys. Until that account exists and is added to the relevant
-teams, use Blake's verified GitHub identity above for commits and deploys rather
-than any external account or placeholder email.
+Asymmetric Core Eve is the team-owned GitHub App identity for fleet automation
+pushes. It is allowlisted for commit email and GitHub actor metadata, and should
+be used for Codex-assisted automation instead of external accounts or placeholder
+emails.
 
-When the team-owned automation account is created:
+When the team-owned automation identity changes:
 
 1. Add it to the Asymmetric.al GitHub organization and Vercel team with the
    minimum deployment permissions required.
@@ -49,6 +54,13 @@ Set local repo attribution before committing:
 ```bash
 git config user.name Blake
 git config user.email 116130409+II-ricky-bobby-II@users.noreply.github.com
+```
+
+Set Asymmetric Core Eve automation attribution with the same required commit name:
+
+```bash
+git config user.name Blake
+git config user.email 299239962+asymmetric-core-eve[bot]@users.noreply.github.com
 ```
 
 Verify attribution before push:

--- a/scripts/verify/git-attribution.mjs
+++ b/scripts/verify/git-attribution.mjs
@@ -4,11 +4,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const REQUIRED_GIT_NAME = "Blake";
-export const ALLOWED_GIT_EMAILS = Object.freeze([
-  "blake@risencode.org",
-  "116130409+II-ricky-bobby-II@users.noreply.github.com",
+export const EXPECTED_GITHUB_LOGIN_BY_EMAIL = Object.freeze({
+  "blake@risencode.org": "II-ricky-bobby-II",
+  "116130409+II-ricky-bobby-II@users.noreply.github.com": "II-ricky-bobby-II",
+  "299239962+asymmetric-core-eve[bot]@users.noreply.github.com":
+    "asymmetric-core-eve[bot]",
+});
+export const ALLOWED_GIT_EMAILS = Object.freeze(
+  Object.keys(EXPECTED_GITHUB_LOGIN_BY_EMAIL),
+);
+export const ALLOWED_GITHUB_LOGINS = Object.freeze([
+  ...new Set(Object.values(EXPECTED_GITHUB_LOGIN_BY_EMAIL)),
 ]);
-export const ALLOWED_GITHUB_LOGINS = Object.freeze(["II-ricky-bobby-II"]);
 export const FORBIDDEN_GIT_EMAILS = Object.freeze(["codex@example.com"]);
 export const FORBIDDEN_GITHUB_LOGINS = Object.freeze(["abiatarprado"]);
 
@@ -24,6 +31,12 @@ const allowedEmailSet = new Set(ALLOWED_GIT_EMAILS.map(normalizeEmail));
 const allowedLoginSet = new Set(ALLOWED_GITHUB_LOGINS.map(normalizeLogin));
 const forbiddenEmailSet = new Set(FORBIDDEN_GIT_EMAILS.map(normalizeEmail));
 const forbiddenLoginSet = new Set(FORBIDDEN_GITHUB_LOGINS.map(normalizeLogin));
+const expectedLoginByEmail = new Map(
+  Object.entries(EXPECTED_GITHUB_LOGIN_BY_EMAIL).map(([email, login]) => [
+    normalizeEmail(email),
+    login,
+  ]),
+);
 
 export function parseGitIdentity(identity) {
   const match = /^(?<name>.+) <(?<email>[^>]+)> \d+ [+-]\d+$/.exec(
@@ -142,6 +155,37 @@ export function validateGitHubActors({ authorLogin, committerLogin }) {
         `${label} resolved to ${login}; expected ${ALLOWED_GITHUB_LOGINS.join(
           " or ",
         )}`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+export function validateGitHubActorAttribution(metadata, actors) {
+  const errors = [];
+
+  for (const { email, label, login } of [
+    {
+      email: metadata.authorEmail,
+      label: "latest commit GitHub author",
+      login: actors.authorLogin,
+    },
+    {
+      email: metadata.committerEmail,
+      label: "latest commit GitHub committer",
+      login: actors.committerLogin,
+    },
+  ]) {
+    const expectedLogin = expectedLoginByEmail.get(normalizeEmail(email));
+
+    if (!expectedLogin || !login) {
+      continue;
+    }
+
+    if (normalizeLogin(login) !== normalizeLogin(expectedLogin)) {
+      errors.push(
+        `${label} resolved to ${login}; email ${email} must resolve to ${expectedLogin}`,
       );
     }
   }
@@ -284,6 +328,9 @@ function collectVerification(options) {
 
           if (actors) {
             errors.push(...validateGitHubActors(actors));
+            errors.push(
+              ...validateGitHubActorAttribution(latestCommit, actors),
+            );
           }
         }
       }

--- a/tests/unit/scripts/git-attribution.test.ts
+++ b/tests/unit/scripts/git-attribution.test.ts
@@ -4,6 +4,7 @@ import {
   parseGitHubRepoSlug,
   parseGitIdentity,
   parseLatestCommitLog,
+  validateGitHubActorAttribution,
   validateGitHubActors,
   validateIdentity,
   validateLatestCommitMetadata,
@@ -11,6 +12,9 @@ import {
 
 const blakeNoReplyEmail =
   "116130409+II-ricky-bobby-II@users.noreply.github.com";
+const asymmetricCoreEveBotEmail =
+  "299239962+asymmetric-core-eve[bot]@users.noreply.github.com";
+const asymmetricCoreEveBotLogin = "asymmetric-core-eve[bot]";
 
 describe("git attribution verifier", () => {
   it("accepts Blake with the configured GitHub noreply address", () => {
@@ -19,6 +23,16 @@ describe("git attribution verifier", () => {
         label: "local git config",
         name: "Blake",
         email: blakeNoReplyEmail,
+      }),
+    ).toEqual([]);
+  });
+
+  it("accepts Blake with the Asymmetric Core Eve bot noreply address", () => {
+    expect(
+      validateIdentity({
+        label: "latest commit author",
+        name: "Blake",
+        email: asymmetricCoreEveBotEmail,
       }),
     ).toEqual([]);
   });
@@ -58,6 +72,53 @@ describe("git attribution verifier", () => {
         authorLogin: "II-ricky-bobby-II",
         committerLogin: "II-ricky-bobby-II",
       }),
+    ).toEqual([]);
+  });
+
+  it("accepts GitHub actor metadata that resolves to Asymmetric Core Eve", () => {
+    expect(
+      validateGitHubActors({
+        authorLogin: asymmetricCoreEveBotLogin,
+        committerLogin: asymmetricCoreEveBotLogin,
+      }),
+    ).toEqual([]);
+  });
+
+  it("rejects mixed human and bot commit attribution", () => {
+    const metadata = {
+      sha: "abc123",
+      authorName: "Blake",
+      authorEmail: asymmetricCoreEveBotEmail,
+      committerName: "Blake",
+      committerEmail: asymmetricCoreEveBotEmail,
+    };
+
+    expect(
+      validateGitHubActorAttribution(metadata, {
+        authorLogin: "II-ricky-bobby-II",
+        committerLogin: "II-ricky-bobby-II",
+      }),
+    ).toEqual([
+      `latest commit GitHub author resolved to II-ricky-bobby-II; email ${asymmetricCoreEveBotEmail} must resolve to ${asymmetricCoreEveBotLogin}`,
+      `latest commit GitHub committer resolved to II-ricky-bobby-II; email ${asymmetricCoreEveBotEmail} must resolve to ${asymmetricCoreEveBotLogin}`,
+    ]);
+  });
+
+  it("accepts matching human and bot commit attribution", () => {
+    expect(
+      validateGitHubActorAttribution(
+        {
+          sha: "abc123",
+          authorName: "Blake",
+          authorEmail: blakeNoReplyEmail,
+          committerName: "Blake",
+          committerEmail: asymmetricCoreEveBotEmail,
+        },
+        {
+          authorLogin: "II-ricky-bobby-II",
+          committerLogin: asymmetricCoreEveBotLogin,
+        },
+      ),
     ).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- allow Asymmetric Core Eve bot noreply email in git attribution verification
- allow the Eve GitHub App login in GitHub actor verification
- document Eve automation attribution and cover it with unit tests

## Verification
- bun test tests/unit/scripts/git-attribution.test.ts
- node scripts/verify/git-attribution.mjs --skip-latest-commit --skip-github
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows Eve bot attribution in the git attribution verifier. The main changes are:

- Adds Eve bot email and GitHub login to the allowed attribution set.
- Checks commit email metadata against the matching GitHub actor.
- Updates attribution docs for Eve automation.
- Adds tests for matching and mixed human/bot attribution.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general contract validation to verify identity and GitHub actor attribution, confirming the transition from prior rejections to after-state acceptance and Eve-related guidance.
- Updated the documentation to include Eve email/login guidance and matching attribution checks, aligning docs with the after-state validation results.

<a href="https://app.greptile.com/trex/runs/13277963/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/verify/git-attribution.mjs | Adds a shared email-to-login mapping and validates latest commit GitHub actors against it. |
| tests/unit/scripts/git-attribution.test.ts | Covers Eve bot attribution, mixed human/bot rejection, and matching human/bot acceptance. |
| docs/ops/git-attribution.md | Documents Eve automation attribution and the matching identity requirement. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: allow Eve bot git attribution"](https://github.com/asymmetric-al/core/commit/da0b81cd6b57b7a791c7ab6da7829b8741cef2de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41822420)</sub>

<!-- /greptile_comment -->