### PR TITLE
fix(scripts): retry transient Windows EPERM on skill-mirror directory swaps

### DIFF
--- a/scripts/sync-agent-skills.mjs
+++ b/scripts/sync-agent-skills.mjs
@@ -158,12 +158,40 @@ function getTemporarySiblingPath(targetDir, label) {
   return path.join(parentDir, `.${targetName}.${label}-${uniqueSuffix}`);
 }
 
+/**
+ * Windows can transiently fail a directory rename with EPERM/EACCES/EBUSY
+ * while an indexer, antivirus scan, or editor watcher briefly holds a handle
+ * on the directory or a child. The contention clears in milliseconds, so a
+ * short bounded retry (the graceful-fs/npm pattern) makes the mirror swap
+ * reliable without masking real permission failures.
+ */
+const TRANSIENT_RENAME_CODES = new Set(["EPERM", "EACCES", "EBUSY"]);
+
+async function renameWithRetry(fromPath, toPath) {
+  const maxAttempts = 6;
+  let delayMs = 50;
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await rename(fromPath, toPath);
+      return;
+    } catch (error) {
+      const isTransient = TRANSIENT_RENAME_CODES.has(getErrorCode(error));
+      if (!isTransient || attempt >= maxAttempts) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * 2, 800);
+    }
+  }
+}
+
 async function swapStagedDirectory(stagingDir, targetDir) {
   const backupDir = getTemporarySiblingPath(targetDir, "backup");
   let hasBackup = false;
 
   try {
-    await rename(targetDir, backupDir);
+    await renameWithRetry(targetDir, backupDir);
     hasBackup = true;
   } catch (error) {
     if (getErrorCode(error) !== "ENOENT") {
@@ -172,10 +200,10 @@ async function swapStagedDirectory(stagingDir, targetDir) {
   }
 
   try {
-    await rename(stagingDir, targetDir);
+    await renameWithRetry(stagingDir, targetDir);
   } catch (error) {
     if (hasBackup) {
-      await rename(backupDir, targetDir);
+      await renameWithRetry(backupDir, targetDir);
     }
     throw error;
   }


### PR DESCRIPTION
## Problem

`bun run skills:sync` / `skills:verify` finish the mirror rebuild with an atomic directory swap (`swapStagedDirectory` in `scripts/sync-agent-skills.mjs`): rename the live mirror to a backup, rename the staged directory into place, and roll back from the backup on failure. On Windows those bare `rename()` calls intermittently fail with `EPERM` (also possible: `EACCES`, `EBUSY`) when Search indexer, antivirus, or an editor watcher briefly holds a handle on the directory or one of its children. Observed on 2026-07-22 failing pre-push `ci:preflight` runs, on a **different skill directory each run** — the signature of transient handle contention, not a real permission problem.

## Fix

Add a `renameWithRetry` helper and use it for all three renames in `swapStagedDirectory`:

- 6 attempts, exponential backoff starting at 50ms and capped at 800ms (~1.5s worst case)
- retries **only** `EPERM` / `EACCES` / `EBUSY` — every other error code rethrows immediately
- exhausted retries rethrow the original error, so real permission failures still surface
- the existing `ENOENT` passthrough on the first backup rename (first-ever sync, no target dir yet) is preserved

This is the same bounded-retry remedy graceful-fs and npm use for Windows rename contention. No behavior change on non-Windows platforms or on the happy path.

## Verification

- `bunx prettier --check scripts/sync-agent-skills.mjs` — pass
- `bunx vitest run tests/unit/script-verifiers.test.ts` — 33/33 pass
- `bun run skills:verify` — pass (exit 0)
- Full pre-push `ci:preflight` passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes skill-mirror directory swaps tolerate transient Windows rename failures. The main changes are:

- Adds bounded retries for `EPERM`, `EACCES`, and `EBUSY` errors.
- Uses exponential backoff across six rename attempts.
- Applies retries to backup creation, staged installation, and rollback.
- Preserves immediate failure for other errors and the existing `ENOENT` handling.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Opened and inspected skills-swap-01-before.log to confirm successful normal synchronization with the pre-retry implementation.
- Opened and inspected skills-swap-02-after.log to confirm HEAD synchronization and verification, followed by empty mirror status and diff output.
- Reviewed the supporting logs to verify formatting, focused tests, clean final worktree state, dependency reuse, and exact focused coverage inspected.

<a href="https://app.greptile.com/trex/runs/15365097/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/sync-agent-skills.mjs | Adds bounded retries to all rename operations in the atomic skill-mirror directory swap. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;develop&#39; into fix/skills-s..."](https://github.com/asymmetric-al/core/commit/c4ce14445ae4dc0978cb853efb9908e3e550b9b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46165929)</sub>

<!-- /greptile_comment -->