### PR TITLE
openspec(eve): add email and Discord notifications

### DIFF
--- a/openspec/changes/add-eve-email-discord-notifications/design.md
+++ b/openspec/changes/add-eve-email-discord-notifications/design.md
@@ -1,0 +1,102 @@
+# Design: Eve Email And Discord Notifications
+
+## Context
+
+#436 consumes already-governed Eve events, including #435 monitor findings, and delivers safe external
+summaries. It owns notification policy, envelope, channel rendering, dedupe, pause, and delivery outcomes. It
+does not own the source event, global kill switches, verified identity, audit shape, or retention policy.
+
+## Decisions
+
+### 1. One safe envelope precedes channel rendering
+
+The source event is normalized into a notification envelope containing stable event/notification ids, event
+type, severity, source and target references, occurred time, safe decision summary, explicitly allowed detail
+fields, policy/redaction versions, dedupe key, intended channel class, and expiry. Unsafe raw source payloads
+are not copied into the envelope.
+
+### 2. Destinations are app-owned and verified
+
+Email recipients come only from enabled platform-owner notification records tied to verified app identity and
+permission state. Discord destinations come only from enabled app-owned operational channel configuration.
+Prompts, models, tools, events, issue bodies, PR content, and monitor evidence cannot add or replace a
+recipient, address, webhook, guild, or channel.
+
+### 3. Email is a platform-owner durable record
+
+V1 email is restricted to platform owners. A durable message includes the safe event class, severity, time,
+decision summary, permitted evidence link/reference, and a link back to authorized Mission Control context.
+Email never becomes the authoritative audit record; #419 audit remains authoritative.
+
+### 4. Discord is urgent awareness with minimal content by default
+
+Only events meeting app-owned urgency/severity policy are eligible for Discord. The default rendering is
+minimal: event class, severity, safe summary, time, and safe internal reference. Rich details may be added only
+when the field allowlist and deterministic safe-content/redaction policy approve each field. Uncertain content
+is omitted, not sent for a model-only safety judgment.
+
+### 5. Sensitive content is excluded by construction
+
+Neither channel may contain secrets/credentials, service-role keys, environment values, raw production
+records, donor/payment data, unapproved identity or tenant data, raw logs, unredacted replay/debug artifacts,
+hidden reasoning, or arbitrary model/tool output. URLs must be allowlisted and must not carry credentials or
+sensitive query parameters.
+
+### 6. Dedupe and lifecycle prevent noise
+
+Stable dedupe combines event class, target, severity band, channel, and configured time window. The lifecycle
+is pending, suppressed, sending, delivered, retryable-failed, terminal-failed, or cancelled. Retries are
+bounded, idempotent, budgeted, and cease on pause or stale/expired events. A severity escalation may create a
+new allowed notification under policy; repeat observations do not spam recipients.
+
+### 7. Pause is notification-local but consumes global controls
+
+Notification settings support channel/global notification pause and recipient opt-out as app-owned state.
+Delivery also consumes #418 release/emergency and #420 relevant kill-switch state. #436 does not invent a new
+global automation switch or override #420. Re-enable/resume requires the existing authorized admin path.
+
+### 8. Every outcome is audited and retained by existing owners
+
+#419 records policy, redaction, dedupe, destination class (not secrets), delivery attempt, provider response
+class, and outcome. Every attempt executes as #426's verified service identity and carries the explicit source
+initiator/trigger metadata; event, prompt, model, or tool content cannot choose the actor or user/tenant scope.
+Audit records both the source initiator and delivery actor. #424 controls retention of notification and audit
+records. Provider payloads/responses are stored only in safe redacted form when necessary; credentials and raw
+sensitive content are never retained.
+
+### 9. Runtime and provider boundaries remain external
+
+#425 owns event-consumer/runtime durability; #436 owns the safe envelope, notification policy, and delivery
+lifecycle rather than a new host. Email delivery remains behind the repository's existing server-side outbound
+email boundary, never a browser-to-provider path. Provider selection remains an implementation decision
+outside this specification.
+
+## State Flow
+
+1. A governed source event requests notification.
+2. Current release, pause, identity, recipient, severity, budget, and channel policy are evaluated.
+3. The safe envelope is built and deterministically redacted.
+4. Dedupe and expiry decide send/suppress/cancel.
+5. Channel renderer includes only allowed fields; destination resolves from app-owned config.
+6. The server-side provider operation executes under verified service identity and idempotently within bounded retry policy.
+7. Safe outcome is audited and shown in #427 Mission Control.
+
+## Alternatives Rejected
+
+- **Let event payloads supply recipients:** enables exfiltration and routing abuse.
+- **Send rich Discord messages then redact at storage:** external leakage has already occurred.
+- **Use Discord as audit history:** it is an awareness channel, not app-owned evidence.
+- **Model-only redaction:** deterministic deny/allow rules must bound any model contribution.
+
+## Risks and Mitigations
+
+- **Data leakage:** safe envelope, field allowlists, URL sanitization, deny-on-uncertainty.
+- **Alert fatigue:** severity routing, stable dedupe, cooldown, bounded retry, pause.
+- **Recipient drift:** verified app-owned platform-owner records and operational destinations.
+- **Provider replay/duplicates:** idempotency keys and durable lifecycle state.
+- **Stale incident delivery:** expiry and current-state checks before every attempt/retry.
+
+## Rollout
+
+This PR defines only the contract. No destination or provider is configured here. Implementation must remain
+disabled until channel tests and #437 final launch verification pass.

--- a/openspec/changes/add-eve-email-discord-notifications/proposal.md
+++ b/openspec/changes/add-eve-email-discord-notifications/proposal.md
@@ -1,0 +1,49 @@
+# Change: Add Eve Email And Discord Notifications
+
+## Why
+
+Important Eve events must not remain trapped in Mission Control. Issue #436 adds the v1 external-notification
+contract: email is the durable record for platform owners, while Discord provides urgent operational
+awareness. Both channels must be policy-controlled, redacted, deduplicated, pausable, and audited.
+
+External delivery raises the cost of a mistake. Recipient and destination configuration therefore remains
+app-owned, content is safe by construction, Discord rich detail requires an explicit safe-content decision,
+and neither a prompt nor a model can choose where a notification goes.
+
+## What Changes
+
+- Define a channel-neutral notification envelope and lifecycle.
+- Restrict v1 email recipients to verified configured platform owners.
+- Restrict Discord to configured operational destinations and urgent operational events.
+- Default Discord to minimal safe content; allow richer detail only after deterministic policy/redaction checks.
+- Define dedupe, retry, suppression, pause/opt-out, delivery outcome, and audit behavior.
+- Require secrets, raw production data, donor/payment details, unsafe identity data, raw logs, unredacted replay,
+  and hidden reasoning to remain out of both channels.
+- Keep the package spec-only with no provider, webhook, credential, schema, send, or runtime activation.
+
+## Impact
+
+- **Affected capability:** `eve-email-discord-notifications` (new)
+- **Dependencies:** #418, #419, #420, #423, #424, #426, #427, and #435
+- **Issue covered:** #436
+- **User stories covered:** 61, 62, 63, and 64
+- **Runtime impact:** none in this PR
+
+## Non-Goals
+
+- Sending email to customers, donors, tenant users, arbitrary admins, or addresses supplied at runtime.
+- Treating Discord as a durable audit/archive system or a safe location for sensitive data.
+- Creating a new global pause or kill-switch owner; #420 remains authoritative.
+- Defining monitor detection; #435 owns monitor findings.
+- Activating the final Eve release switch; #437 owns launch verification.
+
+## Evidence
+
+- The PRD requires email plus Discord, platform-owner-only email, policy-gated rich Discord content, and tests
+  for redaction, severity, dedupe, and pause state.
+  [VERIFIED-REPO: docs/prds/eve-autonomous-operations/01-eve-autonomous-operations-platform.md]
+- The implementation plan assigns the external-notification slice to #436.
+  [VERIFIED-REPO: docs/prds/eve-autonomous-operations/02-implementation-plan.md]
+- #419 owns audit/redaction shape and #424 owns retention/replay lifecycle.
+  [VERIFIED-REPO: openspec/changes/add-eve-audit-tracer-bullet]
+  [VERIFIED-REPO: openspec/changes/add-eve-retention-replay-tracer]

--- a/openspec/changes/add-eve-email-discord-notifications/specs/eve-email-discord-notifications/spec.md
+++ b/openspec/changes/add-eve-email-discord-notifications/specs/eve-email-discord-notifications/spec.md
@@ -1,0 +1,162 @@
+# Delta for Eve Email And Discord Notifications
+
+## ADDED Requirements
+
+### Requirement: Every Notification Starts From A Safe Typed Envelope
+
+Eve MUST normalize a governed source event into a typed notification envelope containing stable event and
+notification ids, event type, severity, safe source/target references, occurred time, safe decision summary,
+explicitly allowed detail fields, policy/redaction versions, dedupe key, intended channel class, and expiry.
+Unsafe raw source payloads and arbitrary model/tool text MUST NOT be copied into the envelope. Deterministic
+validation and redaction MUST run before channel rendering. [VERIFIED-REPO: openspec/changes/add-eve-audit-tracer-bullet]
+
+#### Scenario: A monitor finding requests notification
+
+- **GIVEN** #435 emits a current governed finding eligible for external notification
+- **WHEN** #436 builds the envelope
+- **THEN** it includes only typed safe fields and evidence references allowed by policy
+- **AND** the monitor's raw payload is not forwarded to a channel
+
+#### Scenario: The source contains an unknown field
+
+- **GIVEN** a source event includes content outside the envelope allowlist
+- **WHEN** envelope validation runs
+- **THEN** the unknown content is excluded or the notification is denied
+- **AND** uncertainty never defaults to external disclosure
+
+### Requirement: V1 Email Goes Only To Configured Platform Owners
+
+Email destinations MUST resolve only from enabled app-owned platform-owner notification records whose current
+identity and permission state is valid. V1 MUST NOT send Eve email to customers, donors, tenant users,
+arbitrary admins, or addresses supplied by prompts, models, tools, source events, issues, PRs, or monitor
+evidence. Email MUST contain only the safe envelope rendering and permitted links to authorized app context.
+[VERIFIED-REPO: docs/prds/eve-autonomous-operations/01-eve-autonomous-operations-platform.md]
+
+#### Scenario: A platform-owner notification is eligible
+
+- **GIVEN** an enabled verified platform owner is configured for the event class
+- **WHEN** policy permits an email delivery
+- **THEN** the recipient resolves from app-owned configuration
+- **AND** the durable message contains the safe summary and permitted references only
+
+#### Scenario: Event content supplies an address
+
+- **GIVEN** a prompt, finding, issue, or tool output includes a different email address
+- **WHEN** destination resolution runs
+- **THEN** the supplied address is ignored and cannot become a recipient
+- **AND** no message is sent unless a valid configured platform-owner destination exists
+
+### Requirement: Discord Is Urgent And Rich Only After Safe-Content Policy
+
+Discord MUST receive only events that meet app-owned urgency/severity routing policy and MUST resolve only an
+enabled app-owned operational destination. Its default rendering MUST be minimal safe content. Rich detail MAY
+be included only after deterministic field allowlisting, redaction, and URL safety checks approve every field.
+Model-only safety claims MUST NOT authorize richer content; uncertain fields MUST be omitted.
+[VERIFIED-REPO: docs/prds/eve-autonomous-operations/02-implementation-plan.md]
+
+#### Scenario: An urgent safe alert is sent minimally
+
+- **GIVEN** an urgent event is eligible for Discord but no rich fields are approved
+- **WHEN** the message is rendered
+- **THEN** it contains only event class, severity, safe summary, time, and permitted reference
+- **AND** operational awareness does not depend on exposing raw detail
+
+#### Scenario: A rich detail field passes policy
+
+- **GIVEN** a configured rich field is allowlisted and its redacted value passes deterministic safety checks
+- **WHEN** an urgent Discord message is rendered
+- **THEN** that field may be included with the policy/redaction version recorded
+- **AND** all other unapproved fields remain omitted
+
+#### Scenario: A model says sensitive detail is safe
+
+- **GIVEN** a model recommends including a raw log, donor/payment detail, or credential-like value
+- **WHEN** deterministic content policy evaluates the field
+- **THEN** the field is denied regardless of the model recommendation
+- **AND** the denial is audited safely
+
+### Requirement: Sensitive Material Never Enters External Notification Content
+
+Email and Discord content MUST exclude secrets, credentials, environment values, service-role keys, raw
+production records, donor/payment data, unapproved identity/tenant data, raw logs, unredacted replay/debug
+artifacts, hidden reasoning, and arbitrary model/tool output. Links MUST be allowlisted and sanitized so they
+contain no credentials or sensitive query values. Redaction MUST happen before provider submission, not only
+at storage or display time. [VERIFIED-REPO: docs/prds/eve-autonomous-operations/01-eve-autonomous-operations-platform.md]
+
+#### Scenario: A safe summary links to an unsafe URL
+
+- **GIVEN** a notification contains a URL with a credential or sensitive query parameter
+- **WHEN** URL policy runs before rendering
+- **THEN** the URL is removed or replaced with an approved safe internal route
+- **AND** the unsafe URL is never submitted to the provider
+
+#### Scenario: A replay artifact is referenced
+
+- **GIVEN** the source event relates to a #424 replay/debug artifact
+- **WHEN** notification content is built
+- **THEN** it may include only a permitted safe metadata/reference summary
+- **AND** it never embeds the unredacted artifact or bypasses its access controls
+
+### Requirement: Notification Delivery Is Deduplicated, Idempotent, Bounded, And Pausable
+
+Every notification MUST use a stable dedupe key and lifecycle state. Repeat events inside the configured window
+MUST be suppressed or update the existing notification; provider attempts MUST use idempotency where
+supported. Retries MUST be bounded, consume #423 budgets/rate limits, stop after expiry, and recheck #418
+release/emergency, #420 relevant switch, notification pause/opt-out, recipient validity, and content policy
+before every attempt. #436 MUST NOT create a new global kill switch or self-grant an override.
+[VERIFIED-REPO: openspec/changes/add-eve-approval-budget-policy]
+
+#### Scenario: A duplicate alert is observed
+
+- **GIVEN** the same event class, target, severity band, and channel occur inside the dedupe window
+- **WHEN** delivery is considered
+- **THEN** a duplicate external message is suppressed according to policy
+- **AND** the suppression links to the existing lifecycle and is audited
+
+#### Scenario: Pause begins before a retry
+
+- **GIVEN** a provider attempt failed retryably but notification or global pause becomes active
+- **WHEN** the retry is due
+- **THEN** the retry does not execute
+- **AND** resume requires the existing authorized control path and current policy
+
+### Requirement: Notification Decisions And Outcomes Are Audited And Retained By Existing Owners
+
+#419 MUST record the explicit source initiator/trigger, #426-verified service delivery actor, event class,
+policy/redaction versions, severity, dedupe outcome, channel and destination class, attempt identity, provider
+response class, and delivery result without storing credentials or unsafe payloads. Every generation and
+delivery attempt MUST execute under the verified service identity and user/tenant scope derived by #426;
+prompt, model, event, issue, PR, monitor, or tool content MUST NOT choose that actor or scope. #424 MUST own
+retention/hold/expiry of notification and audit records. #427 MUST expose safe notification status and pause
+controls to authorized admins. Email or Discord MUST NOT become the authoritative audit or retention store.
+[VERIFIED-REPO: openspec/changes/add-eve-retention-replay-tracer]
+
+#### Scenario: Source content claims a different actor or tenant
+
+- **GIVEN** an event or generated field supplies an actor, user, or tenant different from verified context
+- **WHEN** notification generation or delivery begins
+- **THEN** #426-derived service identity and scope remain authoritative and the supplied values are ignored
+- **AND** audit links the real source initiator/trigger to the verified delivery actor without cross-scope access
+
+#### Scenario: Provider delivery fails terminally
+
+- **GIVEN** bounded retries are exhausted or the provider returns a terminal result
+- **WHEN** the lifecycle closes
+- **THEN** the safe response class and terminal outcome are audited and visible in Mission Control
+- **AND** raw provider payloads, credentials, and unsafe content are not retained
+
+### Requirement: This Change Grants No New Delivery Or Runtime Authority
+
+This change MUST remain spec-only and MUST NOT configure providers, webhooks, credentials, destinations,
+schema, event consumers, sends, or runtime activation. #425 remains the owner of event-consumer/runtime
+durability; outbound email MUST remain behind the server-side email boundary rather than a browser/provider-
+direct path. #420 remains the owner of global automation controls; #419/#424 remain owners of audit/redaction
+and retention/replay; #426 remains owner of verified identity and scope. The #418 release switch MUST remain
+off. [VERIFIED-REPO: openspec/project.md]
+
+#### Scenario: The package is reviewed for scope
+
+- **GIVEN** this change is under review
+- **WHEN** repository effects are inspected
+- **THEN** only OpenSpec documents and an implementation checklist are present
+- **AND** no external message can be sent by this PR

--- a/openspec/changes/add-eve-email-discord-notifications/tasks.md
+++ b/openspec/changes/add-eve-email-discord-notifications/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Eve Email And Discord Notifications
+
+## 1. Envelope And Policy
+
+- [ ] 1.1 Define the typed safe envelope, allowed event classes, severity routing, and expiry.
+- [ ] 1.2 Implement deterministic field redaction, URL sanitization, and deny-on-uncertainty behavior.
+- [ ] 1.3 Keep unsafe raw payloads and arbitrary model/tool output outside notification records.
+
+## 2. Destinations And Rendering
+
+- [ ] 2.1 Resolve email only from enabled verified platform-owner configuration.
+- [ ] 2.2 Resolve Discord only from enabled app-owned operational destinations.
+- [ ] 2.3 Render minimal Discord content by default and gate each rich field independently.
+
+## 3. Lifecycle And Controls
+
+- [ ] 3.1 Implement stable channel-aware dedupe and idempotent provider attempts.
+- [ ] 3.2 Implement bounded retries, expiry, terminal states, and current-policy checks before every attempt.
+- [ ] 3.3 Enforce notification pause/opt-out plus #418/#420 global state without creating a new global switch.
+- [ ] 3.4 Consume #423 budget/rate limits for delivery and retry work.
+- [ ] 3.5 Execute every generation/attempt as #426's verified service identity with source initiator/trigger metadata.
+
+## 4. Audit And Visibility
+
+- [ ] 4.1 Emit #419 records for source initiator, verified delivery actor, policy, redaction, dedupe, attempt, suppression, and outcome.
+- [ ] 4.2 Apply #424 retention/hold/expiry to safe notification records.
+- [ ] 4.3 Expose safe status, failures, and pause controls through #427.
+
+## 5. Verification
+
+- [ ] 5.1 Test platform-owner-only email and rejection of runtime-supplied recipients.
+- [ ] 5.2 Test urgent Discord routing, minimal default, approved rich fields, and denied unsafe fields.
+- [ ] 5.3 Test secrets, raw production/donor/payment data, raw logs, replay, and unsafe URL exclusion.
+- [ ] 5.4 Test dedupe, idempotency, retries, expiry, pause, budget exhaustion, and audit.
+- [ ] 5.5 Keep the release switch off and configure/send no external notification in this slice.
+
+## 6. Scope Check
+
+- [ ] 6.1 Confirm #436 owns notification policy/delivery lifecycle, not global kill switches.
+- [ ] 6.2 Confirm #425 owns runtime/event-consumer durability and email stays behind the server-side boundary.
+- [ ] 6.3 Confirm monitor detection and final launch remain #435/#437 scope.


### PR DESCRIPTION
## Summary

- define a safe typed external-notification envelope and lifecycle
- restrict email to configured platform owners and Discord to urgent operational awareness
- require deterministic redaction and field-level policy before rich Discord detail
- specify dedupe, idempotency, bounded retry, pause, audit, and retention ownership

Refs #436.

## Validation

- `bunx @fission-ai/openspec@latest validate add-eve-email-discord-notifications --strict`
- `bunx prettier --check openspec/changes/add-eve-email-discord-notifications`
- `git diff --check`

## Review note

Draft pending explicit human product/maintainer approval. This PR configures no provider, destination, credential, event consumer, or send.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a spec-only OpenSpec change for Eve email and Discord notifications. The main changes are:

- A safe typed notification envelope before channel rendering.
- Platform-owner-only email destinations and app-owned Discord destinations.
- Deterministic redaction, URL safety checks, and field-level rich Discord policy.
- Dedupe, idempotency, bounded retry, pause, audit, and retention ownership requirements.
- A checklist that keeps provider configuration, credentials, event consumers, and sends out of this slice.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are spec-only and introduce no provider configuration, secrets, schema, runtime consumer, or send behavior.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the OpenSpec email-discord validation workflow by executing bun --version, git rev-parse --short HEAD, OpenSpec strict validation, Prettier, and git diff --check, with all steps exiting 0.

<a href="https://app.greptile.com/trex/runs/14907808/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openspec/changes/add-eve-email-discord-notifications/design.md | Adds the design rationale and state flow for spec-only Eve email and Discord notification delivery. |
| openspec/changes/add-eve-email-discord-notifications/proposal.md | Defines the motivation, scope, non-goals, dependencies, and evidence for the new external-notification capability. |
| openspec/changes/add-eve-email-discord-notifications/specs/eve-email-discord-notifications/spec.md | Adds OpenSpec requirements and scenarios for safe envelopes, restricted destinations, redaction, lifecycle controls, audit, retention, and no new runtime authority. |
| openspec/changes/add-eve-email-discord-notifications/tasks.md | Adds the implementation checklist for envelope policy, rendering, lifecycle controls, audit visibility, verification, and scope checks. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Event as Governed Eve Event
participant Policy as Notification Policy
participant Envelope as Safe Envelope Builder
participant Dedupe as Dedupe/Lifecycle
participant Renderer as Channel Renderer
participant Provider as Email/Discord Provider
participant Audit as Audit/Retention Owners

Event->>Policy: Request external notification
Policy->>Policy: Check release, pause, identity, recipient, severity, budget
Policy->>Envelope: Build typed safe envelope
Envelope->>Envelope: Redact fields and sanitize URLs
Envelope->>Dedupe: Evaluate expiry and dedupe key
Dedupe-->>Audit: Record suppress/cancel outcome if blocked
Dedupe->>Renderer: Allowed notification
Renderer->>Renderer: Render minimal/rich content under field policy
Renderer->>Provider: Server-side idempotent send attempt
Provider-->>Audit: Safe provider response class and delivery outcome
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Event as Governed Eve Event
participant Policy as Notification Policy
participant Envelope as Safe Envelope Builder
participant Dedupe as Dedupe/Lifecycle
participant Renderer as Channel Renderer
participant Provider as Email/Discord Provider
participant Audit as Audit/Retention Owners

Event->>Policy: Request external notification
Policy->>Policy: Check release, pause, identity, recipient, severity, budget
Policy->>Envelope: Build typed safe envelope
Envelope->>Envelope: Redact fields and sanitize URLs
Envelope->>Dedupe: Evaluate expiry and dedupe key
Dedupe-->>Audit: Record suppress/cancel outcome if blocked
Dedupe->>Renderer: Allowed notification
Renderer->>Renderer: Render minimal/rich content under field policy
Renderer->>Provider: Server-side idempotent send attempt
Provider-->>Audit: Safe provider response class and delivery outcome
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(pr-loop): sync PR with develop"](https://github.com/asymmetric-al/core/commit/37bc2bfd2e12302f33c8929d96617e388cc21219) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45224809)</sub>

<!-- /greptile_comment -->