### PR TITLE
fix(contributions): complete persisted batch processing

### DIFF
--- a/apps/admin/app/contributions/batch-continuation.ts
+++ b/apps/admin/app/contributions/batch-continuation.ts
@@ -1,0 +1,184 @@
+import type {
+  ContributionBatchApiResponse,
+  ContributionBatchNextAction,
+  ContributionBatchStatus,
+  ContributionBatchSummary,
+} from "@asym/api/admin/contribution-batches";
+
+export type {
+  ContributionBatchApiResponse as ContributionBatchResponse,
+  ContributionBatchNextAction,
+};
+
+export const MAX_CONTRIBUTION_BATCH_PROCESS_REQUESTS = 50;
+
+const contributionBatchStatuses: Record<ContributionBatchStatus, true> = {
+  running: true,
+  complete: true,
+  complete_with_issues: true,
+  failed: true,
+  cancelled: true,
+};
+
+interface BatchResponseLike {
+  ok: boolean;
+  json: () => Promise<unknown>;
+}
+
+type BatchFetcher = (
+  input: string,
+  init?: { method: "POST" },
+) => Promise<BatchResponseLike>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isContributionBatchStatus(
+  value: unknown,
+): value is ContributionBatchStatus {
+  return (
+    typeof value === "string" && Object.hasOwn(contributionBatchStatuses, value)
+  );
+}
+
+function isContributionBatchSummary(
+  value: unknown,
+): value is ContributionBatchSummary {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return [
+    "processed",
+    "succeeded",
+    "skipped",
+    "failed",
+    "followUpTasksCreated",
+  ].every((key) => typeof value[key] === "number");
+}
+
+function isContributionBatchNextAction(
+  value: unknown,
+): value is ContributionBatchNextAction {
+  return (
+    isRecord(value) &&
+    value.method === "POST" &&
+    typeof value.href === "string" &&
+    /^\/api\/admin\/contribution-batches\/[^/?#]+\/process$/.test(value.href)
+  );
+}
+
+function parseContributionBatchResponse(
+  value: unknown,
+): ContributionBatchApiResponse | null {
+  if (!isRecord(value) || !isRecord(value.batch)) {
+    return null;
+  }
+
+  const { batch } = value;
+  if (
+    !isContributionBatchStatus(batch.status) ||
+    !isContributionBatchSummary(batch.summary)
+  ) {
+    return null;
+  }
+
+  const nextAction = value.nextAction;
+  if (
+    nextAction !== undefined &&
+    nextAction !== null &&
+    !isContributionBatchNextAction(nextAction)
+  ) {
+    return null;
+  }
+
+  return value as unknown as ContributionBatchApiResponse;
+}
+
+export async function readContributionBatchResponse(
+  response: BatchResponseLike,
+  fallbackMessage: string,
+): Promise<ContributionBatchApiResponse> {
+  const body = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const errorMessage =
+      isRecord(body) && typeof body.error === "string"
+        ? body.error
+        : fallbackMessage;
+    throw new Error(errorMessage);
+  }
+
+  const parsed = parseContributionBatchResponse(body);
+  if (!parsed) {
+    throw new Error(fallbackMessage);
+  }
+
+  return parsed;
+}
+
+export async function continueContributionBatch(input: {
+  initialResponse: ContributionBatchApiResponse;
+  fetcher: BatchFetcher;
+  maxProcessRequests?: number;
+  onProgress?: (batch: ContributionBatchApiResponse["batch"]) => void;
+  onContinuationAction?: (action: ContributionBatchNextAction) => void;
+}): Promise<ContributionBatchApiResponse> {
+  let currentResponse = input.initialResponse;
+  let continuationAction = currentResponse.nextAction ?? null;
+  const maxProcessRequests =
+    input.maxProcessRequests ?? MAX_CONTRIBUTION_BATCH_PROCESS_REQUESTS;
+
+  input.onProgress?.(currentResponse.batch);
+
+  if (currentResponse.batch.status !== "running") {
+    return currentResponse;
+  }
+
+  if (!continuationAction) {
+    throw new Error(
+      "The running contribution batch did not provide a continuation action.",
+    );
+  }
+  if (!isContributionBatchNextAction(continuationAction)) {
+    throw new Error(
+      "The contribution batch returned an invalid continuation action.",
+    );
+  }
+
+  for (
+    let requestCount = 0;
+    requestCount < maxProcessRequests;
+    requestCount += 1
+  ) {
+    input.onContinuationAction?.(continuationAction);
+    const response = await input.fetcher(continuationAction.href, {
+      method: continuationAction.method,
+    });
+    currentResponse = await readContributionBatchResponse(
+      response,
+      "Could not continue the contribution batch.",
+    );
+    input.onProgress?.(currentResponse.batch);
+
+    if (currentResponse.batch.status !== "running") {
+      return currentResponse;
+    }
+
+    const returnedAction = currentResponse.nextAction;
+    if (returnedAction) {
+      if (!isContributionBatchNextAction(returnedAction)) {
+        throw new Error(
+          "The contribution batch returned an invalid continuation action.",
+        );
+      }
+      continuationAction = returnedAction;
+    }
+  }
+
+  input.onContinuationAction?.(continuationAction);
+  throw new Error(
+    `Contribution batch processing paused after ${maxProcessRequests} process requests. Retry to continue the same batch.`,
+  );
+}

--- a/apps/admin/app/contributions/main-body.tsx
+++ b/apps/admin/app/contributions/main-body.tsx
@@ -5,7 +5,6 @@ import { motion } from "@asym/lib/motion";
 import { getInitials } from "@asym/lib/utils";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -36,6 +35,12 @@ import {
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import {
+  continueContributionBatch,
+  readContributionBatchResponse,
+  type ContributionBatchNextAction,
+  type ContributionBatchResponse,
+} from "./batch-continuation";
 import { getContributionColumns } from "./columns";
 import {
   contributionStatusOptions,
@@ -123,12 +128,14 @@ function BulkReceiptConfirmDialog({
   onConfirm,
   onOpenChange,
   open,
+  processedCount,
   rows,
   submitting,
 }: {
   onConfirm: () => void;
   onOpenChange: (open: boolean) => void;
   open: boolean;
+  processedCount: number | null;
   rows: Contribution[];
   submitting: boolean;
 }) {
@@ -137,7 +144,9 @@ function BulkReceiptConfirmDialog({
   const missingStagedGiftCount = selectedCount - eligibleCount;
   const hasEligibleReceipts = eligibleCount > 0;
   const actionLabel = submitting
-    ? "Starting batch..."
+    ? processedCount === null
+      ? "Starting batch..."
+      : `Processing batch... ${Math.min(processedCount, selectedCount)} of ${selectedCount}`
     : hasEligibleReceipts
       ? "Send receipts"
       : "No eligible receipts";
@@ -201,17 +210,16 @@ function BulkReceiptConfirmDialog({
 
         <AlertDialogFooter>
           <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
-          <AlertDialogAction
+          <Button
             disabled={submitting || !hasEligibleReceipts}
-            onClick={(event) => {
-              event.preventDefault();
+            onClick={() => {
               if (!submitting && hasEligibleReceipts) {
                 onConfirm();
               }
             }}
           >
             {actionLabel}
-          </AlertDialogAction>
+          </Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
@@ -241,8 +249,14 @@ export function ContributionsMainBody({
   const [pendingBulkReceiptRows, setPendingBulkReceiptRows] = useState<
     Contribution[]
   >([]);
+  const [bulkReceiptProcessedCount, setBulkReceiptProcessedCount] = useState<
+    number | null
+  >(null);
   const [isBulkReceiptSubmitting, setIsBulkReceiptSubmitting] = useState(false);
   const isBulkReceiptSubmittingRef = useRef(false);
+  const bulkReceiptContinuationRef = useRef<ContributionBatchResponse | null>(
+    null,
+  );
 
   const handleViewContribution = useCallback(
     (c: Contribution) => {
@@ -308,12 +322,16 @@ export function ContributionsMainBody({
     if (rows.length === 0) {
       return;
     }
+    bulkReceiptContinuationRef.current = null;
+    setBulkReceiptProcessedCount(null);
     setPendingBulkReceiptRows(rows);
   }, []);
 
   const handleBulkReceiptDialogOpenChange = useCallback(
     (open: boolean) => {
       if (!open && !isBulkReceiptSubmitting) {
+        bulkReceiptContinuationRef.current = null;
+        setBulkReceiptProcessedCount(null);
         setPendingBulkReceiptRows([]);
       }
     },
@@ -333,49 +351,78 @@ export function ContributionsMainBody({
     isBulkReceiptSubmittingRef.current = true;
     setIsBulkReceiptSubmitting(true);
     try {
-      const response = await fetch("/api/admin/contribution-batches", {
-        body: JSON.stringify({
-          actionType: "resend_receipt",
-          confirmationToken: crypto.randomUUID(),
-          reason: "Bulk receipt resend requested from Contribution Hub.",
-          records: rows.map((row) => ({
-            id: row.id,
-            receiptStatus: row.receiptStatus,
-            stagedGiftId: row.stagedGiftId,
-          })),
-        }),
-        headers: {
-          "content-type": "application/json",
-        },
-        method: "POST",
-      });
-      if (!response.ok) {
-        const body = (await response.json().catch(() => null)) as {
-          error?: string;
-        } | null;
-        throw new Error(body?.error ?? "Bulk receipt send failed.");
+      let batchResponse = bulkReceiptContinuationRef.current;
+      if (!batchResponse) {
+        const response = await fetch("/api/admin/contribution-batches", {
+          body: JSON.stringify({
+            actionType: "resend_receipt",
+            confirmationToken: crypto.randomUUID(),
+            reason: "Bulk receipt resend requested from Contribution Hub.",
+            records: rows.map((row) => ({
+              id: row.id,
+              receiptStatus: row.receiptStatus,
+              stagedGiftId: row.stagedGiftId,
+            })),
+          }),
+          headers: {
+            "content-type": "application/json",
+          },
+          method: "POST",
+        });
+        batchResponse = await readContributionBatchResponse(
+          response,
+          "Bulk receipt send failed.",
+        );
+        bulkReceiptContinuationRef.current = batchResponse;
       }
-      const body = (await response.json()) as {
-        batch?: {
-          status?: string;
-          summary?: { succeeded?: number; failed?: number };
-        };
+
+      const rememberContinuationAction = (
+        action: ContributionBatchNextAction,
+      ) => {
+        const currentBatch = bulkReceiptContinuationRef.current?.batch;
+        if (currentBatch) {
+          bulkReceiptContinuationRef.current = {
+            batch: currentBatch,
+            nextAction: action,
+          };
+        }
       };
-      const batchStatus = body.batch?.status ?? "completed";
-      if (batchStatus === "running") {
-        // Background batches return before any record is processed, so the
-        // zeroed summary would read as "nothing succeeded".
-        toast.success(
-          `Bulk receipt batch started: ${formatSelectedContributionCount(rows.length)} processing in the background.`,
+      const body = await continueContributionBatch({
+        fetcher: fetch,
+        initialResponse: batchResponse,
+        onContinuationAction: rememberContinuationAction,
+        onProgress: (batch) => {
+          setBulkReceiptProcessedCount(batch.summary.processed);
+          bulkReceiptContinuationRef.current = {
+            batch,
+            nextAction: bulkReceiptContinuationRef.current?.nextAction,
+          };
+        },
+      });
+      const batchStatus = body.batch.status;
+      bulkReceiptContinuationRef.current = null;
+
+      if (batchStatus === "failed" || batchStatus === "cancelled") {
+        toast.error(
+          `Bulk receipt batch ${batchStatus}: ${body.batch.summary.succeeded} succeeded, ${body.batch.summary.failed} failed.`,
+        );
+      } else if (batchStatus === "complete_with_issues") {
+        toast.warning(
+          `Bulk receipt batch complete with issues: ${body.batch.summary.succeeded} succeeded, ${body.batch.summary.failed} failed, ${body.batch.summary.skipped} skipped.`,
         );
       } else {
         toast.success(
-          `Bulk receipt batch ${batchStatus}: ${body.batch?.summary?.succeeded ?? 0} succeeded, ${body.batch?.summary?.failed ?? 0} failed.`,
+          `Bulk receipt batch ${batchStatus}: ${body.batch.summary.succeeded} succeeded, ${body.batch.summary.failed} failed.`,
         );
       }
+      setBulkReceiptProcessedCount(null);
       setPendingBulkReceiptRows([]);
       onBulkReceiptSuccess?.();
     } catch (error) {
+      // AlertDialog may request closure after its action event. Reopen it on
+      // failure so the operator can retry the saved process action instead of
+      // creating a second persisted batch.
+      setPendingBulkReceiptRows(rows);
       toast.error(
         error instanceof Error
           ? error.message
@@ -393,6 +440,7 @@ export function ContributionsMainBody({
         onConfirm={submitBulkReceipt}
         onOpenChange={handleBulkReceiptDialogOpenChange}
         open={pendingBulkReceiptRows.length > 0}
+        processedCount={bulkReceiptProcessedCount}
         rows={pendingBulkReceiptRows}
         submitting={isBulkReceiptSubmitting}
       />

--- a/packages/api/src/admin/contribution-batches/index.ts
+++ b/packages/api/src/admin/contribution-batches/index.ts
@@ -17,13 +17,16 @@ export {
 } from "./results";
 
 export type {
+  ContributionBatchApiResponse,
   ContributionBatchAffectedRecord,
   ContributionBatchExecutionMode,
   ContributionBatchItemResult,
   ContributionBatchItemStatus,
+  ContributionBatchNextAction,
   ContributionBatchRecord,
   ContributionBatchRiskLevel,
   ContributionBatchSkippedRecord,
   ContributionBatchStatus,
+  ContributionBatchSummary,
   ProcessContributionBatchInput,
 } from "./types";

--- a/packages/api/src/admin/contribution-batches/types.ts
+++ b/packages/api/src/admin/contribution-batches/types.ts
@@ -11,6 +11,30 @@ export type ContributionBatchStatus =
   | "complete_with_issues"
   | "failed"
   | "cancelled";
+
+export interface ContributionBatchSummary {
+  processed: number;
+  succeeded: number;
+  skipped: number;
+  failed: number;
+  followUpTasksCreated: number;
+}
+
+export interface ContributionBatchNextAction {
+  method: "POST";
+  href: string;
+}
+
+/** Browser-safe shape returned by contribution batch create/process routes. */
+export interface ContributionBatchApiResponse {
+  batch: {
+    id?: string | null;
+    status: ContributionBatchStatus;
+    executionMode?: ContributionBatchExecutionMode;
+    summary: ContributionBatchSummary;
+  };
+  nextAction?: ContributionBatchNextAction | null;
+}
 export type ContributionBatchItemStatus = "succeeded" | "skipped" | "failed";
 
 export interface ContributionBatchRecord {

--- a/tests/unit/apps/admin/app/contribution-batch-continuation.test.ts
+++ b/tests/unit/apps/admin/app/contribution-batch-continuation.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  continueContributionBatch,
+  readContributionBatchResponse,
+} from "../../../../../apps/admin/app/contributions/batch-continuation";
+
+function response(body: unknown, ok = true) {
+  return {
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+const runningBatch = {
+  id: "batch_1",
+  status: "running" as const,
+  executionMode: "background" as const,
+  summary: {
+    processed: 0,
+    succeeded: 0,
+    skipped: 0,
+    failed: 0,
+    followUpTasksCreated: 0,
+  },
+};
+
+const processAction = {
+  method: "POST" as const,
+  href: "/api/admin/contribution-batches/batch_1/process",
+};
+
+describe("contribution batch continuation", () => {
+  it("continues a running batch through multiple bounded process requests", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          batch: {
+            ...runningBatch,
+            summary: { ...runningBatch.summary, processed: 25, succeeded: 25 },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          batch: {
+            ...runningBatch,
+            status: "complete",
+            summary: { ...runningBatch.summary, processed: 40, succeeded: 40 },
+          },
+        }),
+      );
+    const onProgress = vi.fn();
+
+    const result = await continueContributionBatch({
+      fetcher,
+      initialResponse: {
+        batch: runningBatch,
+        nextAction: processAction,
+      },
+      maxProcessRequests: 3,
+      onProgress,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenNthCalledWith(1, processAction.href, {
+      method: "POST",
+    });
+    expect(fetcher).toHaveBeenNthCalledWith(2, processAction.href, {
+      method: "POST",
+    });
+    expect(onProgress).toHaveBeenLastCalledWith(result.batch);
+    expect(result.batch.status).toBe("complete");
+    expect(result.batch.summary.processed).toBe(40);
+  });
+
+  it.each(["complete", "complete_with_issues", "failed", "cancelled"] as const)(
+    "stops without another request when the batch is %s",
+    async (status) => {
+      const fetcher = vi.fn();
+      const initialResponse = {
+        batch: { ...runningBatch, status },
+        nextAction: processAction,
+      };
+
+      const result = await continueContributionBatch({
+        fetcher,
+        initialResponse,
+      });
+
+      expect(result).toBe(initialResponse);
+      expect(fetcher).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails safely when a running batch has no process action", async () => {
+    await expect(
+      continueContributionBatch({
+        fetcher: vi.fn(),
+        initialResponse: { batch: runningBatch },
+      }),
+    ).rejects.toThrow("did not provide a continuation action");
+  });
+
+  it("rejects an unsafe process action instead of fetching an arbitrary URL", async () => {
+    const fetcher = vi.fn();
+
+    await expect(
+      continueContributionBatch({
+        fetcher,
+        initialResponse: {
+          batch: runningBatch,
+          nextAction: {
+            method: "POST",
+            href: "https://example.com/collect",
+          },
+        },
+      }),
+    ).rejects.toThrow("invalid continuation action");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("stops at the explicit request bound while preserving the resume action", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(response({ batch: runningBatch }));
+    const onContinuationAction = vi.fn();
+
+    await expect(
+      continueContributionBatch({
+        fetcher,
+        initialResponse: {
+          batch: runningBatch,
+          nextAction: processAction,
+        },
+        maxProcessRequests: 2,
+        onContinuationAction,
+      }),
+    ).rejects.toThrow("paused after 2 process requests");
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(onContinuationAction).toHaveBeenLastCalledWith(processAction);
+  });
+
+  it("surfaces an API error message from a failed process request", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        response({ error: "Batch processing is unavailable." }, false),
+      );
+
+    await expect(
+      continueContributionBatch({
+        fetcher,
+        initialResponse: {
+          batch: runningBatch,
+          nextAction: processAction,
+        },
+      }),
+    ).rejects.toThrow("Batch processing is unavailable.");
+  });
+
+  it("rejects a successful response with an unknown batch status", async () => {
+    await expect(
+      readContributionBatchResponse(
+        response({ batch: { ...runningBatch, status: "queued" } }),
+        "Could not read contribution batch.",
+      ),
+    ).rejects.toThrow("Could not read contribution batch.");
+  });
+});

--- a/tests/unit/apps/admin/app/contributions-main-body.test.tsx
+++ b/tests/unit/apps/admin/app/contributions-main-body.test.tsx
@@ -19,10 +19,15 @@ import { JSDOM } from "jsdom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ContributionGridRow as Contribution } from "@asym/api/admin/contributions/types";
+import type {
+  ContributionBatchApiResponse,
+  ContributionBatchStatus,
+} from "@asym/api/admin/contribution-batches";
 
 const selectedRowsRef = { current: [] as unknown[] };
 const toastErrorMock = vi.fn();
 const toastSuccessMock = vi.fn();
+const toastWarningMock = vi.fn();
 const onBulkReceiptSuccessMock = vi.fn();
 
 vi.mock("@asym/lib/motion", async () => {
@@ -83,6 +88,7 @@ vi.mock("sonner", () => ({
   toast: {
     error: toastErrorMock,
     success: toastSuccessMock,
+    warning: toastWarningMock,
     info: vi.fn(),
   },
 }));
@@ -204,16 +210,55 @@ function renderPageActions(canManageContributions?: boolean) {
   );
 }
 
-function stubBatchFetch() {
-  const fetchMock = vi.fn().mockResolvedValue({
-    ok: true,
-    json: async () => ({
-      batch: {
-        status: "complete",
-        summary: { failed: 0, succeeded: 2 },
+const persistedBatchId = "batch_9";
+const persistedBatchProcessHref = `/api/admin/contribution-batches/${persistedBatchId}/process`;
+
+function makeBatchResponse(
+  overrides: {
+    status?: ContributionBatchStatus;
+    processed?: number;
+    succeeded?: number;
+    skipped?: number;
+    failed?: number;
+    followUpTasksCreated?: number;
+    includeNextAction?: boolean;
+  } = {},
+): ContributionBatchApiResponse {
+  return {
+    batch: {
+      id: persistedBatchId,
+      status: overrides.status ?? "complete",
+      executionMode: "background",
+      summary: {
+        processed: overrides.processed ?? 0,
+        succeeded: overrides.succeeded ?? 0,
+        skipped: overrides.skipped ?? 0,
+        failed: overrides.failed ?? 0,
+        followUpTasksCreated: overrides.followUpTasksCreated ?? 0,
       },
+    },
+    nextAction: overrides.includeNextAction
+      ? { method: "POST", href: persistedBatchProcessHref }
+      : undefined,
+  };
+}
+
+function okBatchResponse(
+  overrides: Parameters<typeof makeBatchResponse>[0] = {},
+) {
+  return {
+    ok: true,
+    json: async () => makeBatchResponse(overrides),
+  };
+}
+
+function stubBatchFetch() {
+  const fetchMock = vi.fn().mockResolvedValue(
+    okBatchResponse({
+      processed: 2,
+      succeeded: 2,
     }),
-  });
+  );
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
     value: fetchMock,
@@ -450,15 +495,7 @@ describe("ContributionsMainBody bulk receipt confirmation", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      resolveFetch({
-        ok: true,
-        json: async () => ({
-          batch: {
-            status: "complete",
-            summary: { failed: 0, succeeded: 1 },
-          },
-        }),
-      });
+      resolveFetch(okBatchResponse({ processed: 1, succeeded: 1 }));
     });
   });
 
@@ -525,24 +562,23 @@ describe("ContributionsMainBody bulk receipt confirmation", () => {
     expect(onBulkReceiptSuccessMock).not.toHaveBeenCalled();
   });
 
-  it("describes background batches honestly instead of claiming zero results", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        batch: {
-          id: "batch_9",
-          status: "running",
-          executionMode: "background",
-          summary: {
-            processed: 0,
-            succeeded: 0,
-            skipped: 0,
-            failed: 0,
-            followUpTasksCreated: 0,
-          },
-        },
-      }),
-    });
+  it("continues a background batch until the process endpoint returns a terminal result", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okBatchResponse({ status: "running", includeNextAction: true }),
+      )
+      .mockResolvedValueOnce(
+        okBatchResponse({ status: "running", processed: 25, succeeded: 25 }),
+      )
+      .mockResolvedValueOnce(
+        okBatchResponse({
+          processed: 30,
+          succeeded: 29,
+          failed: 1,
+          followUpTasksCreated: 1,
+        }),
+      );
     Object.defineProperty(globalThis, "fetch", {
       configurable: true,
       value: fetchMock,
@@ -555,9 +591,164 @@ describe("ContributionsMainBody bulk receipt confirmation", () => {
     await waitFor(() => {
       expect(toastSuccessMock).toHaveBeenCalled();
     });
-    const message = toastSuccessMock.mock.calls[0]?.[0] as string;
-    expect(message).toMatch(/background/i);
-    expect(message).not.toMatch(/0 succeeded/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, persistedBatchProcessHref, {
+      method: "POST",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(3, persistedBatchProcessHref, {
+      method: "POST",
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Bulk receipt batch complete: 29 succeeded, 1 failed.",
+    );
+    expect(onBulkReceiptSuccessMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the existing persisted batch instead of creating another batch", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okBatchResponse({ status: "running", includeNextAction: true }),
+      )
+      .mockRejectedValueOnce(new Error("Connection lost."))
+      .mockResolvedValueOnce(okBatchResponse({ processed: 1, succeeded: 1 }));
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+    const view = renderMainBody([makeContribution()]);
+
+    fireEvent.click(view.getByRole("button", { name: "Send Receipts" }));
+    fireEvent.click(await view.findByRole("button", { name: "Send receipts" }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("Connection lost.");
+    });
+    fireEvent.click(view.getByRole("button", { name: "Send receipts" }));
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "Bulk receipt batch complete: 1 succeeded, 0 failed.",
+      );
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/admin/contribution-batches",
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(2, persistedBatchProcessHref, {
+      method: "POST",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(3, persistedBatchProcessHref, {
+      method: "POST",
+    });
+  });
+
+  it("shows processed progress while a later batch chunk is pending", async () => {
+    let resolveFinalProcess: (value: unknown) => void = () => {};
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okBatchResponse({ status: "running", includeNextAction: true }),
+      )
+      .mockResolvedValueOnce(
+        okBatchResponse({ status: "running", processed: 25, succeeded: 25 }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFinalProcess = resolve;
+          }),
+      );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+    const rows = Array.from({ length: 30 }, (_, index) =>
+      makeContribution({
+        id: `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+      }),
+    );
+    const view = renderMainBody(rows);
+
+    fireEvent.click(view.getByRole("button", { name: "Send Receipts" }));
+    fireEvent.click(await view.findByRole("button", { name: "Send receipts" }));
+
+    expect(
+      await view.findByRole("button", {
+        name: "Processing batch... 25 of 30",
+      }),
+    ).toBeTruthy();
+
+    await act(async () => {
+      resolveFinalProcess(okBatchResponse({ processed: 30, succeeded: 30 }));
+    });
+  });
+
+  it("shows a failure message when processing reaches a failed terminal state", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okBatchResponse({ status: "running", includeNextAction: true }),
+      )
+      .mockResolvedValueOnce(
+        okBatchResponse({
+          status: "failed",
+          processed: 1,
+          failed: 1,
+          followUpTasksCreated: 1,
+        }),
+      );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+    const view = renderMainBody([makeContribution()]);
+
+    fireEvent.click(view.getByRole("button", { name: "Send Receipts" }));
+    fireEvent.click(await view.findByRole("button", { name: "Send receipts" }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Bulk receipt batch failed: 0 succeeded, 1 failed.",
+      );
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("warns when processing completes with failed or skipped items", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okBatchResponse({ status: "running", includeNextAction: true }),
+      )
+      .mockResolvedValueOnce(
+        okBatchResponse({
+          status: "complete_with_issues",
+          processed: 3,
+          succeeded: 1,
+          failed: 1,
+          skipped: 1,
+          followUpTasksCreated: 1,
+        }),
+      );
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+    const view = renderMainBody([makeContribution()]);
+
+    fireEvent.click(view.getByRole("button", { name: "Send Receipts" }));
+    fireEvent.click(await view.findByRole("button", { name: "Send receipts" }));
+
+    await waitFor(() => {
+      expect(toastWarningMock).toHaveBeenCalledWith(
+        "Bulk receipt batch complete with issues: 1 succeeded, 1 failed, 1 skipped.",
+      );
+    });
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- continue newly created running contribution batches through the existing process action until a terminal state
- cap browser continuation at 50 requests while each server request retains its 25-item bound and tenant/creator checks
- preserve the persisted process action after transient failures so retry resumes the same batch
- show live processed counts plus distinct success, warning, and failure terminal feedback
- centralize the browser-safe batch API response contract in packages/api

## Reviewer guidance

Start with apps/admin/app/contributions/batch-continuation.ts for the bounded loop, then apps/admin/app/contributions/main-body.tsx for retry/progress wiring. The existing server processor remains unchanged.

## Verification

- 2,937 unit tests passed; 4 skipped
- 56 focused contribution batch tests passed
- full monorepo typecheck passed
- admin lint passed
- data-access boundary check passed
- admin production build passed
- changed-file Prettier check and git diff check passed
- two-axis Standards and Spec review: no remaining findings

Note: the repo-wide local Prettier hook also scans two ignored .local-secrets Markdown files. Those files were not touched; the push used the verified hook exception after all changed-file and CI-equivalent gates above passed.

Closes #841

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes persisted contribution batch processing from the admin bulk receipt flow. The main changes are:

- Adds a bounded browser continuation loop for running contribution batches.
- Preserves the latest batch and process action so retries resume the same persisted batch.
- Shows live processed counts and distinct terminal feedback for success, warning, failure, and cancellation states.
- Centralizes the browser-safe contribution batch response contract in `packages/api`.
- Adds focused unit coverage for continuation, retry, progress, and terminal UI behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge with low risk.

The changed client flow validates server responses, restricts continuation actions to the expected same-origin process route, preserves retry state for transient failures, and has focused tests for the new continuation and UI paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the unit test suite for admin contribution batches and related components using Bunx Vitest; all tests passed with 3 test files and 56 tests completed in 3.15 seconds.

<a href="https://app.greptile.com/trex/runs/14830387/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/admin/app/contributions/batch-continuation.ts | Adds browser-side validation and bounded continuation for persisted contribution batch process actions; no material issues found. |
| apps/admin/app/contributions/main-body.tsx | Wires bulk receipt creation into the continuation loop with retry state, progress text, and terminal toast outcomes; no material issues found. |
| packages/api/src/admin/contribution-batches/index.ts | Exports the centralized browser-safe contribution batch response types; no material issues found. |
| packages/api/src/admin/contribution-batches/types.ts | Defines the public contribution batch response, summary, and next-action contracts used by the admin client; no material issues found. |
| tests/unit/apps/admin/app/contribution-batch-continuation.test.ts | Adds focused coverage for continuation bounds, invalid actions, terminal states, and response parsing; no material issues found. |
| tests/unit/apps/admin/app/contributions-main-body.test.tsx | Extends bulk receipt UI tests for persisted batch continuation, retry behavior, progress display, and terminal feedback; no material issues found. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Operator
participant AdminUI as ContributionsMainBody
participant CreateAPI as POST /api/admin/contribution-batches
participant ProcessAPI as POST /api/admin/contribution-batches/{batchId}/process

Operator->>AdminUI: Confirm bulk receipt resend
AdminUI->>CreateAPI: Create persisted batch
CreateAPI-->>AdminUI: batch(status, summary) + nextAction
loop Until terminal state or 50 process requests
    AdminUI->>AdminUI: Persist latest batch + continuation action
    AdminUI->>ProcessAPI: POST nextAction.href
    ProcessAPI-->>AdminUI: updated batch(status, summary)
    AdminUI->>Operator: Update processed count
end
alt complete
    AdminUI->>Operator: Success toast + refresh callback
else complete_with_issues
    AdminUI->>Operator: Warning toast + refresh callback
else failed/cancelled
    AdminUI->>Operator: Error toast + refresh callback
else transient error / request cap
    AdminUI->>Operator: Keep dialog open for retry
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Operator
participant AdminUI as ContributionsMainBody
participant CreateAPI as POST /api/admin/contribution-batches
participant ProcessAPI as POST /api/admin/contribution-batches/{batchId}/process

Operator->>AdminUI: Confirm bulk receipt resend
AdminUI->>CreateAPI: Create persisted batch
CreateAPI-->>AdminUI: batch(status, summary) + nextAction
loop Until terminal state or 50 process requests
    AdminUI->>AdminUI: Persist latest batch + continuation action
    AdminUI->>ProcessAPI: POST nextAction.href
    ProcessAPI-->>AdminUI: updated batch(status, summary)
    AdminUI->>Operator: Update processed count
end
alt complete
    AdminUI->>Operator: Success toast + refresh callback
else complete_with_issues
    AdminUI->>Operator: Warning toast + refresh callback
else failed/cancelled
    AdminUI->>Operator: Error toast + refresh callback
else transient error / request cap
    AdminUI->>Operator: Keep dialog open for retry
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(contributions): continue persisted b..."](https://github.com/asymmetric-al/core/commit/db96af67cfab6e701c981227d8087d5575b3864a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45063354)</sub>

<!-- /greptile_comment -->