### PR TITLE
fix checkout confirmation finality for non-ACH rails

### DIFF
--- a/packages/lib/payments/checkout-confirmation.ts
+++ b/packages/lib/payments/checkout-confirmation.ts
@@ -86,9 +86,9 @@ export interface CheckoutOutcome {
   isSuccess: boolean;
   /**
    * True when the checkout may advance to its confirmation screen: a collected
-   * gift (`completed`) OR an honestly-pending rail (`processing`, e.g. ACH). It
-   * is NEVER true for requires_action / failed — the donor stays on the payment
-   * step to finish or retry.
+   * gift (`completed`) OR a delayed-notification ACH payment that Stripe has
+   * accepted into `processing`. Card, wallet, and `requires_capture` statuses
+   * stay on the payment step until Stripe reports final collection.
    */
   showConfirmation: boolean;
   /** Truthful donor/staff copy for the state (calm, rail-aware). */
@@ -111,6 +111,8 @@ export function decideCheckoutOutcome({
   });
   const description = describeDonationPaymentStatus({ state, rail, audience });
   const isSuccess = state === "completed";
-  const showConfirmation = state === "completed" || state === "processing";
+  const canShowDelayedRailConfirmation =
+    paymentIntentStatus === "processing" && rail === "ach_debit";
+  const showConfirmation = isSuccess || canShowDelayedRailConfirmation;
   return { state, isSuccess, showConfirmation, description };
 }

--- a/tests/unit/packages/lib/checkout-confirmation.test.ts
+++ b/tests/unit/packages/lib/checkout-confirmation.test.ts
@@ -80,8 +80,8 @@ describe("decideCheckoutOutcome (server truth only)", () => {
     expect(outcome.description.label).toBe("Processing");
   });
 
-  it("does NOT show confirmation for non-final card or wallet processing states", () => {
-    for (const rail of ["card", "wallet"] as const) {
+  it("does NOT show confirmation for non-final non-ACH processing states", () => {
+    for (const rail of ["card", "wallet", "instant_bank", "unknown"] as const) {
       const outcome = decideCheckoutOutcome({
         paymentIntentStatus: "processing",
         rail,

--- a/tests/unit/packages/lib/checkout-confirmation.test.ts
+++ b/tests/unit/packages/lib/checkout-confirmation.test.ts
@@ -80,6 +80,32 @@ describe("decideCheckoutOutcome (server truth only)", () => {
     expect(outcome.description.label).toBe("Processing");
   });
 
+  it("does NOT show confirmation for non-final card or wallet processing states", () => {
+    for (const rail of ["card", "wallet"] as const) {
+      const outcome = decideCheckoutOutcome({
+        paymentIntentStatus: "processing",
+        rail,
+      });
+
+      expect(outcome.state).toBe("processing");
+      expect(outcome.isSuccess).toBe(false);
+      expect(outcome.showConfirmation).toBe(false);
+    }
+  });
+
+  it("does NOT show confirmation for requires_capture authorizations", () => {
+    for (const rail of ["card", "wallet", "ach_debit", "unknown"] as const) {
+      const outcome = decideCheckoutOutcome({
+        paymentIntentStatus: "requires_capture",
+        rail,
+      });
+
+      expect(outcome.state).toBe("processing");
+      expect(outcome.isSuccess).toBe(false);
+      expect(outcome.showConfirmation).toBe(false);
+    }
+  });
+
   it("does NOT show success/confirmation when action is still required", () => {
     const outcome = decideCheckoutOutcome({
       paymentIntentStatus: "requires_action",

--- a/tests/unit/packages/lib/confirm-checkout-payment.test.ts
+++ b/tests/unit/packages/lib/confirm-checkout-payment.test.ts
@@ -52,6 +52,18 @@ describe("confirmCheckoutPayment", () => {
     expect(result.outcome.state).toBe("processing");
   });
 
+  it("keeps non-final card processing on the payment step", async () => {
+    const transport = vi
+      .fn()
+      .mockResolvedValue({ paymentIntentStatus: "processing" });
+    const result = await confirmCheckoutPayment(baseRequest, { transport });
+
+    expect(result.ok).toBe(false);
+    expect(result.outcome.isSuccess).toBe(false);
+    expect(result.outcome.showConfirmation).toBe(false);
+    expect(result.outcome.state).toBe("processing");
+  });
+
   it("never fabricates success when the transport reports a non-succeeded status", async () => {
     const transport = vi
       .fn()


### PR DESCRIPTION
## Summary

Fixes the post-merge PR #549 checkout-confirmation finding: card, wallet, instant-bank, unknown, and `requires_capture` non-final PaymentIntent states no longer advance to the donor confirmation screen. ACH `processing` remains allowed because it is the delayed-notification rail this contract intentionally supports.

## Deploy Checklist (for PRs to `production` or `develop`)

- [x] CI passes locally for focused scope; GitHub CI pending on this PR
- [x] Base branch confirmed: `develop` = development, `production` = production release, `main` = retired/inactive
- [x] `bun run verify:deployment-discipline` passes if deployment controls changed: N/A, no deployment controls changed
- [x] Migrations reviewed (or N/A): N/A
- [x] Migrations tested on development (or N/A): N/A
- [x] New env vars added to all 3 Vercel projects (or N/A): N/A
- [x] Rollback plan reviewed: revert this PR
- [x] Production release will use `bun run release:production` (or N/A): N/A
- [x] Post-deploy smoke tests planned: covered by CI smoke gate for develop PRs

## Validation

- `bunx vitest run tests/unit/packages/lib/checkout-confirmation.test.ts tests/unit/packages/lib/confirm-checkout-payment.test.ts tests/unit/packages/lib/payment-status-language.test.ts`
- `bunx turbo run lint typecheck --filter=@asym/lib`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens checkout confirmation rules for non-final Stripe PaymentIntent states. The main changes are:

- Non-ACH `processing` payments stay on the payment step.
- `requires_capture` authorizations stay off the confirmation screen for all rails.
- ACH `processing` still shows the delayed-rail confirmation.
- Unit tests cover the updated checkout outcome and orchestration behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge with minimal risk.

The change is small, localized to checkout outcome decisions, and matches the stated payment finality contract. Tests cover the newly restricted non-final states and the orchestration path.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a Vitest validation for checkout\_confirmation\_validation and verified test results with exit code 0 in the log.
- T-Rex ran Turbo lint/typecheck for checkout\_confirmation\_validation and verified task status and exit code 0 in the log.

<a href="https://app.greptile.com/trex/runs/13633394/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/lib/payments/checkout-confirmation.ts | Tightens checkout confirmation gating so only succeeded payments or ACH `processing` can advance to confirmation; no material issues found. |
| tests/unit/packages/lib/checkout-confirmation.test.ts | Adds coverage for non-ACH `processing` and `requires_capture` states staying off the confirmation path; no material issues found. |
| tests/unit/packages/lib/confirm-checkout-payment.test.ts | Adds orchestration coverage ensuring card `processing` returns `ok: false`; no material issues found. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Checkout client
participant Orchestrator as confirmCheckoutPayment
participant Server as Payment transport
participant Decision as decideCheckoutOutcome

Client->>Orchestrator: Submit checkout request with rail
Orchestrator->>Server: transport(request)
Server-->>Orchestrator: PaymentIntent status
Orchestrator->>Decision: status + rail
alt status is succeeded
    Decision-->>Orchestrator: "showConfirmation=true, isSuccess=true"
else status is processing and rail is ach_debit
    Decision-->>Orchestrator: "showConfirmation=true, isSuccess=false"
else non-final card/wallet/instant_bank/unknown or requires_capture
    Decision-->>Orchestrator: "showConfirmation=false, isSuccess=false"
end
Orchestrator-->>Client: ok mirrors showConfirmation
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Checkout client
participant Orchestrator as confirmCheckoutPayment
participant Server as Payment transport
participant Decision as decideCheckoutOutcome

Client->>Orchestrator: Submit checkout request with rail
Orchestrator->>Server: transport(request)
Server-->>Orchestrator: PaymentIntent status
Orchestrator->>Decision: status + rail
alt status is succeeded
    Decision-->>Orchestrator: "showConfirmation=true, isSuccess=true"
else status is processing and rail is ach_debit
    Decision-->>Orchestrator: "showConfirmation=true, isSuccess=false"
else non-final card/wallet/instant_bank/unknown or requires_capture
    Decision-->>Orchestrator: "showConfirmation=false, isSuccess=false"
end
Orchestrator-->>Client: ok mirrors showConfirmation
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;develop&#39; into codex/pr549-..."](https://github.com/asymmetric-al/core/commit/6a0a97f1c8c6b46a3d3bf3aae69e5b8d6ed43db7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42584731)</sub>

<!-- /greptile_comment -->