### PR TITLE
docs(statement-studio): complete AL-312 phase 0 audit

### DIFF
--- a/docs/guides/features/statement-studio/README.md
+++ b/docs/guides/features/statement-studio/README.md
@@ -1,14 +1,14 @@
 # Statement Studio
 
-Statement Studio is the planned rebuild of PDF Studio as a fully usable staff-facing Mission Control product for building, assigning, rendering, and managing tenant-safe PDFs and statements.
+Statement Studio is the planned replacement for PDF Studio: a fully usable staff-facing Mission Control product for building, assigning, rendering, and managing tenant-safe PDFs and statements.
 
-It must not be built on Unlayer, and it must not be an email editor pretending to make PDFs. New work should use the custom Statement Studio product model, with pdfx and React PDF used as deeply as makes sense.
+It must not be built on Unlayer, and it must not be an email editor pretending to make PDFs. New work uses the custom Statement Studio product model and an Asym-owned template schema.
 
-**Render stack:** Target production path is pdfx + React PDF on an Asym-owned
-template schema. Phase 0 (#312) reconciles this with the in-flight native PDF
-Studio + DocRaptor stack (`docs/guides/features/pdf-studio.md`) and records a
-single cutover decision—no dual production render stacks without an explicit
-migration plan.
+**Phase 0 proposal (pending HITL merge):** Qualify the current server-side
+DocRaptor adapter, then use it as the sole first-slice provider behind a
+provider-neutral port. The repo has no pdfx or React PDF runtime path, so adding
+either now would create a second greenfield stack. See
+`phase-0-audit-brief.md` for the qualification and migration gates.
 
 ## Triggers
 
@@ -22,16 +22,25 @@ Use this documentation when planning or implementing:
 ## Workflow Steps
 
 1. Read this `README.md`.
-2. Read `phase-0-audit-brief.md` before implementation.
+2. Read the completed `phase-0-audit-brief.md`, its evidence appendix, and the
+   `add-statement-studio` OpenSpec change before implementation.
 3. Load `docs/ai/skills/supabase/SKILL.md`, `docs/ai/rules/backend.md`, and `supabase/AGENTS.md` before any Supabase/database work.
 4. Load `docs/ai/skills/supabase-postgres-best-practices/SKILL.md` for schema, RLS, indexes, query, or migration work.
 5. Load `docs/ai/rules/frontend.md` before UI work.
 6. Keep UI on shared `@asym/ui` components and Maia/Zinc design tokens.
-7. Implement in vertical slices, starting with `donor.statement.annual_giving` unless Phase 0 finds a stronger first slice.
+7. Start with the safe sample-data/admin tracer defined by Phase 0. Keep
+   `donor.statement.annual_giving` as the first donor-facing production job only
+   after its canonical statement snapshot/version and finance/legal gates are
+   complete.
 
 ## Documentation Map
 
-- `phase-0-audit-brief.md` - required implementation audit output.
+- `phase-0-audit-brief.md` - completed research, proposed Phase 0 decisions, and
+  implementation gates.
+- `phase-0-research-evidence.md` - primary-source runtime, schema, migration,
+  Storage, and test evidence behind the audit.
+- `openspec/changes/add-statement-studio/` - proposed durable product and
+  boundary contract.
 - `handoff.md` - current PR, issue, skill, and next-agent handoff context.
 - `prd.md` - issue-source PRD covering scope, phases, UX, Supabase posture, variables, starter jobs, integrations, and testing.
 - `issues.md` - published vertical-slice map (#310 parent, #312–#364) with archival draft bodies.
@@ -50,6 +59,9 @@ Use this documentation when planning or implementing:
 - User-facing product name: Statement Studio.
 - Existing `/pdf` routes and `pdf_*` internals can migrate pragmatically, but users should not see two competing product names.
 - Persisted templates use an Asym-owned JSON template schema, not JSX, raw pdfx registry JSON, HTML, or direct React props.
+- Pending AL-312 HITL approval, the first production renderer is the qualified
+  server-only DocRaptor adapter behind a provider port; do not run a second
+  official renderer without an explicit migration change.
 - Production renders resolve variables server-side from tenant-scoped DTOs.
 - Generated PDFs are exposed through tenant-aware artifact access, not direct cross-dashboard table reads.
 - Tenant admins control how templates, defaults, variables, retention, and capabilities are used inside platform safety floors.
@@ -58,7 +70,7 @@ Use this documentation when planning or implementing:
 
 Final gate before implementation:
 
-- [ ] Phase 0 audit brief exists.
+- [x] Phase 0 audit brief and evidence exist.
 - [ ] UX/IA uses shared design tokens and components.
 - [ ] Supabase/backend rules were loaded for database work.
 - [ ] RLS, grants, Storage, indexes, and tenant boundaries are explicit.

--- a/docs/guides/features/statement-studio/README.md
+++ b/docs/guides/features/statement-studio/README.md
@@ -4,11 +4,11 @@ Statement Studio is the planned replacement for PDF Studio: a fully usable staff
 
 It must not be built on Unlayer, and it must not be an email editor pretending to make PDFs. New work uses the custom Statement Studio product model and an Asym-owned template schema.
 
-**Phase 0 proposal (pending HITL merge):** Qualify the current server-side
-DocRaptor adapter, then use it as the sole first-slice provider behind a
-provider-neutral port. The repo has no pdfx or React PDF runtime path, so adding
-either now would create a second greenfield stack. See
-`phase-0-audit-brief.md` for the qualification and migration gates.
+**Phase 0 decision:** Use the current server-side DocRaptor adapter as the
+first-slice provider candidate behind a provider-neutral port. Production use
+still requires provider qualification and HITL approval. The repo has no pdfx or
+React PDF runtime path, so adding either now would create a second greenfield
+stack. See `phase-0-audit-brief.md` for the qualification and migration gates.
 
 ## Triggers
 
@@ -35,7 +35,7 @@ Use this documentation when planning or implementing:
 
 ## Documentation Map
 
-- `phase-0-audit-brief.md` - completed research, proposed Phase 0 decisions, and
+- `phase-0-audit-brief.md` - completed research, Phase 0 decisions, and
   implementation gates.
 - `phase-0-research-evidence.md` - primary-source runtime, schema, migration,
   Storage, and test evidence behind the audit.
@@ -59,9 +59,10 @@ Use this documentation when planning or implementing:
 - User-facing product name: Statement Studio.
 - Existing `/pdf` routes and `pdf_*` internals can migrate pragmatically, but users should not see two competing product names.
 - Persisted templates use an Asym-owned JSON template schema, not JSX, raw pdfx registry JSON, HTML, or direct React props.
-- Pending AL-312 HITL approval, the first production renderer is the qualified
-  server-only DocRaptor adapter behind a provider port; do not run a second
-  official renderer without an explicit migration change.
+- The first production renderer candidate is the server-only DocRaptor adapter
+  behind a provider port. Enable it only after provider qualification and HITL
+  approval; do not run a second official renderer without an explicit migration
+  change.
 - Production renders resolve variables server-side from tenant-scoped DTOs.
 - Generated PDFs are exposed through tenant-aware artifact access, not direct cross-dashboard table reads.
 - Tenant admins control how templates, defaults, variables, retention, and capabilities are used inside platform safety floors.

--- a/docs/guides/features/statement-studio/data-model.md
+++ b/docs/guides/features/statement-studio/data-model.md
@@ -16,28 +16,29 @@ Use this doc when planning or changing Statement Studio tables, migrations, RLS,
 6. Add explicit grants and RLS together in migrations.
 7. Run focused SQL/type/route verification.
 
-## Canonical Persistence (Phase 0 decision)
+## Canonical Persistence (Phase 0 proposal pending HITL merge)
 
-**Phase 0 (#312) must name one canonical Postgres model before SS-01+ ships
-schema.** The repo already has native PDF Studio tables from
+**Phase 0 (#312) proposes one canonical Postgres migration base before SS-01+
+ships schema.** The repo already has native PDF Studio tables from
 `supabase/migrations/20260515140948_native_pdf_studio_foundation.sql`:
 
 - `pdf_templates`, `pdf_template_versions`, `pdf_template_renders`,
   `pdf_template_artifacts` (and related native PDF Studio tables).
 
-**Default posture:** extend and rename these `pdf_*` tables rather than
-introducing parallel `document_*` tables. The `document_*` names below are
-**conceptual** labels for product language and gap analysis only. Phase 0
-output must map each concept to an existing table, a renamed column, a view,
-or an explicitly justified net-new table with a retirement plan for any
-duplicate vocabulary.
+**Proposal:** extend these `pdf_*` tables rather than introducing parallel
+`document_*` tables. Rename an existing table only through an explicit
+migration/cutover. The `document_*` names below are **conceptual** labels for
+product language and gap analysis only. Each concept must map to an existing
+table/column, an intentional extension, or an explicitly justified net-new
+table without duplicating template, version, render, or artifact truth.
 
-**Single store module:** `packages/api` (or the Phase 0–chosen owner) exposes
+**Single store module:** `packages/api` exposes
 one persistence seam; feature slices must not write parallel table families.
 
 ## Core Tables
 
-Recommended model shape (conceptual — map to `pdf_*` in Phase 0):
+Recommended model shape (conceptual - map existing concepts to `pdf_*` and add
+only missing catalog/assignment/variable/retention concepts):
 
 - `document_job_catalog`: system-owned standard document jobs.
 - `document_template_library`: system-owned starter templates and starter versions.
@@ -48,11 +49,17 @@ Recommended model shape (conceptual — map to `pdf_*` in Phase 0):
 - `document_artifacts` (conceptual alias for **`pdf_template_artifacts`** /
   **`pdf_template_renders`** — do not create a second artifact table family):
   generated PDF artifact records shared safely across app surfaces.
-- `document_artifact_events`: audit history for render, download, purge, retention, rollback, and assignment changes.
+- `pdf_template_audit_events`: canonical audit history for render, download,
+  purge, retention, rollback, and assignment changes; do not add a parallel
+  `document_artifact_events` table.
 - `document_variable_catalog`: platform variable definitions.
 - `tenant_document_variables`: tenant labels, grouping, fallbacks, visibility, custom variables, and mappings.
 
-Phase 0 should choose exact table names. User-facing product language is Statement Studio; internal names can migrate pragmatically.
+Phase 0 proposes retaining the existing `pdf_*` names as the canonical
+migration base.
+Foundation work may choose `pdf_*` names for the missing concepts, but it must
+not introduce a second template/version/render/artifact vocabulary or store.
+User-facing product language remains Statement Studio.
 
 ## Defaults
 

--- a/docs/guides/features/statement-studio/data-model.md
+++ b/docs/guides/features/statement-studio/data-model.md
@@ -16,50 +16,51 @@ Use this doc when planning or changing Statement Studio tables, migrations, RLS,
 6. Add explicit grants and RLS together in migrations.
 7. Run focused SQL/type/route verification.
 
-## Canonical Persistence (Phase 0 proposal pending HITL merge)
+## Canonical Persistence (Phase 0 Decision)
 
-**Phase 0 (#312) proposes one canonical Postgres migration base before SS-01+
+**Phase 0 (#312) selects one canonical Postgres migration base before SS-01+
 ships schema.** The repo already has native PDF Studio tables from
 `supabase/migrations/20260515140948_native_pdf_studio_foundation.sql`:
 
 - `pdf_templates`, `pdf_template_versions`, `pdf_template_renders`,
   `pdf_template_artifacts` (and related native PDF Studio tables).
 
-**Proposal:** extend these `pdf_*` tables rather than introducing parallel
-`document_*` tables. Rename an existing table only through an explicit
-migration/cutover. The `document_*` names below are **conceptual** labels for
-product language and gap analysis only. Each concept must map to an existing
-table/column, an intentional extension, or an explicitly justified net-new
-table without duplicating template, version, render, or artifact truth.
+**Decision:** extend these existing `pdf_*` tables rather than introducing a
+parallel `document_*` template/version/render/artifact/audit store. Rename an
+existing table only through an explicit migration/cutover. The missing product
+concepts below do not prescribe SQL identifiers; implementation must map each to
+an existing table/column, an intentional extension, or an explicitly justified
+net-new `pdf_*` table without duplicating truth.
 
 **Single store module:** `packages/api` exposes
 one persistence seam; feature slices must not write parallel table families.
 
-## Core Tables
+## Core Persistence Concepts
 
-Recommended model shape (conceptual - map existing concepts to `pdf_*` and add
-only missing catalog/assignment/variable/retention concepts):
+Phase 0 ratifies these existing table names and roles:
 
-- `document_job_catalog`: system-owned standard document jobs.
-- `document_template_library`: system-owned starter templates and starter versions.
-- `tenant_document_job_settings`: tenant activation, labels, visibility, and capability overrides.
-- `tenant_document_template_assignments`: tenant default mapping for job plus optional scope.
-- `pdf_templates` or future renamed tenant template table: tenant-owned template records.
-- `pdf_template_versions` or future renamed version table: immutable draft/published/archive versions.
-- `document_artifacts` (conceptual alias for **`pdf_template_artifacts`** /
-  **`pdf_template_renders`** — do not create a second artifact table family):
-  generated PDF artifact records shared safely across app surfaces.
-- `pdf_template_audit_events`: canonical audit history for render, download,
-  purge, retention, rollback, and assignment changes; do not add a parallel
-  `document_artifact_events` table.
-- `document_variable_catalog`: platform variable definitions.
-- `tenant_document_variables`: tenant labels, grouping, fallbacks, visibility, custom variables, and mappings.
+| Product concept                | Canonical persistence direction                                                     |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| Tenant template aggregate      | `pdf_templates`                                                                     |
+| Template working/version state | Mutable drafts and immutable published/archive snapshots in `pdf_template_versions` |
+| Render attempts                | `pdf_template_renders`                                                              |
+| Generated artifact metadata    | `pdf_template_artifacts`                                                            |
+| Lifecycle/access/purge audit   | `pdf_template_audit_events`                                                         |
+| Batch orchestration            | `pdf_template_batches` and `pdf_template_batch_jobs`                                |
 
-Phase 0 proposes retaining the existing `pdf_*` names as the canonical
-migration base.
-Foundation work may choose `pdf_*` names for the missing concepts, but it must
-not introduce a second template/version/render/artifact vocabulary or store.
-User-facing product language remains Statement Studio.
+The remaining product concepts are requirements, not approved table names:
+
+- system document-job catalog;
+- system starter-template ownership;
+- tenant job settings and scoped assignments;
+- variable catalog and tenant overrides;
+- retention and storage-threshold policy.
+
+The foundation change must map each missing concept to an extension of the
+existing `pdf_*` family, a column/view, or an explicitly justified net-new
+`pdf_*` table. It must not turn conceptual `document_*` labels into a parallel
+template, version, render, artifact, or audit store. User-facing product
+language remains Statement Studio.
 
 ## Defaults
 

--- a/docs/guides/features/statement-studio/handoff.md
+++ b/docs/guides/features/statement-studio/handoff.md
@@ -25,13 +25,14 @@ path is safe to change.
   2026-07-03.
 - Parent planning issue
   [#310](https://github.com/Asymmetric-al/core/issues/310) closed on 2026-07-09.
-- [#312](https://github.com/Asymmetric-al/core/issues/312) is implemented by
-  the completed audit/evidence and proposed OpenSpec change in this branch; it
-  remains HITL until reviewed and merged.
+- [#312](https://github.com/Asymmetric-al/core/issues/312) is delivered by the
+  completed audit/evidence and proposed OpenSpec change in
+  [PR #715](https://github.com/Asymmetric-al/core/pull/715). Before that PR
+  merges, its decisions remain proposed; merge records the HITL approval.
 - Canonical implementation issues remain #314 through #364, but their original
   dependency graph predates the Phase 0 findings.
 
-## Approved-When-Merged Decisions
+## Phase 0 Decisions
 
 - Product name: Statement Studio; existing `/pdf` and `pdf_*` internals migrate
   pragmatically.
@@ -102,7 +103,8 @@ synthetic fixtures and reference public issue/file paths.
 
 - [x] Phase 0 audit and evidence are complete.
 - [x] Renderer, canonical persistence, first job, and legacy posture are recorded.
-- [ ] AL-312 HITL review/merge approves the proposed decisions.
+- [x] The AL-312 HITL decision package is complete; PR #715 merge records
+      approval of the proposed decisions.
 - [ ] #322 is re-groomed before production statement work.
 - [ ] Hosted migration and legacy-template state are inspected before cutover.
 - [ ] Each implementation slice uses the appropriate repo skills and checks.

--- a/docs/guides/features/statement-studio/handoff.md
+++ b/docs/guides/features/statement-studio/handoff.md
@@ -1,138 +1,108 @@
 # Statement Studio Handoff
 
-Generated: 2026-06-13 Asia/Bangkok
+Updated: 2026-07-10 Asia/Bangkok
 
 ## Triggers
 
-Use this handoff when a fresh agent is picking up Statement Studio planning or
-implementation work from PR #367 and needs the current repo, PR, issue, and
-verification state without rereading the full conversation.
+Use this handoff when picking up Statement Studio after the AL-312 Phase 0
+audit, reviewing a downstream issue, or deciding whether a legacy/native PDF
+path is safe to change.
 
 ## Workflow Steps
 
-1. Open PR [#367](https://github.com/Asymmetric-al/core/pull/367).
-2. Read parent issue
-   [#310](https://github.com/Asymmetric-al/core/issues/310).
-3. Read this directory's `README.md`, `prd.md`, `issues.md`, and
-   `phase-0-audit-brief.md`.
-4. Start implementation from issue
-   [#312](https://github.com/Asymmetric-al/core/issues/312) unless the user
-   gives a newer explicit priority.
-5. Follow the issue dependency graph in `issues.md` and #310.
-6. Use the suggested skills below before touching their domains.
+1. Read `README.md`, `phase-0-audit-brief.md`, and
+   `phase-0-research-evidence.md`.
+2. Read `openspec/changes/add-statement-studio/` before implementation.
+3. Read the relevant PRD/supporting docs and the live GitHub issue.
+4. Treat source-domain contexts, private artifacts, and role-scoped BFF access
+   as gates, not later cleanup.
+5. Load the repo skills/rulebooks for the files being changed.
 
 ## Current State
 
 - Repository: `Asymmetric-al/core`
-- Planning PR: [#367 - Document Statement Studio rebuild plan](https://github.com/Asymmetric-al/core/pull/367) (docs-only; verify mergeability and required CI on GitHub before merge)
-- Parent planning issue:
-  [#310 - AL-310: PRD - Statement Studio rebuild and implementation backlog](https://github.com/Asymmetric-al/core/issues/310)
-- Canonical implementation issues: `#312` through `#364` (even numbers),
-  mapping to `SS-00` through `SS-26`
-- Temporary duplicate issues from automated publishing were closed with comments
-  pointing to the canonical issue.
-- Rebase PR #367 onto latest `develop` and confirm `gh pr checks --required`
-  before treating docs as merge-ready.
+- Planning PR [#367](https://github.com/Asymmetric-al/core/pull/367) merged on
+  2026-07-03.
+- Parent planning issue
+  [#310](https://github.com/Asymmetric-al/core/issues/310) closed on 2026-07-09.
+- [#312](https://github.com/Asymmetric-al/core/issues/312) is implemented by
+  the completed audit/evidence and proposed OpenSpec change in this branch; it
+  remains HITL until reviewed and merged.
+- Canonical implementation issues remain #314 through #364, but their original
+  dependency graph predates the Phase 0 findings.
 
-## Source Artifacts
+## Approved-When-Merged Decisions
 
-Read these in order:
-
-1. `README.md`
-2. `prd.md`
-3. `issues.md`
-4. `phase-0-audit-brief.md`
-5. `product-plan.md`
-6. `data-model.md`
-7. `variables.md`
-8. `starter-template-catalog.md`
-9. `ux-ia.md`
-10. `integration-map.md`
-11. `rendering-artifacts-retention.md`
-12. `legacy-pdf-studio-removal.md`
-13. `testing-fixtures.md`
-
-## Critical Decisions Already Captured
-
-- Product name: Statement Studio.
-- New implementation must not be built on Unlayer.
-- New implementation must not be an email editor pretending to generate PDFs.
-- Persisted templates use an Asym-owned JSON schema compiled through pdfx and
-  React PDF where appropriate.
-- Production renders resolve server-side from tenant-scoped DTOs.
+- Product name: Statement Studio; existing `/pdf` and `pdf_*` internals migrate
+  pragmatically.
+- Extend the existing `pdf_templates` / `pdf_template_*` family; no parallel
+  document persistence family.
+- Use an Asym-owned template schema. New work does not depend on Unlayer or
+  treat an email editor as the PDF product.
+- Qualify the existing server-only DocRaptor adapter, then use it as the sole
+  first-slice provider behind a renderer port. A later renderer replacement is
+  a separate migration decision.
+- Start infrastructure with an admin/sample-data tracer. Keep
+  `donor.statement.annual_giving` as the first donor-facing production job only
+  after a canonical frozen statement snapshot/version and finance/legal
+  approval.
+- Production renders resolve source-domain contexts server-side.
+  Browser-supplied financial `dataContext` is never official input.
 - Generated PDFs are private, tenant-aware artifacts exposed through authorized
-  access paths, not direct cross-dashboard table reads.
-- Tenant admins can customize templates, variables, defaults, assignments,
-  retention, and capabilities within platform safety floors.
-- UI must use shared `@asym/ui` components and Maia/Zinc design tokens.
-- Database, RLS, Storage, Auth, migration, seed, query, and Supabase client work
-  must load the repo Supabase skill and use Supabase CLI verification.
+  Mission Control/donor/missionary BFF paths.
+- Unlayer is retire-later; delete nothing before hosted tenant-template
+  inventory and verified replacement.
 
 ## Recommended Next Work
 
-Start with
-[#312 - SS-00 Phase 0 Statement Studio audit and first-slice confirmation](https://github.com/Asymmetric-al/core/issues/312).
+After AL-312 is reviewed and merged:
 
-The Phase 0 audit should confirm:
+1. Re-groom [#322](https://github.com/Asymmetric-al/core/issues/322) with the
+   newer proposed statement issues
+   [#579](https://github.com/Asymmetric-al/core/issues/579),
+   [#580](https://github.com/Asymmetric-al/core/issues/580),
+   [#583](https://github.com/Asymmetric-al/core/issues/583), and
+   [#584](https://github.com/Asymmetric-al/core/issues/584). Canonical facts,
+   run/version ownership, frozen formatting, portal cutover, private artifact
+   authorization, and finance/legal approval are production blockers;
+   completing #320 alone is not sufficient.
+2. Allow [#314](https://github.com/Asymmetric-al/core/issues/314) to proceed only
+   as the Statement Studio shell, starter catalog, tenant-safe foundation, and
+   safe sample preview. Do not turn it into an official statement render.
+3. Implement the OpenSpec foundation in thin vertical slices: same-tenant
+   constraints, immutable versions, assignments, server capabilities, private
+   Storage, artifacts, retention, and tests. Coordinate tenant isolation with
+   #505/#516 and outbound delivery with #552-#554/#581; do not create parallel
+   guard or communication infrastructure.
+4. Prove the pipeline with `letterhead.simple` or the annual starter in
+   non-official sample mode before connecting Giving truth.
 
-- Current legacy PDF Studio and Unlayer dependencies.
-- Current donor receipt and annual statement behavior.
-- Current data owner boundaries for donor, missionary, events, finance,
-  reports, care, legal, tasks, and CMS.
-- Current Supabase/RLS/Storage posture and risks.
-- What should be reused, replaced, retired, or deleted.
-- Whether `donor.statement.annual_giving` remains the best first production
-  slice.
-
-After #312, follow the dependency graph in #310 or `issues.md`. Do not start by
-editing legacy Unlayer UI unless the Phase 0 audit explicitly identifies a safe
-removal or migration step.
-
-## Suggested Skills
-
-- `repo-entry`: orientation and repo instruction routing.
-- `supabase`: required for any Supabase database, Auth, Storage, Realtime, Edge
-  Functions, CLI, RLS, or migration work.
-- `supabase-postgres-best-practices`: schema, query, index, policy, RLS, or
-  migration performance work.
-- `vercel-react-best-practices`: React and Next.js implementation quality.
-- `nextjs-app-router` or the repo's relevant Next.js skill: App Router,
-  rendering, routing, and data-fetching work.
-- `frontend-design` or repo frontend rules: Statement Studio UX/UI work using
-  shared design tokens.
-- `to-tickets`: only if future PRD changes need new vertical-slice tickets.
-- `handoff`: use again when pausing after implementation progress.
+Do not begin with legacy Unlayer removal or a second renderer stack.
 
 ## Verification Expectations
 
-For documentation-only changes:
+For foundation/runtime work:
 
-- Run focused Prettier checks on touched docs.
-- Confirm each new workflow doc includes `## Triggers`, `## Workflow Steps`, and
-  `## Checklist`.
-- Keep links to GitHub issues current.
+- Read installed Next.js docs before changing Next.js routes or components.
+- Load the Supabase and Supabase Postgres skills before schema/RLS/Storage work.
+- Verify hosted migration state before assuming committed tables exist.
+- Test cross-tenant foreign keys, immutable versions, capability differences,
+  private Storage paths, recipient denial, artifact integrity, and purge
+  tombstones through public seams.
+- Keep app routes thin and production context resolution inside shared
+  server/source-domain modules.
 
-For implementation changes:
+## Security and Privacy Notes
 
-- Read installed Next.js docs before Next.js coding.
-- Use the Supabase skill and Supabase CLI before database/Supabase work.
-- Add focused tests for tenant safety, variable resolution, assignments,
-  rendering, artifact access, and UI smoke paths based on the slice.
-- Let GitHub Actions settle and inspect failures directly.
-
-## Security and privacy notes
-
-This handoff intentionally contains no secrets, tokens, credentials, donor
-personal data, missionary personal data, or tenant private records. Keep future
-handoffs at the same level: reference artifacts and public GitHub issue numbers
-instead of copying sensitive runtime data.
+Do not copy donor, missionary, tenant, payment, care, or legal production data
+into samples, handoffs, template JSON, render requests, or audit fixtures. Use
+synthetic fixtures and reference public issue/file paths.
 
 ## Checklist
 
-- [ ] Start from #312 before implementation unless the user explicitly redirects.
-- [ ] Read the PRD and issue map before editing code.
-- [ ] Use the Supabase skill and CLI for Supabase work.
-- [ ] Use shared design tokens for UI work.
-- [ ] Keep every Statement Studio slice tenant-safe and tenant-aware.
-- [ ] Update the handoff if meaningful implementation progress changes the next
-      agent's starting point.
+- [x] Phase 0 audit and evidence are complete.
+- [x] Renderer, canonical persistence, first job, and legacy posture are recorded.
+- [ ] AL-312 HITL review/merge approves the proposed decisions.
+- [ ] #322 is re-groomed before production statement work.
+- [ ] Hosted migration and legacy-template state are inspected before cutover.
+- [ ] Each implementation slice uses the appropriate repo skills and checks.

--- a/docs/guides/features/statement-studio/legacy-pdf-studio-removal.md
+++ b/docs/guides/features/statement-studio/legacy-pdf-studio-removal.md
@@ -16,12 +16,18 @@ Use this doc when auditing, removing, replacing, or migrating legacy PDF Studio 
 6. Update docs, env examples, tests, and route references.
 7. Keep the Unlayer allowlist verification script in sync when removing legacy paths.
 
-## Approved Boundary
+## Proposed Phase 0 Boundary (pending HITL merge)
 
-- New templates, assignments, publishing, rendering, and defaults use the custom pdfx/React PDF path (Statement Studio target state).
-- Reconcile with in-flight native PDF Studio + DocRaptor work in `docs/guides/features/pdf-studio.md` during Phase 0; do not run two production render stacks without an explicit migration decision.
-- Unlayer is legacy-only and not a dependency.
-- Existing Unlayer PDF templates may be migrated if useful or removed if Phase 0 confirms removal is acceptable.
+- New templates, assignments, publishing, rendering, and defaults use the
+  Asym-owned schema and Statement Studio lifecycle.
+- Phase 0 proposes the existing server-side DocRaptor adapter as the sole
+  first-slice provider behind a renderer port after qualification and HITL
+  approval. Do not run a second production stack without an explicit migration
+  decision.
+- Unlayer is not a dependency of new Statement Studio templates; it remains a
+  temporary compatibility dependency for the exercised legacy editor/export.
+- Existing Unlayer templates may be migrated, archived, or removed only after
+  hosted tenant-template inventory and verified replacement/cutover.
 - The rebuild is a clean product replacement, not a compatibility layer.
 
 ## Removal Targets To Audit

--- a/docs/guides/features/statement-studio/legacy-pdf-studio-removal.md
+++ b/docs/guides/features/statement-studio/legacy-pdf-studio-removal.md
@@ -16,14 +16,14 @@ Use this doc when auditing, removing, replacing, or migrating legacy PDF Studio 
 6. Update docs, env examples, tests, and route references.
 7. Keep the Unlayer allowlist verification script in sync when removing legacy paths.
 
-## Proposed Phase 0 Boundary (pending HITL merge)
+## Phase 0 Boundary
 
 - New templates, assignments, publishing, rendering, and defaults use the
   Asym-owned schema and Statement Studio lifecycle.
-- Phase 0 proposes the existing server-side DocRaptor adapter as the sole
-  first-slice provider behind a renderer port after qualification and HITL
-  approval. Do not run a second production stack without an explicit migration
-  decision.
+- Phase 0 selects the existing server-side DocRaptor adapter as the first-slice
+  provider candidate behind a renderer port. Production use requires provider
+  qualification and HITL approval. Do not run a second production stack without
+  an explicit migration decision.
 - Unlayer is not a dependency of new Statement Studio templates; it remains a
   temporary compatibility dependency for the exercised legacy editor/export.
 - Existing Unlayer templates may be migrated, archived, or removed only after

--- a/docs/guides/features/statement-studio/phase-0-audit-brief.md
+++ b/docs/guides/features/statement-studio/phase-0-audit-brief.md
@@ -1,7 +1,8 @@
 # Statement Studio Phase 0 Audit Brief
 
-Status: research and proposal complete on 2026-07-10 against `origin/develop`
-at `25b5aae6`; decisions remain proposed until AL-312 HITL review and merge.
+Status: research and the Phase 0 decision package were completed on 2026-07-10
+against `origin/develop` at `25b5aae6`. PR #715 is the merge/approval record;
+provider qualification and the finance/legal gates below remain separate.
 
 This is the decision brief. The path-by-path primary-source inventory is in
 [`phase-0-research-evidence.md`](./phase-0-research-evidence.md), and the
@@ -20,8 +21,8 @@ Use this audit before:
 
 ## Workflow Steps
 
-1. Treat the decisions below as the proposed Phase 0 outcome; merging this
-   HITL change is the owner approval point.
+1. Treat the decisions below as the Phase 0 direction; PR #715 merge records
+   repo approval of the decision package.
 2. Use the evidence appendix when a finding needs exact source paths or test
    boundaries.
 3. Implement only the safe shell/sample-data tracer until the financial and
@@ -29,9 +30,9 @@ Use this audit before:
 4. Re-groom downstream issues when their current dependency graph would skip a
    gate identified here.
 
-## Proposed Decisions (effective on HITL merge)
+## Phase 0 Decisions
 
-| Question                          | Phase 0 proposal                                                                                                                                                                                                                                                    |
+| Question                          | Phase 0 decision                                                                                                                                                                                                                                                    |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Is AL-312 obsolete?               | No. The placeholder audit was never completed, and newer receipt/correction work made the audit more important. It remains a docs/HITL ticket.                                                                                                                      |
 | Canonical persistence             | Extend the existing `pdf_templates` and `pdf_template_*` family. Do not create a parallel `document_*` store.                                                                                                                                                       |
@@ -90,14 +91,14 @@ store.
 
 Reuse the existing concepts as follows:
 
-| Existing table                                     | Canonical role                                      |
-| -------------------------------------------------- | --------------------------------------------------- |
-| `pdf_templates`                                    | Tenant template aggregate and legacy migration root |
-| `pdf_template_versions`                            | Immutable draft/published content                   |
-| `pdf_template_renders`                             | Render attempt and diagnostics                      |
-| `pdf_template_artifacts`                           | Durable output metadata                             |
-| `pdf_template_audit_events`                        | Append-only lifecycle, access, and purge audit      |
-| `pdf_template_batches` / `pdf_template_batch_jobs` | Batch orchestration                                 |
+| Existing table                                     | Canonical role                                                                                     |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `pdf_templates`                                    | Tenant template aggregate and legacy migration root                                                |
+| `pdf_template_versions`                            | Mutable draft working state; immutable published/archive snapshots, enforced by the lifecycle seam |
+| `pdf_template_renders`                             | Render attempt and diagnostics                                                                     |
+| `pdf_template_artifacts`                           | Durable output metadata                                                                            |
+| `pdf_template_audit_events`                        | Append-only lifecycle, access, and purge audit                                                     |
+| `pdf_template_batches` / `pdf_template_batch_jobs` | Batch orchestration                                                                                |
 
 Add only the missing concepts: system job catalog, tenant job settings, scoped
 assignments/defaults, variable catalog/tenant overrides, and retention policy.
@@ -133,8 +134,12 @@ Hardening required before the child tables receive production writers:
 8. Production artifacts must require a private bucket/path, checksum, size,
    immutable source reference, and exact template version. A permanent URL is
    not a sufficient production invariant.
-9. Delete bytes through the Storage API and retain an audited artifact
-   tombstone. Do not delete `storage.objects` rows directly.
+9. Production renders need a stable server-derived logical render key,
+   lease/fencing-token retry ownership, and at most one canonical artifact per
+   immutable input/template/output tuple. Provider retries must not duplicate
+   bytes, delivery, or logical completion audit.
+10. Delete bytes through the Storage API and retain an audited artifact
+    tombstone. Do not delete `storage.objects` rows directly.
 
 Donor and missionary downloads must use authenticated portal BFF routes that
 re-authorize tenant, role, recipient, subject, and document state before
@@ -205,7 +210,7 @@ Safe sequence:
    `SAMPLE - NOT AN OFFICIAL DOCUMENT`; it cannot be assigned or delivered.
 2. Job settings/assignment, render/artifact lifecycle, private Storage, and
    authorized download with cross-tenant tests. Coordinate with the proposed
-   Phase 4 isolation foundation
+   platform tenant-isolation Phase 4 foundation
    ([#505](https://github.com/Asymmetric-al/core/issues/505) and
    [#516](https://github.com/Asymmetric-al/core/issues/516)); reuse its approved
    composite-key, tenant-guard, `FORCE RLS`, and permanent negative-test posture
@@ -290,4 +295,5 @@ send through that seam.
 - [x] RLS, same-tenant integrity, Storage, artifact, and deployment risks are explicit.
 - [x] An evidence-based safe tracer and first donor-facing job recommendation is recorded.
 - [x] Reuse, replace, retire, and delete decisions are actionable.
-- [ ] HITL review/merge approves the proposed decisions.
+- [x] The HITL decision package is complete and linked to PR #715; merge records
+      repo approval of the Phase 0 decisions.

--- a/docs/guides/features/statement-studio/phase-0-audit-brief.md
+++ b/docs/guides/features/statement-studio/phase-0-audit-brief.md
@@ -135,9 +135,15 @@ Hardening required before the child tables receive production writers:
    immutable source reference, and exact template version. A permanent URL is
    not a sufficient production invariant.
 9. Production renders need a stable server-derived logical render key,
-   lease/fencing-token retry ownership, and at most one canonical artifact per
-   immutable input/template/output tuple. Provider retries must not duplicate
-   bytes, delivery, or logical completion audit.
+   lease/fencing-token retry ownership, an immutable database-time provider
+   deadline with finalization margin before lease expiry, and at most one
+   canonical artifact per immutable input/template/output tuple. Cancellation
+   must reach the provider call, while provider response, timeout, cancellation,
+   and completion use current-token compare-and-set transitions. Provider
+   retries may create duplicate remote work or token-scoped staging bytes, but
+   they must expose and retain at most one canonical artifact. Losing staging
+   bytes are durably cleaned, and delivery/logical-completion audit is not
+   duplicated.
 10. Delete bytes through the Storage API and retain an audited artifact
     tombstone. Do not delete `storage.objects` rows directly.
 
@@ -182,7 +188,9 @@ seam; Statement Studio must coordinate with it rather than introduce a parallel
 
 - tenant and legal donor identity;
 - covered period and currency partition;
-- settled and receiptable inclusion decisions;
+- frozen deductible hard-credit and approved indirect line/total partitions;
+- audit-only exclusion references with source-domain-approved reason codes for
+  pending/unsettled and still-unknown-donor candidates;
 - effective designation/allocation lines;
 - corrections, voids, and partial/full refund treatment;
 - totals and generation policy/version;

--- a/docs/guides/features/statement-studio/phase-0-audit-brief.md
+++ b/docs/guides/features/statement-studio/phase-0-audit-brief.md
@@ -1,64 +1,293 @@
-# Phase 0 Audit Brief
+# Statement Studio Phase 0 Audit Brief
 
-Phase 0 is required before implementation. It should be deep research with a brief, AI-oriented output that lets future agents build without rereading the whole repo blindly.
+Status: research and proposal complete on 2026-07-10 against `origin/develop`
+at `25b5aae6`; decisions remain proposed until AL-312 HITL review and merge.
+
+This is the decision brief. The path-by-path primary-source inventory is in
+[`phase-0-research-evidence.md`](./phase-0-research-evidence.md), and the
+proposed durable contract is in
+[`openspec/changes/add-statement-studio`](../../../../openspec/changes/add-statement-studio/).
+No product code or database migration belongs in AL-312.
 
 ## Triggers
 
-Run Phase 0 before:
+Use this audit before:
 
-- Creating Statement Studio schema, routes, UI, or render code.
-- Removing legacy PDF Studio or Unlayer code.
-- Wiring production PDF jobs into Donor Dashboard, Missionary Dashboard, Mission Control, events, finance, care, legal, or CMS surfaces.
+- Implementing Statement Studio issues after AL-312.
+- Adding a production receipt, statement, report, or portal PDF.
+- Writing to the native `pdf_template_*` tables.
+- Removing PDF Studio, Unlayer, or the DocRaptor path.
 
 ## Workflow Steps
 
-1. Read `README.md`, `product-plan.md`, `data-model.md`, `variables.md`, `ux-ia.md`, `integration-map.md`, and `legacy-pdf-studio-removal.md`.
-2. Search existing PDF Studio, donor statement, receipt, artifact, render, Storage, and route code.
-3. Inspect current docs, migrations, tests, and feature flags.
-4. Inspect data owners and resolver candidates across donor, giving, missionary, CRM, CMS, events, reports, care, tasks, legal/signing, and finance.
-5. Confirm current Supabase and Next.js guidance before proposing implementation.
-6. Produce the concise implementation map described below.
+1. Treat the decisions below as the proposed Phase 0 outcome; merging this
+   HITL change is the owner approval point.
+2. Use the evidence appendix when a finding needs exact source paths or test
+   boundaries.
+3. Implement only the safe shell/sample-data tracer until the financial and
+   artifact gates below are closed.
+4. Re-groom downstream issues when their current dependency graph would skip a
+   gate identified here.
 
-## Required Evidence Targets
+## Proposed Decisions (effective on HITL merge)
 
-- `docs/guides/features/pdf-studio.md`
-- `docs/guides/features/email-studio.md`
-- `docs/guides/architecture/data-access-boundary.md`
-- `docs/ai/rules/frontend.md`
-- `docs/ai/rules/backend.md`
-- `docs/ai/skills/supabase/SKILL.md`
-- `docs/ai/skills/supabase-postgres-best-practices/SKILL.md`
-- `supabase/AGENTS.md`
-- `apps/admin/app/pdf/**`
-- `apps/donor/app/api/donor/statements/[year]/route.ts`
-- `packages/api/src/donor-portal/{receipts,statements,service,model}.ts`
-- `packages/api/src/pdf-templates/**`
-- `packages/config/{pdf-studio,pdf-studio-native}.ts`
-- `supabase/migrations/*pdf*`
-- `packages/api/src/admin/**`
-- `apps/admin/src/cms/**`
-- `apps/admin/app/events/**`
-- `packages/api/src/missionary-portal/**`
+| Question                          | Phase 0 proposal                                                                                                                                                                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Is AL-312 obsolete?               | No. The placeholder audit was never completed, and newer receipt/correction work made the audit more important. It remains a docs/HITL ticket.                                                                                                                      |
+| Canonical persistence             | Extend the existing `pdf_templates` and `pdf_template_*` family. Do not create a parallel `document_*` store.                                                                                                                                                       |
+| First plumbing tracer             | Use `letterhead.simple` or the annual starter with synthetic data in Mission Control only. Mark it visibly non-official; it is admin-only, non-assignable, and non-deliverable. It may prove preview selection and infrastructure without claiming financial truth. |
+| First donor-facing production job | Keep `donor.statement.annual_giving`, conditionally. It must consume a frozen, versioned, giving-owned statement context and pass finance/legal review before production render or download.                                                                        |
+| Renderer for the first slice      | Qualify the Asym-owned schema and server-only DocRaptor adapter, then approve it as the sole provider behind a renderer port. Do not add a parallel pdfx/React PDF stack. A future replacement requires a measured migration plan.                                  |
+| Legacy Unlayer                    | Retire later, not now. Keep it as a flagged compatibility path until a production Statement Studio job, authoring replacement, and tenant-template migration inventory are verified.                                                                                |
+| Deletion                          | Delete nothing in Phase 0. There is not enough deployed-data evidence to remove templates, tables, flags, packages, or receipt records safely.                                                                                                                      |
 
-## Output Shape
+## Current Reality
 
-Write a short brief with:
+### PDF Studio and native builder
 
-- Current file map and ownership boundaries.
-- Existing routes, adapters, migrations, feature flags, tests, and docs.
-- What to reuse, replace, retire, or delete.
-- Tenant/RLS/Storage risks.
-- Variable source-map candidates.
-- Starter templates and standard jobs already supported by data.
-- Cross-app PDF opportunities and gaps.
-- Recommended first vertical slice.
-- Open questions that block implementation.
+- `/pdf` is still the user-facing PDF Studio and defaults to the exercised
+  Unlayer editor. Native rollout defaults to `legacy_only` with legacy fallback
+  enabled.
+- The native UI is a raw JSON textarea. The app does not import the vendored
+  `@asym/pdf-editor` at runtime.
+- Native save mutates `pdf_templates.design`; it does not create an immutable
+  `pdf_template_versions` row.
+- Native render accepts client-supplied template data and `dataContext`, calls
+  DocRaptor behind rollout guards, then discards the PDF bytes. It writes no
+  render, artifact, Storage object, or download record.
+- The native adapter does not require DocRaptor production mode; configured
+  test mode can return a watermarked PDF and still report render success. The
+  corrected-receipt path has a stricter production-mode guard that native must
+  adopt before official output.
+- Asset signing returns no URL, and batch execution only returns scaffold
+  metadata. These paths are not production document orchestration.
+
+### Receipts and annual statements
+
+- The donor receipt route returns a live-data `.txt` file and does not require
+  settled status. It is not official receipt truth.
+- Staged-gift receipts use hard-coded HTML/text and the shared email seam, not
+  Statement Studio.
+- Corrected receipts have the strongest reusable seam: a stored correction-time
+  snapshot, capability checks, and production-mode DocRaptor rendering. The app
+  treats snapshots append-only, but the database does not prevent updates,
+  deletes them with the donation, and does not enforce same-tenant references.
+  The path still uses hard-coded HTML and persists no document artifact.
+- `gift_receipt_records` is an unwired, test-language scaffold. Its comment says
+  corrections are append-only, but its unique donation index permits only one
+  row per donation.
+- The annual statement route is donor/tenant/year scoped and filters settled
+  statuses, but recomputes a tab-delimited `.txt` file from mutable flat
+  donations. It has no receiptable eligibility, effective corrections, partial
+  refunds, currency partitioning, frozen inclusion snapshot, template version,
+  artifact, retention, or delivery audit.
+
+Statement Studio must consume source-domain receipt/statement DTOs. It must not
+become another money, legal-donor, designation, correction, or receipt-truth
+store.
+
+## Persistence, RLS, and Storage Findings
+
+Reuse the existing concepts as follows:
+
+| Existing table                                     | Canonical role                                      |
+| -------------------------------------------------- | --------------------------------------------------- |
+| `pdf_templates`                                    | Tenant template aggregate and legacy migration root |
+| `pdf_template_versions`                            | Immutable draft/published content                   |
+| `pdf_template_renders`                             | Render attempt and diagnostics                      |
+| `pdf_template_artifacts`                           | Durable output metadata                             |
+| `pdf_template_audit_events`                        | Append-only lifecycle, access, and purge audit      |
+| `pdf_template_batches` / `pdf_template_batch_jobs` | Batch orchestration                                 |
+
+Add only the missing concepts: system job catalog, tenant job settings, scoped
+assignments/defaults, variable catalog/tenant overrides, and retention policy.
+Keep `gift_receipt_records` and `contribution_receipt_snapshots` outside
+Statement Studio while Giving reconciles them. Each official job must expose one
+canonical domain context/source ID; Statement Studio must not canonize both
+receipt tables as parallel truth.
+
+Hardening required before the child tables receive production writers:
+
+1. `pdf_templates.tenant_id` is nullable. Backfill and require it for tenant
+   templates while modeling system starters explicitly.
+2. Child foreign keys reference IDs without tenant identity. Add same-tenant
+   composite keys/foreign keys, including current-version pointers.
+3. Published versions are described as immutable but authenticated staff have
+   direct `UPDATE` grants and policies. Freeze version content and hash; expose
+   constrained server-side lifecycle operations.
+4. RLS permits any staff member to mutate tables while the API requires
+   admin/super-admin. Revoke direct authenticated writes or add capability-aware
+   policies so the Data API cannot bypass the application contract.
+5. The older demo migration left a permissive `public read` policy on
+   `pdf_templates`. The native migration revokes anonymous table privileges but
+   does not drop that latent policy; a later grant could reactivate it, and a
+   hosted project missing the native migration may still expose templates.
+   Explicitly drop it and verify deployed grants/policies.
+6. Artifacts lack job, scope, subject/recipient, sensitivity, retention,
+   current/superseded/void lineage, expiry/purge/tombstone, and download-audit
+   fields. Add explicit relational access data rather than hiding authorization
+   in generic JSON.
+7. There is no private generated-document bucket or Storage adapter. The
+   existing `document-uploads` bucket is public and must never hold receipts,
+   statements, care packets, or legal documents.
+8. Production artifacts must require a private bucket/path, checksum, size,
+   immutable source reference, and exact template version. A permanent URL is
+   not a sufficient production invariant.
+9. Delete bytes through the Storage API and retain an audited artifact
+   tombstone. Do not delete `storage.objects` rows directly.
+
+Donor and missionary downloads must use authenticated portal BFF routes that
+re-authorize tenant, role, recipient, subject, and document state before
+streaming bytes or issuing a short-lived signed URL. Service-role Storage
+access bypasses RLS, so route authorization is mandatory rather than optional.
+
+The repository proves committed migrations, not deployed Supabase state.
+Hosted migration and tenant-template inventory remain an operator check before
+cutover or deletion.
+
+## Domain Owners and Readiness
+
+| Domain/surface    | Source owner and readiness                                                                                                       | Statement Studio boundary                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Giving / donor    | `packages/api/src/giving/**`, Contribution Operations, and donor-portal BFFs are real but receipt/statement truth is fragmented. | Giving builds immutable official-document contexts; Statement Studio renders them verbatim.                   |
+| Reports / finance | Admin CRM reports expose a tenant-scoped DTO and audited CSV, but still aggregate flat completed donations.                      | Reuse the report service after its financial semantics are approved; keep CSV operational exports.            |
+| Missionary        | `packages/api/src/missionary-portal/**` is a real role-scoped BFF; no statement resolver exists.                                 | Add a missionary-owned DTO later; do not query its tables from the renderer.                                  |
+| Events            | Current event UI/collections are largely mock or seed data.                                                                      | Starter/sample templates only until Events exposes a production resolver.                                     |
+| Support           | Support Hub has real adapters and report routes, though some aggregation remains client-side.                                    | Consolidate a server report DTO before adding PDF output.                                                     |
+| Member care       | Member-care reads/routes are real and sensitive.                                                                                 | Defer until redaction, elevated access, retention, and access audit receive HITL approval.                    |
+| Tasks / mobilize  | Shared Mission Control tasks are the operational owner; several UI collections and Mobilize data are seed/in-memory.             | Use the shared task service only; defer Mobilize documents until its source is durable.                       |
+| Legal / signing   | Current Sign surfaces contain hard-coded/mock values and no production owner model.                                              | Defer; legal copy, evidence, access, and retention require separate HITL review.                              |
+| CMS               | Tenant-scoped Payload collections and published reads are valid approved-content inputs.                                         | CMS can supply branding/content/assets, never donation or operational truth; add a render-safe asset adapter. |
+
+## First Production Slice Contract
+
+`donor.statement.annual_giving` remains the first donor-facing production job
+because it has an existing donor-owned route and dashboard entry point and
+proves repeaters, totals, variables, assignment, immutable versions, private
+artifacts, and recipient-scoped download.
+
+The current route is not the production resolver. Before production, the
+Giving/statement domain must expose one canonical frozen statement snapshot and
+version contract. Newer proposed Phase 7 work in
+[#579](https://github.com/Asymmetric-al/core/issues/579),
+[#580](https://github.com/Asymmetric-al/core/issues/580), and
+[#584](https://github.com/Asymmetric-al/core/issues/584) already reserves this
+seam; Statement Studio must coordinate with it rather than introduce a parallel
+`AnnualGivingStatementContext`. The approved contract must freeze:
+
+- tenant and legal donor identity;
+- covered period and currency partition;
+- settled and receiptable inclusion decisions;
+- effective designation/allocation lines;
+- corrections, voids, and partial/full refund treatment;
+- totals and generation policy/version;
+- raw money/date values, canonical display strings, frozen locale, and
+  formatting-policy version;
+- source record IDs and an immutable context hash.
+
+For official receipt/statement fields, templates bind the frozen display
+strings and use the raw values only for audit/validation; they do not format
+money or dates at render time. Statement Studio may lay out the supplied values
+but may not recalculate, reformat, or override official facts. Production render
+endpoints resolve the snapshot server-side and never accept financial
+`dataContext` from the browser.
+
+When a later correction, refund, donor relink, or void changes official
+statement truth, Giving determines the effect. Statement Studio marks the old
+artifact superseded/void, links correction and replacement lineage, retains old
+bytes/audit only per policy, and keeps stale output out of the portal's current
+download view.
+
+Safe sequence:
+
+1. Mission Control shell, starter catalog, immutable template/version model,
+   and a synthetic admin-only tracer visibly marked
+   `SAMPLE - NOT AN OFFICIAL DOCUMENT`; it cannot be assigned or delivered.
+2. Job settings/assignment, render/artifact lifecycle, private Storage, and
+   authorized download with cross-tenant tests. Coordinate with the proposed
+   Phase 4 isolation foundation
+   ([#505](https://github.com/Asymmetric-al/core/issues/505) and
+   [#516](https://github.com/Asymmetric-al/core/issues/516)); reuse its approved
+   composite-key, tenant-guard, `FORCE RLS`, and permanent negative-test posture
+   instead of building a competing isolation layer.
+3. Canonical Giving/Phase 7 statement snapshot and version contract plus
+   finance/legal approval.
+4. Replace the donor `.txt` response with the authorized Statement Studio
+   artifact path, record delivery/download, and prove correction supersession.
+5. Reconcile the four receipt paths before `donor.receipt.single` becomes the
+   next official-document job.
+
+The published dependency graph is stale at the production-render boundary.
+Issue [#322](https://github.com/Asymmetric-al/core/issues/322) must be
+re-groomed with the newer proposed statement work
+([#579](https://github.com/Asymmetric-al/core/issues/579),
+[#580](https://github.com/Asymmetric-al/core/issues/580),
+[#583](https://github.com/Asymmetric-al/core/issues/583), and
+[#584](https://github.com/Asymmetric-al/core/issues/584)) so canonical facts,
+run/version ownership, frozen formatting, private artifact authorization,
+portal cutover, and finance/legal approval are explicit gates. Completing #320
+alone is not sufficient. Outbound delivery additionally waits for or
+co-sequences with the Phase 6 communication seam
+([#552](https://github.com/Asymmetric-al/core/issues/552),
+[#553](https://github.com/Asymmetric-al/core/issues/553), and
+[#554](https://github.com/Asymmetric-al/core/issues/554)) and its proposed
+document adapter [#581](https://github.com/Asymmetric-al/core/issues/581).
+Authenticated self-download may remain a separate slice because it does not
+send through that seam.
+
+## Reuse, Replace, Retire, Delete
+
+### Reuse
+
+- Asym template schema, preflight, table/repeater primitives, and provider port.
+- DocRaptor server adapter plus the corrected-receipt production-mode guard as
+  the provider candidate. Native rendering must adopt that fail-closed mode
+  check and pass representative qualification before HITL approval.
+- Thin App Router exports and role-scoped portal BFF seams.
+- `pdf_*` migration concepts, corrected-receipt snapshots, shared email seam,
+  idempotency, and delivery logs.
+
+### Replace or complete
+
+- PDF Studio naming, raw JSON authoring, mutable root-row publishing, and
+  client-supplied production data.
+- Metadata-only native render with durable render/artifact/Storage behavior.
+- Broad staff mutation policies and ID-only cross-tenant foreign keys.
+- Live `.txt` official-document routes and hard-coded receipt PDF HTML with
+  source-domain contexts plus assigned immutable templates.
+
+### Retire later
+
+- Unlayer editor/export, fallback flags, dependencies, and legacy tests after
+  verified cutover and tenant-template disposition.
+- Legacy `pdf_templates.design/html/is_default` as native truth after versions
+  and assignments become authoritative.
+
+### Delete now
+
+- Nothing.
+
+## Human Approval Gates
+
+- Qualify DocRaptor with representative repeaters/tables, pagination,
+  headers/footers, fonts/private assets, fidelity/accessibility, fail-closed
+  production mode, provider limits, latency, and cost. HITL then approves it as
+  the sole first-slice provider or selects an explicit alternative.
+- Approve annual statement inclusion/correction/refund/currency semantics and
+  official language with finance/legal owners.
+- Approve the deployed-template migration/disposition plan after querying the
+  hosted project.
+- Re-groom #322 before implementation. Care/legal jobs retain their separate
+  HITL gates.
 
 ## Checklist
 
-- [ ] Current behavior is grounded in exact file paths.
-- [ ] Supabase skill and backend rules were loaded for data findings.
-- [ ] Frontend rulebook was loaded for UX findings.
-- [ ] Existing Unlayer dependencies are classified as remove, migrate, or ignore.
-- [ ] First slice proves template versioning, variables, assignment, render, artifact, Storage, and dashboard download.
-- [ ] Findings are brief enough for an implementation agent to act on.
+- [x] Current behavior is grounded in exact file paths in the evidence appendix.
+- [x] Supabase, backend, frontend, OpenSpec, and installed Next.js guidance were checked.
+- [x] Legacy and native PDF dependencies are classified.
+- [x] Donor receipt and annual-statement behavior is distinguished accurately.
+- [x] Data owner boundaries are recorded across requested product surfaces.
+- [x] RLS, same-tenant integrity, Storage, artifact, and deployment risks are explicit.
+- [x] An evidence-based safe tracer and first donor-facing job recommendation is recorded.
+- [x] Reuse, replace, retire, and delete decisions are actionable.
+- [ ] HITL review/merge approves the proposed decisions.

--- a/docs/guides/features/statement-studio/phase-0-research-evidence.md
+++ b/docs/guides/features/statement-studio/phase-0-research-evidence.md
@@ -1,0 +1,422 @@
+# Statement Studio Phase 0 research evidence
+
+This appendix records primary-source findings for
+[GitHub issue #312](https://github.com/Asymmetric-al/core/issues/312). It is an
+implementation audit, not a replacement PRD. The audited repository baseline is
+`origin/develop` at `25b5aae69086fb2b6ca4e0ef2e0612724360b4ed` (fetched
+2026-07-10).
+
+Evidence labels used below:
+
+- **Runtime** means a reachable route, service, or UI on the audited commit.
+- **Schema** means committed SQL exists; it does not prove that a hosted project
+  has applied the migration.
+- **Test** means the repository contains coverage; the test's actual boundary is
+  stated so source-contract tests are not mistaken for end-to-end proof.
+- **Plan** means a PRD or guide describes intended behavior only.
+
+The repo-scoped Nia index returned obsolete pre-monorepo `src/...` paths for this
+area. Those results were rejected. Every finding below comes from the fetched Git
+object and direct file reads.
+
+## Current platform guidance checked
+
+- Supabase documents that private buckets are private by default and that
+  downloads require either an authenticated request evaluated by
+  `storage.objects` RLS or a time-limited signed URL
+  ([Storage buckets](https://supabase.com/docs/guides/storage/buckets/fundamentals)).
+  It also warns that service keys bypass Storage RLS
+  ([Storage access control](https://supabase.com/docs/guides/storage/security/access-control)).
+  Therefore a service-role portal BFF must authorize the recipient before it
+  streams bytes or signs a URL; possession of the service key is not an access
+  policy.
+- Supabase requires object deletion through the Storage API, not direct SQL,
+  because deleting only Storage metadata orphans the underlying object
+  ([Delete objects](https://supabase.com/docs/guides/storage/management/delete-objects)).
+  Statement Studio retention must delete bytes through the API and preserve its
+  own artifact tombstone/audit record.
+- The installed Next.js 16.2.6 guidance says Route Handlers are public
+  endpoints, can return files, and require explicit authentication,
+  authorization, input validation, and careful handling of sensitive responses
+  (`node_modules/next/dist/docs/01-app/02-guides/backend-for-frontend.md` and
+  `node_modules/next/dist/docs/01-app/02-guides/data-security.md`). The repo's
+  thin route plus `packages/api` BFF pattern is the correct seam; a route
+  filename or hidden UI is not authorization.
+
+## Ticket and planning-document status
+
+- Issue #312 is still correctly shaped as a **docs/HITL audit**, not a runtime
+  implementation ticket. Its acceptance criteria ask for an inventory,
+  reuse/replace/retire/delete decisions, and first-slice confirmation. On the
+  audited baseline,
+  `docs/guides/features/statement-studio/phase-0-audit-brief.md:1` was only an
+  instruction template with unchecked output criteria; this change replaces it
+  with the completed decision brief.
+- At audit start, the Statement Studio PRD named pdfx + React PDF as the target
+  and explicitly delegated reconciliation with native PDF Studio + DocRaptor to
+  Phase 0. There is no `pdfx` or `@react-pdf/renderer` runtime dependency or
+  import under `apps/**` or `packages/**` on the audited commit. The completed
+  audit proposes qualifying the existing server-side DocRaptor adapter behind a
+  provider port for the first slice, pending HITL approval.
+- The PRD also asks Phase 0 to add
+  `openspec/changes/add-statement-studio/`
+  (`docs/guides/features/statement-studio/prd.md:36-43`). No Statement Studio
+  OpenSpec change exists on `origin/develop`. That is a planning/acceptance-scope
+  mismatch that the main audit must resolve explicitly rather than silently
+  treating the PRD sentence as already delivered.
+
+## Newer related work reconciled
+
+- [PR #542](https://github.com/Asymmetric-al/core/pull/542) merged the
+  `gift_receipt_records` scaffold. Its migration explicitly requires Phase 0
+  (#312) to reconcile that record with `pdf_*` and
+  `contribution_receipt_snapshots` before promotion beyond MVP.
+- [PR #451](https://github.com/Asymmetric-al/core/pull/451) merged the
+  staff-only corrected-receipt DocRaptor route as an interim path and defers the
+  template-backed receipt to Statement Studio SS-10. It is reusable evidence,
+  not the final artifact model.
+- The newer Phase 7 epic and issues
+  [#566](https://github.com/Asymmetric-al/core/issues/566),
+  [#579](https://github.com/Asymmetric-al/core/issues/579),
+  [#580](https://github.com/Asymmetric-al/core/issues/580),
+  [#583](https://github.com/Asymmetric-al/core/issues/583), and
+  [#584](https://github.com/Asymmetric-al/core/issues/584) are open proposals,
+  not merged behavior. They retain `donor.statement.annual_giving` while
+  assigning approved facts, inclusion snapshots, runs/versions, portal cutover,
+  and frozen official formatting to the statement domain; Statement Studio owns
+  render artifacts and retention. This audit adopts that stable ownership seam
+  without treating the proposed table names as shipped schema.
+- Those Phase 7 issues also name the open Phase 4 tenant-isolation foundation
+  ([#505](https://github.com/Asymmetric-al/core/issues/505) and
+  [#516](https://github.com/Asymmetric-al/core/issues/516)) and the Phase 6
+  communication seam
+  ([#552](https://github.com/Asymmetric-al/core/issues/552),
+  [#553](https://github.com/Asymmetric-al/core/issues/553), and
+  [#554](https://github.com/Asymmetric-al/core/issues/554)) as production
+  prerequisites. Proposed delivery issue
+  [#581](https://github.com/Asymmetric-al/core/issues/581) owns outbound
+  statement/receipt delivery through that seam; Statement Studio must not add a
+  second tenant guard or communication log/send path. Consent PR #502 has merged
+  and is no longer an open prerequisite.
+- [PR #465](https://github.com/Asymmetric-al/core/pull/465) proposes the same
+  facts-versus-artifacts boundary but remains open and conflicting. It was used
+  as corroborating context only, not as current merged product truth.
+
+## Legacy PDF Studio and Unlayer
+
+### What is real
+
+- **Runtime:** Mission Control still exposes the product as `/pdf` / "PDF
+  Studio." The normal editor is
+  `LegacyUnlayerDocumentEditor`
+  (`apps/admin/app/pdf/page-client.tsx:59`, `:1939-1955`). The only browser E2E
+  spec verifies the legacy page, Unlayer container, and iframe
+  (`tests/e2e/admin-pdf-studio-legacy.spec.ts:29-52`). It can skip when the demo
+  account is unavailable (`:7-22`).
+- **Runtime:** Legacy templates save Unlayer design JSON and cached HTML into
+  `pdf_templates`; legacy PDF export calls the Unlayer browser editor and opens
+  the returned temporary URL (`apps/admin/app/pdf/page-client.tsx:1168-1176`,
+  `:1480-1503`). `react-email-editor` remains a production dependency of
+  `packages/ui/package.json`.
+- **Schema/runtime:** `pdf_templates` is the established root table with tenant,
+  design, HTML, category, layout, status, default, and audit timestamps
+  (`supabase/migrations/20250101000000_init_schema.sql:303-322`). The admin API
+  is a thin App Router export to `packages/api`; handlers require admin or
+  super-admin and the store scopes every read/update by `tenant_id`
+  (`packages/api/src/pdf-templates/index.ts:98-104`,
+  `packages/api/src/pdf-templates/store.ts:247-349`). The store uses the service
+  role/admin client, so those application predicates--not RLS execution--are the
+  live BFF boundary.
+
+### What is not yet replaceable
+
+- The default native rollout is disabled and `legacy_only`; legacy fallback
+  defaults to enabled
+  (`packages/config/pdf-studio-native.ts:119-146`, `:249-260`). Existing Unlayer
+  templates have no automatic conversion. The migration report explicitly
+  chooses `manual_rebuild_with_report`
+  (`packages/api/src/pdf-templates/native-adapter.ts:285-301`).
+- Therefore Unlayer is **retire-later**, not delete-now. Removing it before a
+  native/Statement Studio editor, version publication, production artifact, and
+  download path exist would remove the only exercised authoring/export surface.
+
+## Native builder, rendering, and migration scaffold
+
+### Implemented scaffold
+
+- **Dependencies:** local vendored `@asym/pdf-*` and DocRaptor packages are
+  pinned in the root and app/API package manifests. The native adapter imports
+  the Asym schema, browser preview, preflight, HTML composer, and DocRaptor client
+  (`packages/api/src/pdf-templates/native-adapter.ts:1-45`).
+- **Runtime:** authenticated admin routes exist for native preview, render, and
+  migration report
+  (`apps/admin/app/api/pdf-templates/native/{preview,render,migration-report}/route.ts`).
+  They validate `DocumentTemplateV1`, construct a tenant security context, and
+  delegate through `packages/api/src/pdf-templates/native.ts:38-110`.
+- **Runtime:** browser preview performs schema validation/preflight and returns
+  authoring HTML. Production render composes document HTML and calls DocRaptor
+  only when rollout and provider configuration allow it
+  (`packages/api/src/pdf-templates/native-adapter.ts:136-217`). Missing rollout
+  or provider config fails closed with structured errors (`:153-170`).
+- **Runtime gap:** native configuration defaults DocRaptor to test mode, and
+  the native adapter does not reject that mode. It can return a successful,
+  watermarked test PDF (`packages/config/pdf-studio-native.ts:122-126`,
+  `:187-246`; `native-adapter.ts:146-217`). Only the corrected-receipt path
+  currently requires production mode (`receipt-pdf.ts:173-186`, `:233-249`).
+
+### Material limitations
+
+- The "native builder" shown to staff is currently a raw **Document JSON**
+  `<Textarea>` beside an iframe preview
+  (`apps/admin/app/pdf/page-client.tsx:1080-1160`). There is no runtime import of
+  `@asym/pdf-editor` outside manifests/vendor code. This is a developer scaffold,
+  not the non-technical Statement Studio editor promised by the PRD.
+- Native save writes the mutable source JSON back to the root `pdf_templates`
+  row and sets `html: null`; it does **not** create an immutable version
+  (`packages/api/src/pdf-templates/native-adapter.ts:221-265`). The UI confirms
+  this gap by labeling "Version History" as "coming soon"
+  (`apps/admin/app/pdf/page-client.tsx:653-659`).
+- DocRaptor render receives PDF bytes but the native adapter discards the bytes,
+  returns only size/type plus an `adapter_reference`, and neither inserts an
+  artifact nor gives the browser a file/URL
+  (`packages/api/src/pdf-templates/native-adapter.ts:190-217`). The UI can only
+  toast "Native render completed" (`apps/admin/app/pdf/page-client.tsx:1434-1477`).
+- Asset URL signing and batch execution are placeholders: the asset adapter
+  returns `undefined` for a signed URL and the batch adapter only echoes enqueue
+  metadata (`packages/api/src/pdf-templates/native-adapter.ts:368-403`).
+
+## Template, version, render, and artifact persistence
+
+### Committed schema
+
+- **Schema:** `20260515140948_native_pdf_studio_foundation.sql` extends
+  `pdf_templates` with engine, schema-version, current-version, and migration
+  state (`:3-47`). It creates:
+  `pdf_template_versions` (`:49-64`), `pdf_template_renders` (`:66-86`),
+  `pdf_template_artifacts` (`:88-106`), `pdf_template_audit_events`
+  (`:108-118`), `pdf_template_batches` (`:120-137`), and batch jobs
+  (`:139-152`).
+- **Schema:** all child tables have non-null `tenant_id`, RLS, no anonymous
+  grants, staff-tenant policies, and service-role policies
+  (`supabase/migrations/20260515140948_native_pdf_studio_foundation.sql:231-263`,
+  `:265-487`).
+- **Plan alignment:** the current Statement Studio data-model guide already says
+  to extend/rename this `pdf_*` family and not create parallel
+  `document_*` artifact tables
+  (`docs/guides/features/statement-studio/data-model.md:20-55`).
+
+### Runtime reality and risks
+
+- A repository-wide runtime search finds no `.from("pdf_template_versions")`,
+  `.from("pdf_template_renders")`, `.from("pdf_template_artifacts")`, or
+  `.from("pdf_template_batches")` call in `apps/**` or `packages/**`. Current
+  runtime persistence stops at the mutable `pdf_templates` root row.
+- The migration records a location but does not create a private Storage bucket
+  or object policies. The only generic document bucket in the initial schema is
+  `document-uploads`, and it is public-read
+  (`supabase/migrations/20250101000000_init_schema.sql:460-487`). No PDF/statement
+  Storage adapter exists in `apps/**` or `packages/**`.
+- The artifact row lacks document job, scope, recipient/owner, retention,
+  purge/tombstone, and download-audit fields. Those are required before donor or
+  missionary portal access can be authorized. The planning guide requires
+  private Storage and tenant-aware paths/downloads
+  (`docs/guides/features/statement-studio/data-model.md:86-101`).
+- Tenant safety is only partially encoded relationally: child rows carry
+  `tenant_id`, but their foreign keys reference parent IDs alone rather than a
+  composite `(tenant_id, id)`. The RLS predicates authorize the child row's
+  tenant; they do not prove the referenced template/version belongs to that same
+  tenant. Before activating child-table writers, enforce same-tenant references
+  in schema or a single trusted persistence seam.
+- The committed migration history also contains
+  `20260216153000_demo_readonly_rls.sql`, which replaced policies on
+  `pdf_templates` and core donor/donation/missionary/profile tables with
+  anonymous `public read` policies. The native-PDF migration later revokes anon
+  table privileges from `pdf_*`, but it does not drop the latent permissive
+  policy; a future grant could reactivate it, and a hosted project missing that
+  later migration may still expose templates. The audit also found no blanket
+  cleanup covering every core giving table. This does not prove effective hosted
+  state, but explicit policy removal plus deployed RLS/grant verification are
+  hard gates before official-document resolvers or direct Data API reads are
+  trusted.
+- The repo proves that the migration is committed, not that any hosted project
+  applied it. `docs/features/pdf-studio/native-builder-migration-handoff.md`
+  stated it was unapplied when authored. Hosted migration status must be checked
+  separately before any code assumes these tables exist.
+
+## Current donor receipt behavior
+
+There are four distinct receipt paths; they must not be described as one
+finished Statement Studio flow.
+
+1. **Donor portal text download (runtime).**
+   `packages/api/src/donor-portal/receipts.ts:39-82` authenticates a donor,
+   scopes the lookup by tenant + donor + donation, reads current profile/gift
+   data, and returns `text/plain` named `donation-receipt-<id>.txt`. Unlike the
+   annual statement query, this lookup does not require a settled status; the
+   generated file merely prints the current status (`:15-36`). It is not a PDF,
+   not template-backed, not frozen, and not sufficient tax-receipt evidence.
+
+2. **Staged-gift email receipt (runtime).**
+   `packages/api/src/giving/receipts.ts:144-170` builds hard-coded HTML/text.
+   Delivery goes through the shared `sendEmail` seam, tenant Resend settings,
+   consent policy, idempotency, `email_send_logs`, and `staged_gifts` status
+   updates (`:313-468`). It does not resolve a PDF/Statement Studio assignment
+   or attach/store an artifact.
+
+3. **Corrected receipt snapshot and PDF (runtime).**
+   `contribution_receipt_snapshots` stores correction-time render inputs
+   server-side
+   (`supabase/migrations/20260611140000_contribution_receipt_delivery.sql:17-39`).
+   Staff with the configured capability can render an updated receipt from that
+   snapshot through DocRaptor **production mode** and stream the bytes directly
+   (`packages/api/src/admin/contribution-operations/receipt-pdf.ts:141-186`,
+   `:194-282`). This is the strongest reusable rendering/snapshot seam, but it is
+   hard-coded updated-receipt HTML, has no template/version assignment, and does
+   not persist a generated-file artifact. The application currently writes a
+   new snapshot per action, but the schema permits service-role updates, deletes
+   snapshots on donation deletion, and does not enforce that the referenced
+   donation shares the snapshot tenant. It is not yet database-immutable or
+   retention-durable official evidence.
+
+4. **Gift receipt record scaffold (schema/module/test only).**
+   `gift_receipt_records` stores one server-only frozen snapshot per donation
+   (`supabase/migrations/20260704120000_gift_receipt_records.sql:14-40`).
+   `packages/api/src/giving/receipt-record.ts` builds, renders, and idempotently
+   writes the snapshot, but its own comment says it is intentionally not wired
+   to the payment path (`:216-223`). Repository-wide call-site search confirms
+   `recordGiftReceipt` has no runtime caller. Its donor language is explicitly a
+   non-production placeholder (`:21-26`).
+
+The canonical receipt truth model is therefore unresolved among live donor
+reads, correction snapshots, staged-gift email logs, and the unused frozen gift
+record. Statement Studio should consume a source-domain receipt DTO after those
+owners are reconciled; it should not become a fifth money/receipt truth store.
+
+## Current annual-statement behavior
+
+- **Runtime:** `GET /api/donor/statements/[year]` is a thin export to
+  `packages/api/src/donor-portal/statements.ts`. The donor helper requires donor
+  role and uses a server-only client
+  (`packages/api/src/donor-portal/route-helpers.ts:14-35`).
+- **Runtime/data boundary:** `getOwnedStatementDonations` filters by tenant,
+  donor, UTC year, and the local settled-status set
+  (`packages/api/src/donor-portal/service.ts:279-301`). The history UI links to
+  this route (`apps/donor/app/(dashboard)/donor-dashboard/history/page-content.tsx:234`).
+- **Output:** the handler totals the current `donations` rows and returns a
+  tab-delimited `text/plain` attachment named `giving-statement-<year>.txt`
+  (`packages/api/src/donor-portal/statements.ts:30-93`). It has no template,
+  immutable statement snapshot, version/assignment, PDF renderer, artifact,
+  private Storage object, delivery event, retention, or corrected/refunded gift
+  history.
+- The query projects one current fund or missionary association per donation
+  (`packages/api/src/donor-portal/service.ts:55-72`). A production Statement
+  Studio resolver must remain owned by the giving domain and evolve with the
+  canonical contribution/designation/credit model; Statement Studio must not
+  duplicate those joins as its own financial truth.
+
+## Cross-domain owner and readiness evidence
+
+| Domain / surface  | Primary-source evidence                                                                                                                                                                                                 | Classification and finding                                                                                                                                                                                                                                                                                                                               |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Giving / donor    | `packages/api/src/giving/{receipts,receipt-record}.ts`; `packages/api/src/admin/contribution-operations/{receipt-delivery,receipt-pdf}.ts`; `packages/api/src/donor-portal/{service,receipts,statements}.ts`            | **Runtime + Schema + Test.** Giving and Contribution Operations own gift, correction, receipt, and delivery facts; donor portal is the recipient BFF. The four receipt paths and live annual query are not yet one official-document context.                                                                                                            |
+| Reports / finance | `packages/api/src/admin/crm/reports/service.ts:buildAdminCrmReport`; `packages/api/src/admin/crm/reports/export.ts`; `apps/admin/app/api/admin/crm/reports/{route,export/route}.ts`                                     | **Runtime + Test.** A tenant-scoped report/CSV seam exists, but its giving aggregation selects flat completed `donations` by `created_at`; finance must approve a document DTO before Statement Studio uses it.                                                                                                                                          |
+| Missionary        | `packages/api/src/missionary-portal/service.ts:getMissionaryPortalSnapshot`; `packages/api/src/missionary-portal/{donors,tasks}.ts`; `tests/unit/packages/api/missionary-portal-{redaction,snapshot-redaction}.test.ts` | **Runtime + Test.** This is a real role-scoped BFF/resolver starting point, but there is no statement route/context. The legacy `missionary_tasks` table in `20250101000000_init_schema.sql:287-301` has no tenant column and was initially created with RLS disabled at `:577`, so task documents are not a clean first job without separate hardening. |
+| Events            | `apps/admin/app/events/page-client.tsx:EventsPage`; `packages/database/collections/admin-workspace.ts:eventAttendeesCollection`                                                                                         | **Runtime UI over seed data.** The attendee collection returns `EVENT_ATTENDEES_SEED`; no production event document resolver or artifact route was found. Treat event starters as sample/template-ready only.                                                                                                                                            |
+| Support / reports | `packages/api/src/admin/support-hub/adapter/index.ts:supportHubAdapter`; `apps/admin/app/api/admin/support/reports/route.ts`; `apps/admin/features/support-hub/lib/report-aggregations.ts:buildReportSeries`            | **Runtime.** Supabase is the live Support adapter, but the reports route explicitly delegates part of aggregation to a client-side helper. Consolidate a server-owned report context before PDF output.                                                                                                                                                  |
+| Member care       | `packages/api/src/reads/member-care.ts`; `packages/api/src/admin/member-care/**`; `supabase/migrations/20260414180338_member_care_foundation.sql`                                                                       | **Runtime + Schema + Test.** Tenant-scoped activities, goals, requirements, and private notes exist. Private-note redaction, elevated capability, retention, and access-reason audit need separate HITL policy before any care packet.                                                                                                                   |
+| Shared tasks      | `packages/api/src/admin/mission-control-tasks/**`; `packages/api/src/admin/mission-control-tasks/store.ts` writes `mission_control_tasks`; `packages/database/collections/admin-workspace.ts:adminTasksCollection`      | **Runtime service plus seed/in-memory UI collection.** Shared Mission Control tasks are the source owner. Do not render from `adminTasksCollection`, whose query/mutations operate on in-memory rows.                                                                                                                                                    |
+| Mobilize          | `apps/admin/app/mobilize/**`; `packages/database/collections/admin-workspace.ts:mobilizeCandidatesCollection`                                                                                                           | **Runtime UI over seed data.** Candidate collection reads `MOBILIZE_CANDIDATES_SEED`; no production packet resolver was found. Defer operational packets.                                                                                                                                                                                                |
+| Legal / signing   | `apps/admin/app/sign/page-client.tsx`; `apps/donor/app/(public)/sign/[token]/page-client.tsx`                                                                                                                           | **Prototype/mock.** The public signer assigns the literal mock signature `John Doe`; no production legal evidence/context owner was found. Legal packets remain HITL and not implementation-ready.                                                                                                                                                       |
+| CMS               | `apps/admin/src/cms/access/tenant-access.ts`; `apps/admin/src/cms/public/published-page-read.ts`; `apps/admin/src/cms/collections/media.ts`; `apps/admin/src/cms/payload-runtime-integrations.ts`                       | **Runtime.** Payload provides tenant-scoped approved content and published-page reads. Media uses Vercel Blob when configured and local `staticDir` as the fallback; Statement Studio still needs an authorized, render-safe asset adapter. CMS may supply branding/content, never operational or gift truth.                                            |
+
+Repository searches also covered the report, event, missionary, care, task,
+legal/signing, Mobilize, and CMS app/API/schema paths named by issue #312. A
+missing production resolver is recorded as a gap rather than inferred from a UI
+or planning document.
+
+## Test evidence and remaining proof gaps
+
+| Evidence                                                                                                                 | What it proves                                                                            | What it does not prove                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `tests/e2e/admin-pdf-studio-legacy.spec.ts`                                                                              | Legacy `/pdf` and Unlayer iframe can load with demo auth.                                 | Native editing, production render, persistence, or artifact delivery.                                 |
+| `tests/unit/apps/admin/pdf-studio-native-ui.test.ts`                                                                     | Static source contains flags/routes and avoids client DocRaptor imports.                  | Browser behavior; it reads source text rather than mounting the UI.                                   |
+| `tests/unit/packages/api/pdf-studio-native-{adapter,routes}.test.ts`                                                     | Preview/preflight, fail-closed render config, category mapping, manual migration reports. | A real DocRaptor render, bytes/download, version row, artifact row, or Storage object.                |
+| `tests/unit/packages/api/pdf-template-native-migration.test.ts`                                                          | SQL text contains native tables/RLS/grants.                                               | Successful Supabase apply/reset, hosted migration state, same-tenant FK integrity, or Storage policy. |
+| `tests/unit/packages/api/pdf-template-{store,templates}.test.ts`                                                         | Root CRUD/tenant predicates and route validation with fakes.                              | Child version/artifact lifecycle.                                                                     |
+| `tests/unit/packages/api/admin/contribution-receipt-pdf.test.ts`                                                         | Snapshot HTML escaping, capability gate, fake DocRaptor bytes, production-mode refusal.   | Real provider or persisted artifact delivery.                                                         |
+| `tests/unit/packages/api/donor-portal/auth-ownership.test.ts`                                                            | Receipt ownership predicates and annual statement settled/year filter.                    | Receipt/statement route content and headers.                                                          |
+| `tests/unit/apps/donor/history-receipt-links.test.ts`                                                                    | Static source points controls at receipt/statement URLs.                                  | Successful downloads or PDF fidelity.                                                                 |
+| `tests/unit/packages/api/giving-receipt-record.test.ts` and `tests/unit/supabase/gift-receipt-records-migration.test.ts` | Frozen snapshot logic and migration text.                                                 | Money-path integration; there is no runtime caller.                                                   |
+
+No direct unit/integration test invokes the donor receipt or annual-statement GET
+handler, and no E2E test covers native render, immutable version publication,
+artifact persistence, private Storage, portal artifact authorization, retention,
+or delivery audit.
+
+## Evidence-led disposition
+
+### Reuse
+
+- The existing `pdf_templates` / `pdf_template_*` table family as the canonical
+  migration base; evolve it instead of adding parallel Statement Studio tables.
+- Thin App Router exports, admin-role checks, tenant-scoped store predicates,
+  schema validation, preflight, provider-neutral adapter concepts, and
+  fail-closed provider configuration.
+- The donor-portal ownership query as a source-domain starting seam, not as a
+  Statement Studio-owned SQL model.
+- Stored correction-time receipt snapshots, production-mode DocRaptor guard,
+  capability checks, the shared `sendEmail` seam, idempotency, and delivery logs.
+
+### Replace or complete
+
+- Mutable root-row native saves with immutable version creation/publish/rollback.
+- Raw JSON textarea authoring with the approved non-technical Statement Studio
+  editor.
+- Native render metadata-only responses with actual artifact persistence,
+  private Storage, authorized download, checksum, retention, and audit.
+- Direct live-data `.txt` receipt/statement handlers and hard-coded receipt HTML
+  with source-domain DTOs and assigned, versioned templates.
+- Broad staff-table policies and ID-only foreign keys with capability-aware,
+  same-tenant invariants before those tables become active runtime surfaces.
+
+### Retire later; delete nothing yet
+
+- Keep Unlayer as a flagged legacy fallback through at least one exercised
+  production Statement Studio job and verified migration path. Then retire the
+  legacy editor, public env/config, tests, docs, and dependency together.
+- Do not delete native tables or DocRaptor correction-receipt code. They contain
+  reusable schema and operational seams even if the final compiler/renderer
+  changes.
+
+## First production slice conclusion
+
+Keep `donor.statement.annual_giving` as the first **Statement Studio document
+job**, but make the confirmation conditional:
+
+1. It already has a donor-authenticated, tenant/donor/year-scoped route and a
+   visible dashboard download entry point, so there is a clean replace-in-place
+   vertical seam.
+2. It exercises the architecture more completely than a single receipt:
+   repeaters, multiple gifts, totals, variables, assignment, immutable version,
+   rendering, recipient authorization, private artifact Storage, and download.
+3. `donor.receipt.single` is currently fragmented across four truth/delivery
+   paths and carries unresolved compliance language. Moving it first would mix
+   Statement Studio foundation with receipt-truth consolidation.
+
+However, do **not** call the annual statement production-ready while it reads the
+legacy live `donations` projection directly. The first slices may build the
+shell, starter, schema/version, assignment, fixture preview, and source-domain
+resolver contract; the production render/download slice must be gated on:
+
+- a canonical giving-domain DTO that represents settled, corrected, refunded,
+  designation, and donor-credit truth without Statement Studio owning money;
+- one canonical Postgres model mapped onto the existing `pdf_*` family;
+- private Storage plus recipient predicates and artifact lifecycle fields;
+- the Phase 0 renderer proposal: qualify DocRaptor behind the provider seam for
+  the first slice, obtain HITL approval, and do not silently add a competing
+  stack;
+- hosted migration verification and finance/legal approval of statement and
+  receipt language.
+
+That preserves the intended backlog order while preventing the old ticket from
+baking current flat/live donation reads into the new document platform.

--- a/docs/guides/features/statement-studio/phase-0-research-evidence.md
+++ b/docs/guides/features/statement-studio/phase-0-research-evidence.md
@@ -55,9 +55,9 @@ object and direct file reads.
 - At audit start, the Statement Studio PRD named pdfx + React PDF as the target
   and explicitly delegated reconciliation with native PDF Studio + DocRaptor to
   Phase 0. There is no `pdfx` or `@react-pdf/renderer` runtime dependency or
-  import under `apps/**` or `packages/**` on the audited commit. The completed
-  audit proposes qualifying the existing server-side DocRaptor adapter behind a
-  provider port for the first slice, pending HITL approval.
+  import under `apps/**` or `packages/**` on the audited commit. Phase 0 selects
+  the existing server-side DocRaptor adapter as the provider candidate behind a
+  port; production use remains gated on qualification and HITL approval.
 - The PRD also asks Phase 0 to add
   `openspec/changes/add-statement-studio/`
   (`docs/guides/features/statement-studio/prd.md:36-43`). No Statement Studio
@@ -220,7 +220,11 @@ object and direct file reads.
   purge/tombstone, and download-audit fields. Those are required before donor or
   missionary portal access can be authorized. The planning guide requires
   private Storage and tenant-aware paths/downloads
-  (`docs/guides/features/statement-studio/data-model.md:86-101`).
+  (`docs/guides/features/statement-studio/data-model.md:92-102`).
+- Native render has no stable logical render key, lease/fencing-token recovery,
+  or canonical-artifact uniqueness contract. Client, queue, or provider retries
+  could therefore create duplicate official output once persistence is wired;
+  foundation work must define that boundary before enabling production.
 - Tenant safety is only partially encoded relationally: child rows carry
   `tenant_id`, but their foreign keys reference parent IDs alone rather than a
   composite `(tenant_id, id)`. The RLS predicates authorize the child row's

--- a/docs/guides/features/statement-studio/prd.md
+++ b/docs/guides/features/statement-studio/prd.md
@@ -5,13 +5,15 @@ product inside Mission Control. It must become the platform's own custom PDF
 and statement product surface, not Unlayer, not an email editor pretending to
 make PDFs, and not a thin wrapper around disconnected exports.
 
-The product must use pdfx and React PDF as deeply as makes sense while keeping
-the saved template format Asym-owned, tenant-safe, versioned, auditable, and
-usable by non-technical tenant admins.
+The product must keep its saved template format Asym-owned, tenant-safe,
+versioned, auditable, and usable by non-technical tenant admins. Rendering stays
+behind a provider-neutral server boundary.
 
-**Render-stack note:** Statement Studio's target production path is pdfx + React PDF.
-Reconcile with the in-flight native PDF Studio + DocRaptor stack documented in
-`docs/guides/features/pdf-studio.md` during Phase 0 (#312) before cutover.
+**Phase 0 proposal (effective on AL-312 HITL merge):** Qualify the in-flight
+native PDF Studio server-side DocRaptor adapter, then use it as the sole
+first-slice provider. The repo has no pdfx or React PDF runtime path; adding one
+now would create a competing greenfield stack. See `phase-0-audit-brief.md` for
+qualification, parity, cutover, rollback, and template-migration gates.
 
 ## Triggers
 
@@ -39,9 +41,8 @@ Use it for:
    operational depth, donor and missionary dashboards expose role-scoped
    slices, and tenant safety is non-negotiable. **Phase 0 (#312) deliverable:**
    add `openspec/changes/add-statement-studio/` (proposal, design, tasks, spec
-   deltas for boundaries and data access) and link it from this doc set—this
-   PR documents intent; OpenSpec change lands in the implementation slice, not
-   in the docs-only planning PR.
+   deltas for boundaries and data access) and link it from this doc set. AL-312
+   now supplies that proposed change.
 3. Load the repo Supabase skill before any database, Auth, Storage, Realtime,
    Edge Function, RLS, migration, or Supabase CLI work.
 4. Load the Supabase Postgres best-practices skill before schema, RLS, index,
@@ -105,7 +106,7 @@ statement templates. It should provide:
 - A broad white-label starter library inside Templates, with production-ready
   jobs and template-ready demo jobs clearly labeled.
 - A PDF-native editor built on an Asym-owned constrained JSON template schema,
-  compiled to pdfx and React PDF at render time.
+  compiled through the provider-neutral server renderer boundary.
 - Immutable template versions with draft, preview, publish, set-as-default, and
   rollback workflows.
 - Tenant-scoped assignment records that map a document job and optional scope
@@ -332,7 +333,9 @@ UX requirements:
 - Use a new canonical Statement Studio engine for Asym-owned PDF templates.
 - Persist templates as a constrained Asym JSON block/tree schema, not JSX, raw
   pdfx registry JSON, HTML, direct React props, or Unlayer design JSON.
-- Compile the validated template schema to pdfx and React PDF at render time.
+- Compile the validated template schema through the server-only renderer port.
+  Pending qualification and AL-312 HITL approval, the first production provider
+  is DocRaptor per the Phase 0 proposal.
 - Store immutable published versions with content hashes and schema versions.
 - Store drafts separately from published versions.
 - Allow clone, edit, preview, publish, assign, replace, and rollback workflows.
@@ -397,7 +400,9 @@ Current official Supabase posture checked on 2026-06-12:
 
 ### Core Data Model
 
-Phase 0 should choose exact names, but the model must cover these concepts:
+Phase 0 retained the existing `pdf_*` family as the canonical migration base.
+Foundation work must map or add these concepts without creating a parallel
+template/version/render/artifact store:
 
 - System document job catalog.
 - System starter template library and starter versions.
@@ -548,6 +553,10 @@ Tenant-custom variable support:
 - Registered custom fields on approved entities.
 - Safe no-code derived variables: concatenate, format date, format currency,
   conditional fallback, sum, count, approved filters, simple boolean display.
+- Official receipt/statement money and date fields are excluded from these
+  transformations. Their source snapshot carries frozen display strings plus
+  raw values and locale/version metadata; templates bind those fields and never
+  recompute or reformat them.
 
 Do not support:
 
@@ -1015,7 +1024,7 @@ Create issues from this PRD as epics and thin vertical slices:
 - Product shell and IA issue.
 - Supabase foundation schema/RLS/Storage issue.
 - Template schema and validation issue.
-- Renderer and pdfx/React PDF integration issue.
+- Renderer port and DocRaptor artifact integration issue.
 - Starter Library issue.
 - Variables registry/source maps issue.
 - Tenant custom variables issue.
@@ -1154,14 +1163,26 @@ Definition of done:
 
 ## Further Notes
 
-### Open Questions For Phase 0
+### Phase 0 Answers And Remaining Gates
 
-- What exact table names should be retained, renamed, or introduced to balance
-  migration cost with product clarity?
-- Which current PDF templates, if any, should be migrated rather than removed?
-- Which first-slice route should become canonical for donor annual statement
-  generation and artifact download?
-- How much of the existing native builder schema can be reused safely?
+- Retain the `pdf_*` family and extend it with missing job, assignment,
+  variable, recipient/source, and retention concepts; do not create parallel
+  document tables.
+- Reuse the Asym schema, preflight, and server DocRaptor provider boundary.
+  Complete version/artifact/Storage behavior; do not adopt the raw JSON editor
+  or client-supplied production data route as product behavior.
+- Keep `donor.statement.annual_giving` as the first donor-facing production job
+  through the existing donor BFF route, after the canonical frozen statement
+  snapshot/version seam and finance/legal approval exist. Coordinate with the
+  newer proposed Phase 7 issues #579, #580, #583, and #584 rather than creating
+  a parallel context or formatting model.
+- Keep legacy tenant templates until hosted data is inventoried and each
+  template has an approved migrate/archive/delete disposition.
+- Re-groom issue #322 so the official statement context, private artifact path,
+  and policy approval are explicit blockers.
+
+### Remaining Implementation Questions
+
 - Should batch rendering use the platform's existing job mechanism or add a new
   dedicated execution path?
 - Which document classes need legal retention defaults by jurisdiction or
@@ -1183,12 +1204,13 @@ Definition of done:
 
 ## Checklist
 
-- [ ] Phase 0 audit completed before implementation.
+- [x] Phase 0 audit completed before implementation.
 - [ ] Statement Studio product shell is clean, token-driven, and non-technical.
 - [ ] Supabase skill is used for all database/Supabase work.
 - [ ] Supabase CLI is used for migration and database verification.
 - [ ] RLS, grants, Storage, indexes, and tenant boundaries are explicit.
-- [ ] Template schema is Asym-owned and compiled to pdfx/React PDF.
+- [ ] Template schema is Asym-owned and compiled through the approved
+      server-only renderer port.
 - [ ] Variables have source maps, readiness, sensitivity, and validation.
 - [ ] Starter library is broad, white-label, and tenant-brandable.
 - [ ] Assignments support standard jobs and tenant custom assignments.

--- a/docs/guides/features/statement-studio/prd.md
+++ b/docs/guides/features/statement-studio/prd.md
@@ -9,11 +9,12 @@ The product must keep its saved template format Asym-owned, tenant-safe,
 versioned, auditable, and usable by non-technical tenant admins. Rendering stays
 behind a provider-neutral server boundary.
 
-**Phase 0 proposal (effective on AL-312 HITL merge):** Qualify the in-flight
-native PDF Studio server-side DocRaptor adapter, then use it as the sole
-first-slice provider. The repo has no pdfx or React PDF runtime path; adding one
-now would create a competing greenfield stack. See `phase-0-audit-brief.md` for
-qualification, parity, cutover, rollback, and template-migration gates.
+**Phase 0 decision:** The in-flight native PDF Studio server-side DocRaptor
+adapter is the first-slice provider candidate. If provider qualification and
+HITL approval pass, use it as the sole first-slice provider. The repo has no pdfx
+or React PDF runtime path; adding one now would create a competing greenfield
+stack. See `phase-0-audit-brief.md` for qualification, parity, cutover, rollback,
+and template-migration gates.
 
 ## Triggers
 
@@ -334,8 +335,9 @@ UX requirements:
 - Persist templates as a constrained Asym JSON block/tree schema, not JSX, raw
   pdfx registry JSON, HTML, direct React props, or Unlayer design JSON.
 - Compile the validated template schema through the server-only renderer port.
-  Pending qualification and AL-312 HITL approval, the first production provider
-  is DocRaptor per the Phase 0 proposal.
+  The first production provider candidate is DocRaptor per the Phase 0 decision;
+  production enablement remains gated on provider qualification and HITL
+  approval.
 - Store immutable published versions with content hashes and schema versions.
 - Store drafts separately from published versions.
 - Allow clone, edit, preview, publish, assign, replace, and rollback workflows.

--- a/docs/guides/features/statement-studio/product-plan.md
+++ b/docs/guides/features/statement-studio/product-plan.md
@@ -18,7 +18,10 @@ Use this plan when defining Statement Studio scope, product behavior, implementa
 
 - Fully usable staff-facing product inside Mission Control.
 - Own custom Statement Studio surface, not Unlayer and not an email editor.
-- Uses pdfx and React PDF where they fit the template model and render pipeline.
+- Uses an Asym-owned template schema and provider-neutral render boundary. Phase
+  0 proposes qualifying the current server-only DocRaptor integration for the
+  first production path; renderer replacement remains a later explicit
+  migration decision.
 - White-label, tenant-brandable, accessible, printable, and reliable.
 - Tenant-aware across Mission Control, Donor Dashboard, and Missionary Dashboard.
 
@@ -51,10 +54,15 @@ Owning product surfaces own source facts:
 1. Foundation: schema, RLS, grants, Storage, template JSON, versioning, artifact model.
 2. Editor MVP: create, edit, sample preview, real preview, publish.
 3. Assignments: standard jobs, tenant defaults, custom assignments.
-4. First production jobs: `donor.statement.annual_giving`, then `donor.receipt.single`, then `missionary.statement.monthly_giving`.
-5. Tables/repeaters: donor lists, finance reports, event roster/badge, schedules.
-6. Starter library: broad white-label catalog, design variants, fixtures.
-7. Batch rendering, retention automation, purge/storage management, governance.
+4. Infrastructure tracer: synthetic admin-only preview selection, render,
+   private artifact, download, and audit; never a production assignment/job.
+5. First production jobs: `donor.statement.annual_giving` after its canonical
+   statement snapshot/version and finance/legal gates, then
+   `donor.receipt.single` after receipt-truth reconciliation, then
+   `missionary.statement.monthly_giving`.
+6. Tables/repeaters: donor lists, finance reports, event roster/badge, schedules.
+7. Starter library: broad white-label catalog, design variants, fixtures.
+8. Batch rendering, retention automation, purge/storage management, governance.
 
 ## Capability Groups
 

--- a/docs/guides/features/statement-studio/product-plan.md
+++ b/docs/guides/features/statement-studio/product-plan.md
@@ -19,9 +19,9 @@ Use this plan when defining Statement Studio scope, product behavior, implementa
 - Fully usable staff-facing product inside Mission Control.
 - Own custom Statement Studio surface, not Unlayer and not an email editor.
 - Uses an Asym-owned template schema and provider-neutral render boundary. Phase
-  0 proposes qualifying the current server-only DocRaptor integration for the
-  first production path; renderer replacement remains a later explicit
-  migration decision.
+  0 selects the current server-only DocRaptor integration as the provider
+  candidate; production use remains gated on qualification and HITL approval,
+  and renderer replacement requires a later explicit migration decision.
 - White-label, tenant-brandable, accessible, printable, and reliable.
 - Tenant-aware across Mission Control, Donor Dashboard, and Missionary Dashboard.
 

--- a/docs/guides/features/statement-studio/variables.md
+++ b/docs/guides/features/statement-studio/variables.md
@@ -13,7 +13,9 @@ Use this doc when planning or implementing variable catalogs, source maps, custo
 3. Create source-map records for built-in variables.
 4. Add tenant-level labels, grouping, fallbacks, formatting, sample values, and custom variables.
 5. Validate variables before preview, publish, assignment, and production render.
-6. Resolve production variables on the server at render time.
+6. Resolve production variables on the server. Official receipt/statement
+   display values are frozen by the source domain at issuance and bound at
+   render time; they are not recomputed by Statement Studio.
 
 ## Variable Families
 
@@ -56,6 +58,11 @@ Tenant admins can create or customize:
 - Aliases to approved fields.
 - Registered custom fields for approved entities.
 - Simple no-code derived variables such as concatenate, format date, format currency, conditional fallback, sum, count, and approved filters.
+
+Those transformations are not available for official receipt/statement money
+or date fields. Their source contract supplies raw structured values plus frozen
+display strings and locale/formatting version metadata; templates bind the
+approved display fields.
 
 Do not allow raw SQL, arbitrary joins, arbitrary JSON path expressions, arbitrary
 JavaScript, unsafe resolver access, or cross-tenant references.

--- a/openspec/changes/add-donor-self-service/proposal.md
+++ b/openspec/changes/add-donor-self-service/proposal.md
@@ -4,10 +4,12 @@
 
 `platform-surfaces` promises that donors control their giving, recurring
 gifts, payment methods, receipts, and statements, but the shipped donor portal
-is read-only: recurring gifts display without pause/cancel/amount controls,
-the wallet UI is a stub with no mutation endpoints, and annual statements are
-computed as years but never generated. This change closes the gap between the
-surface intent and the shipped product.
+is read-only for recurring/payment-method controls: recurring gifts display
+without pause/cancel/amount controls and the wallet UI is a stub with no
+mutation endpoints. Annual statements have a donor-owned live `.txt` download,
+but it recomputes flat donation rows and has no frozen receiptable context,
+official template/artifact, retention, or recorded delivery. This change closes
+the gap between the surface intent and shipped product.
 
 ## What Changes
 
@@ -17,11 +19,15 @@ surface intent and the shipped product.
 - Add donor payment-method management (add, update default, remove) through
   Stripe-managed flows; no raw payment data touches Asym servers.
 - Add annual giving statement generation and delivery for receiptable gifts
-  tied to known donor records.
+  tied to known donor records. The Giving/statement domain owns the canonical
+  frozen snapshot/version, including official display strings and raw values;
+  Statement Studio owns assigned template/render/private artifact, and the donor
+  BFF owns recipient-authorized download/delivery.
 
 ## Impact
 
 - Affected specs: `donation-lifecycle`
 - Affected code: `packages/api/src/donor-portal/**`,
   `packages/api/src/stripe/**`, `apps/donor` dashboard (recurring, wallet,
-  statements)
+  statements), and the Statement Studio artifact boundary proposed by
+  `add-statement-studio`

--- a/openspec/changes/add-donor-self-service/specs/donation-lifecycle/spec.md
+++ b/openspec/changes/add-donor-self-service/specs/donation-lifecycle/spec.md
@@ -50,9 +50,20 @@ until settled. Unknown-donor gifts MUST NOT appear on any donor's statement
 unless later matched, and statement language MUST be finance/legal reviewed
 before production use.
 
+Giving MUST produce the frozen, versioned statement context from canonical
+donation/correction truth, including raw structured values and frozen official
+display strings with locale/formatting version metadata. The document-production
+capability MUST resolve the assigned immutable template and private artifact,
+bind those frozen strings, and avoid recalculating or reformatting official
+facts. The donor BFF MUST authorize the recipient, expose only the current
+eligible artifact, and record delivery/download. A later correction, refund, or
+donor relink MUST supersede or void stale output per policy while preserving
+correction and artifact lineage.
+
 #### Scenario: A donor downloads last year's statement
 
 - WHEN a donor requests a statement for a completed year
 - THEN the statement includes exactly their settled, receiptable gifts for that
   year from canonical records
+- AND the portal does not present a superseded or void statement as current
 - AND the delivery or download is recorded

--- a/openspec/changes/add-donor-self-service/specs/donation-lifecycle/spec.md
+++ b/openspec/changes/add-donor-self-service/specs/donation-lifecycle/spec.md
@@ -42,13 +42,18 @@ MUST require choosing a replacement first.
 
 ### Requirement: Donors Receive Annual Giving Statements
 
-The platform MUST generate annual giving statements covering a donor's settled,
-receiptable gifts tied to their donor record, available from the donor portal
-and delivered per tenant policy. Pending or in-flight gifts (for example
-unsettled ACH or not-yet-collected recurring installments) MUST NOT appear
-until settled. Unknown-donor gifts MUST NOT appear on any donor's statement
-unless later matched, and statement language MUST be finance/legal reviewed
-before production use.
+The platform MUST generate annual giving statements whose deductible lines and
+totals cover only settled, receiptable hard-credit gifts tied to the authorized
+donor or household subject. When the canonical source context contains approved
+indirect soft-credit, DAF, or matched-gift lines supplied by the owning domain,
+the statement MUST render those lines only in a clearly labeled indirect
+section, and those lines MUST NOT enter the deductible total. Pending or
+in-flight gifts (for example unsettled ACH or not-yet-collected recurring
+installments) MUST NOT appear in deductible or indirect lines or totals in the
+donor artifact until settled; they MAY remain only in the owning domain's
+excluded/audit set with the approved reason code. Still-unknown-donor gifts MUST
+NOT appear in a donor artifact unless the owning domain later matches them, and
+statement language MUST be finance/legal reviewed before production use.
 
 Giving MUST produce the frozen, versioned statement context from canonical
 donation/correction truth, including raw structured values and frozen official
@@ -63,7 +68,9 @@ correction and artifact lineage.
 #### Scenario: A donor downloads last year's statement
 
 - WHEN a donor requests a statement for a completed year
-- THEN the statement includes exactly their settled, receiptable gifts for that
-  year from canonical records
+- THEN its deductible lines and totals include exactly the settled, receiptable
+  hard-credit gifts for the authorized donor/household subject and year
+- AND any approved indirect lines supplied by the owning domain appear only in
+  a labeled indirect section and remain excluded from the deductible total
 - AND the portal does not present a superseded or void statement as current
 - AND the delivery or download is recorded

--- a/openspec/changes/add-donor-self-service/specs/donation-lifecycle/spec.md
+++ b/openspec/changes/add-donor-self-service/specs/donation-lifecycle/spec.md
@@ -50,16 +50,21 @@ the statement MUST render those lines only in a clearly labeled indirect
 section, and those lines MUST NOT enter the deductible total. Pending or
 in-flight gifts (for example unsettled ACH or not-yet-collected recurring
 installments) MUST NOT appear in deductible or indirect lines or totals in the
-donor artifact until settled; they MAY remain only in the owning domain's
-excluded/audit set with the approved reason code. Still-unknown-donor gifts MUST
-NOT appear in a donor artifact unless the owning domain later matches them, and
-statement language MUST be finance/legal reviewed before production use.
+donor artifact until settled; the owning domain MUST retain their excluded/audit
+record with its approved reason code. Still-unknown-donor gifts MUST NOT appear
+in a donor artifact unless the owning domain later matches them. When such a
+candidate is evaluated for a statement run, the owning domain MUST retain its
+exclusion/audit record with a #579/source-domain-approved reason code. Statement
+language MUST be finance/legal reviewed before production use.
 
 Giving MUST produce the frozen, versioned statement context from canonical
-donation/correction truth, including raw structured values and frozen official
+donation/correction truth, including the deductible hard-credit partition, the
+approved indirect partition, audit-only exclusion references and their
+source-domain-approved reason codes, raw structured values, and frozen official
 display strings with locale/formatting version metadata. The document-production
 capability MUST resolve the assigned immutable template and private artifact,
-bind those frozen strings, and avoid recalculating or reformatting official
+bind those frozen strings and supplied classifications, never render audit-only
+exclusions, and avoid recalculating, reclassifying, or reformatting official
 facts. The donor BFF MUST authorize the recipient, expose only the current
 eligible artifact, and record delivery/download. A later correction, refund, or
 donor relink MUST supersede or void stale output per policy while preserving

--- a/openspec/changes/add-donor-self-service/tasks.md
+++ b/openspec/changes/add-donor-self-service/tasks.md
@@ -39,6 +39,12 @@
       donor-owned only, idempotent, and reflected in Mission Control from the
       same records.
 - [ ] 4.2 E2E: donor pauses and cancels a recurring gift; updates a payment
-      method; downloads the current statement; cannot access another donor's or
-      a superseded statement artifact.
+      method; downloads the current statement; verifies deductible lines and
+      totals use only #579-approved settled, receiptable hard-credit gifts for
+      the authorized donor/household subject; keeps approved indirect lines
+      labeled and outside the deductible total; excludes pending/unsettled gifts
+      from rendered deductible and indirect lines/totals while retaining their
+      owning-domain exclusion/audit record; excludes still-unknown-donor gifts
+      from the donor artifact; and cannot access another subject's or a
+      superseded artifact.
 - [ ] 4.3 Archive this change after deployment verification.

--- a/openspec/changes/add-donor-self-service/tasks.md
+++ b/openspec/changes/add-donor-self-service/tasks.md
@@ -16,9 +16,22 @@
 
 ## 3. Annual statements
 
-- [ ] 3.1 Statement generation for receiptable gifts by year per tenant policy
-      (finance/legal review of statement language before production).
-- [ ] 3.2 Donor download from the portal; delivery recorded.
+- [ ] 3.1 The Giving/statement domain builds the canonical frozen, versioned
+      annual-statement snapshot for receiptable gifts by year and tenant policy,
+      including corrections, refunds, currency, identity, raw values, frozen
+      display strings/locale, source IDs, and policy version (finance/legal
+      review before production).
+- [ ] 3.2 Statement Studio resolves the assigned immutable template and creates
+      the private artifact by binding frozen official display fields, without
+      recalculating or reformatting source facts.
+- [ ] 3.3 The donor BFF authorizes the recipient on every download, exposes only
+      the current eligible artifact, and records delivery/download.
+- [ ] 3.4 Contribution corrections/refunds/relinks supersede or void stale
+      statement artifacts per policy and link replacement lineage without
+      erasing retained audit history.
+- [ ] 3.5 Outbound delivery uses the approved Phase 6 communication seam and
+      document delivery adapter; authenticated self-download remains available
+      without creating a second send/log path.
 
 ## 4. Verification
 
@@ -26,5 +39,6 @@
       donor-owned only, idempotent, and reflected in Mission Control from the
       same records.
 - [ ] 4.2 E2E: donor pauses and cancels a recurring gift; updates a payment
-      method; downloads a statement.
+      method; downloads the current statement; cannot access another donor's or
+      a superseded statement artifact.
 - [ ] 4.3 Archive this change after deployment verification.

--- a/openspec/changes/add-donor-self-service/tasks.md
+++ b/openspec/changes/add-donor-self-service/tasks.md
@@ -18,9 +18,11 @@
 
 - [ ] 3.1 The Giving/statement domain builds the canonical frozen, versioned
       annual-statement snapshot for receiptable gifts by year and tenant policy,
-      including corrections, refunds, currency, identity, raw values, frozen
-      display strings/locale, source IDs, and policy version (finance/legal
-      review before production).
+      including deductible hard-credit and approved indirect partitions,
+      audit-only exclusion references with source-domain-approved reason codes,
+      corrections, refunds, currency, identity, raw values, frozen display
+      strings/locale, source IDs, and policy version (finance/legal review before
+      production).
 - [ ] 3.2 Statement Studio resolves the assigned immutable template and creates
       the private artifact by binding frozen official display fields, without
       recalculating or reformatting source facts.
@@ -44,7 +46,8 @@
       the authorized donor/household subject; keeps approved indirect lines
       labeled and outside the deductible total; excludes pending/unsettled gifts
       from rendered deductible and indirect lines/totals while retaining their
-      owning-domain exclusion/audit record; excludes still-unknown-donor gifts
-      from the donor artifact; and cannot access another subject's or a
-      superseded artifact.
+      reason-bearing owning-domain exclusion/audit record; excludes
+      still-unknown-donor gifts from the donor artifact while retaining the
+      source-domain exclusion/audit record when evaluated for the run; and
+      cannot access another subject's or a superseded artifact.
 - [ ] 4.3 Archive this change after deployment verification.

--- a/openspec/changes/add-statement-studio/design.md
+++ b/openspec/changes/add-statement-studio/design.md
@@ -119,18 +119,58 @@ separately auditable beneath that logical render.
 
 A request for a completed key returns the existing canonical artifact. A request
 for a queued or running key joins or resumes it while its bounded lease remains
-valid. After lease timeout or a retryable failure, a worker may claim a new
-attempt for the same key with compare-and-set ownership, bounded backoff, an
-attempt limit, and a visible terminal failure. Concurrent or late successes use
-atomic promotion. Each claim receives a monotonically increasing fencing token.
-An attempt writes, if needed, only to a private attempt-scoped staging path
-owned by `(render_key, fencing_token)`; staged bytes are never recipient-visible.
-Canonical artifact promotion is a database compare-and-set that verifies the
-current unexpired lease/token and the unique `(tenant_id, render_key)` guard.
-Only the winning promotion may publish its token-owned object as the canonical
-artifact location. A stale or losing attempt cannot update canonical metadata
-or delete another token's object. It durably schedules cleanup for only its own
-staged object, which remains inaccessible until retried cleanup succeeds.
+valid. Each claimed attempt persists an immutable provider deadline using
+database time. That deadline must precede worker-lease expiry by a configured
+post-provider safety margin sufficient for checksum calculation, private
+staging upload, and canonical-promotion persistence. If the remaining lease
+cannot satisfy that invariant, the worker renews or reclaims ownership, or
+transitions the attempt without invoking the provider. Once the provider call
+starts, lease renewal does not extend that attempt's provider deadline.
+
+The renderer port propagates a combined cancellation signal for provider
+deadline expiry, worker shutdown, observed lease/token loss, and explicit
+operator cancellation through to the provider call. A caller/request disconnect
+only detaches that waiter from the shared logical render; it does not cancel the
+render or enter a state transition.
+
+The provider-response path uses a database-time, current-token compare-and-set
+from `provider_running` to `staging` only when `db_now()` is earlier than
+`provider_deadline_at`. The deadline path uses a database-time, current-token
+compare-and-set from `provider_running` to `retryable` only when `db_now()` is at
+or later than that deadline. This phase transition, not the local cancellation
+signal, is authoritative. If `staging` wins, the deadline handler is a no-op and
+post-provider work may use the reserved lease margin. If timeout wins, the late
+response cannot stage or promote and follows token-scoped cleanup.
+
+Retryable infrastructure cancellation uses a current-token compare-and-set to
+move a nonterminal attempt to retryable, release ownership, increment the
+attempt count, and set bounded next-attempt backoff. Exhaustion records a visible
+terminal failure. If canonical promotion already won or the worker no longer
+owns the token, that handler cannot change logical state and performs only
+token-owned cleanup. Provider cancellation is best-effort: an accepted remote
+render may continue, but a late result remains fenced and cannot become
+canonical.
+
+Explicit operator cancellation uses its own compare-and-set: it may move only a
+nonterminal logical render to `canceled` and invalidates the current fencing
+token. If cancellation wins, all late response, staging, and promotion work is
+fenced and token-cleaned. If canonical completion already won, cancellation is
+a no-op for that render and must not silently demote or delete the official
+artifact; later removal uses the explicit supersede, void, or retention
+lifecycle.
+
+After lease timeout or a retryable transition, a worker may claim a new attempt
+for the same key through compare-and-set ownership and the attempt limit.
+Concurrent or late successes use atomic promotion. Each claim receives a
+monotonically increasing fencing token. An attempt writes, if needed, only to a
+private attempt-scoped staging path owned by `(render_key, fencing_token)`;
+staged bytes are never recipient-visible. Canonical artifact promotion is a
+database compare-and-set that verifies the current unexpired lease/token and
+the unique `(tenant_id, render_key)` guard. Only the winning promotion may
+publish its token-owned object as the canonical artifact location. A stale or
+losing attempt cannot update canonical metadata or delete another token's
+object. It durably schedules cleanup for only its own staged object, which
+remains inaccessible until retried cleanup succeeds.
 
 Retries may append attempt-level diagnostics and audit events, but they do not
 duplicate the logical render-completed event. Changing the source-context hash,
@@ -211,9 +251,16 @@ recipient delivery.
 
 The Giving/statement domain must first produce the canonical immutable,
 versioned statement snapshot/run contract. It captures legal donor,
-period/currency, settled and receiptable inclusion, effective designations,
-corrections/refunds, totals, frozen display strings plus raw values and locale,
-policy version, source IDs, and a context hash. Newer proposed issues
+period/currency, and three frozen source-owned partitions: deductible settled,
+receiptable hard-credit lines and totals; approved labeled indirect
+soft-credit/DAF/matched lines and totals that never affect the deductible total;
+and audit-only exclusion references with source-domain-approved reason codes
+for pending/unsettled and still-unknown-donor candidates. It also captures
+effective designations, corrections/refunds, frozen display strings plus raw
+values and locale, policy version, source IDs, and a context hash. Excluded
+entries are never renderable donor content. Statement Studio binds the supplied
+partitions without reclassification and does not invent a parallel context or
+reason-code vocabulary. Newer proposed issues
 [#579](https://github.com/Asymmetric-al/core/issues/579),
 [#580](https://github.com/Asymmetric-al/core/issues/580), and
 [#584](https://github.com/Asymmetric-al/core/issues/584) already reserve this

--- a/openspec/changes/add-statement-studio/design.md
+++ b/openspec/changes/add-statement-studio/design.md
@@ -13,8 +13,9 @@
 
 ## Phase 0 Decisions
 
-1. Extend the existing `pdf_*` persistence family; do not create parallel
-   `document_*` tables.
+1. Extend the existing `pdf_*` template/version/render/artifact/audit
+   persistence family; missing concepts must extend that family rather than
+   create a parallel `document_*` store.
 2. Use a safe admin/sample-data tracer before an official financial document.
 3. Keep `donor.statement.annual_giving` as the first donor-facing production
    job, but gate it on the canonical frozen statement snapshot/version contract
@@ -26,8 +27,9 @@
 5. Retire Unlayer only after replacement authoring/render/download and deployed
    tenant-template disposition are verified.
 
-Merging this HITL change approves those decisions. Until then they are proposed
-Phase 0 outcomes, not permission to enable official-document production.
+PR #715 is the approval record for these Phase 0 decisions. Provider
+qualification, finance/legal review, and the production gates below remain
+separate; this change does not enable official-document production.
 
 ## Ownership Boundary
 
@@ -59,7 +61,8 @@ the context for validation and audit, not template-side calculation.
 Map the current tables as follows:
 
 - `pdf_templates`: tenant template aggregate and legacy source root;
-- `pdf_template_versions`: immutable content and lifecycle versions;
+- `pdf_template_versions`: mutable draft working state plus immutable
+  published/archive snapshots enforced by the lifecycle seam;
 - `pdf_template_renders`: attempts, provider state, inputs by reference, and
   diagnostics;
 - `pdf_template_artifacts`: exact version/source/output metadata;
@@ -105,6 +108,38 @@ Before runtime writers use the child tables:
     links replacement context/artifact lineage, and keeps stale output out of
     the portal's current-document view without erasing retained history.
 
+### Render idempotency and retry recovery
+
+For every production output, Statement Studio derives a non-null server-side
+render key from the canonical serialization of job key, scope,
+subject/recipient, source-context reference and hash, immutable template-version
+ID, and artifact kind. The database enforces one logical render and at most one
+canonical artifact per `(tenant_id, render_key)`. Provider attempts remain
+separately auditable beneath that logical render.
+
+A request for a completed key returns the existing canonical artifact. A request
+for a queued or running key joins or resumes it while its bounded lease remains
+valid. After lease timeout or a retryable failure, a worker may claim a new
+attempt for the same key with compare-and-set ownership, bounded backoff, an
+attempt limit, and a visible terminal failure. Concurrent or late successes use
+atomic promotion. Each claim receives a monotonically increasing fencing token.
+An attempt writes, if needed, only to a private attempt-scoped staging path
+owned by `(render_key, fencing_token)`; staged bytes are never recipient-visible.
+Canonical artifact promotion is a database compare-and-set that verifies the
+current unexpired lease/token and the unique `(tenant_id, render_key)` guard.
+Only the winning promotion may publish its token-owned object as the canonical
+artifact location. A stale or losing attempt cannot update canonical metadata
+or delete another token's object. It durably schedules cleanup for only its own
+staged object, which remains inaccessible until retried cleanup succeeds.
+
+Retries may append attempt-level diagnostics and audit events, but they do not
+duplicate the logical render-completed event. Changing the source-context hash,
+assigned template version, or artifact kind creates a new key and preserves
+lineage. For annual statements, #580 supplies the immutable statement
+version/snapshot reference and owns issuance/content-hash idempotency; #581 owns
+version-scoped `communication_events` delivery dedupe. A render retry never
+sends a document or creates a parallel delivery log.
+
 Preview routes may accept safe sample contexts. Production routes must resolve
 domain contexts server-side and must not accept official `dataContext` values
 from the browser.
@@ -122,9 +157,10 @@ treated as recipient authorization. Public `document-uploads` and `email-assets`
 buckets are ineligible.
 
 Before production, the schema and persistence seam MUST coordinate with the
-approved Phase 4 isolation foundation (#505/#516) and reuse its composite-key,
-tenant-guard, `FORCE RLS`, and permanent cross-tenant negative-test posture.
-Statement Studio does not invent a competing tenant-isolation primitive.
+approved platform tenant-isolation Phase 4 foundation (#505/#516) and reuse its
+composite-key, tenant-guard, `FORCE RLS`, and permanent cross-tenant
+negative-test posture. Statement Studio does not invent a competing
+tenant-isolation primitive.
 
 Authenticated portal self-download may be implemented through the role-scoped
 BFF once artifact authorization is proven. Outbound email/delivery MUST wait for
@@ -177,10 +213,13 @@ The Giving/statement domain must first produce the canonical immutable,
 versioned statement snapshot/run contract. It captures legal donor,
 period/currency, settled and receiptable inclusion, effective designations,
 corrections/refunds, totals, frozen display strings plus raw values and locale,
-policy version, source IDs, and a context hash. Newer proposed issues #579,
-#580, and #584 already reserve this ownership; implementation coordinates with
-that seam rather than creating a parallel `AnnualGivingStatementContext`. This
-also aligns with `add-donor-self-service` without duplicating its truth.
+policy version, source IDs, and a context hash. Newer proposed issues
+[#579](https://github.com/Asymmetric-al/core/issues/579),
+[#580](https://github.com/Asymmetric-al/core/issues/580), and
+[#584](https://github.com/Asymmetric-al/core/issues/584) already reserve this
+ownership; implementation coordinates with that seam rather than creating a
+parallel `AnnualGivingStatementContext`. This also aligns with
+`add-donor-self-service` without duplicating its truth.
 
 The current live `.txt` route remains non-official until the artifact path is
 ready. Receipt production follows only after the live donor receipt,

--- a/openspec/changes/add-statement-studio/design.md
+++ b/openspec/changes/add-statement-studio/design.md
@@ -1,0 +1,202 @@
+# Design: Statement Studio Document Production
+
+## Source Inputs
+
+- `openspec/project.md`
+- `openspec/specs/platform-{boundaries,principles,surfaces}/spec.md`
+- `openspec/specs/{donation-lifecycle,contribution-operations,identity-and-access}/spec.md`
+- `openspec/changes/add-donor-self-service/**`
+- `docs/guides/features/statement-studio/**`
+- `docs/guides/architecture/data-access-boundary.md`
+- Current PDF, donor portal, receipt, migration, and test evidence recorded in
+  `docs/guides/features/statement-studio/phase-0-research-evidence.md`
+
+## Phase 0 Decisions
+
+1. Extend the existing `pdf_*` persistence family; do not create parallel
+   `document_*` tables.
+2. Use a safe admin/sample-data tracer before an official financial document.
+3. Keep `donor.statement.annual_giving` as the first donor-facing production
+   job, but gate it on the canonical frozen statement snapshot/version contract
+   and finance/legal review.
+4. Propose the current Asym schema and DocRaptor server adapter as the only
+   first-slice production renderer, subject to provider qualification and HITL
+   approval. Keep a renderer port so replacement remains possible without
+   running two official paths.
+5. Retire Unlayer only after replacement authoring/render/download and deployed
+   tenant-template disposition are verified.
+
+Merging this HITL change approves those decisions. Until then they are proposed
+Phase 0 outcomes, not permission to enable official-document production.
+
+## Ownership Boundary
+
+Statement Studio owns:
+
+- template aggregates, drafts, and immutable published versions;
+- document-job catalog/settings and scoped version assignments;
+- variable metadata and validation against domain context contracts;
+- render orchestration and provider diagnostics;
+- private artifact metadata, access delivery, retention, purge, and audit.
+
+Source domains own:
+
+- inclusion/eligibility, money, identity, designation, correction, refund, and
+  receipt/statement truth;
+- canonical raw values plus frozen official display strings, locale, and
+  formatting-policy version for receipts/statements;
+- event, missionary, report, care, task, legal/signing, and CMS facts;
+- versioned context builders that enforce permissions and redaction before
+  Statement Studio receives values.
+
+The renderer treats an approved domain context as data, not as a suggestion.
+For official receipt/statement values it binds the frozen display strings and
+must not format money/dates or recompute facts. Raw structured values remain in
+the context for validation and audit, not template-side calculation.
+
+## Canonical Persistence
+
+Map the current tables as follows:
+
+- `pdf_templates`: tenant template aggregate and legacy source root;
+- `pdf_template_versions`: immutable content and lifecycle versions;
+- `pdf_template_renders`: attempts, provider state, inputs by reference, and
+  diagnostics;
+- `pdf_template_artifacts`: exact version/source/output metadata;
+- `pdf_template_audit_events`: append-only lifecycle, access, and purge events;
+- `pdf_template_batches` and `pdf_template_batch_jobs`: batch orchestration.
+
+Add only missing concepts: system job catalog, tenant job settings, scoped
+assignments/defaults, variable catalog/tenant overrides, and retention policy.
+`gift_receipt_records` and `contribution_receipt_snapshots` remain outside
+Statement Studio while Giving reconciles them. A production document artifact
+references one canonical domain context/source ID selected by the owner for that
+job; Statement Studio does not canonize both receipt tables as parallel truth.
+
+Before runtime writers use the child tables:
+
+- require tenant identity on tenant-owned roots;
+- enforce same-tenant composite foreign keys across template, version, render,
+  artifact, assignment, and current-version references;
+- prevent updates to published version content/hash;
+- remove broad direct authenticated writes or enforce capability-aware RLS;
+- add artifact job, scope, subject/recipient, sensitivity, source, retention,
+  current/superseded/void lineage, expiry/purge/tombstone, checksum, and
+  download-audit data;
+- update generated database types and prove policy behavior with real SQL tests.
+
+## Production Pipeline
+
+1. An authenticated caller requests a known document job and subject/scope.
+2. The owning domain authorizes the request and builds a versioned context.
+3. Statement Studio resolves the tenant/scoped assignment to one immutable
+   published template version.
+4. The template schema validates variables against the context contract.
+5. A render row is created before invoking the renderer provider.
+6. The server-only renderer returns bytes and diagnostics.
+7. Bytes are uploaded to a private generated-document bucket at an immutable,
+   tenant-aware path.
+8. An artifact records exact template version, job, scope, recipient/subject,
+   source context ID/hash, checksum, size, retention, and render outcome.
+9. The authorized surface streams the bytes or creates a short-lived signed URL
+   and records access/delivery.
+10. If the source domain later corrects, refunds, relinks, or voids facts that
+    made the document official, its policy marks the artifact superseded/void,
+    links replacement context/artifact lineage, and keeps stale output out of
+    the portal's current-document view without erasing retained history.
+
+Preview routes may accept safe sample contexts. Production routes must resolve
+domain contexts server-side and must not accept official `dataContext` values
+from the browser.
+
+## Authorization and Storage
+
+Mission Control uses server-resolved capabilities for template lifecycle,
+assignment, render, artifact, and retention operations. Donor and missionary
+portals use their existing BFF boundaries and re-authorize tenant, role,
+recipient/subject, source state, and artifact state on every download.
+
+Generated documents use a private bucket. Service-role clients may write and
+read after application authorization, but service-role RLS bypass is never
+treated as recipient authorization. Public `document-uploads` and `email-assets`
+buckets are ineligible.
+
+Before production, the schema and persistence seam MUST coordinate with the
+approved Phase 4 isolation foundation (#505/#516) and reuse its composite-key,
+tenant-guard, `FORCE RLS`, and permanent cross-tenant negative-test posture.
+Statement Studio does not invent a competing tenant-isolation primitive.
+
+Authenticated portal self-download may be implemented through the role-scoped
+BFF once artifact authorization is proven. Outbound email/delivery MUST wait for
+or co-sequence with the Phase 6 communication spine and send seam (#552-#554)
+plus the document delivery adapter (#581); Statement Studio does not create a
+parallel provider send or communication-audit path.
+
+Purge deletes bytes through the Storage API, then preserves a tombstone and
+audit event. It does not delete `storage.objects` metadata directly.
+
+## Sample Tracer Boundary
+
+The infrastructure tracer uses synthetic data only and records an explicit
+`sample`/`preview` purpose. Its output is admin-only, visibly marked
+`SAMPLE - NOT AN OFFICIAL DOCUMENT`, ineligible for production assignment or
+portal delivery, and excluded from official retention/delivery metrics. The
+annual starter may be used only under those constraints until the Giving-owned
+context and policy gates are complete.
+
+## Renderer and Legacy Migration
+
+The repository has working Asym schema/HTML composition and DocRaptor adapter
+code but no pdfx or React PDF runtime dependency. Phase 0 therefore proposes
+DocRaptor behind the provider port rather than adding a second production
+stack. Before official enablement, representative fixtures must qualify its
+repeaters/tables, page breaks, headers/footers, fonts and private assets,
+fidelity/accessibility, fail-closed production mode, provider limits, latency,
+and expected cost. HITL review either accepts those results/risks or selects a
+different migration path.
+
+The raw JSON native UI is not the target editor. The vendored editor package is
+not adopted automatically because it depends on email-editor primitives and is
+not used by the app. A later editor slice must prove a non-technical,
+PDF-oriented experience against the Asym schema.
+
+Unlayer remains read/edit/export compatibility for existing templates during
+cutover. New Statement Studio templates use the native schema. Removal requires
+a deployed template inventory, explicit migrate/archive/delete disposition,
+and verified replacement flows.
+
+## First Job and Rollout
+
+The shell and infrastructure tracer uses safe sample data. The first
+donor-facing production job remains `donor.statement.annual_giving` because the
+donor portal already has an ownership-scoped route and visible download entry,
+and the job proves repeaters, totals, versions, assignments, artifacts, and
+recipient delivery.
+
+The Giving/statement domain must first produce the canonical immutable,
+versioned statement snapshot/run contract. It captures legal donor,
+period/currency, settled and receiptable inclusion, effective designations,
+corrections/refunds, totals, frozen display strings plus raw values and locale,
+policy version, source IDs, and a context hash. Newer proposed issues #579,
+#580, and #584 already reserve this ownership; implementation coordinates with
+that seam rather than creating a parallel `AnnualGivingStatementContext`. This
+also aligns with `add-donor-self-service` without duplicating its truth.
+
+The current live `.txt` route remains non-official until the artifact path is
+ready. Receipt production follows only after the live donor receipt,
+staged-gift email, correction snapshots, and gift receipt scaffold have one
+documented source-of-truth contract.
+
+## Risks and Tradeoffs
+
+- DocRaptor is a vendor dependency, but reusing the existing provider reduces
+  migration risk and avoids dual renderer drift. The port preserves a later
+  replacement path.
+- Annual statements exercise more architecture than a one-gift receipt and
+  therefore require a larger context contract. The sample-data tracer keeps
+  infrastructure work from being blocked on financial semantics.
+- Server-only mutations are less convenient than direct Data API writes but
+  align authorization with Mission Control capabilities and protect sensitive
+  artifacts.
+- Hosted migration and tenant-template state are unknown from the repository;
+  no destructive migration is allowed until operators inspect that state.

--- a/openspec/changes/add-statement-studio/proposal.md
+++ b/openspec/changes/add-statement-studio/proposal.md
@@ -1,0 +1,63 @@
+# Add Statement Studio Document Production
+
+## Why
+
+The platform has a working legacy PDF Studio, an incomplete native builder,
+plain-text donor receipt/statement downloads, and a separate corrected-receipt
+PDF path. These paths do not share immutable template versions, assignments,
+server-owned source contexts, private artifacts, recipient authorization, or
+retention. Treating any one of them as a finished document platform would risk
+tenant isolation, money truth, and donor trust.
+
+Statement Studio needs one durable production contract while preserving the
+fact that Giving, Reports, Events, Missionary, Care, Legal, Tasks, and CMS own
+their source data.
+
+## What Changes
+
+- Establish Statement Studio as the Mission Control product for templates,
+  immutable versions, job assignments, rendering, artifacts, retention, and
+  audit.
+- Ratify the existing `pdf_templates` / `pdf_template_*` family as the migration
+  base instead of introducing a parallel document store.
+- Require production document facts to come from versioned, tenant-scoped,
+  server-resolved domain contexts. Official receipt/statement contexts include
+  frozen canonical display strings plus raw values and locale/version metadata;
+  browsers cannot supply official financial facts to render endpoints.
+- Require generated documents to use private Storage, durable artifact
+  metadata, same-tenant relational integrity, and recipient-scoped portal BFF
+  authorization.
+- Propose the existing Asym-owned schema plus server-only DocRaptor adapter as
+  the sole first-slice production renderer behind a provider port, subject to a
+  representative provider-qualification gate and HITL approval. A future
+  renderer replacement requires an explicit measured migration change.
+- Keep Unlayer as a bounded legacy fallback until a production replacement and
+  tenant-template disposition are verified; new Statement Studio work does not
+  depend on it.
+- Keep `donor.statement.annual_giving` as the first donor-facing production job,
+  gated on the canonical frozen statement snapshot/version contract and
+  finance/legal approval.
+
+## What Does Not Change
+
+- Statement Studio does not own donations, legal-donor identity, receipt
+  eligibility, corrections, refunds, designations, CRM truth, event truth,
+  care records, legal evidence, tasks, or CMS publishing truth.
+- Donor and missionary portals remain role-scoped self-service surfaces; they
+  do not become staff document administration surfaces.
+- Existing CSV operational exports remain available where PDF is only a
+  readable companion.
+- This proposal does not delete legacy templates or assert that committed
+  migrations are applied to a hosted Supabase project.
+
+## Impact
+
+- New capability: `document-production`
+- Affected intent specs: `platform-boundaries`, `platform-surfaces`
+- Related active change: `add-donor-self-service` owns annual-statement donor
+  semantics and delivery; this change owns template/render/artifact production
+- Affected code when implemented: `apps/admin/app/pdf/**`, donor and missionary
+  portal download routes, `packages/api/src/pdf-templates/**`, source-domain
+  resolver modules, and generated-document Storage adapters
+- Affected data when implemented: existing `pdf_*` tables plus missing job,
+  assignment, variable, recipient, and retention concepts

--- a/openspec/changes/add-statement-studio/specs/document-production/spec.md
+++ b/openspec/changes/add-statement-studio/specs/document-production/spec.md
@@ -100,9 +100,46 @@ recorded separately beneath that logical render.
 
 A retry of a completed key MUST return the existing canonical artifact. A retry
 of a queued or running key MUST join or resume that logical render while its
-bounded lease remains valid. After lease expiry or a retryable failure, a worker
-MAY claim another attempt for the same key through compare-and-set ownership,
-with bounded backoff, an attempt limit, and visible terminal failure.
+bounded lease remains valid.
+
+Every provider invocation MUST have an immutable per-attempt deadline persisted
+from database time. The deadline MUST precede worker-lease expiry by a configured
+post-provider safety margin sufficient for checksum calculation, private
+staging upload, and canonical-promotion persistence. If the remaining lease
+cannot satisfy that invariant, the provider MUST NOT be invoked. Lease renewal
+after invocation begins MUST NOT extend the provider deadline. The renderer and
+provider call MUST receive cancellation for deadline expiry, worker shutdown,
+observed lease/token loss, and explicit operator cancellation. A caller
+disconnect MUST only detach that waiter from the shared logical render and MUST
+NOT enter a render-state transition.
+
+The provider-response path MUST use a database-time, current-token
+compare-and-set from `provider_running` to `staging` only when `db_now()` is
+earlier than `provider_deadline_at`. The deadline path MUST use a database-time,
+current-token compare-and-set from `provider_running` to `retryable` only when
+`db_now()` is at or later than that deadline. This database transition, not the
+local cancellation signal, MUST be authoritative. If `staging` wins, the
+deadline handler MUST be a no-op and post-provider work MAY use the reserved
+lease margin. If timeout wins, the late response MUST NOT stage or promote and
+MUST follow token-scoped cleanup.
+
+Retryable infrastructure cancellation MUST attempt a current-token
+compare-and-set from a nonterminal attempt to retryable, release ownership, and
+set bounded next-attempt backoff. After that transition, another retryable
+failure, or lease expiry, a worker MAY claim another attempt for the same key
+through compare-and-set ownership and an attempt limit. Exhaustion MUST become a
+visible terminal failure. If canonical promotion already won or the worker no
+longer owns the token, a retry handler MUST be a no-op for logical state and MAY
+clean up only that token's staging object.
+
+Explicit operator cancellation MUST use a compare-and-set that moves only a
+nonterminal logical render to `canceled` and invalidates its current fencing
+token. If cancellation wins, all late provider, staging, and promotion work MUST
+remain fenced and follow token-scoped cleanup. If canonical completion already
+won, cancellation MUST be a no-op for that render and MUST NOT demote or delete
+the official artifact; later removal MUST use the explicit supersede, void, or
+retention lifecycle. Explicit cancellation MUST NOT be reclassified as
+retryable.
 
 Concurrent or late successes MUST use atomic promotion and database uniqueness
 so exactly one artifact becomes canonical. Each claim MUST receive a
@@ -117,6 +154,7 @@ object; it MUST durably schedule cleanup for only its own staged object, which
 MUST remain inaccessible until retried cleanup succeeds. Attempt-level
 diagnostics and audit events MAY be appended, but retries MUST NOT create a
 second logical completion event.
+
 Source-domain issuance/version idempotency and outbound communication
 idempotency remain outside this render key; render recovery MUST NOT send a
 document or create a parallel delivery log.
@@ -129,15 +167,48 @@ document or create a parallel delivery log.
 - AND does not invoke another provider attempt or record another logical
   completion
 
+#### Scenario: A provider call exceeds its deadline
+
+- GIVEN a running provider call has an immutable deadline before lease expiry
+- WHEN the call remains in flight at that deadline
+- THEN the cancellation signal reaches the renderer/provider call
+- AND a database-time, current-token compare-and-set moves `provider_running` to
+  `retryable`, releases ownership, and schedules bounded backoff
+- AND exhausting the attempt limit records a visible terminal failure without
+  a canonical artifact
+
+#### Scenario: Provider response races the deadline
+
+- GIVEN a provider response and its deadline become ready concurrently
+- WHEN the response attempts `provider_running` to `staging` with
+  `db_now() < provider_deadline_at` and the deadline handler attempts
+  `provider_running` to `retryable` with `db_now() >= provider_deadline_at`
+- THEN the database-time phase transition authorizes exactly one path
+- AND a `staging` winner may finish within the reserved lease margin while the
+  deadline handler becomes a no-op
+- AND a response that loses cannot stage or become canonical and follows
+  token-scoped cleanup
+
+#### Scenario: Operator cancellation races canonical completion
+
+- GIVEN an operator cancels a nonterminal logical render as its worker attempts
+  canonical completion
+- WHEN both paths compare-and-set logical state and the current fencing token
+- THEN exactly one transition wins
+- AND a winning cancellation fences and cleans all late token-owned work
+- AND a winning completion makes cancellation a no-op; later removal uses the
+  supersede, void, or retention lifecycle
+
 #### Scenario: A timed-out attempt succeeds after recovery starts
 
 - GIVEN a render lease expired and a recovery worker claimed a new attempt for
   the same key
 - WHEN the original and recovery attempts both return bytes
-- THEN both attempts may stage bytes at their own token-scoped private paths,
-  but only the current-token compare-and-set promotes one canonical artifact
-- AND the losing token's object is never exposed and is durably retried for
-  cleanup until deleted
+- THEN the original response cannot pass the current-token provider-phase
+  transition or become canonical
+- AND only the recovery attempt may stage and promote with its current token
+- AND any object already staged under the original token before lease loss is
+  never exposed and is durably retried for cleanup until deleted
 - AND attempt diagnostics remain auditable without triggering outbound delivery
 
 ### Requirement: Document Persistence Enforces Same-Tenant Integrity

--- a/openspec/changes/add-statement-studio/specs/document-production/spec.md
+++ b/openspec/changes/add-statement-studio/specs/document-production/spec.md
@@ -4,10 +4,10 @@
 
 ### Requirement: Statement Studio Owns Document Production, Not Domain Truth
 
-Statement Studio MUST own templates, immutable versions, document-job
-assignments, rendering, generated artifacts, retention, purge, and document
-production audit. The domain that owns the source facts MUST authorize the
-request and build the versioned render context.
+Statement Studio MUST own templates, mutable drafts, immutable published
+versions, document-job assignments, rendering, generated artifacts, retention,
+purge, and document production audit. The domain that owns the source facts
+MUST authorize the request and build the versioned render context.
 
 Statement Studio MUST NOT independently recompute money, legal-donor identity,
 receipt or statement eligibility, corrections, refunds, designations,
@@ -88,6 +88,57 @@ without durable bytes and metadata MUST NOT count as a completed artifact.
 - WHEN rendering succeeds but private upload or artifact persistence fails
 - THEN the operation reports a failed or partial state honestly
 - AND does not advertise a downloadable production document
+
+### Requirement: Production Rendering Is Idempotent Across Retries
+
+For each production artifact kind, Statement Studio MUST derive a non-null,
+server-controlled render key from the job key, scope, subject/recipient,
+canonical source-context reference and hash, immutable template-version ID, and
+artifact kind. The database MUST enforce at most one logical render and one
+canonical artifact for each `(tenant_id, render_key)`. Provider attempts MAY be
+recorded separately beneath that logical render.
+
+A retry of a completed key MUST return the existing canonical artifact. A retry
+of a queued or running key MUST join or resume that logical render while its
+bounded lease remains valid. After lease expiry or a retryable failure, a worker
+MAY claim another attempt for the same key through compare-and-set ownership,
+with bounded backoff, an attempt limit, and visible terminal failure.
+
+Concurrent or late successes MUST use atomic promotion and database uniqueness
+so exactly one artifact becomes canonical. Each claim MUST receive a
+monotonically increasing fencing token. An attempt MUST write, if needed, only
+to a private attempt-scoped staging path owned by `(render_key, fencing_token)`;
+staged bytes MUST never be recipient-visible. Canonical artifact promotion MUST
+be a database compare-and-set that verifies the current unexpired lease/token
+and the unique `(tenant_id, render_key)` guard. Only the winning promotion MAY
+publish its token-owned object as the canonical artifact location. A stale or
+losing attempt MUST NOT update canonical metadata or delete another token's
+object; it MUST durably schedule cleanup for only its own staged object, which
+MUST remain inaccessible until retried cleanup succeeds. Attempt-level
+diagnostics and audit events MAY be appended, but retries MUST NOT create a
+second logical completion event.
+Source-domain issuance/version idempotency and outbound communication
+idempotency remain outside this render key; render recovery MUST NOT send a
+document or create a parallel delivery log.
+
+#### Scenario: A completed production render is retried
+
+- GIVEN a canonical artifact exists for a production render key
+- WHEN a client, queue, or provider callback repeats that render request
+- THEN Statement Studio returns the existing canonical artifact
+- AND does not invoke another provider attempt or record another logical
+  completion
+
+#### Scenario: A timed-out attempt succeeds after recovery starts
+
+- GIVEN a render lease expired and a recovery worker claimed a new attempt for
+  the same key
+- WHEN the original and recovery attempts both return bytes
+- THEN both attempts may stage bytes at their own token-scoped private paths,
+  but only the current-token compare-and-set promotes one canonical artifact
+- AND the losing token's object is never exposed and is durably retried for
+  cleanup until deleted
+- AND attempt diagnostics remain auditable without triggering outbound delivery
 
 ### Requirement: Document Persistence Enforces Same-Tenant Integrity
 

--- a/openspec/changes/add-statement-studio/specs/document-production/spec.md
+++ b/openspec/changes/add-statement-studio/specs/document-production/spec.md
@@ -1,0 +1,260 @@
+# Delta for Document Production
+
+## ADDED Requirements
+
+### Requirement: Statement Studio Owns Document Production, Not Domain Truth
+
+Statement Studio MUST own templates, immutable versions, document-job
+assignments, rendering, generated artifacts, retention, purge, and document
+production audit. The domain that owns the source facts MUST authorize the
+request and build the versioned render context.
+
+Statement Studio MUST NOT independently recompute money, legal-donor identity,
+receipt or statement eligibility, corrections, refunds, designations,
+permissions, redaction, or other source-domain truth.
+
+For official receipt/statement fields, the source context MUST provide both raw
+structured values and frozen canonical display strings with locale/formatting
+version metadata. Statement Studio MUST bind those fields and MUST NOT format
+money or dates at render time.
+
+#### Scenario: An annual giving statement is rendered
+
+- GIVEN Giving has authorized the donor and built a versioned annual statement
+  context from canonical contribution truth
+- WHEN Statement Studio renders the annual statement
+- THEN it binds the supplied frozen display fields through the assigned
+  immutable template
+- AND it does not query or recalculate donation eligibility or totals itself
+
+#### Scenario: A template tries to reformat an official amount
+
+- GIVEN an official statement context contains the frozen display string and
+  raw structured value for an amount
+- WHEN the assigned template attempts to format that raw amount at render time
+- THEN validation rejects the template for official production use
+- AND the issued document continues to bind the frozen display string
+
+#### Scenario: A browser supplies financial render data
+
+- WHEN a production render request includes browser-supplied official financial
+  facts
+- THEN the server rejects or ignores those facts
+- AND resolves the authorized source-domain context server-side
+
+### Requirement: Published Templates Are Immutable And Assigned Explicitly
+
+Production document jobs MUST resolve to an immutable published template
+version through an explicit tenant/scoped assignment. Mutable drafts and legacy
+root-row defaults MUST NOT be production assignment targets.
+
+Published content, schema version, content hash, and source variable contract
+MUST NOT change in place. Replacement or rollback MUST create or select an
+explainable version and MUST be audited.
+
+#### Scenario: Staff publishes and assigns a template
+
+- GIVEN an authorized staff user has a valid template draft
+- WHEN the user publishes and assigns it to a document job
+- THEN production resolution points to the immutable published version
+- AND the assignment and publication are recorded in the audit trail
+
+#### Scenario: Staff edits a published version
+
+- WHEN any caller attempts to change published template content or its hash in
+  place
+- THEN the platform rejects the update
+- AND requires a new draft/version for the change
+
+### Requirement: Production Renders Create Durable Private Artifacts
+
+Every successful production render MUST record the exact tenant, job, scope,
+subject/recipient, source context reference and hash, assigned template version,
+renderer outcome, checksum, size, private Storage location, retention state,
+and audit linkage.
+
+Generated official or sensitive documents MUST use private Storage. A public
+bucket, permanent public URL, provider-only reference, or render-success toast
+without durable bytes and metadata MUST NOT count as a completed artifact.
+
+#### Scenario: A production render succeeds
+
+- WHEN the renderer returns document bytes successfully
+- THEN the server stores the bytes at an immutable tenant-aware private path
+- AND persists the complete artifact record before reporting completion
+
+#### Scenario: Artifact persistence fails after rendering
+
+- WHEN rendering succeeds but private upload or artifact persistence fails
+- THEN the operation reports a failed or partial state honestly
+- AND does not advertise a downloadable production document
+
+### Requirement: Document Persistence Enforces Same-Tenant Integrity
+
+The platform MUST enforce same-tenant integrity for tenant-owned templates,
+versions, assignments, renders, artifacts, batches, and audit records through
+database constraints and server authorization. An independently supplied child
+`tenant_id` MUST NOT be sufficient proof that its referenced parent belongs to
+that tenant.
+
+Production foundation work MUST reuse the platform's approved composite-key,
+tenant-guard, `FORCE RLS`, and permanent cross-tenant negative-test posture. It
+MUST NOT introduce a competing tenant-isolation primitive.
+
+Direct Data API grants and RLS MUST NOT provide broader mutation authority than
+the server-side Statement Studio capability model.
+
+#### Scenario: A tenant-A artifact references a tenant-B template
+
+- WHEN a caller attempts to create an artifact in tenant A that references a
+  template or version in tenant B
+- THEN the database rejects the relationship
+- AND no cross-tenant metadata or bytes become accessible
+
+#### Scenario: Staff without publish capability writes through the Data API
+
+- WHEN an authenticated staff member without template publish capability tries
+  to update a published version directly
+- THEN grants/RLS reject the mutation
+- AND UI visibility is not treated as the security boundary
+
+### Requirement: Portal Downloads Reauthorize The Recipient
+
+Donor and missionary document access MUST flow through their role-scoped BFF
+boundaries. Each request MUST re-authorize tenant, role, recipient/subject,
+source state, artifact state, and sensitivity before streaming bytes or issuing
+a short-lived signed URL.
+
+Service-role Storage access MUST NOT be treated as recipient authorization, and
+portal clients MUST NOT receive direct broad reads over artifact or Storage
+tables.
+
+Authenticated self-download MAY remain independent of outbound communications.
+Email or other outbound document delivery MUST use the platform communication
+spine/send seam and document delivery adapter; Statement Studio MUST NOT create
+a parallel provider-send or communication-audit path.
+
+#### Scenario: A donor downloads their annual statement
+
+- GIVEN the artifact belongs to the signed-in donor in the active tenant and is
+  eligible for delivery
+- WHEN the donor requests the statement through the donor BFF
+- THEN the server returns or signs only that artifact
+- AND records the download/delivery event
+
+#### Scenario: A donor requests another donor's artifact
+
+- WHEN a donor requests an artifact whose recipient/subject is another donor
+- THEN the server returns a non-disclosing denial
+- AND does not sign, stream, or reveal artifact metadata
+
+### Requirement: Retention Purges Bytes Without Erasing Audit Truth
+
+Document retention MUST apply a protected policy to each artifact class. Purge
+MUST delete object bytes through the Storage API and retain a tombstone plus
+audit evidence describing what was removed, by which policy/actor, and when.
+
+#### Scenario: An eligible artifact reaches its retention date
+
+- WHEN an authorized purge deletes the object through the Storage API
+- THEN the artifact becomes a non-downloadable tombstone
+- AND its tenant, job, source, version, checksum, purge reason, and timestamps
+  remain auditable
+
+### Requirement: Official Artifacts Preserve Correction Lineage
+
+The platform MUST preserve correction lineage when a source-domain correction,
+refund, donor relink, void, or other official fact change affects an
+already-generated document. The source domain MUST determine the
+official-document effect, and Statement Studio MUST record the prior artifact
+as superseded or void according to that policy.
+
+The prior artifact MUST link to the correction and replacement context/artifact
+when one exists. Retained bytes and audit history MUST remain immutable, while
+portal current-document views MUST NOT present stale output as current.
+
+#### Scenario: A contribution correction changes an annual statement
+
+- GIVEN a donor has an official annual statement artifact
+- WHEN an approved contribution correction changes its included gifts or total
+- THEN the old artifact is marked superseded and linked to the correction
+- AND the replacement context/artifact links back to the old version
+- AND the donor portal presents only the current eligible artifact as current
+
+#### Scenario: A statement becomes void without replacement
+
+- WHEN source-domain policy determines an official statement is no longer valid
+- THEN the artifact is marked void and removed from current download choices
+- AND retained bytes and audit history remain available only to authorized
+  operational users under retention policy
+
+### Requirement: Sample Tracer Artifacts Are Non-Official
+
+Infrastructure tracer and preview artifacts MUST use synthetic data, carry an
+explicit sample/preview purpose, be visibly marked
+`SAMPLE - NOT AN OFFICIAL DOCUMENT`, and remain admin-only. They MUST NOT be
+eligible for production assignment, donor/missionary portal delivery, official
+document notification, or official retention/delivery metrics.
+
+#### Scenario: Staff renders the annual starter before statement facts are ready
+
+- GIVEN the canonical annual statement snapshot/version contract is not
+  production-approved
+- WHEN staff render the annual starter with a synthetic fixture
+- THEN the artifact is recorded and displayed as admin-only sample output
+- AND it cannot be assigned or delivered as a donor's official statement
+
+#### Scenario: A portal requests a sample artifact
+
+- WHEN a donor or missionary portal requests a sample/preview artifact
+- THEN the BFF denies the request without signing or streaming the object
+
+### Requirement: One Production Renderer Is Active During Cutover
+
+Statement Studio MUST expose a provider-neutral renderer boundary and MUST have
+one authoritative production renderer for a document job at a time. Running
+legacy Unlayer export, DocRaptor, pdfx, React PDF, or another engine as competing
+official paths requires an explicit migration and parity plan.
+
+Before first-slice production enablement, the proposed DocRaptor provider MUST
+pass representative qualification for tables/repeaters, pagination,
+headers/footers, fonts/private assets, fidelity/accessibility, fail-closed
+production mode, provider limits, latency, and expected cost. HITL review MUST
+accept the qualification and known risks. Once approved, the first Statement
+Studio production path MUST use that server-side integration behind the
+renderer boundary until a later approved change replaces it.
+
+#### Scenario: DocRaptor qualification is incomplete
+
+- WHEN representative output, operational limits, latency, or cost have not
+  been evaluated and accepted
+- THEN official Statement Studio production rendering remains disabled
+- AND sample/admin preview work may continue under the non-official boundary
+
+#### Scenario: A new renderer is proposed
+
+- WHEN the platform proposes replacing DocRaptor for a production job
+- THEN the change defines output parity, artifact continuity, rollout,
+  rollback, and legacy-template migration
+- AND the platform does not silently enable both renderers as official truth
+
+### Requirement: Legacy PDF Studio Is Retired Only After Verified Replacement
+
+New Statement Studio templates MUST NOT depend on Unlayer. Existing Unlayer
+templates MAY remain behind a documented legacy fallback until replacement
+authoring, rendering, artifact delivery, rollback, and deployed tenant-template
+disposition are verified.
+
+#### Scenario: Staff opens an existing legacy template during migration
+
+- GIVEN the tenant template has not been rebuilt and approved in Statement
+  Studio
+- WHEN authorized staff open it during the migration window
+- THEN the product may route to the bounded legacy editor/export path
+- AND does not claim that the template is a native Statement Studio version
+
+#### Scenario: Legacy removal is requested
+
+- WHEN maintainers propose deleting Unlayer code, flags, dependencies, or data
+- THEN they must show verified replacement flows and tenant-template disposition
+- AND removal is blocked while active tenant templates still depend on it

--- a/openspec/changes/add-statement-studio/specs/platform-boundaries/spec.md
+++ b/openspec/changes/add-statement-studio/specs/platform-boundaries/spec.md
@@ -1,0 +1,42 @@
+# Delta for Platform System Boundaries
+
+## ADDED Requirements
+
+### Requirement: Document Production Consumes Domain-Owned Contexts
+
+Statement Studio MUST remain a document production subsystem rather than a
+competing operational truth store. Giving, CRM, Missionary, Reports, Events,
+Care, Tasks, Legal/Signing, and CMS MUST retain ownership of their source facts,
+authorization, redaction, and versioned render-context builders.
+
+Production document routes MUST resolve those contexts server-side through the
+owning domain. App-level routes SHOULD remain thin delegates to shared server
+modules.
+
+#### Scenario: A care packet requests private notes
+
+- GIVEN the Care domain has not authorized and redacted the requested notes
+- WHEN Statement Studio receives a packet render request
+- THEN it cannot query or include the private notes itself
+- AND the request remains blocked until Care returns an approved context
+
+#### Scenario: CMS supplies document branding
+
+- GIVEN CMS exposes approved tenant branding or published content
+- WHEN Statement Studio renders a document
+- THEN it may consume that approved content through a render-safe adapter
+- AND CMS does not supply contribution, receipt, or other operational truth
+
+### Requirement: Generated Document Access Follows Surface Roles
+
+Mission Control MUST own staff document administration and operational depth.
+Donor and missionary surfaces MUST expose only recipient/subject-authorized
+artifacts through their own BFF boundaries. A shared artifact table or Storage
+bucket MUST NOT collapse those surface roles.
+
+#### Scenario: Missionary portal requests a monthly statement
+
+- WHEN an authenticated missionary requests a statement
+- THEN the missionary BFF verifies the artifact's tenant and authorized
+  missionary subject
+- AND does not expose tenant-wide Statement Studio administration or artifacts

--- a/openspec/changes/add-statement-studio/specs/platform-surfaces/spec.md
+++ b/openspec/changes/add-statement-studio/specs/platform-surfaces/spec.md
@@ -1,0 +1,36 @@
+# Delta for Platform Surfaces
+
+## ADDED Requirements
+
+### Requirement: Mission Control Presents One Statement Studio Product
+
+Mission Control MUST present Statement Studio as the staff-facing product for
+template authoring, publication, assignment, generated artifacts, retention,
+and audit. It MUST NOT present PDF Studio and Statement Studio as two competing
+long-term products.
+
+During migration, a bounded legacy template MAY open in the old editor, but the
+UI MUST identify it as legacy and MUST NOT allow new Statement Studio behavior
+to depend on Unlayer.
+
+#### Scenario: Staff opens the template library during migration
+
+- WHEN authorized staff open Statement Studio
+- THEN they see one product and can distinguish native, legacy, and migration
+  state for each template
+- AND they are not asked to choose between two competing product surfaces
+
+### Requirement: Portals Expose Role-Scoped Generated Documents
+
+Donor Dashboard and Missionary Dashboard MUST expose generated documents as
+role-scoped self-service records. They MUST consume authorized artifacts through
+their existing server boundaries and MUST NOT expose staff template,
+assignment, retention, batch, or tenant-wide artifact controls.
+
+#### Scenario: A donor views available statements
+
+- WHEN a donor opens statement history
+- THEN the portal lists only eligible artifacts addressed to that donor in the
+  active tenant
+- AND Statement Studio administration remains available only in Mission
+  Control

--- a/openspec/changes/add-statement-studio/tasks.md
+++ b/openspec/changes/add-statement-studio/tasks.md
@@ -15,7 +15,8 @@
 
 - [ ] 2.1 Qualify DocRaptor with representative tables/repeaters, pagination,
       headers/footers, fonts/private assets, fidelity/accessibility, fail-closed
-      production mode, limits, latency, and cost fixtures; HITL approves it
+      production mode, limits, latency, timeout/abort behavior, ambiguous
+      accepted-request cancellation/cost, and cost fixtures; HITL approves it
       behind the renderer port as the sole first-slice provider or selects an
       explicit alternative.
 - [ ] 2.2 Finance/legal approve annual statement inclusion, correction,
@@ -43,11 +44,15 @@
       lease-safe retry, canonical-artifact reuse, and purge tombstones with real
       SQL/integration tests.
 - [ ] 3.6 Add DB-enforced logical render keys, bounded lease/attempt recovery,
+      immutable database-time provider deadlines shorter than leases by a
+      finalization margin, propagated deadline/worker/lease-loss cancellation,
       monotonically increasing fencing tokens, token-owned private staging
-      paths, current-token compare-and-set canonical-artifact promotion, and
-      durable token-scoped cleanup; cover concurrency, timeout, stale-writer,
-      and cleanup-retry behavior while keeping issuance under #580 and outbound
-      delivery under #581.
+      paths, current-token timeout and canonical-promotion transitions, and
+      durable token-scoped cleanup. Cover hung providers, ignored cancellation,
+      post-provider lease margin, lease loss, worker shutdown, database-time
+      provider-response-versus-deadline phase races,
+      operator-cancel-versus-completion, exhaustion, stale writers, and cleanup
+      retry while keeping issuance under #580 and outbound delivery under #581.
 
 ## 4. Safe vertical tracer
 
@@ -66,9 +71,12 @@
 - [ ] 5.1 Coordinate #322 with the newer proposed #579/#580/#583/#584 work and
       consume the approved canonical statement snapshot/version contract; do
       not introduce a parallel annual-context, run, or formatting model.
-- [ ] 5.2 Verify that the contract covers eligibility, corrections/refunds,
-      currency, identity, totals, raw values, frozen display strings and locale,
-      source IDs, policy version, and context hash.
+- [ ] 5.2 Verify that the contract covers the #579-owned deductible
+      hard-credit, approved indirect, and audit-only exclusion partitions;
+      source-domain-approved exclusion reason codes; corrections/refunds;
+      currency; identity; totals; raw values; frozen display strings and locale;
+      source IDs; policy version; and context hash. Statement Studio does not
+      reclassify entries or invent a parallel reason-code vocabulary.
 - [ ] 5.3 Publish and assign the annual statement template against that
       contract; official money/date fields bind frozen display strings.
 - [ ] 5.4 Render/store an immutable private artifact and expose it through the

--- a/openspec/changes/add-statement-studio/tasks.md
+++ b/openspec/changes/add-statement-studio/tasks.md
@@ -1,0 +1,87 @@
+# Tasks
+
+## 1. Phase 0 proposal package
+
+- [x] 1.1 Audit current PDF Studio, native builder, receipts, statements,
+      domain owners, migrations, Storage, and tests against fetched source.
+- [x] 1.2 Record reuse/replace/retire/delete decisions and first-slice gates in
+      the Statement Studio audit brief.
+- [x] 1.3 Add the Statement Studio OpenSpec proposal, design, and capability /
+      intent deltas required by the PRD.
+- [x] 1.4 Validate this change with strict OpenSpec validation and complete
+      documentation checks.
+
+## 2. Human approval and downstream grooming
+
+- [ ] 2.1 Qualify DocRaptor with representative tables/repeaters, pagination,
+      headers/footers, fonts/private assets, fidelity/accessibility, fail-closed
+      production mode, limits, latency, and cost fixtures; HITL approves it
+      behind the renderer port as the sole first-slice provider or selects an
+      explicit alternative.
+- [ ] 2.2 Finance/legal approve annual statement inclusion, correction,
+      refund, currency, identity, and official-language policy.
+- [ ] 2.3 Inspect hosted migration/template state and approve each legacy
+      template's migrate/archive/delete disposition.
+- [ ] 2.4 Re-groom issue #322 so canonical statement context, artifact access,
+      and finance/legal approval are explicit blockers.
+
+## 3. Tenant-safe foundation
+
+- [ ] 3.1 Extend the `pdf_*` family with job catalog/settings, scoped immutable
+      version assignments, variables, recipient/source, and retention concepts.
+- [ ] 3.2 Backfill/require tenant identity, add same-tenant composite foreign
+      keys, and make published version content immutable. Coordinate with the
+      approved #505/#516 isolation foundation and reuse its tenant guard,
+      `FORCE RLS`, and permanent cross-tenant negative-test tier.
+- [ ] 3.3 Align grants/RLS with server capabilities and add a private generated
+      document bucket with tenant-aware paths and object policies.
+- [ ] 3.4 Add one `packages/api` persistence/orchestration seam and generated DB
+      types; app routes remain thin.
+- [ ] 3.5 Prove cross-tenant rejection, immutable versions, capability
+      differences, private paths, portal denial, and purge tombstones with real
+      SQL/integration tests.
+
+## 4. Safe vertical tracer
+
+- [ ] 4.1 Ship the Statement Studio shell and starter catalog using synthetic
+      sample data only; sample outputs are purpose-tagged, visibly non-official,
+      admin-only, non-assignable, and non-deliverable.
+- [ ] 4.2 Prove immutable version, preview-only template selection, server
+      render, private upload, artifact metadata, admin download, and audit with
+      `letterhead.simple` or the annual starter in non-official sample mode.
+- [ ] 4.3 Keep production endpoints from accepting browser-supplied official
+      domain contexts.
+
+## 5. First donor-facing production job
+
+- [ ] 5.1 Coordinate #322 with the newer proposed #579/#580/#583/#584 work and
+      consume the approved canonical statement snapshot/version contract; do
+      not introduce a parallel annual-context, run, or formatting model.
+- [ ] 5.2 Verify that the contract covers eligibility, corrections/refunds,
+      currency, identity, totals, raw values, frozen display strings and locale,
+      source IDs, policy version, and context hash.
+- [ ] 5.3 Publish and assign the annual statement template against that
+      contract; official money/date fields bind frozen display strings.
+- [ ] 5.4 Render/store an immutable private artifact and expose it through the
+      donor-owned BFF route with authenticated self-download audit.
+- [ ] 5.5 When a source correction/refund/relink changes official output, mark
+      the old artifact superseded/void per policy, link replacement lineage,
+      preserve retained history, and keep stale output out of current portal
+      views.
+- [ ] 5.6 Replace the current live `.txt` response only after parity, finance /
+      legal approval, tenant isolation, supersession, and correction fixtures
+      pass.
+- [ ] 5.7 Route outbound statement delivery through #552-#554 and #581 with
+      version-scoped communication audit/idempotency; do not create a parallel
+      Statement Studio send/log path.
+
+## 6. Follow-on and legacy retirement
+
+- [ ] 6.1 Reconcile original, staged-gift, corrected, and scaffold receipt paths
+      before making `donor.receipt.single` an official Statement Studio job.
+- [ ] 6.2 Add missionary/report/event/care/task/legal/CMS jobs only through
+      owner-provided contexts with the sensitivity gates in the design.
+- [ ] 6.3 Retire Unlayer only after native authoring, production jobs, tenant
+      template disposition, and rollback verification are complete.
+- [ ] 6.4 Archive this OpenSpec change only after deployed behavior and merged
+      specs match the contract.

--- a/openspec/changes/add-statement-studio/tasks.md
+++ b/openspec/changes/add-statement-studio/tasks.md
@@ -28,7 +28,8 @@
 ## 3. Tenant-safe foundation
 
 - [ ] 3.1 Extend the `pdf_*` family with job catalog/settings, scoped immutable
-      version assignments, variables, recipient/source, and retention concepts.
+      version assignments, variables, recipient/source, retention, and logical
+      render idempotency/canonical-artifact concepts.
 - [ ] 3.2 Backfill/require tenant identity, add same-tenant composite foreign
       keys, and make published version content immutable. Coordinate with the
       approved #505/#516 isolation foundation and reuse its tenant guard,
@@ -38,8 +39,15 @@
 - [ ] 3.4 Add one `packages/api` persistence/orchestration seam and generated DB
       types; app routes remain thin.
 - [ ] 3.5 Prove cross-tenant rejection, immutable versions, capability
-      differences, private paths, portal denial, and purge tombstones with real
+      differences, private paths, portal denial, concurrent-render convergence,
+      lease-safe retry, canonical-artifact reuse, and purge tombstones with real
       SQL/integration tests.
+- [ ] 3.6 Add DB-enforced logical render keys, bounded lease/attempt recovery,
+      monotonically increasing fencing tokens, token-owned private staging
+      paths, current-token compare-and-set canonical-artifact promotion, and
+      durable token-scoped cleanup; cover concurrency, timeout, stale-writer,
+      and cleanup-retry behavior while keeping issuance under #580 and outbound
+      delivery under #581.
 
 ## 4. Safe vertical tracer
 
@@ -47,8 +55,9 @@
       sample data only; sample outputs are purpose-tagged, visibly non-official,
       admin-only, non-assignable, and non-deliverable.
 - [ ] 4.2 Prove immutable version, preview-only template selection, server
-      render, private upload, artifact metadata, admin download, and audit with
-      `letterhead.simple` or the annual starter in non-official sample mode.
+      render, retry convergence, private upload, canonical artifact metadata,
+      admin download, and audit with `letterhead.simple` or the annual starter
+      in non-official sample mode.
 - [ ] 4.3 Keep production endpoints from accepting browser-supplied official
       domain contexts.
 


### PR DESCRIPTION
## Summary

- Complete the AL-312 Statement Studio Phase 0 audit with a decision brief and primary-source evidence appendix.
- Add the proposed `add-statement-studio` OpenSpec contract for mutable drafts, immutable published versions, assignments, private artifacts, retry-safe canonical rendering, retention, and role-scoped access.
- Reconcile the current Unlayer/native DocRaptor paths, receipt and statement implementations, existing `pdf_*` persistence, Supabase Storage/RLS posture, and current domain owners.
- Keep `donor.statement.annual_giving` as the first donor-facing production job, preceded by a synthetic admin-only tracer and gated on the newer statement eligibility, issuance, and delivery seams.

## Why

AL-312 was still open and its original audit brief remained an unchecked template. Since the ticket was published, receipt correction work, receipt-record scaffolding, and the newer statement issues (#579, #580, and #581) refined the product boundary.

This PR records the current direction without treating proposed table names as shipped behavior. Statement Studio owns template, render, artifact, and retention concerns. The source domain owns frozen official facts and display strings, eligibility, corrections, statement runs, and issued versions.

The older pdfx/React PDF target also conflicts with current repository reality: no production runtime path exists today, while the Asym schema and server-side DocRaptor adapter do. The proposal selects DocRaptor as the candidate to qualify behind a provider-neutral port for the first slice, keeps Unlayer as a bounded fallback, and requires an explicit migration decision before another production renderer is introduced.

## Impact

- Documentation and OpenSpec only; no runtime code, migrations, environment variables, or deployed behavior change.
- Downstream Statement Studio work now has explicit tenant-isolation, frozen-facts/formatting, statement-eligibility, render-idempotency, provider-deadline/cancellation, private-artifact, communication-seam, and finance/legal gates.
- No legacy template, table, route, dependency, or artifact is deleted by this change.

## Validation

- `npx -y @fission-ai/openspec@latest validate --all --strict` - 15/15 items passed.
- Prettier, Markdownlint, and `git diff --check` - passed for every changed file.
- `bun run check` - 14/14 lint tasks and 14/14 typecheck tasks passed; 415 unit-test files and 2,424 tests passed (2 files and 3 tests skipped).
- `bun run build:admin` - passed with the repository's CI-equivalent build environment.
- Three independent documentation, contract, and quality reviews - no remaining P1/P2 findings after all follow-up fixes.

Closes #312

## Deploy Checklist (for PRs to `production` or `develop`)

- [x] CI passes
- [x] Base branch confirmed: `develop` = development, `production` = production release, `main` = retired/inactive
- [x] `bun run verify:deployment-discipline` passes if deployment controls changed (N/A - no deployment controls changed)
- [x] Migrations reviewed (N/A - documentation/OpenSpec only)
- [x] Migrations tested on development (N/A - no migrations)
- [x] New env vars added to all 3 Vercel projects (N/A - no env changes)
- [x] Rollback plan reviewed (revert the eventual merge commit; branch commits are `b6308966`, `367b3216`, and `9f56c3d3`)
- [x] Production release will use `bun run release:production` (N/A - no production release in this PR)
- [x] Post-deploy smoke tests planned (N/A - no deployed behavior changes)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the Statement Studio Phase 0 audit and proposed contract. The main changes are:

- Adds the completed decision brief and evidence appendix.
- Aligns Statement Studio on the existing `pdf_*` persistence family.
- Records DocRaptor qualification, private artifact, tenant isolation, and finance/legal gates.
- Adds OpenSpec coverage for document production, platform boundaries, and donor annual statements.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed docs or proposed contracts.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an OpenSpec strict rerun to validate the changed donor self-service, change/add-statement-studio, and all current specs; the run reported totals of 19 passed, 0 failed.
- Executed the statement-studio format check, which flagged issues on unrelated trex-upload-slots.json files and did not indicate failures on the changed PR files.
- Performed a direct Prettier check for the changed docs/OpenSpec paths; the result shows all matched files use Prettier code style.

<a href="https://app.greptile.com/trex/runs/14068034/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/guides/features/statement-studio/data-model.md | Clarifies that implementation should extend the existing `pdf_*` family instead of creating a parallel document store. |
| docs/guides/features/statement-studio/phase-0-audit-brief.md | Replaces the placeholder audit with the completed Phase 0 decision brief and rollout gates. |
| docs/guides/features/statement-studio/phase-0-research-evidence.md | Adds the evidence appendix for current routes, schema posture, Storage boundaries, and implementation readiness. |
| openspec/changes/add-statement-studio/specs/document-production/spec.md | Defines the proposed document-production contract for immutable versions, private artifacts, retry-safe rendering, and portal reauthorization. |
| openspec/changes/add-donor-self-service/specs/donation-lifecycle/spec.md | Adds donor annual statement lifecycle requirements that separate Giving-owned facts from Statement Studio artifact production. |

</details>

<sub>Reviews (6): Last reviewed commit: ["chore(pr-loop): sync PR with develop"](https://github.com/asymmetric-al/core/commit/f96c129a74ac6eaf9c3e86c8522010ee2709150a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43178830)</sub>

<!-- /greptile_comment -->