### PR TITLE
fix(contributions): harden offline gift entry follow-up

### DIFF
--- a/apps/admin/app/boneyard/contributions/page-client.tsx
+++ b/apps/admin/app/boneyard/contributions/page-client.tsx
@@ -26,7 +26,7 @@ export default function BoneyardContributionsCapturePage() {
     <PageShell
       title="Contributions"
       description="Track and manage all donations and contributions."
-      actions={<ContributionsPageActions />}
+      actions={<ContributionsPageActions canManageContributions={false} />}
     >
       <BoneyardSkeleton
         name="admin-contributions-content"

--- a/apps/admin/app/contributions/main-body.tsx
+++ b/apps/admin/app/contributions/main-body.tsx
@@ -85,6 +85,8 @@ const statusShortLabel: Record<ContributionStatus, string> = {
   refunded: "Refunded",
 };
 
+const OFFLINE_GIFT_ENTRY_PERSISTENCE_ENABLED = false;
+
 function StatCard({
   label,
   value,
@@ -555,9 +557,15 @@ export function ContributionsMainBody({
   );
 }
 
-export function ContributionsPageActions() {
+export function ContributionsPageActions({
+  canManageContributions = false,
+}: {
+  canManageContributions?: boolean;
+} = {}) {
   const queryClient = useQueryClient();
   const [offlineEntryOpen, setOfflineEntryOpen] = useState(false);
+  const canShowOfflineGiftEntry =
+    OFFLINE_GIFT_ENTRY_PERSISTENCE_ENABLED && canManageContributions;
 
   const handleExport = () => {
     toast.info("Export coming soon.");
@@ -573,23 +581,27 @@ export function ContributionsPageActions() {
         <Download className="size-4" />
         Export
       </Button>
-      <Button
-        className="h-11 gap-2 px-6 font-semibold uppercase tracking-widest text-[10px] shadow-lg"
-        onClick={() => setOfflineEntryOpen(true)}
-      >
-        <HandCoins className="size-4" />
-        Enter Offline Gift
-      </Button>
-      <OfflineGiftEntryDialog
-        open={offlineEntryOpen}
-        onOpenChange={setOfflineEntryOpen}
-        onRecorded={() => {
-          toast.success("Offline gift recorded.");
-          void queryClient.invalidateQueries({
-            queryKey: ADMIN_CONTRIBUTIONS_QUERY_KEY,
-          });
-        }}
-      />
+      {canShowOfflineGiftEntry ? (
+        <>
+          <Button
+            className="h-11 gap-2 px-6 font-semibold uppercase tracking-widest text-[10px] shadow-lg"
+            onClick={() => setOfflineEntryOpen(true)}
+          >
+            <HandCoins className="size-4" />
+            Enter Offline Gift
+          </Button>
+          <OfflineGiftEntryDialog
+            open={offlineEntryOpen}
+            onOpenChange={setOfflineEntryOpen}
+            onRecorded={() => {
+              toast.success("Offline gift recorded.");
+              void queryClient.invalidateQueries({
+                queryKey: ADMIN_CONTRIBUTIONS_QUERY_KEY,
+              });
+            }}
+          />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/admin/app/contributions/offline-gift/offline-gift-entry-dialog.tsx
+++ b/apps/admin/app/contributions/offline-gift/offline-gift-entry-dialog.tsx
@@ -24,7 +24,8 @@ import {
   LoaderCircle,
   Receipt,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { z } from "zod";
 
 import {
   INITIAL_OFFLINE_GIFT_FORM_VALUES,
@@ -40,11 +41,21 @@ import {
 const LABEL_CLASS =
   "text-[9px] font-bold uppercase tracking-widest text-muted-foreground";
 
-interface OfflineGiftEntryResult {
-  contributionId: string;
-  receiptStatus: keyof typeof OFFLINE_RECEIPT_STATUS_DISPLAY;
-  donorIdentityStatus: "known" | "unknown_offline";
-}
+const SUBMIT_TIMEOUT_MS = 15_000;
+const GENERIC_RECORDING_ERROR =
+  "We couldn't record this gift. Please review the details and try again.";
+
+const offlineGiftEntryResultSchema = z.object({
+  contributionId: z.string().min(1),
+  receiptStatus: z.enum(["pending", "no_receipt_requested", "not_receiptable"]),
+  donorIdentityStatus: z.enum(["known", "unknown_offline"]),
+});
+const offlineGiftEntryResponseSchema = z.object({
+  result: offlineGiftEntryResultSchema.optional(),
+  error: z.string().optional(),
+});
+
+type OfflineGiftEntryResult = z.infer<typeof offlineGiftEntryResultSchema>;
 
 interface OfflineGiftEntryDialogProps {
   open: boolean;
@@ -83,13 +94,54 @@ function OfflineGiftEntryForm({
 }) {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [recorded, setRecorded] = useState<OfflineGiftEntryResult | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const isActiveRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isActiveRef.current = false;
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+    };
+  }, []);
+
+  const abortInFlightSubmit = () => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+  };
+
+  const handleClose = () => {
+    abortInFlightSubmit();
+    onClose();
+  };
 
   const form = useOfflineGiftForm({
-    onError: setSubmitError,
-    onBeforeSubmit: () => setSubmitError(null),
+    clearAbortController: (controller) => {
+      if (abortControllerRef.current === controller) {
+        abortControllerRef.current = null;
+      }
+    },
+    createAbortController: () => {
+      abortInFlightSubmit();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      return controller;
+    },
+    onError: (message) => {
+      if (isActiveRef.current) {
+        setSubmitError(message);
+      }
+    },
+    onBeforeSubmit: () => {
+      if (isActiveRef.current) {
+        setSubmitError(null);
+      }
+    },
     onRecorded: (result) => {
-      setRecorded(result);
-      onRecorded?.(result);
+      if (isActiveRef.current) {
+        setRecorded(result);
+        onRecorded?.(result);
+      }
     },
   });
 
@@ -97,7 +149,7 @@ function OfflineGiftEntryForm({
     return (
       <OfflineGiftEntrySuccess
         result={recorded}
-        onClose={onClose}
+        onClose={handleClose}
         onAddAnother={() => {
           setRecorded(null);
           setSubmitError(null);
@@ -205,7 +257,7 @@ function OfflineGiftEntryForm({
       </div>
 
       <DialogFooter className="gap-2 border-t border-border px-6 py-4 sm:gap-2">
-        <Button onClick={onClose} type="button" variant="outline">
+        <Button onClick={handleClose} type="button" variant="outline">
           Cancel
         </Button>
         <form.Subscribe
@@ -233,6 +285,8 @@ function OfflineGiftEntryForm({
 }
 
 interface UseOfflineGiftFormHandlers {
+  clearAbortController: (controller: AbortController) => void;
+  createAbortController: () => AbortController;
   onBeforeSubmit: () => void;
   onError: (message: string) => void;
   onRecorded: (result: OfflineGiftEntryResult) => void;
@@ -249,25 +303,48 @@ function useOfflineGiftForm(handlers: UseOfflineGiftFormHandlers) {
     validators: { onChange: offlineGiftFormSchema },
     onSubmit: async ({ value }: { value: OfflineGiftFormValues }) => {
       handlers.onBeforeSubmit();
-      const response = await fetch("/api/admin/contributions/offline", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(toOfflineContributionRequest(value)),
-      });
-      const payload = (await response.json().catch(() => null)) as {
-        result?: OfflineGiftEntryResult;
-        error?: string;
-      } | null;
+      const controller = handlers.createAbortController();
+      let timedOut = false;
+      const timeoutId = globalThis.setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, SUBMIT_TIMEOUT_MS);
 
-      if (!response.ok || !payload?.result) {
-        handlers.onError(
-          payload?.error ??
-            "We couldn't record this gift. Please review the details and try again.",
-        );
-        return;
+      try {
+        const response = await fetch("/api/admin/contributions/offline", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(toOfflineContributionRequest(value)),
+          signal: controller.signal,
+        });
+        const rawPayload = await response.json().catch(() => null);
+        const parsedPayload =
+          offlineGiftEntryResponseSchema.safeParse(rawPayload);
+        const payload = parsedPayload.success ? parsedPayload.data : null;
+
+        if (!response.ok) {
+          handlers.onError(payload?.error ?? GENERIC_RECORDING_ERROR);
+          return;
+        }
+
+        if (!payload?.result) {
+          handlers.onError(GENERIC_RECORDING_ERROR);
+          return;
+        }
+
+        handlers.onRecorded(payload.result);
+      } catch {
+        if (controller.signal.aborted) {
+          if (timedOut) {
+            handlers.onError("Recording timed out. Please try again.");
+          }
+          return;
+        }
+        handlers.onError(GENERIC_RECORDING_ERROR);
+      } finally {
+        globalThis.clearTimeout(timeoutId);
+        handlers.clearAbortController(controller);
       }
-
-      handlers.onRecorded(payload.result);
     },
   });
 }
@@ -301,12 +378,12 @@ function ModeToggle({
   return (
     <fieldset>
       <legend className={cn(LABEL_CLASS, "mb-2")}>Donor</legend>
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2" role="radiogroup">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         {options.map((option) => {
           const active = option.mode === value;
           return (
             <button
-              aria-checked={active}
+              aria-pressed={active}
               className={cn(
                 "flex flex-col items-start rounded-xl border px-3 py-2.5 text-left transition-colors",
                 active
@@ -315,7 +392,6 @@ function ModeToggle({
               )}
               key={option.mode}
               onClick={() => onChange(option.mode)}
-              role="radio"
               type="button"
             >
               <span className="text-sm font-medium text-foreground">

--- a/apps/admin/app/contributions/offline-gift/offline-gift-form-model.ts
+++ b/apps/admin/app/contributions/offline-gift/offline-gift-form-model.ts
@@ -177,9 +177,15 @@ export function toOfflineContributionRequest(
   };
 
   if (values.donorMode === "unknown_offline") {
+    if (values.method !== "cash" && values.method !== "other") {
+      throw new Error(
+        "Unknown offline gifts must be cash or other; payer-identifying methods must be entered as known gifts.",
+      );
+    }
+
     return {
       donorMode: "unknown_offline",
-      method: values.method === "other" ? "other" : "cash",
+      method: values.method,
       ...shared,
     };
   }
@@ -212,6 +218,7 @@ const KNOWN_METHODS = OFFLINE_METHOD_OPTIONS_KNOWN.map(
 const UNKNOWN_METHODS = OFFLINE_METHOD_OPTIONS_UNKNOWN.map(
   (option) => option.value,
 );
+const emailFormat = z.email();
 
 /**
  * Form-values schema for inline (onChange) UX validation. This is the
@@ -303,6 +310,17 @@ export const offlineGiftFormSchema = z
           code: z.ZodIssueCode.custom,
           path: ["lastName"],
           message: "Last name is required",
+        });
+      }
+      const trimmedEmail = values.email.trim();
+      if (
+        trimmedEmail.length > 0 &&
+        !emailFormat.safeParse(trimmedEmail).success
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["email"],
+          message: "Enter a valid email address",
         });
       }
     } else if (values.donorId.trim().length === 0) {

--- a/apps/admin/app/contributions/page-client.tsx
+++ b/apps/admin/app/contributions/page-client.tsx
@@ -29,7 +29,11 @@ export { invalidateContributionOperationQueries } from "./contribution-detail-ov
 const USE_MOCK_CONTRIBUTIONS_UI =
   process.env.NEXT_PUBLIC_ADMIN_CONTRIBUTIONS_USE_MOCK === "1";
 
-export default function ContributionsPage() {
+export default function ContributionsPage({
+  canManageContributions = false,
+}: {
+  canManageContributions?: boolean;
+}) {
   const contributionsQuery = useAdminContributions();
   const needsAttentionQuery = useMissionControlNeedsAttention();
   const queryClient = useQueryClient();
@@ -152,7 +156,11 @@ export default function ContributionsPage() {
       title="Contributions"
       description="Track and manage all donations and contributions."
       density="compact"
-      actions={<ContributionsPageActions />}
+      actions={
+        <ContributionsPageActions
+          canManageContributions={canManageContributions}
+        />
+      }
     >
       <div data-testid="mc-contributions-live">
         {showFreshness && (

--- a/apps/admin/app/contributions/page.tsx
+++ b/apps/admin/app/contributions/page.tsx
@@ -1,3 +1,9 @@
+import { hasContributionPermission } from "@asym/api/admin/contribution-operations";
+import {
+  getAuthContext,
+  type AuthContext,
+  type AuthenticatedContext,
+} from "@asym/auth/context";
 import { PageShell } from "@asym/ui/components/primitives/page-shell";
 import { Suspense } from "react";
 
@@ -16,10 +22,27 @@ function ContributionsPageFallback() {
   );
 }
 
-export default function Page() {
+function isAuthenticatedContext(
+  auth: AuthContext,
+): auth is AuthenticatedContext {
+  return auth.isAuthenticated;
+}
+
+function canManageOfflineContributions(auth: AuthContext): boolean {
+  if (!isAuthenticatedContext(auth)) {
+    return false;
+  }
+
+  return hasContributionPermission(auth, "finance:manage_contributions");
+}
+
+export default async function Page() {
+  const auth = await getAuthContext();
+  const canManageContributions = canManageOfflineContributions(auth);
+
   return (
     <Suspense fallback={<ContributionsPageFallback />}>
-      <PageClient />
+      <PageClient canManageContributions={canManageContributions} />
     </Suspense>
   );
 }

--- a/packages/api/src/admin/contributions/offline-dependencies.ts
+++ b/packages/api/src/admin/contributions/offline-dependencies.ts
@@ -10,33 +10,34 @@ type AdminSupabaseClient = Exclude<
 >;
 
 /**
- * Offline gift entry — DB dependency binding (Gate-8 boundary).
+ * Offline gift entry DB dependency binding (Gate-8 boundary).
  *
- * The pure orchestration (`recordOfflineContribution`), the §9.3 contract, and
- * the receipt/anonymity logic are all built and unit-tested. What remains is
- * binding the three side-effects to real infra, and that is deliberately NOT
- * done here because it depends on changes that are NOT yet landed and MUST go
- * through human sign-off:
+ * The pure orchestration (`recordOfflineContribution`), the section 9.3
+ * contract, and the receipt/anonymity logic are built and unit-tested. What
+ * remains is binding the side effects to real infra, and that is deliberately
+ * not done here because it depends on changes that are not yet landed and must
+ * go through human sign-off:
  *
- *   1. The Track B §8.1 migration (adds `donor_identity_status`,
+ *   1. The Track B section 8.1 migration (adds `donor_identity_status`,
  *      `receipt_status`, `entered_by_user_id`, `anonymous_to_*` to `donations`).
  *   2. Extending `CONTRIBUTION_ACTION_TYPES` with `offline_gift_entry` and the
  *      `sourceSurface` enum with `offline`.
  *   3. A donor create/match resolver keyed on (tenant, normalized email) that
- *      does NOT leak donor existence, plus the shared
- *      `appendContributionOperationAuditEvent` audit write.
+ *      does not leak donor existence, plus an atomic contribution+audit write.
  *
  * Writing gift/money truth is a protected area (charter Gate 4 + Gate 8), so
  * until the migration + enum extension land and a maintainer wires these deps
  * against live infra, the route surfaces a precise 501 rather than inventing a
  * blind insert against columns that do not exist yet.
  *
- * See proposals/track-b/OFFLINE_GIFT_ENTRY_DESIGN.md §5 (BLOCKED-FOR-LATER).
+ * See proposals/track-b/OFFLINE_GIFT_ENTRY_DESIGN.md section 5
+ * (BLOCKED-FOR-LATER).
  */
 export const OFFLINE_ENTRY_UNBOUND_MESSAGE =
   "Offline gift entry persistence is not yet enabled: it requires the Track B " +
-  "§8.1 donations migration, the offline_gift_entry/offline enum extension, and " +
-  "a maintainer to bind the donor resolver + insert + audit deps (Gate 8).";
+  "section 8.1 donations migration, the offline_gift_entry/offline enum " +
+  "extension, and a maintainer to bind the donor resolver + atomic insert/audit " +
+  "deps (Gate 8).";
 
 class OfflineEntryUnboundError extends ApiHttpError {
   constructor() {
@@ -49,25 +50,19 @@ class OfflineEntryUnboundError extends ApiHttpError {
  * Build the injected side-effects for {@link recordOfflineContribution}.
  *
  * `supabaseAdmin` is threaded through so the maintainer PR only has to fill the
- * three function bodies (donor resolve/create, `donations` insert with the §8.1
- * columns, and `appendContributionOperationAuditEvent`) — the route, gate,
+ * donor resolver plus one atomic contribution+audit write. The route, gate,
  * validation, and orchestration around them are already wired and tested.
  */
 export function createOfflineEntryDependencies(
-  supabaseAdmin: AdminSupabaseClient,
+  _supabaseAdmin: AdminSupabaseClient,
 ): OfflineEntryDependencies {
-  // Intentionally unbound until the Gate-8 maintainer PR fills the three bodies
-  // against `supabaseAdmin` (see the module doc above). Referenced so the client
-  // stays threaded through the signature without a dead-parameter lint warning.
-  void supabaseAdmin;
+  // Intentionally unbound until the Gate-8 maintainer PR wires these closures
+  // against `_supabaseAdmin` (see the module doc above).
   return {
     resolveKnownDonor: async () => {
       throw new OfflineEntryUnboundError();
     },
-    insertContribution: async () => {
-      throw new OfflineEntryUnboundError();
-    },
-    appendAudit: async () => {
+    recordContributionWithAudit: async () => {
       throw new OfflineEntryUnboundError();
     },
   };

--- a/packages/api/src/admin/contributions/offline-entry.ts
+++ b/packages/api/src/admin/contributions/offline-entry.ts
@@ -42,26 +42,29 @@ export interface OfflineEntryDependencies {
       { donorMode: "known" }
     >["donorInput"];
   }) => Promise<{ donorId: string }>;
-  /** Insert the assembled contribution row; returns the new contribution id. */
-  insertContribution: (
+  /**
+   * Persist the assembled contribution row and its matching audit event in one
+   * atomic dependency. The real binding must commit both records together or
+   * fail both; the orchestration deliberately avoids a split insert-then-audit
+   * contract for this money/audit-critical path.
+   */
+  recordContributionWithAudit: (args: {
     row: OfflineContributionRow & {
       tenant_id: string;
       donor_id: string | null;
       entered_by_user_id: string;
       source: "offline";
-    },
-  ) => Promise<{ contributionId: string }>;
-  /** Append the shared contribution-operations audit event. */
-  appendAudit: (event: {
-    tenantId: string;
-    actorProfileId: string;
-    contributionId: string;
-    actionType: "offline_gift_entry";
-    sourceSurface: "offline";
-    donorMode: OfflineContributionRequest["donorMode"];
-    amountCents: number;
-    receivedDate: string;
-  }) => Promise<{ auditEventId: string }>;
+    };
+    audit: {
+      tenantId: string;
+      actorProfileId: string;
+      actionType: "offline_gift_entry";
+      sourceSurface: "offline";
+      donorMode: OfflineContributionRequest["donorMode"];
+      amountCents: number;
+      receivedDate: string;
+    };
+  }) => Promise<{ contributionId: string; auditEventId: string }>;
 }
 
 export interface OfflineEntryResult {
@@ -100,24 +103,25 @@ export async function recordOfflineContribution(args: {
     donorId = resolved.donorId;
   }
 
-  const { contributionId } = await deps.insertContribution({
-    ...row,
-    tenant_id: actor.tenantId,
-    donor_id: donorId,
-    entered_by_user_id: actor.actorProfileId,
-    source: "offline",
-  });
-
-  const { auditEventId } = await deps.appendAudit({
-    tenantId: actor.tenantId,
-    actorProfileId: actor.actorProfileId,
-    contributionId,
-    actionType: "offline_gift_entry",
-    sourceSurface: "offline",
-    donorMode: input.donorMode,
-    amountCents: row.amount_cents,
-    receivedDate: row.received_date,
-  });
+  const { contributionId, auditEventId } =
+    await deps.recordContributionWithAudit({
+      row: {
+        ...row,
+        tenant_id: actor.tenantId,
+        donor_id: donorId,
+        entered_by_user_id: actor.actorProfileId,
+        source: "offline",
+      },
+      audit: {
+        tenantId: actor.tenantId,
+        actorProfileId: actor.actorProfileId,
+        actionType: "offline_gift_entry",
+        sourceSurface: "offline",
+        donorMode: input.donorMode,
+        amountCents: row.amount_cents,
+        receivedDate: row.received_date,
+      },
+    });
 
   return {
     contributionId,

--- a/packages/api/src/schemas/contributions-offline.ts
+++ b/packages/api/src/schemas/contributions-offline.ts
@@ -55,9 +55,10 @@ function isValidIsoDate(value: string): boolean {
   );
 }
 
+const isoDateTimeWithOffset = z.iso.datetime({ offset: true });
+
 function isValidIsoDateTime(value: string): boolean {
-  const parsed = z.iso.datetime({ offset: true }).safeParse(value);
-  return parsed.success && Number.isFinite(Date.parse(value));
+  return isoDateTimeWithOffset.safeParse(value).success;
 }
 
 // ISO date (YYYY-MM-DD) or full ISO timestamp - staff-entered received date.

--- a/packages/api/src/schemas/contributions-offline.ts
+++ b/packages/api/src/schemas/contributions-offline.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 const requiredText = (label: string) =>
   z.string().trim().min(1, `${label} is required`);
 
-const normalizedEmail = z.string().trim().toLowerCase().email();
+const normalizedEmail = z.string().trim().toLowerCase().pipe(z.email());
 
 export const offlineAddressSchema = z.object({
   line1: requiredText("Address line 1"),
@@ -39,8 +39,32 @@ const designationSchema = z.object({
   fundId: z.string().trim().min(1).optional(),
 });
 
-// ISO date (YYYY-MM-DD) or full ISO timestamp — staff-entered received date.
-const receivedDate = requiredText("Received date");
+function isValidIsoDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function isValidIsoDateTime(value: string): boolean {
+  const parsed = z.iso.datetime({ offset: true }).safeParse(value);
+  return parsed.success && Number.isFinite(Date.parse(value));
+}
+
+// ISO date (YYYY-MM-DD) or full ISO timestamp - staff-entered received date.
+const receivedDate = requiredText("Received date").refine(
+  (value) => isValidIsoDate(value) || isValidIsoDateTime(value),
+  "Received date must be a valid ISO date or timestamp",
+);
 
 const amount = z.coerce
   .number()

--- a/packages/api/tests/unit/contributions-offline-entry.test.ts
+++ b/packages/api/tests/unit/contributions-offline-entry.test.ts
@@ -16,15 +16,14 @@ const actor = { tenantId: "tenant-1", actorProfileId: "profile-9" };
 
 function deps(): OfflineEntryDependencies & {
   resolveKnownDonor: ReturnType<typeof vi.fn>;
-  insertContribution: ReturnType<typeof vi.fn>;
-  appendAudit: ReturnType<typeof vi.fn>;
+  recordContributionWithAudit: ReturnType<typeof vi.fn>;
 } {
   return {
     resolveKnownDonor: vi.fn().mockResolvedValue({ donorId: "donor-created" }),
-    insertContribution: vi
-      .fn()
-      .mockResolvedValue({ contributionId: "contrib-1" }),
-    appendAudit: vi.fn().mockResolvedValue({ auditEventId: "audit-1" }),
+    recordContributionWithAudit: vi.fn().mockResolvedValue({
+      contributionId: "contrib-1",
+      auditEventId: "audit-1",
+    }),
   };
 }
 
@@ -66,13 +65,15 @@ describe("recordOfflineContribution", () => {
     expect(res.donorId).toBeNull();
     expect(res.donorIdentityStatus).toBe("unknown_offline");
     expect(res.receiptStatus).toBe("not_receiptable");
-    expect(d.insertContribution).toHaveBeenCalledWith(
+    expect(d.recordContributionWithAudit).toHaveBeenCalledWith(
       expect.objectContaining({
-        donor_id: null,
-        tenant_id: "tenant-1",
-        entered_by_user_id: "profile-9",
-        source: "offline",
-        donor_identity_status: "unknown_offline",
+        row: expect.objectContaining({
+          donor_id: null,
+          tenant_id: "tenant-1",
+          entered_by_user_id: "profile-9",
+          source: "offline",
+          donor_identity_status: "unknown_offline",
+        }),
       }),
     );
   });
@@ -91,25 +92,28 @@ describe("recordOfflineContribution", () => {
     });
     expect(res.donorId).toBe("donor-created");
     expect(res.receiptStatus).toBe("pending");
-    expect(d.insertContribution).toHaveBeenCalledWith(
+    expect(d.recordContributionWithAudit).toHaveBeenCalledWith(
       expect.objectContaining({
-        donor_id: "donor-created",
-        anonymous_to_recipient: true,
-        source: "offline",
+        row: expect.objectContaining({
+          donor_id: "donor-created",
+          anonymous_to_recipient: true,
+          source: "offline",
+        }),
       }),
     );
   });
 
-  it("always writes exactly one audit event tagged offline", async () => {
+  it("persists the contribution row and audit event through one atomic dependency", async () => {
     await recordOfflineContribution({ input: unknownGift, actor, deps: d });
-    expect(d.appendAudit).toHaveBeenCalledTimes(1);
-    expect(d.appendAudit).toHaveBeenCalledWith(
+    expect(d.recordContributionWithAudit).toHaveBeenCalledTimes(1);
+    expect(d.recordContributionWithAudit).toHaveBeenCalledWith(
       expect.objectContaining({
-        actionType: "offline_gift_entry",
-        sourceSurface: "offline",
-        contributionId: "contrib-1",
-        actorProfileId: "profile-9",
-        donorMode: "unknown_offline",
+        audit: expect.objectContaining({
+          actionType: "offline_gift_entry",
+          sourceSurface: "offline",
+          actorProfileId: "profile-9",
+          donorMode: "unknown_offline",
+        }),
       }),
     );
   });

--- a/packages/api/tests/unit/contributions-offline-schema.test.ts
+++ b/packages/api/tests/unit/contributions-offline-schema.test.ts
@@ -107,6 +107,23 @@ describe("offlineContributionSchema — shared rules", () => {
     expect(() => offlineContributionSchema.parse(bad)).toThrow();
   });
 
+  it("rejects a received date that is not an ISO date or timestamp", () => {
+    for (const receivedDate of ["not-a-date", "2026-13-01", "2026-02-30"]) {
+      expect(() =>
+        offlineContributionSchema.parse({ ...knownWithId, receivedDate }),
+      ).toThrow();
+    }
+  });
+
+  it("accepts a full ISO timestamp as a received date", () => {
+    expect(() =>
+      offlineContributionSchema.parse({
+        ...knownWithId,
+        receivedDate: "2026-07-01T10:30:00.000Z",
+      }),
+    ).not.toThrow();
+  });
+
   it("rejects a non-usd currency", () => {
     expect(() =>
       offlineContributionSchema.parse({ ...knownWithId, currency: "eur" }),

--- a/tests/unit/apps/admin/app/contributions-main-body.test.tsx
+++ b/tests/unit/apps/admin/app/contributions-main-body.test.tsx
@@ -7,6 +7,7 @@ import { readFileSync } from "node:fs";
 // file"). Alias Node's own `URL` so source-file reads use a real `file:` URL.
 import { URL as NodeURL, fileURLToPath } from "node:url";
 
+import { QueryProvider } from "@asym/database/providers";
 import {
   act,
   cleanup,
@@ -17,7 +18,7 @@ import {
 import { JSDOM } from "jsdom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Contribution } from "../../../../../apps/admin/app/contributions/types";
+import type { ContributionGridRow as Contribution } from "@asym/api/admin/contributions/types";
 
 const selectedRowsRef = { current: [] as unknown[] };
 const toastErrorMock = vi.fn();
@@ -89,7 +90,10 @@ vi.mock("sonner", () => ({
 const root = new NodeURL("../../../../../", import.meta.url);
 type ContributionsMainBodyComponent =
   typeof import("../../../../../apps/admin/app/contributions/main-body").ContributionsMainBody;
+type ContributionsPageActionsComponent =
+  typeof import("../../../../../apps/admin/app/contributions/main-body").ContributionsPageActions;
 let ContributionsMainBody: ContributionsMainBodyComponent;
+let ContributionsPageActions: ContributionsPageActionsComponent;
 let confirmDescriptor: PropertyDescriptor | undefined;
 let cryptoDescriptor: PropertyDescriptor | undefined;
 let customEventDescriptor: PropertyDescriptor | undefined;
@@ -190,6 +194,16 @@ function renderMainBody(rows: Contribution[]) {
   );
 }
 
+function renderPageActions(canManageContributions?: boolean) {
+  return render(
+    <QueryProvider>
+      <ContributionsPageActions
+        canManageContributions={canManageContributions}
+      />
+    </QueryProvider>,
+  );
+}
+
 function stubBatchFetch() {
   const fetchMock = vi.fn().mockResolvedValue({
     ok: true,
@@ -284,9 +298,10 @@ beforeEach(async () => {
       randomUUID: vi.fn(() => "confirmation-token"),
     },
   });
-  ContributionsMainBody = (
-    await import("../../../../../apps/admin/app/contributions/main-body")
-  ).ContributionsMainBody;
+  const mainBodyModule =
+    await import("../../../../../apps/admin/app/contributions/main-body");
+  ContributionsMainBody = mainBodyModule.ContributionsMainBody;
+  ContributionsPageActions = mainBodyModule.ContributionsPageActions;
   selectedRowsRef.current = [];
 });
 
@@ -571,13 +586,20 @@ describe("contributions surface design tokens", () => {
 });
 
 describe("offline gift entry readiness gate", () => {
-  it("keeps the unbound offline gift form behind persistence and finance gates", () => {
-    const source = readRepoFile("apps/admin/app/contributions/main-body.tsx");
+  it("keeps the unbound offline gift form hidden by default", () => {
+    const view = renderPageActions();
 
-    expect(source).toContain("OFFLINE_GIFT_ENTRY_PERSISTENCE_ENABLED");
-    expect(source).toContain("canManageContributions");
-    expect(source).toContain(
-      "OFFLINE_GIFT_ENTRY_PERSISTENCE_ENABLED && canManageContributions",
-    );
+    expect(
+      view.queryByRole("button", { name: /Enter Offline Gift/i }),
+    ).toBeNull();
+  });
+
+  it("keeps finance-authorized users behind the persistence flag until DB dependencies are bound", () => {
+    const view = renderPageActions(true);
+
+    expect(
+      view.queryByRole("button", { name: /Enter Offline Gift/i }),
+    ).toBeNull();
+    expect(view.getByRole("button", { name: "Export" })).toBeTruthy();
   });
 });

--- a/tests/unit/apps/admin/app/contributions-main-body.test.tsx
+++ b/tests/unit/apps/admin/app/contributions-main-body.test.tsx
@@ -569,3 +569,15 @@ describe("contributions surface design tokens", () => {
     }
   });
 });
+
+describe("offline gift entry readiness gate", () => {
+  it("keeps the unbound offline gift form behind persistence and finance gates", () => {
+    const source = readRepoFile("apps/admin/app/contributions/main-body.tsx");
+
+    expect(source).toContain("OFFLINE_GIFT_ENTRY_PERSISTENCE_ENABLED");
+    expect(source).toContain("canManageContributions");
+    expect(source).toContain(
+      "OFFLINE_GIFT_ENTRY_PERSISTENCE_ENABLED && canManageContributions",
+    );
+  });
+});

--- a/tests/unit/apps/admin/app/contributions-page-auth.test.tsx
+++ b/tests/unit/apps/admin/app/contributions-page-auth.test.tsx
@@ -1,0 +1,139 @@
+import { isValidElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReactElement, ReactNode } from "react";
+
+const { getAuthContextMock, hasContributionPermissionMock } = vi.hoisted(
+  () => ({
+    getAuthContextMock: vi.fn(),
+    hasContributionPermissionMock: vi.fn(),
+  }),
+);
+
+type PageClientProps = {
+  canManageContributions?: boolean;
+};
+
+type PageComponent = () => Promise<ReactElement>;
+
+type AuthContextShape = {
+  email: string | null;
+  isAuthenticated: boolean;
+  memberships: unknown[];
+  profileId: string | null;
+  profileRole: string | null;
+  role: string | null;
+  tenantId: string | null;
+  userId: string | null;
+};
+
+let Page: PageComponent;
+
+function unauthenticatedContext(): AuthContextShape {
+  return {
+    email: null,
+    isAuthenticated: false,
+    memberships: [],
+    profileId: null,
+    profileRole: null,
+    role: null,
+    tenantId: null,
+    userId: null,
+  };
+}
+
+function authenticatedContext(): AuthContextShape {
+  return {
+    email: "finance@example.com",
+    isAuthenticated: true,
+    memberships: [],
+    profileId: "profile_1",
+    profileRole: "admin",
+    role: "admin",
+    tenantId: "tenant_1",
+    userId: "user_1",
+  };
+}
+
+function assertElement(value: ReactNode): ReactElement {
+  expect(isValidElement(value)).toBe(true);
+  return value as ReactElement;
+}
+
+async function renderPageClientProps(): Promise<PageClientProps> {
+  const pageElement = assertElement(await Page());
+  const pageChildren = (pageElement.props as { children: ReactNode }).children;
+  const pageClientElement = assertElement(pageChildren);
+
+  return pageClientElement.props as PageClientProps;
+}
+
+describe("apps/admin/app/contributions/page auth gate", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    getAuthContextMock.mockReset();
+    hasContributionPermissionMock.mockReset();
+
+    vi.doMock("@asym/auth/context", () => ({
+      getAuthContext: getAuthContextMock,
+    }));
+    vi.doMock("../../../../../packages/auth/context", () => ({
+      getAuthContext: getAuthContextMock,
+    }));
+    vi.doMock("@asym/api/admin/contribution-operations", () => ({
+      hasContributionPermission: hasContributionPermissionMock,
+    }));
+    vi.doMock(
+      "../../../../../packages/api/src/admin/contribution-operations/index",
+      () => ({
+        hasContributionPermission: hasContributionPermissionMock,
+      }),
+    );
+    vi.doMock(
+      "../../../../../apps/admin/app/contributions/page-client",
+      () => ({
+        default: () => null,
+      }),
+    );
+
+    Page = (await import("../../../../../apps/admin/app/contributions/page"))
+      .default as PageComponent;
+  });
+
+  it("does not expose contribution management actions to unauthenticated visitors", async () => {
+    getAuthContextMock.mockResolvedValue(unauthenticatedContext());
+
+    const props = await renderPageClientProps();
+
+    expect(props.canManageContributions).toBe(false);
+    expect(hasContributionPermissionMock).not.toHaveBeenCalled();
+  });
+
+  it("threads denied finance permission into the client page actions", async () => {
+    const auth = authenticatedContext();
+    getAuthContextMock.mockResolvedValue(auth);
+    hasContributionPermissionMock.mockReturnValue(false);
+
+    const props = await renderPageClientProps();
+
+    expect(hasContributionPermissionMock).toHaveBeenCalledWith(
+      auth,
+      "finance:manage_contributions",
+    );
+    expect(props.canManageContributions).toBe(false);
+  });
+
+  it("threads granted finance permission into the client page actions", async () => {
+    const auth = authenticatedContext();
+    getAuthContextMock.mockResolvedValue(auth);
+    hasContributionPermissionMock.mockReturnValue(true);
+
+    const props = await renderPageClientProps();
+
+    expect(hasContributionPermissionMock).toHaveBeenCalledWith(
+      auth,
+      "finance:manage_contributions",
+    );
+    expect(props.canManageContributions).toBe(true);
+  });
+});

--- a/tests/unit/apps/admin/app/contributions-page.test.tsx
+++ b/tests/unit/apps/admin/app/contributions-page.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
 type ContributionsPageComponent =
-  typeof import("../../../../../apps/admin/app/contributions/page").default;
+  typeof import("../../../../../apps/admin/app/contributions/page-client").default;
 type InvalidateContributionOperationQueries =
   typeof import("../../../../../apps/admin/app/contributions/page-client").invalidateContributionOperationQueries;
 type ContributionsDataModule =
@@ -283,10 +283,8 @@ async function loadEnvSensitiveModules() {
     await import("../../../../../apps/admin/app/contributions/data");
   const pageClientModule =
     await import("../../../../../apps/admin/app/contributions/page-client");
-  const contributionsPageModule =
-    await import("../../../../../apps/admin/app/contributions/page");
 
-  ContributionsPage = contributionsPageModule.default;
+  ContributionsPage = pageClientModule.default;
   invalidateContributionOperationQueries =
     pageClientModule.invalidateContributionOperationQueries;
   boneyardContributionsFixture = dataModule.boneyardContributionsFixture;
@@ -299,7 +297,7 @@ async function loadEnvSensitiveModules() {
     databaseHooksModule.MISSION_CONTROL_NEEDS_ATTENTION_QUERY_KEY;
 }
 
-describe("apps/admin/app/contributions/page", () => {
+describe("apps/admin/app/contributions/page-client", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();

--- a/tests/unit/apps/admin/app/offline-gift-entry-dialog.test.tsx
+++ b/tests/unit/apps/admin/app/offline-gift-entry-dialog.test.tsx
@@ -1,7 +1,13 @@
 /** @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { OfflineGiftEntryDialog } from "../../../../../apps/admin/app/contributions/offline-gift/offline-gift-entry-dialog";
 
@@ -11,10 +17,39 @@ import { OfflineGiftEntryDialog } from "../../../../../apps/admin/app/contributi
  * mode, and the anonymous-gift guidance appears in unknown mode. No network.
  */
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
-function renderDialog() {
-  return render(<OfflineGiftEntryDialog open onOpenChange={() => undefined} />);
+function renderDialog(
+  props: Partial<Parameters<typeof OfflineGiftEntryDialog>[0]> = {},
+) {
+  return render(
+    <OfflineGiftEntryDialog open onOpenChange={() => undefined} {...props} />,
+  );
+}
+
+function fillValidKnownGift() {
+  fireEvent.change(screen.getByPlaceholderText("Ada"), {
+    target: { value: "Ada" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("Lovelace"), {
+    target: { value: "Lovelace" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("0.00"), {
+    target: { value: "100" },
+  });
+  const receivedDate = document.querySelector('input[type="date"]');
+  if (!(receivedDate instanceof HTMLInputElement)) {
+    throw new Error("received date input not found");
+  }
+  fireEvent.change(receivedDate, {
+    target: { value: "2026-07-01" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("fund ID"), {
+    target: { value: "fund-1" },
+  });
 }
 
 describe("OfflineGiftEntryDialog", () => {
@@ -28,9 +63,99 @@ describe("OfflineGiftEntryDialog", () => {
   it("switches to an anonymous gift: shows guidance and a not-receiptable tile", () => {
     renderDialog();
     fireEvent.click(
-      screen.getByRole("radio", { name: /Unknown \/ anonymous/i }),
+      screen.getByRole("button", { name: /Unknown \/ anonymous/i }),
     );
     expect(screen.getByText(/no donor identity is stored/i)).toBeTruthy();
     expect(screen.getByText("Not receiptable")).toBeTruthy();
+  });
+
+  it("uses toggle-button semantics for donor mode instead of incomplete radio semantics", () => {
+    renderDialog();
+    const knownButton = screen.getByRole("button", { name: /Known donor/i });
+    const unknownButton = screen.getByRole("button", {
+      name: /Unknown \/ anonymous/i,
+    });
+
+    expect(knownButton.getAttribute("aria-pressed")).toBe("true");
+    expect(unknownButton.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("submits a valid known gift and renders the success state", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          contributionId: "contrib-1",
+          donorIdentityStatus: "known",
+          receiptStatus: "pending",
+        },
+      }),
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    renderDialog();
+    fillValidKnownGift();
+    fireEvent.click(screen.getByRole("button", { name: "Record gift" }));
+
+    expect(await screen.findByText("Gift recorded")).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/contributions/offline",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("shows an error banner when the route rejects the request", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Persistence is not enabled." }),
+    } as Response);
+
+    renderDialog();
+    fillValidKnownGift();
+    fireEvent.click(screen.getByRole("button", { name: "Record gift" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Persistence is not enabled.");
+  });
+
+  it("routes malformed success payloads through the error banner", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { contributionId: "contrib-1" } }),
+    } as Response);
+
+    renderDialog();
+    fillValidKnownGift();
+    fireEvent.click(screen.getByRole("button", { name: "Record gift" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/review the details/i);
+  });
+
+  it("aborts an in-flight submit when the dialog closes", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      capturedSignal = init?.signal;
+      return new Promise<Response>(() => undefined);
+    });
+
+    const view = renderDialog();
+    fillValidKnownGift();
+    fireEvent.click(screen.getByRole("button", { name: "Record gift" }));
+
+    await waitFor(() => {
+      expect(capturedSignal).toBeDefined();
+    });
+
+    view.rerender(
+      <OfflineGiftEntryDialog open={false} onOpenChange={() => undefined} />,
+    );
+
+    expect(capturedSignal?.aborted).toBe(true);
   });
 });

--- a/tests/unit/apps/admin/app/offline-gift-form-model.test.ts
+++ b/tests/unit/apps/admin/app/offline-gift-form-model.test.ts
@@ -112,6 +112,12 @@ describe("toOfflineContributionRequest — unknown_offline mode", () => {
       (request as Record<string, unknown>).anonymousToRecipient,
     ).toBeUndefined();
   });
+
+  it("does not silently coerce a stale payer-identifying method to cash", () => {
+    expect(() =>
+      toOfflineContributionRequest(unknownValues({ method: "check" })),
+    ).toThrow(/cash or other/i);
+  });
 });
 
 describe("designation mapping", () => {
@@ -169,6 +175,17 @@ describe("offlineGiftFormSchema — inline UX validation", () => {
       knownValues({ lastName: "" }),
     );
     expect(result.success).toBe(false);
+  });
+
+  it("rejects a malformed optional email before the submit round-trip", () => {
+    const result = offlineGiftFormSchema.safeParse(
+      knownValues({ email: "not-an-email" }),
+    );
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected invalid email");
+    expect(result.error.issues.some((issue) => issue.path[0] === "email")).toBe(
+      true,
+    );
   });
 
   it("rejects a known existing-donor gift with no donor selected", () => {

--- a/tests/unit/apps/admin/app/offline-gift-route.test.ts
+++ b/tests/unit/apps/admin/app/offline-gift-route.test.ts
@@ -58,10 +58,10 @@ const ctxBase = () => ({
 function okDepsFactory() {
   return () => ({
     resolveKnownDonor: vi.fn().mockResolvedValue({ donorId: "donor-1" }),
-    insertContribution: vi
-      .fn()
-      .mockResolvedValue({ contributionId: "contrib-1" }),
-    appendAudit: vi.fn().mockResolvedValue({ auditEventId: "audit-1" }),
+    recordContributionWithAudit: vi.fn().mockResolvedValue({
+      contributionId: "contrib-1",
+      auditEventId: "audit-1",
+    }),
   });
 }
 


### PR DESCRIPTION
Follow-up to #540. The PR branch was merged and deleted while I was pushing the review hardening commit, but the merged code still had the review findings in the offline gift entry path.

This PR applies the focused hardening patch on top of the #540 merge commit:

- hide the unbound offline gift entry UI behind persistence + finance gates
- make offline contribution persistence dependency atomic for row + audit
- validate received dates and use Zod 4 `z.email()` composition
- validate dialog response payloads, abort stale submits, and use toggle-button semantics
- add focused unit coverage for the review findings

## Deploy Checklist (for PRs to `production` or `develop`)

- [ ] CI passes
- [x] Base branch confirmed: `develop` = development, `production` = production release,
      `main` = retired/inactive
- [x] `bun run verify:deployment-discipline` passes if deployment controls changed (N/A)
- [x] Migrations reviewed (or N/A)
- [x] Migrations tested on development (or N/A)
- [x] New env vars added to all 3 Vercel projects (or N/A)
- [x] Rollback plan reviewed
- [x] Production release will use `bun run release:production` (or N/A)
- [x] Post-deploy smoke tests planned

Local validation:

- `bunx vitest run packages/api/tests/unit/contributions-offline-schema.test.ts packages/api/tests/unit/contributions-offline-entry.test.ts tests/unit/apps/admin/app/offline-gift-form-model.test.ts tests/unit/apps/admin/app/offline-gift-entry-dialog.test.tsx tests/unit/apps/admin/app/offline-gift-route.test.ts tests/unit/apps/admin/app/contributions-main-body.test.tsx --no-file-parallelism`
- `bunx prettier --check <touched files>`
- `bun run verify:workspace-contract`
- `bunx eslint <touched source files>`
- `bun run --cwd packages/api typecheck`
- `bun run --cwd apps/admin typecheck`
- `bun run build:admin`
- `node scripts/verify/bun-version.mjs; bunx vitest run --coverage --maxWorkers=50% --testTimeout=30000 --no-file-parallelism --exclude tests/unit/scripts/bun-version.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the offline gift entry path. The main changes are:

- Hides the offline gift entry UI behind persistence and finance gates.
- Makes offline contribution persistence require one atomic row-plus-audit dependency.
- Tightens offline contribution schema validation for received dates and email composition.
- Validates dialog response payloads and aborts stale or closed submits.
- Updates focused unit tests for the hardened offline gift entry behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changed paths are narrowly scoped to gating, validation, dependency contracts, and tests. The offline persistence UI remains disabled until the real database binding lands, and server-side finance authorization remains enforced on the route.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the offline contributions focused Vitest log to confirm the foreground test run started with a command, captured timestamps, and a Vitest summary, and ended with EXIT\_CODE: 0.
- Confirmed that the run did not involve Docker, an external database, broad lint or type checks, a full coverage suite, or an admin build.

<a href="https://app.greptile.com/trex/runs/13634756/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/admin/app/contributions/main-body.tsx | Adds the persistence and finance gates around the offline gift entry action while leaving export available. |
| apps/admin/app/contributions/offline-gift/offline-gift-entry-dialog.tsx | Hardens submit handling with aborts, timeouts, response schema validation, and corrected toggle-button semantics. |
| apps/admin/app/contributions/offline-gift/offline-gift-form-model.ts | Adds client-side email validation and prevents stale unknown-gift method coercion for payer-identifying methods. |
| apps/admin/app/contributions/page.tsx | Adds server-side auth context resolution and finance permission derivation before rendering the client page. |
| packages/api/src/admin/contributions/offline-entry.ts | Replaces split insert/audit dependencies with one atomic recordContributionWithAudit dependency while preserving orchestration invariants. |
| packages/api/src/schemas/contributions-offline.ts | Uses Zod 4 email composition and validates receivedDate as a real ISO date or offset timestamp. |
| tests/unit/apps/admin/app/contributions-page-auth.test.tsx | Adds auth-gate coverage for threading finance permission into the contributions page client. |
| tests/unit/apps/admin/app/offline-gift-entry-dialog.test.tsx | Adds dialog coverage for successful submit, malformed payloads, route errors, abort-on-close, and toggle semantics. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Staff as Finance staff
  participant Page as Contributions page
  participant Dialog as OfflineGiftEntryDialog
  participant Route as POST /api/admin/contributions/offline
  participant Service as recordOfflineContribution
  participant Deps as recordContributionWithAudit

  Page->>Page: Resolve auth + finance permission
  Page->>Dialog: Render only if persistence flag and finance gate pass
  Staff->>Dialog: Submit offline gift
  Dialog->>Dialog: Validate form + abort stale submit
  Dialog->>Route: POST validated request payload
  Route->>Route: Assert finance permission + parse schema
  Route->>Service: Orchestrate offline contribution
  Service->>Deps: Persist row + audit atomically
  Deps-->>Service: contributionId + auditEventId
  Service-->>Route: Recorded result
  Route-->>Dialog: JSON result
  Dialog->>Page: onRecorded invalidates contributions query
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Staff as Finance staff
  participant Page as Contributions page
  participant Dialog as OfflineGiftEntryDialog
  participant Route as POST /api/admin/contributions/offline
  participant Service as recordOfflineContribution
  participant Deps as recordContributionWithAudit

  Page->>Page: Resolve auth + finance permission
  Page->>Dialog: Render only if persistence flag and finance gate pass
  Staff->>Dialog: Submit offline gift
  Dialog->>Dialog: Validate form + abort stale submit
  Dialog->>Route: POST validated request payload
  Route->>Route: Assert finance permission + parse schema
  Route->>Service: Orchestrate offline contribution
  Service->>Deps: Persist row + audit atomically
  Deps-->>Service: contributionId + auditEventId
  Service-->>Route: Recorded result
  Route-->>Dialog: JSON result
  Dialog->>Page: onRecorded invalidates contributions query
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["chore(pr-loop): sync PR with develop"](https://github.com/asymmetric-al/core/commit/fae7e9332b373095e6264320ea44660a4a8a78fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42504057)</sub>

<!-- /greptile_comment -->