### PR TITLE
fix(auth): enforce E2E bypass guard semantics

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -276,13 +276,16 @@ jobs:
       # Required secrets for the datasource-bound bypass against the hosted demo project:
       #   E2E_AUTH_SECRET                 — HMAC signing key shared by producer + verifiers
       #   E2E_AUTH_ALLOWED_SUPABASE_REFS  — project ref of the demo Supabase project (never prod)
+      # If either bypass binding secret is unavailable, fall back to the
+      # non-confidential placeholder datasource so the informational full E2E job
+      # still exercises demo auth instead of failing with all roles disabled.
       E2E_AUTH_SECRET: ${{ secrets.E2E_AUTH_SECRET }}
       E2E_AUTH_ALLOWED_SUPABASE_REFS: ${{ secrets.E2E_AUTH_ALLOWED_SUPABASE_REFS }}
       PLAYWRIGHT_ADMIN_BASE_URL: "http://127.0.0.1:3030"
       PLAYWRIGHT_INCLUDE_ADMIN: "1"
       PLAYWRIGHT_REUSE_EXISTING_SERVER: "1"
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_AUTH_SECRET && secrets.E2E_AUTH_ALLOWED_SUPABASE_REFS && secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_AUTH_SECRET && secrets.E2E_AUTH_ALLOWED_SUPABASE_REFS && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'example-anon-key' }}
       DEMO_PASSWORD: ${{ secrets.DEMO_PASSWORD }}
       DEMO_ADMIN_EMAIL: ${{ secrets.DEMO_ADMIN_EMAIL }}
       DEMO_MISSIONARY_EMAIL: ${{ secrets.DEMO_MISSIONARY_EMAIL }}

--- a/packages/auth/e2e-auth.edge.test.ts
+++ b/packages/auth/e2e-auth.edge.test.ts
@@ -191,7 +191,7 @@ describe("parseE2EAuthCookieValue", () => {
   });
 
   it("rejects a token signed with a different secret", async () => {
-    process.env.E2E_AUTH_SECRET = "attacker-secret";
+    process.env.E2E_AUTH_SECRET = "attacker-secret-key";
     const forged = await createE2EAuthCookieValue({
       userId: "u1",
       role: "super_admin",

--- a/packages/auth/e2e-auth.ts
+++ b/packages/auth/e2e-auth.ts
@@ -64,6 +64,7 @@ export function getE2EAuthCookieNameForProxyHost(
   return null;
 }
 const E2E_AUTH_BYPASS_VALUES = new Set(["1", "true"]);
+const E2E_AUTH_MIN_SECRET_LENGTH = 16;
 const USER_ROLES: readonly UserRole[] = [
   "donor",
   "missionary",
@@ -133,7 +134,9 @@ const E2E_AUTH_DEV_FALLBACK_SECRET =
  */
 function getE2EAuthSecret(): string | null {
   const explicit = process.env.E2E_AUTH_SECRET?.trim();
-  if (explicit) return explicit;
+  if (explicit) {
+    return explicit.length >= E2E_AUTH_MIN_SECRET_LENGTH ? explicit : null;
+  }
   if (isNonConfidentialE2EDatasource(process.env.NEXT_PUBLIC_SUPABASE_URL)) {
     return E2E_AUTH_DEV_FALLBACK_SECRET;
   }

--- a/packages/auth/e2e-auth.ts
+++ b/packages/auth/e2e-auth.ts
@@ -1,3 +1,5 @@
+import { E2E_AUTH_MIN_SECRET_LENGTH } from "@asym/env/e2e-auth";
+
 import type { UserRole } from "@asym/database/types";
 
 /** @deprecated Prefer surface-specific names; kept for grep/docs compatibility */
@@ -64,7 +66,6 @@ export function getE2EAuthCookieNameForProxyHost(
   return null;
 }
 const E2E_AUTH_BYPASS_VALUES = new Set(["1", "true"]);
-const E2E_AUTH_MIN_SECRET_LENGTH = 16;
 const USER_ROLES: readonly UserRole[] = [
   "donor",
   "missionary",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./index.ts",
+    "./e2e-auth": "./src/e2e-auth.ts",
     "./target-env": "./src/target-env.ts"
   },
   "scripts": {

--- a/packages/env/src/e2e-auth.ts
+++ b/packages/env/src/e2e-auth.ts
@@ -1,0 +1,1 @@
+export const E2E_AUTH_MIN_SECRET_LENGTH = 16;

--- a/packages/env/src/schema.ts
+++ b/packages/env/src/schema.ts
@@ -1,6 +1,7 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+import { E2E_AUTH_MIN_SECRET_LENGTH } from "./e2e-auth";
 import {
   isProtectedDeployment,
   resolveDeploymentEnvironment,
@@ -207,7 +208,10 @@ export const env = createEnv({
     /** HMAC secret used to sign/verify E2E bypass cookies. Non-production only. */
     E2E_AUTH_SECRET: z
       .string()
-      .min(16, "E2E_AUTH_SECRET must be at least 16 characters")
+      .min(
+        E2E_AUTH_MIN_SECRET_LENGTH,
+        "E2E_AUTH_SECRET must be at least 16 characters",
+      )
       .optional(),
     /**
      * Comma-separated Supabase project refs (or datasource hostnames) that the

--- a/packages/env/src/schema.ts
+++ b/packages/env/src/schema.ts
@@ -86,6 +86,10 @@ const requireCloudinaryWhenEnabled = (variableName: string) =>
       }
     });
 
+const skipEnvValidation =
+  process.env.SKIP_ENV_VALIDATION === "1" ||
+  process.env.SKIP_ENV_VALIDATION === "true";
+
 const resendApiKeySchema = requireInProtectedDeployments(
   "RESEND_API_KEY",
 ).refine(
@@ -437,14 +441,12 @@ export const env = createEnv({
       process.env.NEXT_PUBLIC_VIEW_TRANSITIONS_ENABLED,
     NEXT_PUBLIC_DONOR_URL: process.env.NEXT_PUBLIC_DONOR_URL,
   },
-  skipValidation:
-    process.env.SKIP_ENV_VALIDATION === "1" ||
-    process.env.SKIP_ENV_VALIDATION === "true",
+  skipValidation: skipEnvValidation,
   emptyStringAsUndefined: true,
 });
 
 if (
-  !process.env.SKIP_ENV_VALIDATION &&
+  !skipEnvValidation &&
   !env.NEXT_PUBLIC_SUPABASE_ANON_KEY &&
   !env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 ) {
@@ -459,7 +461,7 @@ if (
 // targets report NODE_ENV !== "production", so gate on deployment identity here too.
 const e2eAuthBypassRaw = process.env.E2E_AUTH_BYPASS?.trim().toLowerCase();
 if (
-  !process.env.SKIP_ENV_VALIDATION &&
+  !skipEnvValidation &&
   isProtectedRuntimeDeployment &&
   (e2eAuthBypassRaw === "true" || e2eAuthBypassRaw === "1")
 ) {

--- a/tests/e2e/base-urls.ts
+++ b/tests/e2e/base-urls.ts
@@ -14,9 +14,10 @@ export const adminBaseURL =
   `http://localhost:${adminPort}`;
 
 /**
- * Next dev responds to `/_next/static/` with redirects (308) in some setups, which
- * breaks Playwright `webServer` readiness. A stable app route is more reliable.
+ * Next dev responds to `/_next/static/` with redirects (308) in some setups,
+ * and page routes can trigger cold compiles after CI has already started the
+ * app. The health endpoint is the same readiness signal CI waits on directly.
  */
 export function nextDevReadyURL(base: string): string {
-  return `${base.replace(/\/$/, "")}/login`;
+  return `${base.replace(/\/$/, "")}/api/health`;
 }

--- a/tests/unit/auth/e2e-auth.test.ts
+++ b/tests/unit/auth/e2e-auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   createE2EAuthCookieValue,
+  hasE2EAuthSecret,
   isE2EAuthBypassEnabled,
   parseE2EAuthCookieValue,
 } from "../../../packages/auth/e2e-auth";
@@ -13,6 +14,7 @@ import {
 const originalBypass = process.env.E2E_AUTH_BYPASS;
 const originalNodeEnv = process.env.NODE_ENV;
 const originalSecret = process.env.E2E_AUTH_SECRET;
+const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 
 describe("e2e auth helpers", () => {
   beforeEach(() => {
@@ -26,6 +28,11 @@ describe("e2e auth helpers", () => {
       delete process.env.E2E_AUTH_SECRET;
     } else {
       process.env.E2E_AUTH_SECRET = originalSecret;
+    }
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
     }
   });
 
@@ -64,5 +71,20 @@ describe("e2e auth helpers", () => {
 
     process.env.NODE_ENV = "production";
     expect(isE2EAuthBypassEnabled()).toBe(false);
+  });
+
+  it("rejects explicit E2E auth secrets shorter than the signing key floor", async () => {
+    process.env.E2E_AUTH_SECRET = "too-short";
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://realproj12345.supabase.co";
+
+    expect(hasE2EAuthSecret()).toBe(false);
+    await expect(
+      createE2EAuthCookieValue({
+        userId: "e2e-donor-user",
+        role: "donor",
+        tenantId: DEMO_TENANT_ID,
+        profileId: DEMO_PROFILE_ID,
+      }),
+    ).rejects.toThrow(/E2E_AUTH_SECRET/);
   });
 });

--- a/tests/unit/packages/env/schema.test.ts
+++ b/tests/unit/packages/env/schema.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalEnv = { ...process.env };
+
+function withProtectedDeploymentEnv() {
+  process.env = {
+    ...originalEnv,
+    NODE_ENV: "development",
+    VERCEL_ENV: "preview",
+    VERCEL_TARGET_ENV: "core-development",
+    SKIP_ENV_VALIDATION: "false",
+    NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-anon-key",
+    SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+    STRIPE_SECRET_KEY: "sk_test_123",
+    STRIPE_WEBHOOK_SECRET: "whsec_test_123",
+    INNGEST_EVENT_KEY: "test-event-key",
+    INNGEST_SIGNING_KEY: "signkey-test",
+    RESEND_API_KEY: "re_test_123",
+    RESEND_WEBHOOK_SECRET: "whsec_test_123",
+    RESEND_ENCRYPTION_KEY: "12345678901234567890123456789012",
+    SENTRY_DSN: "https://public@example.com/1",
+    E2E_AUTH_BYPASS: "true",
+  };
+}
+
+describe("env schema", () => {
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it("does not treat false-like SKIP_ENV_VALIDATION values as skipping protected E2E bypass guards", async () => {
+    withProtectedDeploymentEnv();
+    vi.resetModules();
+
+    await expect(import("../../../../packages/env/src/schema")).rejects.toThrow(
+      "E2E_AUTH_BYPASS must not be enabled",
+    );
+  });
+});

--- a/tests/unit/playwright-config.test.ts
+++ b/tests/unit/playwright-config.test.ts
@@ -3,6 +3,7 @@ import {
   getDefaultProjectTestIgnore,
   shouldReuseExistingServer,
 } from "../../playwright.config";
+import { nextDevReadyURL } from "../e2e/base-urls";
 
 describe("shouldReuseExistingServer", () => {
   it("defaults to reusing an existing server outside CI", () => {
@@ -72,5 +73,13 @@ describe("getDefaultProjectTestIgnore", () => {
     expect(
       getDefaultProjectTestIgnore({ PLAYWRIGHT_INCLUDE_ADMIN: "1" }),
     ).toEqual(defaultProjectIgnores);
+  });
+});
+
+describe("nextDevReadyURL", () => {
+  it("uses the health endpoint for web server readiness", () => {
+    expect(nextDevReadyURL("http://localhost:3030/")).toBe(
+      "http://localhost:3030/api/health",
+    );
   });
 });

--- a/tests/unit/scripts/ci-integration-workflow.contract.test.ts
+++ b/tests/unit/scripts/ci-integration-workflow.contract.test.ts
@@ -83,6 +83,11 @@ describe("ci-integration workflow contract", () => {
     expect(testE2e).toContain("continue-on-error:");
     expect(testE2e).toContain("github.base_ref == 'develop'");
     expect(testE2e).toContain("refs/heads/develop");
+    expect(testE2e).toContain(
+      "secrets.E2E_AUTH_SECRET && secrets.E2E_AUTH_ALLOWED_SUPABASE_REFS",
+    );
+    expect(testE2e).toContain("https://example.supabase.co");
+    expect(testE2e).toContain("example-anon-key");
 
     expect(integrationGate).toContain(
       "needs: [migrate, smoke, e2e-smoke-gate]",


### PR DESCRIPTION
Follow-up to #688. PR 688 was merged at `6097bcea` before the final review-finding fixes could land on the base branch.

This PR carries the post-merge fix commit already pushed to the original PR branch:

- Treat only `SKIP_ENV_VALIDATION=1` or `true` as validation skip so protected deployment guards still run for false-like values.
- Enforce the 16-character minimum at `getE2EAuthSecret()` so edge-safe direct env reads cannot accept a short explicit signing secret.
- Add regression coverage for both review findings.

Local verification run by the normal pre-push hook:

- `prettier . --check`
- `bun run skills:verify`
- `bun run lint`
- `bun run verify:data-boundary`
- `bun run verify:workspace-contract`
- `bun run verify:eslint`
- `bun run verify:shadcn-config`
- `bun run verify:shadcn-diff`
- `bun run typecheck`
- `bun run build`
- `bun run test:unit`

## Deploy Checklist

- [x] CI: required GitHub checks are green (`ci-gate`, `e2e-smoke-gate`, `smoke`, `migrate`).
- [x] Branch: `claude/e2e-auth-bypass-hardening-d22` is current with `develop` and mergeable.
- [x] Deployment discipline: no production deploy or release command required for this PR.
- [x] Migrations: no schema migration changes; existing migration checks passed.
- [x] Env vars: no new required env vars; full E2E now falls back to placeholder Supabase values when hosted bypass-binding secrets are absent.
- [x] Rollback: revert this PR to restore the previous E2E auth/CI behavior.
- [x] Release command: N/A for this repo PR.
- [x] Smoke tests: GitHub `smoke`, `test-e2e-smoke`, full `test-e2e`, and local focused auth/env tests passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens E2E auth bypass handling and CI test setup. The main changes are:

- Exact `SKIP_ENV_VALIDATION` semantics for protected deployment guards.
- Shared E2E auth secret length floor.
- Direct secret length enforcement in the auth helper.
- Placeholder Supabase values for the informational full E2E workflow.
- Health endpoint readiness for Playwright dev servers.
- Tests for the guard and secret-length regressions.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the auth-env regression with Vitest, recording the exact command, working directory, and a PASS summary with Exit code 0.
- Reviewed the primary and supplemental logs and verified the Vitest run passed, while the shell wrapper failed with a Bad substitution error, not due to test failures.

<a href="https://app.greptile.com/trex/runs/13791996/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/auth/e2e-auth.ts | Enforces the shared minimum length before accepting an explicit E2E signing secret. |
| packages/env/src/schema.ts | Uses exact skip-validation values and keeps protected deployment bypass checks active for false-like values. |
| packages/env/src/e2e-auth.ts | Adds the shared E2E auth secret length constant. |
| packages/env/package.json | Exports the new E2E auth constant through a direct subpath. |
| .github/workflows/ci-integration.yml | Adds placeholder Supabase public values when full E2E bypass-binding secrets are unavailable. |
| tests/e2e/base-urls.ts | Uses `/api/health` as the Playwright dev-server readiness URL. |
| tests/unit/auth/e2e-auth.test.ts | Covers rejection of short explicit E2E auth secrets. |
| tests/unit/packages/env/schema.test.ts | Covers false-like skip-validation values in protected deployment bypass checks. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;develop&#39; into claude/e2e-a..."](https://github.com/asymmetric-al/core/commit/ae6b9523fb584b18d364239bf57567abb61bf518) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42847481)</sub>

<!-- /greptile_comment -->