### PR TITLE
feat(api): Phase 5 shared public-content contract package (@asym/api/cms/public)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -249,6 +249,7 @@
         "@supabase/ssr": "^0.8.0",
         "inngest": "4.5.1",
         "next": "16.2.6",
+        "server-only": "0.0.1",
         "stripe": "22.2.0",
         "zod": "^4.3.6",
       },
@@ -3539,6 +3540,8 @@
     "seroval-plugins": ["seroval-plugins@1.5.5", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg=="],
 
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
+    "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,6 +93,26 @@ const eslintConfig = defineConfig([
     },
   },
   {
+    // Phase 5 public-content contract package (ADR-0027): dependencies point
+    // inward — the package never imports Payload or an app. The single
+    // Payload-touching reader implementation lives in apps/admin. CI lints
+    // packages with cwd=packages/api, so the ENFORCING copy of this block
+    // lives in packages/api/eslint.config.mjs; this one covers root-cwd runs
+    // and editors.
+    files: ["packages/api/src/cms/public/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}"],
+    rules: {
+      "no-restricted-imports": appRestrictedImports({
+        extraPatterns: [
+          {
+            group: ["payload", "payload/*", "@payloadcms/*", "@payloadcms/**"],
+            message:
+              "The public-content contract package must not import Payload; the single Payload-touching reader implementation is co-located in apps/admin (ADR-0027).",
+          },
+        ],
+      }),
+    },
+  },
+  {
     files: ["apps/*/app/api/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}"],
     rules: {
       "no-restricted-imports": appRestrictedImports({

--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -1,5 +1,30 @@
 import { libraryConfig } from "@asym/eslint-config/library.mjs";
+import { restrictedImports } from "@asym/eslint-config/restricted-imports.mjs";
 
 export { libraryConfig };
 
-export default libraryConfig;
+export default [
+  ...libraryConfig,
+  {
+    // Phase 5 public-content contract package (ADR-0027): dependencies point
+    // inward — the package never imports Payload. This lives HERE (not only in
+    // the root eslint.config.mjs) because CI lints this package with
+    // cwd=packages/api, where flat-config lookup resolves this file and never
+    // the root one. Globs cover both cwds so editors and root runs agree.
+    files: [
+      "src/cms/public/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}",
+      "**/packages/api/src/cms/public/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}",
+    ],
+    rules: {
+      "no-restricted-imports": restrictedImports({
+        extraPatterns: [
+          {
+            group: ["payload", "payload/*", "@payloadcms/*", "@payloadcms/**"],
+            message:
+              "The public-content contract package must not import Payload; the single Payload-touching reader implementation is co-located in apps/admin (ADR-0027).",
+          },
+        ],
+      }),
+    },
+  },
+];

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -101,6 +101,7 @@
     "./health/app": "./src/health/app.ts",
     "./health/db": "./src/health/db.ts",
     "./health/crm": "./src/health/crm.ts",
+    "./cms/public": "./src/cms/public/index.ts",
     "./email/connect": "./src/email/connect.ts",
     "./email/test-send": "./src/email/test-send.ts",
     "./email/templates": "./src/email/templates.ts",
@@ -177,6 +178,7 @@
     "@supabase/ssr": "^0.8.0",
     "inngest": "4.5.1",
     "next": "16.2.6",
+    "server-only": "0.0.1",
     "stripe": "22.2.0",
     "zod": "^4.3.6"
   },

--- a/packages/api/src/cms/public/README.md
+++ b/packages/api/src/cms/public/README.md
@@ -1,0 +1,49 @@
+# Public-content contract package
+
+The one owner of the public tenant website's content rules (Phase 5 (Public
+Website Runtime Contract); PRD
+`docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`,
+the five Phase 5 ADRs from the #521 docs ticket — allocated ADR-0026–0030 in
+PR #962 — and epic #520).
+
+## What lives here
+
+| Module                | Owns                                                                                                             |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `context.ts`          | `PublicRequestContext` (operational tenant id + CMS tenant id + reserved `siteId`), fail-closed resolution shape |
+| `reader.ts`           | `PublishedContentReader` interface, page-type config registry, result unions, updates-limit clamp                |
+| `serialized.ts`       | The serialized public types (page, layout blocks, media, navigation, updates, tenant summary)                    |
+| `serializer.ts`       | The allowlist serializer — named public-safe fields only; unknown fields/blocks are excluded by default          |
+| `cache-tags.ts`       | The tenant/document cache-tag scheme + bounded `cacheLife` profile name; reserved site/locale dimensions         |
+| `checkout-handoff.ts` | Checkout-handoff types, reserved attribution fields, Phase 7 pass-through seams, wire parameter names            |
+
+## Boundary rules (enforced)
+
+- **Server-only.** `index.ts` imports `server-only`; a client-component import
+  fails the Next.js build. The package is exported only as
+  `@asym/api/cms/public` — deep imports are not exposed.
+- **Dependencies point inward.** Apps depend on this package; the package
+  never imports Payload, `@payloadcms/*`, or any `apps/*` code. Enforced by a
+  scoped `no-restricted-imports` rule in `packages/api/eslint.config.mjs`
+  (the config CI's per-package lint resolves; the root `eslint.config.mjs`
+  mirrors it for root-cwd runs) and by the boundary unit test
+  (`packages/api/tests/unit/cms-public-boundary.test.ts`).
+- **Serialized output only.** Consumers never see raw Payload documents or
+  the `cms` schema. Rich-text `content`/`body` fields carry Lexical JSON —
+  the one intentional pass-through, rendered by the shared renderer. The
+  reader implementation (#523) is contractually bound to read rich text at
+  depth 0 or strip populated `upload`/`relationship` node values, so no
+  populated Payload document rides inside the pass-through.
+- **Payload-touching implementation lives elsewhere.** The single concrete
+  `PublishedContentReader` is co-located with Payload in `apps/admin` (#523);
+  the host resolver that produces `PublicRequestContext` is #524; the cache
+  runtime is #525; the checkout resolver implementation is #526.
+
+## Reserved seams (plumbed now, populated later)
+
+- `siteId` on the context, cache tags, and handoff — Phase 2 (#479/#482/#485).
+- `locale` tag dimension and handoff field — Phase 2 (#483).
+- `source_code`, `currency`, `entry_method = 'public_checkout'` — Phase 2.
+- Tribute annotation, giving-intent hints, `party_kind` (default `person`,
+  org routing via `org_type`; never `party_type`) — Phase 7 credit model
+  (Phase 9 C2 amendment, 2026-07-06).

--- a/packages/api/src/cms/public/cache-tags.ts
+++ b/packages/api/src/cms/public/cache-tags.ts
@@ -1,0 +1,147 @@
+import type { PublicRequestContext } from "./context";
+
+/**
+ * The tenant/document-derived cache-tag scheme (Phase 5 (Public Website
+ * Runtime Contract), ruling A9; ADR-0030).
+ *
+ * Tags are for INVALIDATION ONLY — they never isolate cache entries.
+ * Cache-key isolation comes from passing the resolved tenant as a function
+ * argument to every `use cache` read (#525 applies the runtime). Tags respect
+ * the platform limits: no commas, bounded length via stable ids, consistent
+ * lowercase casing.
+ */
+
+/**
+ * Name of the bounded `cacheLife` profile for published public reads. The
+ * profile is a bounded expiry (about an hour — never "never"): the
+ * self-healing backstop for a missed admin→public invalidation signal.
+ */
+export const PUBLIC_CONTENT_CACHE_LIFE_PROFILE = "public-content";
+
+/** Vercel limit: a tag must stay within 256 BYTES; keep well under it. */
+export const PUBLIC_CACHE_TAG_MAX_BYTES = 256;
+
+const TAG_PREFIX = "public-cms";
+const SEGMENT_MAX_LENGTH = 64;
+
+/**
+ * Normalizes one tag segment: lowercase, bounded, and reduced to
+ * `[a-z0-9_-]` — anything else (commas, whitespace, and critically `:`, the
+ * scheme's own structural delimiter) collapses to `-`, so no input can forge
+ * another builder's tag structure. Stable ids (not long slugs) should be the
+ * inputs; this is a guard, not an encoder.
+ */
+export function sanitizeCacheTagSegment(value: string | number): string {
+  const normalized = String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-");
+
+  return normalized.slice(0, SEGMENT_MAX_LENGTH);
+}
+
+/** Every cached public read for the tenant (broadest invalidation handle). */
+export function publicTenantCacheTag(context: PublicRequestContext): string {
+  return `${TAG_PREFIX}:tenant:${sanitizeCacheTagSegment(context.cmsTenantId)}`;
+}
+
+/** Every cached read of one collection for the tenant (lists, navigation). */
+export function publicCollectionCacheTag(
+  context: PublicRequestContext,
+  collection: string,
+): string {
+  return `${publicTenantCacheTag(context)}:collection:${sanitizeCacheTagSegment(collection)}`;
+}
+
+/** One document's cached reads for the tenant (detail pages). */
+export function publicDocumentCacheTag(
+  context: PublicRequestContext,
+  collection: string,
+  documentId: string | number,
+): string {
+  return `${publicCollectionCacheTag(context, collection)}:doc:${sanitizeCacheTagSegment(documentId)}`;
+}
+
+/**
+ * Reserved Phase 2 dimension: per-site invalidation. Returns `null` until
+ * Phase 2 populates `siteId` on the context (#479/#482/#485).
+ */
+export function publicSiteCacheTag(
+  context: PublicRequestContext,
+): string | null {
+  if (!context.siteId) {
+    return null;
+  }
+
+  return `${TAG_PREFIX}:site:${sanitizeCacheTagSegment(context.siteId)}`;
+}
+
+/**
+ * Reserved Phase 2 dimension: per-locale invalidation. Returns `null` until
+ * locale values ship (#483).
+ */
+export function publicLocaleCacheTag(locale: string | null): string | null {
+  if (!locale) {
+    return null;
+  }
+
+  return `${TAG_PREFIX}:locale:${sanitizeCacheTagSegment(locale)}`;
+}
+
+export type PublishedReadCacheTagInput = {
+  context: PublicRequestContext;
+  collection: string;
+  /** Omit for list reads; provide for document/detail reads. */
+  documentId?: string | number;
+  /** Reserved Phase 2 locale dimension. */
+  locale?: string | null;
+};
+
+/**
+ * The full tag set to attach to one published read: tenant + collection
+ * (+ document, + reserved site/locale when present). The publish-invalidation
+ * signal (#525) revalidates by these same builders, so emitter and reader can
+ * never drift.
+ */
+export function buildPublishedReadCacheTags(
+  input: PublishedReadCacheTagInput,
+): string[] {
+  const { context, collection, documentId, locale } = input;
+
+  const tags: string[] = [
+    publicTenantCacheTag(context),
+    publicCollectionCacheTag(context, collection),
+  ];
+
+  if (documentId !== undefined) {
+    tags.push(publicDocumentCacheTag(context, collection, documentId));
+  }
+
+  const siteTag = publicSiteCacheTag(context);
+  if (siteTag !== null) {
+    tags.push(siteTag);
+  }
+
+  const localeTag = publicLocaleCacheTag(locale ?? null);
+  if (localeTag !== null) {
+    tags.push(localeTag);
+  }
+
+  return tags;
+}
+
+/** Structural validity check used by tests and the invalidation endpoint. */
+export function isValidPublicCacheTag(tag: string): boolean {
+  const byteLength = new TextEncoder().encode(tag).length;
+  if (byteLength === 0 || byteLength > PUBLIC_CACHE_TAG_MAX_BYTES) {
+    return false;
+  }
+
+  if (!tag.startsWith(`${TAG_PREFIX}:`)) {
+    return false;
+  }
+
+  // Every segment between the `:` delimiters must be non-empty sanitized
+  // output — this is what makes delimiter forgery structurally impossible.
+  const segments = tag.split(":");
+  return segments.every((segment) => /^[a-z0-9_-]+$/.test(segment));
+}

--- a/packages/api/src/cms/public/checkout-handoff.ts
+++ b/packages/api/src/cms/public/checkout-handoff.ts
@@ -11,6 +11,8 @@
  * opaque Phase 7 pass-through seams, and the wire parameter names.
  */
 
+import type { PublicRequestContext } from "./context";
+
 /** The reserved entry-method value for public-checkout gifts (Phase 2 vocabulary). */
 export const PUBLIC_CHECKOUT_ENTRY_METHOD = "public_checkout";
 
@@ -26,10 +28,16 @@ export const DEFAULT_CHECKOUT_PARTY_KIND = "person";
  * The single designation target carried by a giving CTA today. A giving-cart
  * multi-line seam is reserved, not built (ruling A8).
  */
-export type CheckoutHandoffTarget = {
-  missionaryId: string | null;
-  fundId: string | null;
-};
+export type CheckoutHandoffTarget =
+  | { missionaryId: string; fundId: null }
+  | { missionaryId: null; fundId: string }
+  | { missionaryId: null; fundId: null };
+
+/** Draft form of the exclusive single-designation target. */
+export type CheckoutHandoffTargetDraft =
+  | { missionaryId: string; fundId?: null }
+  | { missionaryId?: null; fundId: string }
+  | { missionaryId?: null; fundId?: null };
 
 /**
  * Reserved attribution fields — plumbed now, populated by Phase 2 (Site,
@@ -86,10 +94,12 @@ export type CheckoutHandoff = {
 
 /** Draft input for {@link buildCheckoutHandoff}; omitted fields get safe defaults. */
 export type CheckoutHandoffDraft = {
-  target?: Partial<CheckoutHandoffTarget>;
+  target?: CheckoutHandoffTargetDraft;
   suggestedAmount?: string | null;
   suggestedFrequency?: string | null;
-  attribution?: Partial<Omit<CheckoutHandoffAttribution, "entryMethod">>;
+  attribution?: Partial<
+    Omit<CheckoutHandoffAttribution, "entryMethod" | "siteId">
+  >;
   tribute?: Partial<CheckoutTributeAnnotation>;
   intent?: Partial<CheckoutGivingIntentHints>;
   partyKind?: string;
@@ -123,19 +133,20 @@ export const CHECKOUT_HANDOFF_PARAM_NAMES = {
   orgType: "org_type",
 } as const;
 
-/** Builds a complete handoff from a draft, applying the safe defaults. */
+/**
+ * Builds a complete handoff from trusted request context and a draft, applying
+ * safe defaults and rejecting ambiguous designations.
+ */
 export function buildCheckoutHandoff(
+  context: PublicRequestContext,
   draft: CheckoutHandoffDraft = {},
 ): CheckoutHandoff {
   return {
-    target: {
-      missionaryId: draft.target?.missionaryId ?? null,
-      fundId: draft.target?.fundId ?? null,
-    },
+    target: buildCheckoutHandoffTarget(draft.target),
     suggestedAmount: draft.suggestedAmount ?? null,
     suggestedFrequency: draft.suggestedFrequency ?? null,
     attribution: {
-      siteId: draft.attribution?.siteId ?? null,
+      siteId: context.siteId,
       sourceCode: draft.attribution?.sourceCode ?? null,
       currency: draft.attribution?.currency ?? null,
       locale: draft.attribution?.locale ?? null,
@@ -154,6 +165,29 @@ export function buildCheckoutHandoff(
     partyKind: draft.partyKind ?? DEFAULT_CHECKOUT_PARTY_KIND,
     orgType: draft.orgType ?? null,
   };
+}
+
+function buildCheckoutHandoffTarget(
+  draft: CheckoutHandoffTargetDraft | undefined,
+): CheckoutHandoffTarget {
+  const missionaryId = draft?.missionaryId ?? null;
+  const fundId = draft?.fundId ?? null;
+
+  if (missionaryId !== null && fundId !== null) {
+    throw new Error(
+      "Checkout handoff must have at most one designation target",
+    );
+  }
+
+  if (missionaryId !== null) {
+    return { missionaryId, fundId: null };
+  }
+
+  if (fundId !== null) {
+    return { missionaryId: null, fundId };
+  }
+
+  return { missionaryId: null, fundId: null };
 }
 
 /**

--- a/packages/api/src/cms/public/checkout-handoff.ts
+++ b/packages/api/src/cms/public/checkout-handoff.ts
@@ -1,0 +1,206 @@
+/**
+ * CTA / checkout-handoff resolver types (Phase 5 (Public Website Runtime
+ * Contract), ruling A8, as amended 2026-07-06 by the Phase 9 party-model
+ * ruling C2).
+ *
+ * The handoff is a server-validated contract, never a trusted URL: checkout
+ * re-resolves and validates every operational reference against the resolved
+ * tenant before rendering or charging, and a preset amount is a re-validated
+ * suggestion, never a trusted charge value. The resolver implementation is
+ * #526; this module owns the shapes, the reserved attribution fields, the
+ * opaque Phase 7 pass-through seams, and the wire parameter names.
+ */
+
+/** The reserved entry-method value for public-checkout gifts (Phase 2 vocabulary). */
+export const PUBLIC_CHECKOUT_ENTRY_METHOD = "public_checkout";
+
+/**
+ * Party-kind hint for the Phase 7 credit model. Canonical default for the
+ * guest public path is `person`; org routing is carried by `orgType` — never
+ * by a `party_type` field, which must not exist anywhere in this package
+ * (Phase 9 C2 amendment).
+ */
+export const DEFAULT_CHECKOUT_PARTY_KIND = "person";
+
+/**
+ * The single designation target carried by a giving CTA today. A giving-cart
+ * multi-line seam is reserved, not built (ruling A8).
+ */
+export type CheckoutHandoffTarget = {
+  missionaryId: string | null;
+  fundId: string | null;
+};
+
+/**
+ * Reserved attribution fields — plumbed now, populated by Phase 2 (Site,
+ * Locale & Currency Foundation). `entryMethod` is intrinsic to the public
+ * handoff and always set.
+ */
+export type CheckoutHandoffAttribution = {
+  siteId: string | null;
+  /** Attaches at the CTA/link level — one page may carry several codes. */
+  sourceCode: string | null;
+  currency: string | null;
+  locale: string | null;
+  entryMethod: typeof PUBLIC_CHECKOUT_ENTRY_METHOD;
+};
+
+/**
+ * Opaque tribute/honor-memorial pass-through seam (Phase 7 credit model).
+ * Phase 5 builds no capture UI; values stay `null` until Phase 7 populates
+ * them.
+ */
+export type CheckoutTributeAnnotation = {
+  tributeType: string | null;
+  honoree: string | null;
+  notifyPartyReference: string | null;
+};
+
+/**
+ * Opaque giving-intent pass-through seam (Phase 7 credit model). Values are
+ * uninterpreted strings on the wire; Phase 5 never reads them.
+ */
+export type CheckoutGivingIntentHints = {
+  dafIntent: string | null;
+  matchingIntent: string | null;
+  employerIntent: string | null;
+};
+
+/**
+ * The server-validated handoff a public "Give" CTA resolves to. Everything
+ * here is re-validated server-side by checkout against the resolved tenant —
+ * nothing is trusted from the URL.
+ */
+export type CheckoutHandoff = {
+  target: CheckoutHandoffTarget;
+  /** A re-validated suggestion — never a trusted charge value. */
+  suggestedAmount: string | null;
+  suggestedFrequency: string | null;
+  attribution: CheckoutHandoffAttribution;
+  tribute: CheckoutTributeAnnotation;
+  intent: CheckoutGivingIntentHints;
+  /** Defaults to {@link DEFAULT_CHECKOUT_PARTY_KIND}; org routing via `orgType`. */
+  partyKind: string;
+  orgType: string | null;
+};
+
+/** Draft input for {@link buildCheckoutHandoff}; omitted fields get safe defaults. */
+export type CheckoutHandoffDraft = {
+  target?: Partial<CheckoutHandoffTarget>;
+  suggestedAmount?: string | null;
+  suggestedFrequency?: string | null;
+  attribution?: Partial<Omit<CheckoutHandoffAttribution, "entryMethod">>;
+  tribute?: Partial<CheckoutTributeAnnotation>;
+  intent?: Partial<CheckoutGivingIntentHints>;
+  partyKind?: string;
+  orgType?: string | null;
+};
+
+/**
+ * Wire parameter names for the plain-query-parameter transport (ruling A8:
+ * plain params that checkout re-validates server-side; a signed token is
+ * redundant once the server re-resolves). The `missionary_id` / `fund_id` /
+ * `amount` / `frequency` names are the shipped checkout contract; the rest
+ * are the reserved names later phases populate.
+ */
+export const CHECKOUT_HANDOFF_PARAM_NAMES = {
+  missionaryId: "missionary_id",
+  fundId: "fund_id",
+  suggestedAmount: "amount",
+  suggestedFrequency: "frequency",
+  siteId: "site_id",
+  sourceCode: "source_code",
+  currency: "currency",
+  locale: "locale",
+  entryMethod: "entry_method",
+  tributeType: "tribute_type",
+  honoree: "honoree",
+  notifyPartyReference: "notify_party_ref",
+  dafIntent: "daf_intent",
+  matchingIntent: "matching_intent",
+  employerIntent: "employer_intent",
+  partyKind: "party_kind",
+  orgType: "org_type",
+} as const;
+
+/** Builds a complete handoff from a draft, applying the safe defaults. */
+export function buildCheckoutHandoff(
+  draft: CheckoutHandoffDraft = {},
+): CheckoutHandoff {
+  return {
+    target: {
+      missionaryId: draft.target?.missionaryId ?? null,
+      fundId: draft.target?.fundId ?? null,
+    },
+    suggestedAmount: draft.suggestedAmount ?? null,
+    suggestedFrequency: draft.suggestedFrequency ?? null,
+    attribution: {
+      siteId: draft.attribution?.siteId ?? null,
+      sourceCode: draft.attribution?.sourceCode ?? null,
+      currency: draft.attribution?.currency ?? null,
+      locale: draft.attribution?.locale ?? null,
+      entryMethod: PUBLIC_CHECKOUT_ENTRY_METHOD,
+    },
+    tribute: {
+      tributeType: draft.tribute?.tributeType ?? null,
+      honoree: draft.tribute?.honoree ?? null,
+      notifyPartyReference: draft.tribute?.notifyPartyReference ?? null,
+    },
+    intent: {
+      dafIntent: draft.intent?.dafIntent ?? null,
+      matchingIntent: draft.intent?.matchingIntent ?? null,
+      employerIntent: draft.intent?.employerIntent ?? null,
+    },
+    partyKind: draft.partyKind ?? DEFAULT_CHECKOUT_PARTY_KIND,
+    orgType: draft.orgType ?? null,
+  };
+}
+
+/**
+ * Serializes a handoff to its wire query parameters. `null` values are
+ * omitted, so until Phase 2/7 populate the reserved seams the emitted params
+ * match the shipped checkout contract (target + suggestion + entry_method +
+ * party_kind).
+ */
+export function checkoutHandoffSearchParams(
+  handoff: CheckoutHandoff,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  const names = CHECKOUT_HANDOFF_PARAM_NAMES;
+
+  setParam(params, names.missionaryId, handoff.target.missionaryId);
+  setParam(params, names.fundId, handoff.target.fundId);
+  setParam(params, names.suggestedAmount, handoff.suggestedAmount);
+  setParam(params, names.suggestedFrequency, handoff.suggestedFrequency);
+  setParam(params, names.siteId, handoff.attribution.siteId);
+  setParam(params, names.sourceCode, handoff.attribution.sourceCode);
+  setParam(params, names.currency, handoff.attribution.currency);
+  setParam(params, names.locale, handoff.attribution.locale);
+  setParam(params, names.entryMethod, handoff.attribution.entryMethod);
+  setParam(params, names.tributeType, handoff.tribute.tributeType);
+  setParam(params, names.honoree, handoff.tribute.honoree);
+  setParam(
+    params,
+    names.notifyPartyReference,
+    handoff.tribute.notifyPartyReference,
+  );
+  setParam(params, names.dafIntent, handoff.intent.dafIntent);
+  setParam(params, names.matchingIntent, handoff.intent.matchingIntent);
+  setParam(params, names.employerIntent, handoff.intent.employerIntent);
+  setParam(params, names.partyKind, handoff.partyKind);
+  setParam(params, names.orgType, handoff.orgType);
+
+  return params;
+}
+
+function setParam(
+  params: URLSearchParams,
+  name: string,
+  value: string | null,
+): void {
+  if (value === null || value === "") {
+    return;
+  }
+
+  params.set(name, value);
+}

--- a/packages/api/src/cms/public/context.ts
+++ b/packages/api/src/cms/public/context.ts
@@ -1,0 +1,49 @@
+/**
+ * The unified public request context — the result of resolving a public
+ * request from the platform-trusted host (Phase 5 (Public Website Runtime
+ * Contract), ruling A6).
+ *
+ * Every reader, serializer, cache, and checkout-handoff signature accepts
+ * this context so Phase 2 (Site, Locale & Currency Foundation) can populate
+ * the reserved site dimension (issues #479 / #482 / #485) without changing
+ * any caller.
+ */
+export type PublicRequestContext = {
+  /**
+   * Operational tenant id (`public` schema) — used for funds, missionaries,
+   * and the checkout handoff.
+   */
+  operationalTenantId: string;
+  /**
+   * CMS tenant document id (`cms` schema) — used for content reads. Payload
+   * document ids may be numeric or string depending on the collection setup.
+   */
+  cmsTenantId: string | number;
+  /**
+   * Reserved Phase 2 seam. Today every tenant has exactly one implicit site,
+   * so this stays `null` until Phase 2 introduces the `sites` primitive
+   * (#479), the host→site→tenant resolver (#482), and CMS site-scoping
+   * (#485).
+   */
+  siteId: string | null;
+};
+
+/**
+ * Fail-closed resolution result produced by the host→tenant/site resolver
+ * (#524). An unknown or disabled host never yields an unfiltered context —
+ * it yields `site-not-found`, and the public runtime renders the neutral
+ * "site not found" page.
+ */
+export type PublicRequestResolution =
+  | { status: "resolved"; context: PublicRequestContext }
+  | { status: "site-not-found" };
+
+/**
+ * Narrowing guard for the resolved arm of {@link PublicRequestResolution}.
+ * Callers must treat anything else as "serve nothing".
+ */
+export function isResolvedPublicRequest(
+  resolution: PublicRequestResolution,
+): resolution is { status: "resolved"; context: PublicRequestContext } {
+  return resolution.status === "resolved";
+}

--- a/packages/api/src/cms/public/index.ts
+++ b/packages/api/src/cms/public/index.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+/**
+ * The shared public-content contract package (Phase 5 (Public Website
+ * Runtime Contract); epic #520, issue #522).
+ *
+ * One owner for the public-content rules: the published-content reader
+ * interface, the allowlist serializer, the public request context, the
+ * cache-tag scheme, and the checkout-handoff types. Server-only by
+ * construction (the `server-only` import above fails any client bundle);
+ * dependencies point INWARD — apps depend on this package, and this package
+ * never imports Payload or an app (enforced by lint and the boundary test).
+ *
+ * See `docs/prds/sitestacker-parity/phase-05-public-website-runtime-contract.md`
+ * (rulings A3–A9) and the five Phase 5 ADRs authored by the #521 docs ticket
+ * (allocated as ADR-0026–0030 in PR #962).
+ */
+
+export * from "./cache-tags";
+export * from "./checkout-handoff";
+export * from "./context";
+export * from "./reader";
+export * from "./serialized";
+export * from "./serializer";

--- a/packages/api/src/cms/public/reader.ts
+++ b/packages/api/src/cms/public/reader.ts
@@ -1,0 +1,144 @@
+import type { PublicRequestContext } from "./context";
+import type {
+  SerializedPublicNavigation,
+  SerializedPublicPage,
+  SerializedPublicTenantSummary,
+  SerializedPublicUpdate,
+} from "./serialized";
+
+/**
+ * The published-content reader — the sole entry for public content (Phase 5
+ * (Public Website Runtime Contract), rulings A3/A4/A5; ADR-0027/ADR-0028).
+ *
+ * This package defines the interface and serialized result shapes only. The
+ * single Payload-touching implementation lives co-located with Payload in
+ * `apps/admin` (#523); it takes the resolved tenant (and reserved site) as a
+ * required argument through {@link PublicRequestContext}, always applies the
+ * tenant-and-published constraint, runs with `overrideAccess: false` under
+ * the public-read policy, and returns empty on an unresolved tenant.
+ */
+
+/**
+ * A public page type is configuration over the shared primitives (ruling
+ * A14): the collection, lookup field, and operational-reference kind are
+ * parameters. Adding a later page type (project, event, campaign) is a new
+ * config entry plus a renderer — never an interface or serializer change.
+ */
+export type PublicPageTypeConfig = {
+  /** Stable key callers pass to {@link PublishedContentReader.getPublishedPage}. */
+  key: string;
+  /** CMS collection slug the page type reads from. */
+  collection: string;
+  /** Document field matched against the query key (for example `slug`). */
+  lookupField: string;
+  /**
+   * The kind of operational record the page references (`missionary`,
+   * `fund`, …) or `null` for standalone content pages. Reference resolution
+   * and validation against the resolved tenant happen at read time (A7).
+   */
+  operationalReferenceKind: string | null;
+};
+
+/** The page types shipped today. Later phases extend this record — only. */
+export const PUBLIC_PAGE_TYPES: Readonly<Record<string, PublicPageTypeConfig>> =
+  {
+    page: {
+      key: "page",
+      collection: "pages",
+      lookupField: "slug",
+      operationalReferenceKind: null,
+    },
+    "missionary-giving-page": {
+      key: "missionary-giving-page",
+      collection: "missionary-giving-pages",
+      lookupField: "missionaryId",
+      operationalReferenceKind: "missionary",
+    },
+    "project-page": {
+      key: "project-page",
+      collection: "project-pages",
+      lookupField: "slug",
+      operationalReferenceKind: "fund",
+    },
+  };
+
+export type PublishedPageQuery = {
+  /** A key of {@link PUBLIC_PAGE_TYPES} (or a later registered config). */
+  pageType: string;
+  /** The lookup value for the page type's `lookupField` (slug, missionary id, …). */
+  key: string;
+};
+
+export type PublishedUpdatesQuery = {
+  /** Clamped to [1, {@link PUBLISHED_UPDATES_MAX_LIMIT}]; defaults to {@link PUBLISHED_UPDATES_DEFAULT_LIMIT}. */
+  limit?: number;
+};
+
+export const PUBLISHED_UPDATES_DEFAULT_LIMIT = 5;
+export const PUBLISHED_UPDATES_MAX_LIMIT = 20;
+
+export function clampPublishedUpdatesLimit(limit: number | undefined): number {
+  if (limit === undefined || Number.isNaN(limit)) {
+    return PUBLISHED_UPDATES_DEFAULT_LIMIT;
+  }
+
+  const floored = Math.floor(limit);
+  return Math.min(Math.max(floored, 1), PUBLISHED_UPDATES_MAX_LIMIT);
+}
+
+/**
+ * Result unions are fail-closed: there is no arm that carries unfiltered or
+ * draft content. `unavailable` covers transient reader/transport failures so
+ * pages can degrade the affected element instead of leaking an error shape.
+ */
+export type PublishedPageResult =
+  | {
+      status: "found";
+      page: SerializedPublicPage;
+      tenant: SerializedPublicTenantSummary;
+    }
+  | { status: "bad-request"; error: string }
+  | { status: "not-found" }
+  | { status: "unavailable"; error: string };
+
+export type PublishedNavigationResult =
+  | {
+      status: "found";
+      /** `null` when the tenant has not configured navigation yet. */
+      navigation: SerializedPublicNavigation | null;
+      tenant: SerializedPublicTenantSummary;
+    }
+  | { status: "unavailable"; error: string };
+
+export type PublishedUpdatesResult =
+  | {
+      status: "found";
+      updates: SerializedPublicUpdate[];
+      tenant: SerializedPublicTenantSummary;
+    }
+  | { status: "unavailable"; error: string };
+
+/**
+ * The sole entry for public content. Interface growth is additive
+ * (listing/detail operations for events and campaigns arrive as new methods,
+ * never as changes to these signatures).
+ *
+ * BINDING on the implementation (#523): rich-text fields (`content`,
+ * rich-text block `body`) pass through the serializer as Lexical JSON, so
+ * the reader must not let populated Payload documents ride inside them —
+ * read rich text at depth 0, or strip/reduce populated `upload` and
+ * `relationship` node values to ids/public URLs before serialization.
+ */
+export interface PublishedContentReader {
+  getPublishedPage(
+    context: PublicRequestContext,
+    query: PublishedPageQuery,
+  ): Promise<PublishedPageResult>;
+  getNavigation(
+    context: PublicRequestContext,
+  ): Promise<PublishedNavigationResult>;
+  getUpdates(
+    context: PublicRequestContext,
+    query?: PublishedUpdatesQuery,
+  ): Promise<PublishedUpdatesResult>;
+}

--- a/packages/api/src/cms/public/serialized.ts
+++ b/packages/api/src/cms/public/serialized.ts
@@ -41,10 +41,10 @@ export type SerializedPublicMediaValue =
 export type SerializedPublicBlockBase = {
   id: string | null;
   blockName: string | null;
-  blockType: string | null;
 };
 
 export type SerializedPublicHeroBlock = SerializedPublicBlockBase & {
+  blockType: "hero";
   eyebrow: string | null;
   headline: string;
   subheading: string | null;
@@ -54,6 +54,7 @@ export type SerializedPublicHeroBlock = SerializedPublicBlockBase & {
 };
 
 export type SerializedPublicCallToActionBlock = SerializedPublicBlockBase & {
+  blockType: "call-to-action";
   headline: string;
   copy: string | null;
   buttonLabel: string | null;
@@ -62,12 +63,14 @@ export type SerializedPublicCallToActionBlock = SerializedPublicBlockBase & {
 };
 
 export type SerializedPublicRichTextBlock = SerializedPublicBlockBase & {
+  blockType: "rich-text";
   heading: string | null;
   /** Lexical rich-text JSON; rendered by the shared rich-text renderer. */
   body: unknown;
 };
 
 export type SerializedPublicMediaFeatureBlock = SerializedPublicBlockBase & {
+  blockType: "media-feature";
   title: string | null;
   body: string | null;
   media: SerializedPublicMediaValue;
@@ -81,6 +84,7 @@ export type SerializedPublicFaqItem = {
 };
 
 export type SerializedPublicFaqBlock = SerializedPublicBlockBase & {
+  blockType: "faq";
   heading: string | null;
   items: SerializedPublicFaqItem[];
 };
@@ -93,20 +97,16 @@ export type SerializedPublicImpactStat = {
 };
 
 export type SerializedPublicImpactStatsBlock = SerializedPublicBlockBase & {
+  blockType: "impact-stats";
   heading: string | null;
   items: SerializedPublicImpactStat[];
 };
 
 export type SerializedPublicTestimonialBlock = SerializedPublicBlockBase & {
+  blockType: "testimonial";
   quote: string;
   attribution: string | null;
 };
-
-/**
- * A block whose `blockType` the allowlist does not recognize: only the base
- * identity fields survive serialization. Unknown fields never leak.
- */
-export type SerializedPublicUnknownBlock = SerializedPublicBlockBase;
 
 export type SerializedPublicLayoutBlock =
   | SerializedPublicHeroBlock
@@ -115,8 +115,7 @@ export type SerializedPublicLayoutBlock =
   | SerializedPublicMediaFeatureBlock
   | SerializedPublicFaqBlock
   | SerializedPublicImpactStatsBlock
-  | SerializedPublicTestimonialBlock
-  | SerializedPublicUnknownBlock;
+  | SerializedPublicTestimonialBlock;
 
 /**
  * The serialized public page. Field-compatible with the shipped

--- a/packages/api/src/cms/public/serialized.ts
+++ b/packages/api/src/cms/public/serialized.ts
@@ -1,0 +1,172 @@
+/**
+ * Serialized public types — the only shapes the public runtime may consume.
+ *
+ * Consuming apps depend on these types and the allowlist serializer's output,
+ * never on raw Payload documents or the `cms` schema (Phase 5 (Public Website
+ * Runtime Contract), rulings A3/A7; ADR-0027). The page shape stays
+ * additively compatible with the shipped `PublicCmsPage` contract consumed by
+ * `apps/donor`.
+ */
+
+/**
+ * Public media shape: normalized URLs and display metadata only. Raw Payload
+ * media objects are never emitted through MEDIA FIELDS. Rich-text
+ * (`content`/`body`) is an intentional Lexical-JSON pass-through, so the
+ * reader implementation is contractually bound to keep populated Payload
+ * documents out of rich-text nodes — see the depth rule on
+ * {@link import("./reader").PublishedContentReader}.
+ */
+export type SerializedPublicMedia = {
+  id: string | null;
+  alt: string | null;
+  url: string | null;
+  thumbnailURL: string | null;
+  cardURL: string | null;
+  width: number | null;
+  height: number | null;
+  mimeType: string | null;
+};
+
+/**
+ * A media field value after serialization. Unpopulated Payload relationships
+ * arrive as bare ids (string/number) and pass through unchanged — the shipped
+ * public contract behaves the same way.
+ */
+export type SerializedPublicMediaValue =
+  | SerializedPublicMedia
+  | string
+  | number
+  | null;
+
+export type SerializedPublicBlockBase = {
+  id: string | null;
+  blockName: string | null;
+  blockType: string | null;
+};
+
+export type SerializedPublicHeroBlock = SerializedPublicBlockBase & {
+  eyebrow: string | null;
+  headline: string;
+  subheading: string | null;
+  backgroundImage: SerializedPublicMediaValue;
+  primaryCtaLabel: string | null;
+  primaryCtaHref: string | null;
+};
+
+export type SerializedPublicCallToActionBlock = SerializedPublicBlockBase & {
+  headline: string;
+  copy: string | null;
+  buttonLabel: string | null;
+  buttonHref: string | null;
+  openInNewTab: boolean;
+};
+
+export type SerializedPublicRichTextBlock = SerializedPublicBlockBase & {
+  heading: string | null;
+  /** Lexical rich-text JSON; rendered by the shared rich-text renderer. */
+  body: unknown;
+};
+
+export type SerializedPublicMediaFeatureBlock = SerializedPublicBlockBase & {
+  title: string | null;
+  body: string | null;
+  media: SerializedPublicMediaValue;
+  mediaCaption: string | null;
+};
+
+export type SerializedPublicFaqItem = {
+  id: string | null;
+  question: string;
+  answer: string;
+};
+
+export type SerializedPublicFaqBlock = SerializedPublicBlockBase & {
+  heading: string | null;
+  items: SerializedPublicFaqItem[];
+};
+
+export type SerializedPublicImpactStat = {
+  id: string | null;
+  value: string;
+  label: string;
+  description: string | null;
+};
+
+export type SerializedPublicImpactStatsBlock = SerializedPublicBlockBase & {
+  heading: string | null;
+  items: SerializedPublicImpactStat[];
+};
+
+export type SerializedPublicTestimonialBlock = SerializedPublicBlockBase & {
+  quote: string;
+  attribution: string | null;
+};
+
+/**
+ * A block whose `blockType` the allowlist does not recognize: only the base
+ * identity fields survive serialization. Unknown fields never leak.
+ */
+export type SerializedPublicUnknownBlock = SerializedPublicBlockBase;
+
+export type SerializedPublicLayoutBlock =
+  | SerializedPublicHeroBlock
+  | SerializedPublicCallToActionBlock
+  | SerializedPublicRichTextBlock
+  | SerializedPublicMediaFeatureBlock
+  | SerializedPublicFaqBlock
+  | SerializedPublicImpactStatsBlock
+  | SerializedPublicTestimonialBlock
+  | SerializedPublicUnknownBlock;
+
+/**
+ * The serialized public page. Field-compatible with the shipped
+ * `PublicCmsPage` shape (`@asym/lib/cms/public-page`) so existing donor
+ * consumers keep working; `layout` is the typed allowlist block set.
+ */
+export type SerializedPublicPage = {
+  id: string;
+  title: string;
+  slug: string;
+  summary: string | null;
+  /** Lexical rich-text JSON for legacy single-column pages. */
+  content: unknown;
+  layout: SerializedPublicLayoutBlock[] | null;
+  pageType: string | null;
+  missionaryId: string | null;
+  fundId: string | null;
+  legacyContentFallback: boolean | null;
+  updatedAt?: string;
+};
+
+export type SerializedPublicNavigationItem = {
+  id: string | null;
+  label: string;
+  /** Sanitized href — unsafe protocols and control characters are dropped. */
+  href: string | null;
+  openInNewTab: boolean;
+};
+
+export type SerializedPublicNavigation = {
+  id: string;
+  label: string;
+  items: SerializedPublicNavigationItem[];
+  updatedAt?: string;
+};
+
+export type SerializedPublicUpdate = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  /** Lexical rich-text JSON. */
+  content: unknown;
+  /** Operational missionary reference (id only — never a populated record). */
+  missionaryId: string | null;
+  publishedAt: string | null;
+  updatedAt?: string;
+};
+
+/** Tenant presentation summary exposed on public payloads (parity: slug only). */
+export type SerializedPublicTenantSummary = {
+  slug: string | null;
+};

--- a/packages/api/src/cms/public/serializer.ts
+++ b/packages/api/src/cms/public/serializer.ts
@@ -148,13 +148,13 @@ function serializePublicBlock(
   const base = {
     id: readOptionalString(block.id),
     blockName: readOptionalString(block.blockName),
-    blockType: readOptionalString(block.blockType),
   };
 
   switch (block.blockType) {
     case "hero":
       return {
         ...base,
+        blockType: "hero",
         eyebrow: readOptionalString(block.eyebrow),
         headline: readRequiredString(block.headline),
         subheading: readOptionalString(block.subheading),
@@ -168,6 +168,7 @@ function serializePublicBlock(
     case "call-to-action":
       return {
         ...base,
+        blockType: "call-to-action",
         headline: readRequiredString(block.headline),
         copy: readOptionalString(block.copy),
         buttonLabel: readOptionalString(block.buttonLabel),
@@ -181,12 +182,14 @@ function serializePublicBlock(
     case "rich-text":
       return {
         ...base,
+        blockType: "rich-text",
         heading: readOptionalString(block.heading),
         body: block.body,
       };
     case "media-feature":
       return {
         ...base,
+        blockType: "media-feature",
         title: readOptionalString(block.title),
         body: readOptionalString(block.body),
         media: serializePublicMediaValue(block.media),
@@ -195,24 +198,26 @@ function serializePublicBlock(
     case "faq":
       return {
         ...base,
+        blockType: "faq",
         heading: readOptionalString(block.heading),
         items: serializeItems(block.items, serializeFaqItem),
       };
     case "impact-stats":
       return {
         ...base,
+        blockType: "impact-stats",
         heading: readOptionalString(block.heading),
         items: serializeItems(block.items, serializeImpactStat),
       };
     case "testimonial":
       return {
         ...base,
+        blockType: "testimonial",
         quote: readRequiredString(block.quote),
         attribution: readOptionalString(block.attribution),
       };
     default:
-      // Allowlist: unrecognized block types keep identity fields only.
-      return base;
+      return null;
   }
 }
 

--- a/packages/api/src/cms/public/serializer.ts
+++ b/packages/api/src/cms/public/serializer.ts
@@ -1,0 +1,328 @@
+import {
+  resolvePublicCmsCtaHref,
+  sanitizePublicCmsHref,
+} from "@asym/lib/cms/public-page";
+
+import type {
+  SerializedPublicFaqItem,
+  SerializedPublicImpactStat,
+  SerializedPublicLayoutBlock,
+  SerializedPublicMedia,
+  SerializedPublicMediaValue,
+  SerializedPublicNavigation,
+  SerializedPublicNavigationItem,
+  SerializedPublicPage,
+  SerializedPublicUpdate,
+} from "./serialized";
+
+/**
+ * The allowlist public serializer (Phase 5 (Public Website Runtime Contract),
+ * ruling A5; deep module `public-serializer`).
+ *
+ * Only explicitly named public-safe fields and the typed layout-block set are
+ * emitted; new or unknown fields are excluded by default. The page output is
+ * behavior-compatible with the shipped published-page serialization in
+ * `apps/admin` (the parity baseline the proof-slice test guards).
+ */
+
+type UnknownRecord = Record<string, unknown>;
+
+type PageCtaContext = {
+  pageType: string | null;
+  missionaryId: string | null;
+  fundId: string | null;
+};
+
+export function serializePublicPage(doc: UnknownRecord): SerializedPublicPage {
+  const pageType = readOptionalString(doc.pageType);
+  const missionaryId = readOptionalString(doc.missionaryId);
+  const fundId = readOptionalString(doc.fundId);
+  const ctaContext: PageCtaContext = { pageType, missionaryId, fundId };
+
+  const page: SerializedPublicPage = {
+    id: String(doc.id),
+    title: readRequiredString(doc.title),
+    slug: readRequiredString(doc.slug),
+    summary: readOptionalString(doc.summary),
+    content: doc.content,
+    layout: serializePublicLayout(doc.layout, ctaContext),
+    pageType,
+    missionaryId,
+    fundId,
+    legacyContentFallback:
+      typeof doc.legacyContentFallback === "boolean"
+        ? doc.legacyContentFallback
+        : null,
+  };
+
+  const updatedAt = readOptionalString(doc.updatedAt);
+  if (updatedAt !== null) {
+    page.updatedAt = updatedAt;
+  }
+
+  return page;
+}
+
+export function serializePublicNavigation(
+  doc: UnknownRecord,
+): SerializedPublicNavigation {
+  const rawItems = Array.isArray(doc.items) ? doc.items : [];
+  const items = rawItems
+    .map(serializePublicNavigationItem)
+    .filter((item): item is SerializedPublicNavigationItem => item !== null);
+
+  const navigation: SerializedPublicNavigation = {
+    id: String(doc.id),
+    label: readRequiredString(doc.label),
+    items,
+  };
+
+  const updatedAt = readOptionalString(doc.updatedAt);
+  if (updatedAt !== null) {
+    navigation.updatedAt = updatedAt;
+  }
+
+  return navigation;
+}
+
+export function serializePublicUpdate(
+  doc: UnknownRecord,
+): SerializedPublicUpdate {
+  const update: SerializedPublicUpdate = {
+    id: String(doc.id),
+    title: readRequiredString(doc.title),
+    slug: readRequiredString(doc.slug),
+    excerpt: readOptionalString(doc.excerpt),
+    content: doc.content,
+    missionaryId: readRelationshipId(doc.missionary),
+    publishedAt: readOptionalString(doc.publishedAt),
+  };
+
+  const updatedAt = readOptionalString(doc.updatedAt);
+  if (updatedAt !== null) {
+    update.updatedAt = updatedAt;
+  }
+
+  return update;
+}
+
+function serializePublicNavigationItem(
+  value: unknown,
+): SerializedPublicNavigationItem | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const item = value as UnknownRecord;
+  return {
+    id: readOptionalString(item.id),
+    label: readRequiredString(item.label),
+    href: sanitizePublicCmsHref(item.href),
+    openInNewTab:
+      typeof item.openInNewTab === "boolean" ? item.openInNewTab : false,
+  };
+}
+
+function serializePublicLayout(
+  value: unknown,
+  ctaContext: PageCtaContext,
+): SerializedPublicLayoutBlock[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  return value
+    .map((block) => serializePublicBlock(block, ctaContext))
+    .filter((block): block is SerializedPublicLayoutBlock => block !== null);
+}
+
+function serializePublicBlock(
+  value: unknown,
+  ctaContext: PageCtaContext,
+): SerializedPublicLayoutBlock | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const block = value as UnknownRecord;
+  const base = {
+    id: readOptionalString(block.id),
+    blockName: readOptionalString(block.blockName),
+    blockType: readOptionalString(block.blockType),
+  };
+
+  switch (block.blockType) {
+    case "hero":
+      return {
+        ...base,
+        eyebrow: readOptionalString(block.eyebrow),
+        headline: readRequiredString(block.headline),
+        subheading: readOptionalString(block.subheading),
+        backgroundImage: serializePublicMediaValue(block.backgroundImage),
+        primaryCtaLabel: readOptionalString(block.primaryCtaLabel),
+        primaryCtaHref: resolvePublicCmsCtaHref({
+          rawHref: block.primaryCtaHref,
+          ...ctaContext,
+        }),
+      };
+    case "call-to-action":
+      return {
+        ...base,
+        headline: readRequiredString(block.headline),
+        copy: readOptionalString(block.copy),
+        buttonLabel: readOptionalString(block.buttonLabel),
+        buttonHref: resolvePublicCmsCtaHref({
+          rawHref: block.buttonHref,
+          ...ctaContext,
+        }),
+        openInNewTab:
+          typeof block.openInNewTab === "boolean" ? block.openInNewTab : false,
+      };
+    case "rich-text":
+      return {
+        ...base,
+        heading: readOptionalString(block.heading),
+        body: block.body,
+      };
+    case "media-feature":
+      return {
+        ...base,
+        title: readOptionalString(block.title),
+        body: readOptionalString(block.body),
+        media: serializePublicMediaValue(block.media),
+        mediaCaption: readOptionalString(block.mediaCaption),
+      };
+    case "faq":
+      return {
+        ...base,
+        heading: readOptionalString(block.heading),
+        items: serializeItems(block.items, serializeFaqItem),
+      };
+    case "impact-stats":
+      return {
+        ...base,
+        heading: readOptionalString(block.heading),
+        items: serializeItems(block.items, serializeImpactStat),
+      };
+    case "testimonial":
+      return {
+        ...base,
+        quote: readRequiredString(block.quote),
+        attribution: readOptionalString(block.attribution),
+      };
+    default:
+      // Allowlist: unrecognized block types keep identity fields only.
+      return base;
+  }
+}
+
+function serializeItems<T>(
+  value: unknown,
+  serializeItem: (item: unknown) => T | null,
+): T[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map(serializeItem).filter((item): item is T => item !== null);
+}
+
+function serializeFaqItem(value: unknown): SerializedPublicFaqItem | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const item = value as UnknownRecord;
+  return {
+    id: readOptionalString(item.id),
+    question: readRequiredString(item.question),
+    answer: readRequiredString(item.answer),
+  };
+}
+
+function serializeImpactStat(
+  value: unknown,
+): SerializedPublicImpactStat | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const item = value as UnknownRecord;
+  return {
+    id: readOptionalString(item.id),
+    value: readRequiredString(item.value),
+    label: readRequiredString(item.label),
+    description: readOptionalString(item.description),
+  };
+}
+
+function serializePublicMediaValue(value: unknown): SerializedPublicMediaValue {
+  if (typeof value === "string" || typeof value === "number") {
+    return value;
+  }
+
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const media = value as UnknownRecord;
+  const sizes =
+    media.sizes && typeof media.sizes === "object"
+      ? (media.sizes as UnknownRecord)
+      : undefined;
+
+  const serialized: SerializedPublicMedia = {
+    id:
+      typeof media.id === "string" || typeof media.id === "number"
+        ? String(media.id)
+        : null,
+    alt: readOptionalString(media.alt),
+    url: readOptionalString(media.url),
+    thumbnailURL: readMediaSizeUrl(sizes?.thumbnail),
+    cardURL: readMediaSizeUrl(sizes?.card),
+    width: typeof media.width === "number" ? media.width : null,
+    height: typeof media.height === "number" ? media.height : null,
+    mimeType: readOptionalString(media.mimeType),
+  };
+
+  return serialized;
+}
+
+function readMediaSizeUrl(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  return readOptionalString((value as UnknownRecord).url);
+}
+
+/**
+ * Reads a Payload relationship value down to its id: bare ids pass through,
+ * populated documents reduce to their `id` — the full record never leaks.
+ */
+function readRelationshipId(value: unknown): string | null {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  if (value && typeof value === "object") {
+    const related = value as UnknownRecord;
+    if (typeof related.id === "string" || typeof related.id === "number") {
+      return String(related.id);
+    }
+  }
+
+  return null;
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readRequiredString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/packages/api/tests/unit/cms-public-boundary.test.ts
+++ b/packages/api/tests/unit/cms-public-boundary.test.ts
@@ -1,0 +1,106 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Structural boundary guards for the public-content contract package
+ * (Phase 5 #522, ADR-0027):
+ *
+ * - the package is server-only (the entrypoint carries the `server-only`
+ *   poison import, so a client-bundle import fails the Next.js build);
+ * - dependencies point inward — the package never imports Payload,
+ *   `@payloadcms/*`, or any app code (also enforced by the scoped
+ *   `no-restricted-imports` rule in `packages/api/eslint.config.mjs`, the
+ *   config CI's per-package lint actually resolves; the root
+ *   `eslint.config.mjs` carries a mirror for root-cwd runs);
+ * - no `party_type` field exists anywhere in the package (Phase 9 C2
+ *   amendment: the hint is `party_kind`, org routing via `org_type`).
+ */
+
+const packageDir = path.dirname(
+  fileURLToPath(new URL("../../src/cms/public/index.ts", import.meta.url)),
+);
+
+function readPackageSources(): Array<{ file: string; source: string }> {
+  // Recursive so a future subdirectory (or .tsx/.mts module) cannot slip
+  // beneath the guard.
+  return readdirSync(packageDir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.(ts|tsx|mts|cts)$/.test(entry.name))
+    .map((entry) => {
+      const absolutePath = path.join(entry.parentPath, entry.name);
+      return {
+        file: path.relative(packageDir, absolutePath),
+        source: readFileSync(absolutePath, "utf8"),
+      };
+    });
+}
+
+describe("public-content contract package boundary", () => {
+  const sources = readPackageSources();
+
+  it("has source modules to guard", () => {
+    expect(sources.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("marks the entrypoint server-only", () => {
+    const index = sources.find(({ file }) => file === "index.ts");
+
+    expect(index).toBeDefined();
+    expect(index?.source).toContain('import "server-only";');
+  });
+
+  it("never imports Payload or app code from inside the package", () => {
+    const forbiddenImportPatterns = [
+      // Static, dynamic, and require forms of Payload imports:
+      /from\s+["']payload["']/,
+      /from\s+["']payload\//,
+      /from\s+["']@payloadcms\//,
+      /import\s*\(\s*["'](payload["']|payload\/|@payloadcms\/)/,
+      /require\s*\(\s*["'](payload["']|payload\/|@payloadcms\/)/,
+      // App code by path or by workspace package name:
+      /from\s+["'][^"']*apps\/(admin|donor|missionary)\//,
+      /import\s*\(\s*["'][^"']*apps\//,
+      /require\s*\(\s*["'][^"']*apps\//,
+      /from\s+["']@asym\/admin/,
+      /from\s+["']@asym\/donor/,
+      /from\s+["']@asym\/missionary-app/,
+    ];
+
+    for (const { file, source } of sources) {
+      for (const pattern of forbiddenImportPatterns) {
+        expect(pattern.test(source), `${file} must not match ${pattern}`).toBe(
+          false,
+        );
+      }
+    }
+  });
+
+  it("contains no party_type field anywhere (party_kind + org_type only)", () => {
+    for (const { file, source } of sources) {
+      // Comments may explain the rule; code may not carry the field.
+      const codeOnly = source
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/^\s*\/\/.*$/gm, "");
+
+      expect(
+        /party_type|partyType/.test(codeOnly),
+        `${file} must not reference party_type in code`,
+      ).toBe(false);
+    }
+  });
+
+  it("is exported as @asym/api/cms/public with the server-only dependency", () => {
+    const packageJsonPath = path.join(packageDir, "../../../package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      exports?: Record<string, string>;
+      dependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.exports?.["./cms/public"]).toBe(
+      "./src/cms/public/index.ts",
+    );
+    expect(packageJson.dependencies?.["server-only"]).toBeDefined();
+  });
+});

--- a/packages/api/tests/unit/cms-public-contract.test.ts
+++ b/packages/api/tests/unit/cms-public-contract.test.ts
@@ -26,6 +26,7 @@ import {
   PUBLISHED_UPDATES_MAX_LIMIT,
 } from "../../src/cms/public/reader";
 
+import type { CheckoutHandoffDraft } from "../../src/cms/public/checkout-handoff";
 import type { PublicRequestContext } from "../../src/cms/public/context";
 import type {
   PublicPageTypeConfig,
@@ -60,7 +61,7 @@ describe("PublicRequestContext", () => {
 
 describe("checkout handoff contract", () => {
   it("defaults party_kind to 'person' and entry_method to public_checkout", () => {
-    const handoff = buildCheckoutHandoff({
+    const handoff = buildCheckoutHandoff(context, {
       target: { missionaryId: "mis_1" },
       suggestedAmount: "50",
     });
@@ -86,12 +87,12 @@ describe("checkout handoff contract", () => {
   });
 
   it("serializes populated reserved fields under their reserved wire names", () => {
-    const handoff = buildCheckoutHandoff({
+    const siteContext = { ...context, siteId: "site_1" };
+    const handoff = buildCheckoutHandoff(siteContext, {
       target: { fundId: "fund_1" },
       suggestedAmount: "100",
       suggestedFrequency: "monthly",
       attribution: {
-        siteId: "site_1",
         sourceCode: "spring-appeal",
         currency: "USD",
         locale: "en-US",
@@ -131,7 +132,7 @@ describe("checkout handoff contract", () => {
   });
 
   it("never emits a party_type parameter (Phase 9 C2 amendment)", () => {
-    const handoff = buildCheckoutHandoff({ partyKind: "person" });
+    const handoff = buildCheckoutHandoff(context, { partyKind: "person" });
     const params = checkoutHandoffSearchParams(handoff);
 
     expect(params.has("party_type")).toBe(false);
@@ -144,12 +145,36 @@ describe("checkout handoff contract", () => {
   });
 
   it("omits unpopulated reserved params so today's wire matches the shipped checkout contract", () => {
-    const handoff = buildCheckoutHandoff({ target: { missionaryId: "mis_1" } });
+    const handoff = buildCheckoutHandoff(context, {
+      target: { missionaryId: "mis_1" },
+    });
     const params = checkoutHandoffSearchParams(handoff);
 
     expect([...params.keys()].sort()).toEqual(
       ["entry_method", "missionary_id", "party_kind"].sort(),
     );
+  });
+
+  it("rejects a draft containing both designation targets", () => {
+    const ambiguousDraft = {
+      target: { missionaryId: "mis_1", fundId: "fund_1" },
+    } as unknown as CheckoutHandoffDraft;
+
+    expect(() => buildCheckoutHandoff(context, ambiguousDraft)).toThrow(
+      "Checkout handoff must have at most one designation target",
+    );
+  });
+
+  it("derives site attribution from the trusted request context", () => {
+    const callerControlledDraft = {
+      attribution: { siteId: "forged-site", sourceCode: "spring-appeal" },
+    } as CheckoutHandoffDraft;
+    const siteContext = { ...context, siteId: "trusted-site" };
+
+    const handoff = buildCheckoutHandoff(siteContext, callerControlledDraft);
+
+    expect(handoff.attribution.siteId).toBe("trusted-site");
+    expect(handoff.attribution.sourceCode).toBe("spring-appeal");
   });
 });
 

--- a/packages/api/tests/unit/cms-public-contract.test.ts
+++ b/packages/api/tests/unit/cms-public-contract.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPublishedReadCacheTags,
+  isValidPublicCacheTag,
+  PUBLIC_CACHE_TAG_MAX_BYTES,
+  PUBLIC_CONTENT_CACHE_LIFE_PROFILE,
+  publicCollectionCacheTag,
+  publicDocumentCacheTag,
+  publicLocaleCacheTag,
+  publicSiteCacheTag,
+  publicTenantCacheTag,
+} from "../../src/cms/public/cache-tags";
+import {
+  buildCheckoutHandoff,
+  CHECKOUT_HANDOFF_PARAM_NAMES,
+  checkoutHandoffSearchParams,
+  DEFAULT_CHECKOUT_PARTY_KIND,
+  PUBLIC_CHECKOUT_ENTRY_METHOD,
+} from "../../src/cms/public/checkout-handoff";
+import { isResolvedPublicRequest } from "../../src/cms/public/context";
+import {
+  clampPublishedUpdatesLimit,
+  PUBLIC_PAGE_TYPES,
+  PUBLISHED_UPDATES_DEFAULT_LIMIT,
+  PUBLISHED_UPDATES_MAX_LIMIT,
+} from "../../src/cms/public/reader";
+
+import type { PublicRequestContext } from "../../src/cms/public/context";
+import type {
+  PublicPageTypeConfig,
+  PublishedContentReader,
+} from "../../src/cms/public/reader";
+
+/**
+ * Type-contract tests (Phase 5 #522): the reader/serializer/cache/handoff
+ * signatures accept the PublicRequestContext and carry every reserved seam —
+ * siteId, site_id/source_code/currency/locale/entry_method, the Phase 7
+ * pass-through fields, and party_kind (never party_type).
+ */
+
+const context: PublicRequestContext = {
+  operationalTenantId: "tenant-op-1",
+  cmsTenantId: 7,
+  siteId: null,
+};
+
+describe("PublicRequestContext", () => {
+  it("carries the reserved siteId and both tenant ids", () => {
+    expect(context.siteId).toBeNull();
+    expect(context.operationalTenantId).toBe("tenant-op-1");
+    expect(context.cmsTenantId).toBe(7);
+  });
+
+  it("narrows fail-closed resolutions", () => {
+    expect(isResolvedPublicRequest({ status: "site-not-found" })).toBe(false);
+    expect(isResolvedPublicRequest({ status: "resolved", context })).toBe(true);
+  });
+});
+
+describe("checkout handoff contract", () => {
+  it("defaults party_kind to 'person' and entry_method to public_checkout", () => {
+    const handoff = buildCheckoutHandoff({
+      target: { missionaryId: "mis_1" },
+      suggestedAmount: "50",
+    });
+
+    expect(handoff.partyKind).toBe(DEFAULT_CHECKOUT_PARTY_KIND);
+    expect(handoff.partyKind).toBe("person");
+    expect(handoff.orgType).toBeNull();
+    expect(handoff.attribution.entryMethod).toBe(PUBLIC_CHECKOUT_ENTRY_METHOD);
+    expect(handoff.attribution.siteId).toBeNull();
+    expect(handoff.attribution.sourceCode).toBeNull();
+    expect(handoff.attribution.currency).toBeNull();
+    expect(handoff.attribution.locale).toBeNull();
+    expect(handoff.tribute).toEqual({
+      tributeType: null,
+      honoree: null,
+      notifyPartyReference: null,
+    });
+    expect(handoff.intent).toEqual({
+      dafIntent: null,
+      matchingIntent: null,
+      employerIntent: null,
+    });
+  });
+
+  it("serializes populated reserved fields under their reserved wire names", () => {
+    const handoff = buildCheckoutHandoff({
+      target: { fundId: "fund_1" },
+      suggestedAmount: "100",
+      suggestedFrequency: "monthly",
+      attribution: {
+        siteId: "site_1",
+        sourceCode: "spring-appeal",
+        currency: "USD",
+        locale: "en-US",
+      },
+      tribute: {
+        tributeType: "memorial",
+        honoree: "Jane",
+        notifyPartyReference: "party_5",
+      },
+      intent: {
+        dafIntent: "yes",
+        matchingIntent: "employer",
+        employerIntent: "acme",
+      },
+      partyKind: "organization",
+      orgType: "church",
+    });
+
+    const params = checkoutHandoffSearchParams(handoff);
+
+    expect(params.get("fund_id")).toBe("fund_1");
+    expect(params.get("amount")).toBe("100");
+    expect(params.get("frequency")).toBe("monthly");
+    expect(params.get("site_id")).toBe("site_1");
+    expect(params.get("source_code")).toBe("spring-appeal");
+    expect(params.get("currency")).toBe("USD");
+    expect(params.get("locale")).toBe("en-US");
+    expect(params.get("entry_method")).toBe("public_checkout");
+    expect(params.get("tribute_type")).toBe("memorial");
+    expect(params.get("honoree")).toBe("Jane");
+    expect(params.get("notify_party_ref")).toBe("party_5");
+    expect(params.get("daf_intent")).toBe("yes");
+    expect(params.get("matching_intent")).toBe("employer");
+    expect(params.get("employer_intent")).toBe("acme");
+    expect(params.get("party_kind")).toBe("organization");
+    expect(params.get("org_type")).toBe("church");
+  });
+
+  it("never emits a party_type parameter (Phase 9 C2 amendment)", () => {
+    const handoff = buildCheckoutHandoff({ partyKind: "person" });
+    const params = checkoutHandoffSearchParams(handoff);
+
+    expect(params.has("party_type")).toBe(false);
+    expect(Object.values(CHECKOUT_HANDOFF_PARAM_NAMES)).not.toContain(
+      "party_type",
+    );
+    expect(Object.keys(CHECKOUT_HANDOFF_PARAM_NAMES)).not.toContain(
+      "partyType",
+    );
+  });
+
+  it("omits unpopulated reserved params so today's wire matches the shipped checkout contract", () => {
+    const handoff = buildCheckoutHandoff({ target: { missionaryId: "mis_1" } });
+    const params = checkoutHandoffSearchParams(handoff);
+
+    expect([...params.keys()].sort()).toEqual(
+      ["entry_method", "missionary_id", "party_kind"].sort(),
+    );
+  });
+});
+
+describe("cache-tag scheme", () => {
+  it("derives tenant, collection, and document tags from the context argument", () => {
+    expect(publicTenantCacheTag(context)).toBe("public-cms:tenant:7");
+    expect(publicCollectionCacheTag(context, "pages")).toBe(
+      "public-cms:tenant:7:collection:pages",
+    );
+    expect(publicDocumentCacheTag(context, "pages", "abc")).toBe(
+      "public-cms:tenant:7:collection:pages:doc:abc",
+    );
+  });
+
+  it("keeps every produced tag comma-free, lowercase, and byte-bounded", () => {
+    const hostileContext: PublicRequestContext = {
+      operationalTenantId: "tenant-op-1",
+      cmsTenantId: "Tenant, With Spaces 💥".repeat(20),
+      siteId: "SITE, one",
+    };
+
+    const tags = buildPublishedReadCacheTags({
+      context: hostileContext,
+      collection: "Missionary, Giving Pages",
+      documentId: "DOC, 1",
+      locale: "EN, US",
+    });
+
+    for (const tag of tags) {
+      expect(isValidPublicCacheTag(tag)).toBe(true);
+      expect(new TextEncoder().encode(tag).length).toBeLessThanOrEqual(
+        PUBLIC_CACHE_TAG_MAX_BYTES,
+      );
+    }
+  });
+
+  it("neutralizes the ':' delimiter so no input can forge another tenant's tag structure", () => {
+    const forgingContext: PublicRequestContext = {
+      operationalTenantId: "tenant-op-1",
+      cmsTenantId: "7:collection:pages",
+      siteId: null,
+    };
+
+    const forgedAttempt = publicTenantCacheTag(forgingContext);
+    const legitimateCollectionTag = publicCollectionCacheTag(
+      { operationalTenantId: "tenant-op-2", cmsTenantId: 7, siteId: null },
+      "pages",
+    );
+
+    // The hostile tenant id collapses to a single segment — it can never
+    // equal the structured collection tag of the real tenant 7.
+    expect(forgedAttempt).toBe("public-cms:tenant:7-collection-pages");
+    expect(forgedAttempt).not.toBe(legitimateCollectionTag);
+    expect(isValidPublicCacheTag(forgedAttempt)).toBe(true);
+    expect(isValidPublicCacheTag("public-cms:tenant:se:cr:et")).toBe(true);
+    expect(isValidPublicCacheTag("public-cms:tenant:")).toBe(false);
+    expect(isValidPublicCacheTag("public-cms:tenant:UPPER")).toBe(false);
+    expect(isValidPublicCacheTag("public-cms:tenant:a,b")).toBe(false);
+  });
+
+  it("includes the reserved site/locale dimensions only when populated", () => {
+    const withoutReserved = buildPublishedReadCacheTags({
+      context,
+      collection: "pages",
+    });
+    expect(withoutReserved).toEqual([
+      "public-cms:tenant:7",
+      "public-cms:tenant:7:collection:pages",
+    ]);
+
+    const siteContext: PublicRequestContext = { ...context, siteId: "site1" };
+    const withReserved = buildPublishedReadCacheTags({
+      context: siteContext,
+      collection: "pages",
+      documentId: 5,
+      locale: "en-us",
+    });
+    expect(withReserved).toContain("public-cms:site:site1");
+    expect(withReserved).toContain("public-cms:locale:en-us");
+
+    expect(publicSiteCacheTag(context)).toBeNull();
+    expect(publicLocaleCacheTag(null)).toBeNull();
+  });
+
+  it("names a bounded cacheLife profile (never 'never')", () => {
+    expect(PUBLIC_CONTENT_CACHE_LIFE_PROFILE).toBe("public-content");
+  });
+});
+
+describe("reader contract", () => {
+  it("clamps the updates limit into [1, max] with a default", () => {
+    expect(clampPublishedUpdatesLimit(undefined)).toBe(
+      PUBLISHED_UPDATES_DEFAULT_LIMIT,
+    );
+    expect(clampPublishedUpdatesLimit(Number.NaN)).toBe(
+      PUBLISHED_UPDATES_DEFAULT_LIMIT,
+    );
+    expect(clampPublishedUpdatesLimit(0)).toBe(1);
+    expect(clampPublishedUpdatesLimit(-5)).toBe(1);
+    expect(clampPublishedUpdatesLimit(7.9)).toBe(7);
+    expect(clampPublishedUpdatesLimit(999)).toBe(PUBLISHED_UPDATES_MAX_LIMIT);
+  });
+
+  it("ships the three page types as configuration over shared primitives", () => {
+    expect(PUBLIC_PAGE_TYPES["page"]?.collection).toBe("pages");
+    expect(PUBLIC_PAGE_TYPES["missionary-giving-page"]).toEqual({
+      key: "missionary-giving-page",
+      collection: "missionary-giving-pages",
+      lookupField: "missionaryId",
+      operationalReferenceKind: "missionary",
+    });
+    expect(PUBLIC_PAGE_TYPES["project-page"]?.operationalReferenceKind).toBe(
+      "fund",
+    );
+  });
+
+  it("admits a new page type as pure configuration — no interface change", () => {
+    // Compile-level proof: a later page type is only a new config object.
+    const eventPage = {
+      key: "event-page",
+      collection: "event-pages",
+      lookupField: "slug",
+      operationalReferenceKind: "event",
+    } satisfies PublicPageTypeConfig;
+
+    expect(eventPage.operationalReferenceKind).toBe("event");
+  });
+
+  it("accepts the PublicRequestContext on every reader operation", async () => {
+    // Compile-level proof that the interface signatures take the context and
+    // return the fail-closed result unions.
+    const reader: PublishedContentReader = {
+      async getPublishedPage(ctx, query) {
+        expect(ctx.siteId).toBeNull();
+        expect(query.pageType).toBe("page");
+        return { status: "not-found" };
+      },
+      async getNavigation() {
+        return {
+          status: "found",
+          navigation: null,
+          tenant: { slug: null },
+        };
+      },
+      async getUpdates(_ctx, query) {
+        expect(clampPublishedUpdatesLimit(query?.limit)).toBe(5);
+        return { status: "found", updates: [], tenant: { slug: "t" } };
+      },
+    };
+
+    const page = await reader.getPublishedPage(context, {
+      pageType: "page",
+      key: "home",
+    });
+    expect(page.status).toBe("not-found");
+
+    const navigation = await reader.getNavigation(context);
+    expect(navigation.status).toBe("found");
+
+    const updates = await reader.getUpdates(context, {});
+    expect(updates.status).toBe("found");
+  });
+});

--- a/packages/api/tests/unit/cms-public-serializer.test.ts
+++ b/packages/api/tests/unit/cms-public-serializer.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  serializePublicNavigation,
+  serializePublicPage,
+  serializePublicUpdate,
+} from "../../src/cms/public/serializer";
+
+/**
+ * The public serializer is an ALLOWLIST (Phase 5 A5): only named public-safe
+ * fields and typed layout blocks are emitted; adding an unknown field to a
+ * source document must never surface it in the serialized output.
+ */
+
+describe("serializePublicPage", () => {
+  const baseDoc = {
+    id: 42,
+    title: "Serve With Us",
+    slug: "serve-with-us",
+    summary: "A page summary",
+    content: { root: { type: "doc" } },
+    pageType: "missionary_giving",
+    missionaryId: "mis_123",
+    fundId: null,
+    legacyContentFallback: false,
+    updatedAt: "2026-07-22T00:00:00.000Z",
+  };
+
+  it("emits only the named public-safe fields", () => {
+    const doc = {
+      ...baseDoc,
+      // Private/unexpected fields that must be stripped:
+      tenant: { id: "cms-tenant-1", apiKey: "secret" },
+      _status: "published",
+      internalNotes: "do not leak",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const page = serializePublicPage(doc);
+
+    expect(page).toEqual({
+      id: "42",
+      title: "Serve With Us",
+      slug: "serve-with-us",
+      summary: "A page summary",
+      content: { root: { type: "doc" } },
+      layout: null,
+      pageType: "missionary_giving",
+      missionaryId: "mis_123",
+      fundId: null,
+      legacyContentFallback: false,
+      updatedAt: "2026-07-22T00:00:00.000Z",
+    });
+    expect(page).not.toHaveProperty("tenant");
+    expect(page).not.toHaveProperty("_status");
+    expect(page).not.toHaveProperty("internalNotes");
+  });
+
+  it("serializes each supported layout block to its documented public shape", () => {
+    const doc = {
+      ...baseDoc,
+      layout: [
+        {
+          id: "b1",
+          blockType: "hero",
+          headline: "Go",
+          eyebrow: "Now",
+          subheading: null,
+          backgroundImage: "media_1",
+          primaryCtaLabel: "Give",
+          primaryCtaHref: "/give",
+          adminOnlyFlag: true,
+        },
+        {
+          id: "b2",
+          blockType: "call-to-action",
+          headline: "Support",
+          copy: "Monthly support",
+          buttonLabel: "Give now",
+          buttonHref: "https://example.org/give",
+          openInNewTab: true,
+        },
+        { id: "b3", blockType: "rich-text", heading: "Story", body: { p: 1 } },
+        {
+          id: "b4",
+          blockType: "media-feature",
+          title: "Field",
+          body: "Photo story",
+          media: 7,
+          mediaCaption: "The team",
+        },
+        {
+          id: "b5",
+          blockType: "faq",
+          heading: "FAQ",
+          items: [
+            { id: "q1", question: "How?", answer: "Like this", secret: "x" },
+            "not-an-object",
+          ],
+        },
+        {
+          id: "b6",
+          blockType: "impact-stats",
+          heading: "Impact",
+          items: [
+            { id: "s1", value: "12", label: "Countries", description: null },
+          ],
+        },
+        {
+          id: "b7",
+          blockType: "testimonial",
+          quote: "It mattered.",
+          attribution: "A donor",
+        },
+      ],
+    };
+
+    const page = serializePublicPage(doc);
+    const layout = page.layout ?? [];
+
+    expect(layout).toHaveLength(7);
+    expect(layout[0]).toEqual({
+      id: "b1",
+      blockName: null,
+      blockType: "hero",
+      eyebrow: "Now",
+      headline: "Go",
+      subheading: null,
+      backgroundImage: "media_1",
+      primaryCtaLabel: "Give",
+      // missionary_giving page type routes the CTA to checkout:
+      primaryCtaHref: "/checkout?missionary_id=mis_123",
+    });
+    expect(layout[0]).not.toHaveProperty("adminOnlyFlag");
+    expect(layout[1]).toEqual({
+      id: "b2",
+      blockName: null,
+      blockType: "call-to-action",
+      headline: "Support",
+      copy: "Monthly support",
+      buttonLabel: "Give now",
+      buttonHref: "/checkout?missionary_id=mis_123",
+      openInNewTab: true,
+    });
+    expect(layout[2]).toEqual({
+      id: "b3",
+      blockName: null,
+      blockType: "rich-text",
+      heading: "Story",
+      body: { p: 1 },
+    });
+    expect(layout[3]).toEqual({
+      id: "b4",
+      blockName: null,
+      blockType: "media-feature",
+      title: "Field",
+      body: "Photo story",
+      media: 7,
+      mediaCaption: "The team",
+    });
+    expect(layout[4]).toEqual({
+      id: "b5",
+      blockName: null,
+      blockType: "faq",
+      heading: "FAQ",
+      items: [{ id: "q1", question: "How?", answer: "Like this" }],
+    });
+    expect(layout[5]).toEqual({
+      id: "b6",
+      blockName: null,
+      blockType: "impact-stats",
+      heading: "Impact",
+      items: [{ id: "s1", value: "12", label: "Countries", description: null }],
+    });
+    expect(layout[6]).toEqual({
+      id: "b7",
+      blockName: null,
+      blockType: "testimonial",
+      quote: "It mattered.",
+      attribution: "A donor",
+    });
+  });
+
+  it("reduces an unknown block type to identity fields only", () => {
+    const doc = {
+      ...baseDoc,
+      layout: [
+        {
+          id: "x1",
+          blockName: "Mystery",
+          blockType: "internal-experiment",
+          secretConfig: { flag: true },
+          html: "<script>alert(1)</script>",
+        },
+      ],
+    };
+
+    const page = serializePublicPage(doc);
+
+    expect(page.layout).toEqual([
+      { id: "x1", blockName: "Mystery", blockType: "internal-experiment" },
+    ]);
+  });
+
+  it("normalizes populated media to the public URL shape with no raw Payload fields", () => {
+    const doc = {
+      ...baseDoc,
+      layout: [
+        {
+          id: "m1",
+          blockType: "media-feature",
+          title: null,
+          body: null,
+          mediaCaption: null,
+          media: {
+            id: 9,
+            alt: "Team photo",
+            url: "/media/team.jpg",
+            width: 1200,
+            height: 800,
+            mimeType: "image/jpeg",
+            sizes: {
+              thumbnail: { url: "/media/team-thumb.jpg", filesize: 999 },
+              card: { url: "/media/team-card.jpg" },
+            },
+            // Raw Payload internals that must never be emitted:
+            filename: "team.jpg",
+            filesize: 123456,
+            focalX: 50,
+            focalY: 50,
+            tenant: "cms-tenant-1",
+          },
+        },
+      ],
+    };
+
+    const page = serializePublicPage(doc);
+    const block = (page.layout ?? [])[0] as { media: unknown };
+
+    expect(block.media).toEqual({
+      id: "9",
+      alt: "Team photo",
+      url: "/media/team.jpg",
+      thumbnailURL: "/media/team-thumb.jpg",
+      cardURL: "/media/team-card.jpg",
+      width: 1200,
+      height: 800,
+      mimeType: "image/jpeg",
+    });
+  });
+
+  it("passes bare media ids through unchanged (unpopulated relationships)", () => {
+    const doc = {
+      ...baseDoc,
+      layout: [
+        {
+          id: "m2",
+          blockType: "hero",
+          headline: "Go",
+          backgroundImage: 15,
+          primaryCtaHref: null,
+        },
+      ],
+    };
+
+    const page = serializePublicPage(doc);
+    const hero = (page.layout ?? [])[0] as { backgroundImage: unknown };
+
+    expect(hero.backgroundImage).toBe(15);
+  });
+});
+
+describe("serializePublicNavigation", () => {
+  it("emits only label/items and sanitizes hrefs", () => {
+    const navigation = serializePublicNavigation({
+      id: 3,
+      label: "Main",
+      tenant: "cms-tenant-1",
+      _status: "draft",
+      items: [
+        { id: "n1", label: "Home", href: "/", openInNewTab: false },
+        { id: "n2", label: "Evil", href: "javascript:alert(1)" },
+        { id: "n3", label: "Give", href: "https://example.org/give" },
+        "not-an-object",
+      ],
+      updatedAt: "2026-07-22T00:00:00.000Z",
+    });
+
+    expect(navigation).toEqual({
+      id: "3",
+      label: "Main",
+      items: [
+        { id: "n1", label: "Home", href: "/", openInNewTab: false },
+        { id: "n2", label: "Evil", href: null, openInNewTab: false },
+        {
+          id: "n3",
+          label: "Give",
+          href: "https://example.org/give",
+          openInNewTab: false,
+        },
+      ],
+      updatedAt: "2026-07-22T00:00:00.000Z",
+    });
+    expect(navigation).not.toHaveProperty("tenant");
+    expect(navigation).not.toHaveProperty("_status");
+  });
+});
+
+describe("serializePublicUpdate", () => {
+  it("emits the named fields and reduces the missionary relationship to an id", () => {
+    const update = serializePublicUpdate({
+      id: "u1",
+      title: "Field news",
+      slug: "field-news",
+      excerpt: "Short version",
+      content: { root: {} },
+      missionary: { id: "mis_9", email: "private@example.org" },
+      publishedAt: "2026-07-20T00:00:00.000Z",
+      tenant: "cms-tenant-1",
+      internalReviewNotes: "not public",
+    });
+
+    expect(update).toEqual({
+      id: "u1",
+      title: "Field news",
+      slug: "field-news",
+      excerpt: "Short version",
+      content: { root: {} },
+      missionaryId: "mis_9",
+      publishedAt: "2026-07-20T00:00:00.000Z",
+    });
+    expect(update).not.toHaveProperty("tenant");
+    expect(update).not.toHaveProperty("internalReviewNotes");
+  });
+
+  it("passes a bare missionary id through and nulls a missing one", () => {
+    const withBareId = serializePublicUpdate({
+      id: "u2",
+      title: "t",
+      slug: "s",
+      missionary: "mis_2",
+    });
+    const withoutMissionary = serializePublicUpdate({
+      id: "u3",
+      title: "t",
+      slug: "s",
+    });
+
+    expect(withBareId.missionaryId).toBe("mis_2");
+    expect(withoutMissionary.missionaryId).toBeNull();
+  });
+});

--- a/packages/api/tests/unit/cms-public-serializer.test.ts
+++ b/packages/api/tests/unit/cms-public-serializer.test.ts
@@ -181,7 +181,7 @@ describe("serializePublicPage", () => {
     });
   });
 
-  it("reduces an unknown block type to identity fields only", () => {
+  it("excludes unknown block types", () => {
     const doc = {
       ...baseDoc,
       layout: [
@@ -197,9 +197,7 @@ describe("serializePublicPage", () => {
 
     const page = serializePublicPage(doc);
 
-    expect(page.layout).toEqual([
-      { id: "x1", blockName: "Mystery", blockType: "internal-experiment" },
-    ]);
+    expect(page.layout).toEqual([]);
   });
 
   it("normalizes populated media to the public URL shape with no raw Payload fields", () => {


### PR DESCRIPTION
Closes #522 (Phase 5 (Public Website Runtime Contract) — T2 foundation ticket; parent epic #520). Companion to #962 (the #521 governance docs).

## Summary

Creates the server-only shared public-content contract package at `packages/api/src/cms/public`, exported as `@asym/api/cms/public` — the one owner of the public-content rules, contract-surface only (the Payload-touching reader implementation is #523, the host resolver #524, the cache runtime #525, the checkout resolver #526):

- **`PublishedContentReader` interface** (`reader.ts`) — `getPublishedPage` / `getNavigation` / `getUpdates`, each taking the resolved `PublicRequestContext`; page-type-agnostic via the `PUBLIC_PAGE_TYPES` config registry (collection/lookup-field/reference-kind are parameters); fail-closed result unions; updates-limit clamp; a **binding rich-text depth rule** for the #523 implementation so no populated Payload document rides inside the Lexical pass-through.
- **Allowlist serializer** (`serializer.ts`) — page/navigation/updates; only named public-safe fields and the 7 typed layout blocks (hero, call-to-action, rich-text, media-feature, faq, impact-stats, testimonial); unknown fields/blocks excluded by default; media normalized to public URL shape; navigation hrefs sanitized; relationship values reduced to ids. Behavior-parity with the shipped published-page serialization (the #530 parity baseline).
- **`PublicRequestContext`** (`context.ts`) — operational tenant id + CMS tenant id + **reserved `siteId`** (Phase 2 #479/#482/#485), plus the fail-closed resolution union for #524.
- **Cache-tag scheme** (`cache-tags.ts`) — tenant/document-derived tags, **forgery-safe segment sanitizer** (everything outside `[a-z0-9_-]` collapses, including `:` the structural delimiter), byte-accurate 256-byte validation, reserved **site/locale** dimensions, bounded `cacheLife` profile name. Tags are invalidation-only; isolation is the tenant argument (PRD A9).
- **Checkout-handoff types** (`checkout-handoff.ts`) — reserved `site_id`/`source_code`/`currency`/`locale`/`entry_method='public_checkout'` wire names + the amended Phase 7 pass-through seams: tribute annotation, giving-intent hints, and **`party_kind` defaulting to `'person'` with org routing via `org_type` — no `party_type` anywhere** (Phase 9 C2 amendment); pure builder + wire serializer that emits only populated params (today's wire matches the shipped `/checkout` contract).
- **Boundary enforcement** — `server-only` poison import at the entrypoint (verified against the installed Next 16.2 docs); scoped `no-restricted-imports` Payload ban in **`packages/api/eslint.config.mjs`** (the config CI's per-package lint actually resolves — verified firing from the package cwd; the root config mirrors it for root-cwd runs); recursive boundary unit test covering static/dynamic/`require` import forms and all three app package names.

## Acceptance criteria

- ✅ Server-only package under `packages/api` exporting the reader interface, serialized types, `PublicRequestContext` (reserved `siteId`), cache-tag types (reserved site/locale), CTA-resolver types (reserved five attribution fields)
- ✅ Serializer is an allowlist — unknown source fields never surface (tested)
- ✅ Server-only + no Payload/apps imports, enforced by lint (package-level config, probe-verified) and the boundary test
- ✅ Consumers depend on types/serialized output only — no raw Payload documents or `cms` schema
- ✅ Page-type-agnostic: a new page type is a config entry (compile-level test)
- ✅ Amended criterion: tribute/intent/`party_kind` (default `'person'`, `org_type` routing) pass-through seams carried; **no `party_type` in code** (structural test)

## Verification

- 28 unit tests across three suites (allowlist, contract seams, boundary) — green
- `bunx turbo run lint --filter=@asym/api` green; Payload-import probe errors correctly from the package cwd; `node scripts/verify-eslint-config.mjs` passes
- `bunx turbo run typecheck --filter=@asym/api` green; `bun run verify:data-boundary` passes
- Full local `ci:preflight` (format, skills:verify, lint, verify gates, typecheck, all-app builds, full unit suite) **passed on pre-push — no hook bypass**
- A 4-lens adversarial review workflow (acceptance-criteria, security/allowlist, PRD congruence, repo conventions) ran pre-push; every confirmed finding fixed (notably: moved the Payload lint ban into the package-level flat config where CI actually lints, hardened cache-tag sanitization against `:` forgery, byte-length tag validation, recursive boundary scanning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the shared server-only public-content contract package. The main changes are:

- Published-content reader interfaces and serialized result types.
- Allowlist serializers for pages, navigation, updates, media, and layout blocks.
- Tenant-aware request context and cache-tag builders.
- Checkout handoff types, defaults, and query serialization.
- Package-boundary lint rules and unit tests.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files require additional attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused CMS public test suites (serializer, contract, and boundary) and the API package lint task, confirming 3 test files with 30 tests passed and the lint completed with no errors.
- Executed bunx vitest run for packages/api/tests/unit/cms-public-serializer.test.ts, packages/api/tests/unit/cms-public-contract.test.ts, and packages/api/tests/unit/cms-public-boundary.test.ts and captured a post-run log showing exit code 0 and 3/3 files with 30/30 tests passed in 567ms.
- Executed bunx turbo run lint --filter=@asym/api and captured a post-run log showing exit code 0, 0 errors, and one unrelated warning in process-batch.ts.

<a href="https://app.greptile.com/trex/runs/15305782/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/cms/public/reader.ts | Defines the published-content reader contract, page registry, result unions, and update limits. |
| packages/api/src/cms/public/cache-tags.ts | Adds sanitized cache-tag builders and validation for public-content invalidation. |
| packages/api/src/cms/public/serializer.ts | Adds allowlist serialization for pages, navigation, updates, media, and supported layout blocks. |
| packages/api/src/cms/public/checkout-handoff.ts | Adds checkout handoff construction, attribution fields, designation validation, and wire serialization. |
| packages/api/src/cms/public/index.ts | Creates the server-only package entrypoint and exports the public contract modules. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(pr-fast): resolve confirmed review f..."](https://github.com/asymmetric-al/core/commit/331c9d97d16d71643bc72217d1da40fb9e2e1d52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46064781)</sub>

<!-- /greptile_comment -->