### PR TITLE
fix(api): tolerate clock skew on qualification evidence check time

### DIFF
--- a/packages/api/src/generated-documents/purpose-catalog/availability.ts
+++ b/packages/api/src/generated-documents/purpose-catalog/availability.ts
@@ -13,6 +13,22 @@ import type {
 
 const QUALIFICATION_FRESHNESS_WITHOUT_EXPIRY_MS = 5 * 60 * 1000;
 
+/**
+ * How far ahead of our own clock a port's `checked_at` may sit before we treat
+ * it as a broken or forged clock rather than ordinary skew.
+ *
+ * The resolver samples `now` once on entry and only afterwards awaits the
+ * qualification port, so a port that stamps `checked_at` when it answers is
+ * *always* at or ahead of `now`. With a zero tolerance a single millisecond
+ * tick between the two reads flipped a qualified purpose to `dark`, which made
+ * `document-purpose-availability.test.ts` fail intermittently under load. A
+ * real port is a separate process anyway, so its clock is never exactly ours.
+ *
+ * Five seconds absorbs call latency and normal NTP skew while still rejecting
+ * evidence stamped meaningfully in the future.
+ */
+const QUALIFICATION_MAX_CLOCK_SKEW_MS = 5 * 1000;
+
 export interface ResolvePurposeAvailabilityInput {
   purpose_id: string;
   context: PurposeAvailabilityContext;
@@ -82,7 +98,7 @@ function resolveOfficialQualification(
       if (
         !Number.isFinite(nowMs) ||
         !Number.isFinite(checkedAtMs) ||
-        checkedAtMs > nowMs
+        checkedAtMs - nowMs > QUALIFICATION_MAX_CLOCK_SKEW_MS
       ) {
         return [
           cause(

--- a/tests/unit/packages/api/document-purpose-availability.test.ts
+++ b/tests/unit/packages/api/document-purpose-availability.test.ts
@@ -106,6 +106,52 @@ describe("resolvePurposeAvailability", () => {
     expect(sibling.state).toBe("dark");
   });
 
+  it("still supports a purpose when the port stamps checked_at just after the resolver read its clock", async () => {
+    // The resolver samples `now` on entry and only then awaits the port, so a
+    // port that stamps `checked_at` when it answers always lands at or ahead of
+    // `now`. Rejecting that outright made this suite fail intermittently under
+    // load, and would reject a real out-of-process port on any clock skew.
+    const resolverNow = new Date();
+    const portStamp = new Date(resolverNow.getTime() + 1);
+
+    const result = await resolvePurposeAvailability(
+      {
+        purpose_id: "us.contribution_acknowledgment.single@1",
+        context: domainReadyContext(),
+        now: () => resolverNow,
+      },
+      createStaticQualificationPort(
+        { "us.contribution_acknowledgment.single@1": "qualified" },
+        () => portStamp,
+      ),
+    );
+
+    expect(result.state).toBe("supported");
+    expect(result.causes).toEqual([]);
+  });
+
+  it("still rejects evidence stamped meaningfully in the future", async () => {
+    const resolverNow = new Date();
+    const wayAhead = new Date(resolverNow.getTime() + 60 * 60 * 1000);
+
+    const result = await resolvePurposeAvailability(
+      {
+        purpose_id: "us.contribution_acknowledgment.single@1",
+        context: domainReadyContext(),
+        now: () => resolverNow,
+      },
+      createStaticQualificationPort(
+        { "us.contribution_acknowledgment.single@1": "qualified" },
+        () => wayAhead,
+      ),
+    );
+
+    expect(result.state).toBe("dark");
+    expect(result.causes.map((entry) => entry.code)).toContain(
+      "qualification_not_ready",
+    );
+  });
+
   it("treats not-ready, expired, and revoked evidence as dark with distinct safe causes", async () => {
     const cases = [
       { outcome: "not_ready", code: "contract_dark" },


### PR DESCRIPTION
## Why

`tests/unit/packages/api/document-purpose-availability.test.ts:98` passes in
isolation and fails in the full suite with `expected 'dark' to be 'supported'`.
It is not a flaky test — it is a real ordering bug.

`resolvePurposeAvailability` samples `now` once on entry and only afterwards
awaits the qualification port:

```ts
const now = (input.now ?? (() => new Date()))();   // sampled here
...
const evidence = await qualificationPort.checkPurposeQualification(...); // stamps checked_at here
```

A port that stamps `checked_at` when it answers is therefore *always* at or
ahead of that `now`, and the guard rejected `checkedAtMs > nowMs` outright as
"an invalid or future check time". **A single millisecond tick between the two
clock reads flips a qualified purpose to `dark`.** Under full-suite load the
tick almost always happens; in isolation both reads land in the same
millisecond.

Proved deterministically: same instant -> `supported`; port clock at `now + 1ms`
-> `dark`.

This is not only a test concern. The same guard would reject a real
out-of-process qualification port on any clock skew, since its clock is never
exactly ours.

## Blast radius

Random `test-unit` failures on unrelated PRs. It took down CI on #862 and
blocked a push on #1039.

## What changed

- `QUALIFICATION_MAX_CLOCK_SKEW_MS = 5s`, documented at the constant. Five
  seconds absorbs call latency and normal NTP drift while still rejecting
  evidence stamped meaningfully in the future.
- Two regression tests: the skew case now resolves `supported`, and evidence
  stamped an hour ahead is still rejected with `qualification_not_ready`.

Freshness (`QUALIFICATION_FRESHNESS_WITHOUT_EXPIRY_MS`) and the `expires_at`
path are untouched.

## Verification

- `bunx vitest run tests/unit/packages/api/` -> 178 files, 1386 tests pass
- full `bun run test:unit` -> 520 files, 3530 tests pass
- full `bun run ci:preflight` passes (this branch was pushed through the hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)