### PR TITLE
docs(sitestacker-parity): Phase 5 governance — ADRs 0026–0030, OpenSpec runtime-contract requirement, glossary + doc wiring

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,6 +79,80 @@ get the same real-world job done here?" and tracked in the parity matrix
 (`docs/prds/sitestacker-parity/`). Child sponsorship is out of scope.
 _Avoid_: SiteStacker clone, screen-for-screen copy, feature-for-feature parity
 
+**Public tenant website** (Phase 5):
+The tenant's public-facing ministry site — branded public pages, missionary
+and project pages, storytelling, and giving entry points — served today as a
+surface inside the donor app, on the tenant's domain. It is a public ministry
+experience, never an operational console, and "channel" is retired as a
+public/attribution concept (Phase 2's four axes replaced it: site,
+entry method, source code, designation).
+_Avoid_: public admin console, marketing microsite outside the platform,
+channel
+
+**Public runtime** (Phase 5):
+The governed way the public tenant website actually runs: host-based tenant
+resolution, published-only isolated content reads, reference validation,
+enumeration-safe checkout handoff, tagged caching with secured invalidation,
+and Draft Mode preview — one contract every public page type builds on.
+_Avoid_: per-page fetch rules, ad hoc public data paths
+
+**Published-content reader / choke-point** (Phase 5):
+The sole entry for public content reads. It takes the resolved tenant (and
+reserved site) as a required argument, always applies tenant-and-published,
+runs with Payload access control enforced, and returns empty when no tenant
+resolves. A hard-blocking lint forbids raw Payload reads in public paths.
+_Avoid_: direct Payload reads in public code, hand-written tenant `where`
+clauses, `overrideAccess: true` public reads
+
+**Public serializer** (Phase 5):
+The allowlist between CMS documents and the public. It emits only named
+public-safe fields and typed layout blocks; new or unknown fields are
+excluded by default; media is normalized to public URLs. Raw Payload
+documents never cross it.
+_Avoid_: passing raw CMS documents to pages, denylist filtering, leaking
+internal fields by default
+
+**Public request context** (Phase 5):
+The unified result of resolving a public request from the platform-trusted
+host: operational tenant id, CMS tenant id, and a reserved site id. Fail
+closed — an unknown or disabled host resolves to "site not found," never to
+an unfiltered read. Client-supplied tenant overrides are dev-only.
+_Avoid_: trusting `?tenant=` in production, per-page host parsing
+
+**Checkout handoff / CTA resolver** (Phase 5):
+The resolver that turns a public "Give" CTA into a server-validated checkout
+handoff. Every operational reference is re-validated server-side against the
+resolved tenant; a preset amount is a re-validated suggestion, never a
+trusted charge value; the handoff carries the reserved attribution fields
+(site, source code, currency, locale, entry method). Invalid links fail to
+"give another way," never a mis-designated gift.
+_Avoid_: hand-rolled giving URLs, client-trusted amounts or references,
+enumeration-leaking giving forms
+
+**Preview (Draft Mode) / preview token** (Phase 5):
+Staff preview renders the real public page with drafts on via Next.js Draft
+Mode, behind a signed-secret route that authenticates the staff user and
+checks the tenant; the response is never cached and never indexed. A
+shareable, expiring non-staff preview token is a reserved seam.
+_Avoid_: separate preview templates that drift from the live page, publicly
+reachable drafts, indexable preview URLs
+
+**Public page identity** (Phase 5):
+A public page's presentation identity — display name, slug, publish state —
+linked to, but never equal to, the operational record behind it. CMS wins
+for presentation; operational truth wins for identity, money, and existence;
+a dangling or cross-tenant reference fails safe.
+_Avoid_: treating the page as the operational record, copying operational
+truth into CMS
+
+**Cache tag scheme** (Phase 5):
+The tenant/document-derived tags on cached public reads, used for prompt
+invalidation when content publishes. Tags invalidate; they never isolate —
+cache-key isolation comes from passing the resolved tenant as a function
+argument. Site and locale tag dimensions are reserved.
+_Avoid_: tag-only tenant isolation, route-segment cache config, unbounded
+"never expire" caching
+
 **Workflow Orchestration**:
 Durable coordination of background work after authoritative product records
 exist. It does not become the source of truth for donations, CRM state,

--- a/docs/adr/0026-public-website-surface-in-donor-app.md
+++ b/docs/adr/0026-public-website-surface-in-donor-app.md
@@ -1,0 +1,50 @@
+# ADR-0026: Public Website is a surface in `apps/donor`, `apps/web` reserved
+
+**Status:** Accepted (founder ruling, Phase 5 grill session 2026-07-05 — A2)
+
+> Full record: `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`
+> (ruling A2; see also A1 scope and A12 public-web mechanics).
+
+## Context
+
+The public tenant website already ships in production as the `(public)` route
+group inside the donor app, and the platform-surfaces spec names it a
+first-class product surface. Phase 5 (Public Website Runtime Contract) had to
+decide where that surface lives going forward. The alternatives were: extract
+a separate `apps/web` package now (deployment isolation, independent
+availability, a clean home for future public features), or keep the public
+website as a surface inside `apps/donor` (today's shipped reality, no second
+app to build, deploy, and keep healthy while the runtime contract itself is
+still being formalized). Extracting first would have meant standing up a new
+app around an undocumented, partially unsafe runtime — moving the problem
+before fixing it.
+
+## Decision
+
+The public tenant website is a **product surface, not (yet) a separate app**.
+It stays at the `(public)` route group in `apps/donor`, per the
+platform-surfaces intent. No `apps/web` is created now; the extraction is
+**reserved**, and the runtime contract is deliberately written so that a
+future extraction is a re-import, not a rewrite: all public-runtime rules live
+in one server-only shared package under `packages/api` (the published-content
+reader interface, allowlist serializer, checkout-handoff resolver, cache-tag
+scheme, and public request context), and consuming pages depend only on that
+package's serialized types. The future public route families (`/give`,
+`/projects`, `/events`, `/campaigns`, `/updates/[slug]`, `/thank-you`,
+`/sitemap.xml`, `/robots.txt`, `/preview`) are reserved now so later phases do
+not collide; checkout stays public at `/checkout` and the donor dashboard
+stays authenticated.
+
+## Consequences
+
+- No second Next.js app to operate while the contract is proven; the public
+  website keeps shipping from the donor app's deployment.
+- The shared contract package is mandatory, not optional — it is what keeps
+  the reserved `apps/web` extraction cheap (re-point the imports, not
+  re-derive the rules).
+- Public website behavior and authenticated portal behavior must stay clearly
+  split inside the one app, per the platform-boundaries spec; the reserved
+  route families make that split structural.
+- The extraction trigger is explicit and deferred: an `apps/web` split (or an
+  availability SLO that demands removing admin from the hot read path — see
+  ADR-0027) re-opens this decision with the contract already in place.

--- a/docs/adr/0027-transport-agnostic-public-content-reader.md
+++ b/docs/adr/0027-transport-agnostic-public-content-reader.md
@@ -1,0 +1,49 @@
+# ADR-0027: Transport-agnostic reader, single Payload read in admin, availability seam
+
+**Status:** Accepted (founder ruling, Phase 5 grill session 2026-07-05 — A3/A4)
+
+> Full record: `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`
+> (rulings A3 and A4; deep modules in Section B).
+
+## Context
+
+Every public content read today is a live call from the public pages into the
+admin app, where Payload CMS runs — the public website is welded to the staff
+app's uptime and speed, and the "resolve tenant → fetch published → serialize"
+rules live implicitly in that split. Any second consumer (a future `apps/web`,
+a native surface) would have to re-derive those rules. Payload itself runs on
+a pre-release spike dependency whose internals churn. The alternatives were:
+scatter per-app Payload calls (status quo — every consumer re-implements the
+safety rules), hard-weld an HTTP dependency into the contract (the transport
+becomes the contract), or define the contract at the Asym boundary with the
+transport as an implementation detail.
+
+## Decision
+
+The public-content contract lives in **one server-only shared package under
+`packages/api`**, and dependencies point **into** it: admin, donor, and any
+future web app depend on the package; the package never imports Payload or
+the admin app. The package defines a **`PublishedContentReader` interface**
+returning serialized public types; **exactly one concrete implementation
+touches Payload's Local API**, co-located where Payload runs (admin). The
+transport between the public runtime and that reader (HTTP today) is a
+swappable implementation detail — consuming pages read only through the
+package client, never a hard-coded admin URL. The cache-tag scheme is built
+now so public reads are cacheable; an alternate transport that removes admin
+from the hot read path (CDN/replica) is a **reserved capability with an
+explicit trigger** (an `apps/web` extraction or an availability SLO).
+
+## Consequences
+
+- The public runtime depends on a stable serialized contract, never raw
+  Payload documents or the `cms` schema — Payload's pre-release churn stays
+  invisible above the boundary.
+- One owner for the safety rules (tenant scoping, published-only,
+  serialization) keeps apps thin; a second consumer is an import, not a
+  re-derivation.
+- Availability honesty: in Phase 5 (Public Website Runtime Contract) the
+  admin app is still on the cold-read path for public content. The
+  availability seam is designed (via the cache-tag scheme) but not built —
+  a later, triggered capability, not a Phase-5 guarantee.
+- The reader interface grows additively (listing/detail for events and
+  campaigns later); adding a page type never re-opens the transport question.

--- a/docs/adr/0028-defense-in-depth-public-isolation.md
+++ b/docs/adr/0028-defense-in-depth-public-isolation.md
@@ -1,0 +1,58 @@
+# ADR-0028: Defense-in-depth public isolation
+
+**Status:** Accepted (founder ruling, Phase 5 grill session 2026-07-05 — A5)
+
+> Full record: `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`
+> (ruling A5; A15 explains why RLS cannot carry this; testing tier in
+> Testing Decisions).
+
+## Context
+
+The shipped public-read pattern runs Payload's Local API with
+`overrideAccess: true` — which skips Payload access control entirely — plus a
+hand-written `where` clause for tenant + published on every query. Isolation
+therefore depends on every query author remembering the right clause, and one
+already forgot: the public navigation route omitted the published filter and
+returned drafts. There is no structural guard, and there cannot be a
+database-level one: Postgres row-level security does not protect the `cms`
+schema, because the Payload database role bypasses RLS. The alternatives were:
+keep the hand-written-`where` pattern and add review discipline (no safety
+net — it already leaked), rely on RLS (impossible for `cms`), or make
+isolation structural at the application boundary with independent enforcement
+layers.
+
+## Decision
+
+Public content is readable **only through one choke-point** — the
+published-content reader — with layered, independent guarantees:
+
+- the resolved tenant (and reserved site) is a **required typed argument**,
+  so isolation cannot be forgotten at a call site;
+- the choke-point **always applies the tenant-and-published constraint**;
+- an unresolved tenant returns **empty, never unfiltered** (fail-closed);
+- the read runs **`overrideAccess: false` under an explicit public-read
+  access policy** ("anonymous ⇒ published + resolved tenant only"), so
+  Payload independently enforces isolation even if the choke-point has a
+  bug; the policy is extensible for future restricted-content predicates;
+- a **hard-blocking sole-entry lint** forbids raw Payload reads
+  (`payload.find` / `findByID`) in public code paths outside the reader;
+- a permanent **negative-test tier** asserts cross-tenant emptiness, draft
+  unreachability (including a navigation regression test), and fail-closed
+  behavior.
+
+The shipped navigation draft-leak is fixed by routing navigation through the
+same choke-point. This retires the `overrideAccess: true` +
+hand-written-`where` pattern for public reads.
+
+## Consequences
+
+- The worst-case public bug becomes "site not found," never "serve everyone"
+  or "serve a draft."
+- Two independent layers (choke-point argument + Payload policy) must both
+  fail before content crosses a tenant boundary — a single forgotten clause
+  can no longer leak.
+- The lint and negative tests are permanent CI gates, not one-time checks;
+  new public read paths must go through the reader or the build fails.
+- Payload access policies gain a real public-read policy instead of being
+  skipped, which future restricted-content rules (for example
+  restricted-worker suppression) extend rather than bypass.

--- a/docs/adr/0029-reference-not-copy-cms-operational.md
+++ b/docs/adr/0029-reference-not-copy-cms-operational.md
@@ -1,0 +1,53 @@
+# ADR-0029: Reference-not-copy CMS↔operational, operational-wins on drift
+
+**Status:** Accepted (founder ruling, Phase 5 grill session 2026-07-05 — A7)
+
+> Full record: `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`
+> (ruling A7; A15 records the two-schema footgun rules this preserves).
+
+## Context
+
+The platform runs one database with two schemas: `public` (operational truth,
+RLS-protected) and `cms` (Payload-owned presentation). CMS pages need to point
+at operational records — a missionary giving page needs its missionary, a
+project page its fund. The alternatives were: **copy** operational data into
+CMS documents (names, goals, support progress — which drifts the moment the
+operational record changes, and puts money/identity truth in a schema RLS does
+not protect), **hard foreign keys** across the schema boundary (couples
+Payload's migrations to Supabase's, breaks the disjoint migration tooling, and
+is the classic two-schema footgun), or **soft references validated in the
+application layer** at read time.
+
+## Decision
+
+CMS stores **stable operational references plus presentation content — never
+money or identity truth**. Cross-schema links stay soft UUID references; the
+runtime resolves and **validates every reference at read time** (the record
+exists, belongs to the resolved tenant, and is public-eligible); references
+are batched and cached; live operational data (for example support progress)
+is read at render, never copied into CMS. On drift, **operational truth wins**
+for identity, money, existence, and permission; **CMS wins** for presentation.
+A dangling or cross-tenant reference **fails safe** (hide the CTA, 404 the
+page) — never a charge to a stale designation. **Public page identity is a
+presentation identity linked to — not equal to — the operational record**,
+which is what enables display names, family/team pages (one page, several
+records, an explicit designation target), restricted-country suppression,
+independent slugs, and independent publish state. Graceful degradation
+distinguishes an invalid reference (hide/refuse) from a transient operational
+outage (retry or degrade the affected element, not the whole page).
+
+## Consequences
+
+- No sync engine and no snapshot job between `cms` and `public` — there is
+  nothing to drift, reconcile, or repair.
+- Migration tooling stays disjoint (Payload owns `cms`; the Supabase CLI owns
+  `public` plus shared roles/extensions); neither schema's migrations can
+  break the other's.
+- Reference validation is a read-time cost, paid once per render and
+  amortized by batching and the Phase 5 cache contract (ADR-0030).
+- Deleting or reassigning an operational record cannot leave a public page
+  charging the wrong target — the reference fails validation and the page
+  fails safe instead.
+- The presentation-identity split is load-bearing for later phases
+  (family/team pages, restricted-worker suppression) and must not be
+  collapsed into "the page is the record."

--- a/docs/adr/0030-function-level-tagged-caching-publish-signal.md
+++ b/docs/adr/0030-function-level-tagged-caching-publish-signal.md
@@ -1,0 +1,56 @@
+# ADR-0030: Function-level tagged caching + cross-app publish signal, no route-segment config
+
+**Status:** Accepted (founder ruling, Phase 5 grill session 2026-07-05 — A9)
+
+> Full record: `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`
+> (ruling A9; wiring details in Section E, verified against the installed
+> Next.js 16.2 bundled docs and official Vercel documentation).
+
+## Context
+
+Public pages must be fast (cached) and fresh (a publish appears promptly),
+without ever serving one tenant's page from another tenant's cache. The repo
+runs Next.js Cache Components (`cacheComponents: true`), where route-segment
+config exports (`revalidate`, `dynamic`, and friends) are build-breaking —
+see `docs/guides/architecture/runtime-map.md`. Two doc-verified findings
+shaped the decision: **cache tags do not isolate cache entries** (a tag is an
+invalidation handle, not part of the cache key — tag-alone caching would
+bleed content across tenants), and cross-deployment invalidation needs an
+explicit signal from the app that knows a publish happened (admin) to the app
+that serves the cached page (the public runtime). The alternatives were
+time-based-only caching (stale pages, editor frustration), no caching (public
+availability rides every admin read), or function-level tagged caching with
+an explicit publish signal.
+
+## Decision
+
+Published reads use **function-level `use cache` + `cacheTag` + `cacheLife`**.
+**Cache-key isolation comes from passing the resolved tenant as a function
+argument** — tags are for invalidation only. Tags are tenant/document-derived,
+mandatory by construction, and respect platform limits (no commas, bounded
+length via stable ids, consistent casing); `site` and `locale` tag dimensions
+are reserved. Publishing (and navigation/redirect/media/CTA changes) emits a
+**secured admin→public-runtime invalidation signal** — HMAC-signed and
+verified in constant time — that calls `revalidateTag(..., "max")` in the
+public app's route handler, propagating globally in roughly 300ms. A
+**bounded `cacheLife` expire (about an hour, never "never")** is the
+self-healing backstop for a missed signal. **No route-segment cache config
+exists anywhere in the public app**, and request-specific values (host,
+headers, draft state) are read outside `use cache` and passed as arguments.
+
+## Consequences
+
+- Tenant cache isolation is triple-layered: the tenant argument in the cache
+  key, Vercel's host-in-cache-key default, and tenant-derived tags — a tag
+  bug alone cannot serve tenant B from tenant A's entry.
+- Editors see publishes propagate in seconds (the signal), and a missed
+  signal self-heals within the bounded `cacheLife` window instead of pinning
+  stale content forever.
+- The invalidation endpoint is an authenticated machine surface: a forged or
+  replayed call cannot force cache purges, because the signature is verified
+  in constant time before any revalidation runs.
+- A structural CI assertion keeps route-segment config out of the public app
+  permanently; caching decisions stay at the function level where the tenant
+  argument is visible.
+- Draft Mode requests are dynamic by construction (the bypass cookie), so
+  preview traffic can never populate or read the published cache.

--- a/docs/guides/architecture/runtime-map.md
+++ b/docs/guides/architecture/runtime-map.md
@@ -12,6 +12,34 @@ For every `apps/*/app/**/{route,layout,page}.{ts,tsx,js,jsx,mts,mjs}` file while
 - For API route handlers specifically, treat `export const runtime = ...` as build-breaking in this repo.
 - Rely on framework defaults and handler-level implementation constraints instead of segment config exports.
 
+## Public Runtime Contract (Phase 5)
+
+Phase 5 (Public Website Runtime Contract) governs how the public tenant
+website reads, caches, and previews content
+(`docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`;
+ADRs 0026–0030):
+
+- **One reader choke-point.** All public content reads go through the
+  published-content reader (server-only, under `packages/api`), which takes
+  the resolved tenant (and reserved site) as a required argument, always
+  applies tenant-and-published, runs Payload with `overrideAccess: false`
+  under the public-read policy, and returns empty on an unresolved tenant.
+  Raw Payload reads (`payload.find`/`findByID`) in public code paths are
+  forbidden by a hard-blocking lint; the `/api/cms/public/*` routes above are
+  transport behind the reader, never a second rule set.
+- **Function-level caching only.** Published reads cache with `use cache` +
+  `cacheTag` + a bounded `cacheLife`; **cache-key isolation comes from
+  passing the tenant as a function argument** (tags are invalidation-only).
+  Publishing emits an HMAC-signed, constant-time-verified admin→public
+  signal that calls `revalidateTag(..., "max")` in the public app's route
+  handler. Request-specific values (host, headers, draft state) are read
+  outside `use cache` and passed as arguments.
+- **No route-segment cache config.** The segment-config rule above is a hard
+  contract for the public app: no `revalidate`/`dynamic`/etc. anywhere in
+  public routes — a structural CI assertion enforces it. Draft Mode preview
+  requests are dynamic by construction and never populate the published
+  cache.
+
 ## Shared Health Contract
 
 `admin`, `donor`, and `missionary` expose `/api/health` through

--- a/docs/guides/architecture/web-studio-living-spec.md
+++ b/docs/guides/architecture/web-studio-living-spec.md
@@ -307,6 +307,8 @@ Giving source-reference fields (`missionaryId`, `fundId`, `supabaseMissionaryId`
 
 The native edit shell now reports loading, dirty, saving, autosave, validation, lock, trash, preview, and publish states without replacing Payload's document form. The authenticated preview route uses `overrideAccess: false`; public routes stay published-only and never receive draft data.
 
+**Preview convergence (Phase 5 (Public Website Runtime Contract)):** preview converges on the public runtime via Next.js Draft Mode — staff preview renders the **real public page** through the shared published-content reader with drafts on, behind a signed-secret route that authenticates the staff user, checks the tenant, enables Draft Mode (so the request is dynamic and drafts are never cached), redirects to a validated internal path, and marks the response `noindex`; it reads with `overrideAccess: false` so a tenant-A staffer cannot preview tenant-B drafts. The authenticated admin-template preview above remains the **interim** path until the Draft Mode public preview is proven. A shareable, expiring non-staff review token and Payload Live Preview remain reserved seams. See `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md` (A10) and ADR-0028/ADR-0030.
+
 ---
 
 ## 15. Media, uploads, relationships

--- a/docs/prds/sitestacker-parity/parity-matrix.md
+++ b/docs/prds/sitestacker-parity/parity-matrix.md
@@ -243,8 +243,13 @@ questions**. Benchmark source root: `https://sitestacker.training`.
 - **Benchmark:** SiteStacker missionary/project public pages. (s)
 - **Current state:** public `/workers` + profile pages currently render **mock
   data**, not real CRM-backed entities (see PR #462 audit note); CMS foundation
-  built. (v)
-- **Depends on:** #1, #13.
+  built. (v) The runtime contract these pages run on — isolation choke-point,
+  host resolution, reference validation, enumeration-safe checkout handoff,
+  caching, Draft Mode preview — is governed by Phase 5 (Public Website Runtime
+  Contract): PRD `phase-05-public-website-runtime-contract.md`, epic #520,
+  ADRs 0026–0030; the missionary giving page is its proof slice (mock →
+  contract, built as a generalizable template).
+- **Depends on:** #1, #13; Phase 5 (public runtime contract).
 - **Acceptance test:** a real CRM missionary has a public, CMS-managed page with
   native giving.
 - **Evidence:** phase 06/07 CMS evidence; PR #462 project.md current-state note.
@@ -254,8 +259,12 @@ questions**. Benchmark source root: `https://sitestacker.training`.
 
 - **Benchmark:** SiteStacker Site Planner / dynamic content. (s)
 - **Current state:** Payload Web Studio CMS foundation built (phase 06/07);
-  dynamic-content parity partial. (v)
-- **Depends on:** —.
+  dynamic-content parity partial. (v) Public delivery of that content —
+  published-only isolated reads, allowlist serialization, tagged caching with
+  secured invalidation, Draft Mode preview convergence — is governed by
+  Phase 5 (Public Website Runtime Contract): PRD
+  `phase-05-public-website-runtime-contract.md`, epic #520, ADRs 0026–0030.
+- **Depends on:** —; Phase 5 governs the public delivery contract.
 - **Acceptance test:** staff build/publish tenant-branded dynamic pages.
 - **Evidence:** `docs/ops/phase-evidence/2026-05-15_phase-07_web-studio-ux.md`.
 - **Open questions:** dynamic content-type breadth.

--- a/openspec/changes/sitestacker-parity/proposal.md
+++ b/openspec/changes/sitestacker-parity/proposal.md
@@ -47,6 +47,18 @@ platform boundaries already warn against.
   authorize the superseded one-Stripe-subscription-to-one-legacy-pledge model or
   provider-owned retry policy. Detailed behavior is governed by the Phase 16
   PRD, dated congruence package, and ADRs.
+- **Amended 2026-07-22 (Phase 5 (Public Website Runtime Contract)):** add a
+  durable requirement recording the public-tenant-website runtime contract —
+  one server-only published-content choke-point with the resolved tenant as a
+  required argument (fail-closed, `overrideAccess: false` under a public-read
+  policy), host-only tenant resolution, no publicly reachable drafts with
+  Draft Mode preview, a server-validated enumeration-safe checkout handoff
+  carrying the reserved `site_id`/`source_code`/`currency`/`locale`/
+  `entry_method` attribution fields ("channel" stays retired),
+  tenant-as-argument cache keys with a secured admin→public revalidation
+  signal and no route-segment config, and reference-not-copy
+  CMS↔operational with operational-wins. Detailed behavior is governed by the
+  Phase 5 PRD and ADRs 0026–0030.
 
 ## Impact
 

--- a/openspec/changes/sitestacker-parity/specs/platform-product-intent/spec.md
+++ b/openspec/changes/sitestacker-parity/specs/platform-product-intent/spec.md
@@ -441,3 +441,61 @@ incomplete or conflicting evidence MAY create a suggestion only.
 - AND missionaries remain cash-first, automatic-recurring-first, view-only, and
   free of payment credentials, provider identifiers, decline details,
   authorization evidence, and pledge-reminder noise
+
+### Requirement: The Public Tenant Website Runs On One Governed Runtime Contract
+
+The public tenant website MUST run on one governed runtime contract, per
+Phase 5 (Public Website Runtime Contract) and
+`docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`.
+Public content MUST be readable only through one server-only published-content
+choke-point that takes the resolved tenant (and reserved site) as a required
+argument, always applies the tenant-and-published constraint, runs with
+Payload access control enforced (`overrideAccess: false`) under an explicit
+public-read policy, and returns empty — never unfiltered — when no tenant
+resolves. A public request MUST resolve its tenant only from the
+platform-trusted host in production and MUST fail closed to a neutral "site
+not found" on an unknown or disabled host. No draft or unpublished document
+may be reachable through any public route; staff preview goes through Draft
+Mode behind a signed, tenant-checked route and is never cached and never
+indexed. A giving CTA MUST hand off through the server-validated,
+enumeration-safe checkout resolver — every operational reference re-validated
+server-side against the resolved tenant, a preset amount treated as a
+re-validated suggestion — and the handoff carries the reserved
+`site_id` / `source_code` / `currency` / `locale` /
+`entry_method = 'public_checkout'` attribution fields ("channel" stays
+retired). Cached public reads MUST key on the tenant passed as an argument
+(tags are invalidation-only) with a secured admin→public revalidation signal
+and a bounded-staleness backstop, and no route-segment cache config may exist
+in the public app. CMS pages reference operational records
+(reference-not-copy); operational truth wins for identity, money, and
+existence, and a dangling or cross-tenant reference fails safe.
+
+#### Scenario: A visitor requests a public page
+
+- WHEN a public request arrives for a tenant page
+- THEN the tenant resolves only from the platform-trusted host, the page reads
+  published content solely through the choke-point with the resolved tenant as
+  a required argument, and an unknown host or unresolved tenant yields a
+  neutral "site not found" rather than any other tenant's content
+- AND no draft, cross-tenant document, or unserialized Payload internals reach
+  the response
+
+#### Scenario: A giving CTA hands off into checkout
+
+- WHEN a visitor follows a "Give" CTA from a public page
+- THEN checkout re-resolves and validates every operational reference
+  server-side against the resolved tenant and public-eligibility before
+  rendering or charging, the form stays enumeration-safe and constant-time,
+  and the handoff carries the reserved attribution fields
+- AND an invalid, stale, or cross-tenant giving link fails to a friendly
+  "give another way" instead of a mis-designated gift
+
+#### Scenario: Staff preview and publish a draft
+
+- WHEN a staff member previews a draft or publishes a change
+- THEN preview renders the real page through the same reader with drafts on,
+  behind a signed-secret route that authenticates the staff user and checks
+  the tenant, marked noindex and never cached
+- AND publishing emits the secured admin→public invalidation signal so the
+  right cache tags revalidate promptly, with the bounded-staleness backstop
+  self-healing a missed signal

--- a/openspec/changes/sitestacker-parity/tasks.md
+++ b/openspec/changes/sitestacker-parity/tasks.md
@@ -64,6 +64,22 @@
       evidence/targets remain distinct from application authority, and heuristic
       evidence remains suggestion-only.
 
+## 2e. Phase 5 (Public Website Runtime Contract) (2026-07-22)
+
+- [x] 2e.1 Record the public-tenant-website runtime-contract durable
+      requirement in this change's `platform-product-intent` delta (per
+      `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`).
+- [x] 2e.2 Author the five Phase 5 ADRs (`docs/adr/0026`–`0030`): surface in
+      `apps/donor` with `apps/web` reserved; transport-agnostic reader with
+      the single Payload read in admin; defense-in-depth public isolation;
+      reference-not-copy CMS↔operational; function-level tagged caching with
+      the cross-app publish signal and no route-segment config.
+- [x] 2e.3 Add the Phase 5 public-runtime glossary entries to `CONTEXT.md`
+      (glossary only; "channel" stays retired) and record the contract in
+      `docs/guides/architecture/runtime-map.md`,
+      `docs/guides/architecture/web-studio-living-spec.md`, and the parity
+      matrix (areas 12/13).
+
 ## 3. Verification
 
 - [x] 3.1 `bunx @fission-ai/openspec@latest validate --all --strict` passes.


### PR DESCRIPTION
Closes #521 (Phase 5 (Public Website Runtime Contract) — T1 docs ticket; parent epic #520).

## Summary

Authors the Phase 5 governance layer from the settled PRD (`docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`) — no decisions re-opened, docs only:

- **Five ADRs** in the canonical series: `docs/adr/0026` (public website is a surface in `apps/donor`, `apps/web` reserved), `0027` (transport-agnostic reader, single Payload read in admin, availability seam), `0028` (defense-in-depth public isolation), `0029` (reference-not-copy CMS↔operational, operational-wins), `0030` (function-level tagged caching + cross-app publish signal, no route-segment config) — each with decision/alternatives/hard-to-reverse framing in the house ADR style, mapped to PRD rulings A2/A3–A4/A5/A7/A9.
- **OpenSpec**: a durable *public-tenant-website runtime contract* requirement (3 scenarios) added to the `sitestacker-parity` change's `platform-product-intent` delta, plus the dated proposal amendment and tasks section 2e. `platform-surfaces`/`platform-boundaries` already name the surface consistently — no touch needed (checked; no source-of-truth conflict introduced).
- **CONTEXT.md**: nine glossary-only entries (public tenant website, public runtime, published-content reader / choke-point, public serializer, public request context, checkout handoff / CTA resolver, preview (Draft Mode) / preview token, public page identity, cache tag scheme), placed beside the Phase 2 Site/Entry Method/Source Code cluster; "channel" noted retired.
- **Doc wiring**: `runtime-map.md` gains a Public Runtime Contract section (reader choke-point, function-level caching, no-segment-config); `web-studio-living-spec.md` §14 records the Draft Mode preview convergence; `parity-matrix.md` areas 12/13 now reference Phase 5.

## Acceptance criteria

- ✅ Five ADRs exist in `docs/adr/` (0026–0030), decision + alternatives + why, consistent style
- ✅ OpenSpec change under `openspec/changes/sitestacker-parity/` records the runtime contract; `bunx @fission-ai/openspec@latest validate --all --strict` → 41 passed / 0 failed
- ✅ `CONTEXT.md` has the listed terms as glossary entries only; channel retired noted
- ✅ `runtime-map.md` + `web-studio-living-spec.md` updated; `parity-matrix.md` references Phase 5
- ✅ No source-of-truth conflict with Phase-2/3/4 docs (reserved-seam ownership stated, not duplicated)

## Verification

- `bunx @fission-ai/openspec@latest validate --all --strict` — 41/41 pass
- Prettier clean on all touched files
- Full local `ci:preflight` (format, skills:verify, lint, verify gates, typecheck, all-app builds, 1900+ unit tests) **passed on pre-push — no hook bypass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Phase 5 governance contract for the public tenant website. The main changes are:

- Five ADRs covering app ownership, content reads, tenant isolation, operational references, and caching.
- An OpenSpec requirement for public pages, checkout handoff, preview, and publishing.
- New glossary terms and architecture, preview, and parity documentation.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

A clear authenticated exception is needed for draft preview before merging.

The public reader is required to enforce published-only filtering on every read, while the preview scenario requires that same reader to return drafts. Leaving both rules normative can produce a broken preview or an overly broad draft bypass.

openspec/changes/sitestacker-parity/specs/platform-product-intent/spec.md and matching preview/reader language in CONTEXT.md, ADR-0028, and web-studio-living-spec.md
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a focused Bun harness to compare the authenticated draft preview path against the anonymous public reader.
- The harness reproduced a contract divergence, with the authenticated draft preview resolving to /web-studio/preview/pages/draft\_123 while the public reader returned not-found at /api/cms/public/pages/draft-only.
- The harness reported the contract assertion failed because the preview did not invoke the same public reader under an authenticated drafts-on context.
- The Playwright CMS flow started both applications but could not launch Chromium because the configured browser executable was missing.
- OpenSpec validation and Prettier checks completed successfully, both exiting with code 0.

<a href="https://app.greptile.com/trex/runs/15288461/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openspec/changes/sitestacker-parity/specs/platform-product-intent/spec.md | Adds the durable public-runtime contract, but the preview scenario conflicts with its unconditional published-only reader rule. |
| docs/adr/0028-defense-in-depth-public-isolation.md | Defines the tenant-scoped, published-only public reader and layered isolation controls. |
| docs/adr/0030-function-level-tagged-caching-publish-signal.md | Defines tenant-keyed function caching, secured invalidation, and bounded staleness. |
| docs/guides/architecture/web-studio-living-spec.md | Documents convergence on real-page Draft Mode preview and inherits the reader exception ambiguity. |
| CONTEXT.md | Adds the Phase 5 public-runtime glossary and its tenant, checkout, preview, and caching boundaries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(sitestacker-parity): Phase 5 govern..."](https://github.com/asymmetric-al/core/commit/b5770e60dc13fbdfe6ddf747f54aed8c1dbe5401) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46044155)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->