### PR TITLE
docs(skills): add nextjs-app-architecture with Core overlay

### DIFF
--- a/.agents/skills/.repo-canonical-skills.json
+++ b/.agents/skills/.repo-canonical-skills.json
@@ -58,6 +58,7 @@
     "moai-library-shadcn",
     "motion",
     "new-branch-and-pr",
+    "nextjs-app-architecture",
     "nextjs-app-router",
     "nextjs-supabase-auth",
     "npm-deps-cleanup",
@@ -468,6 +469,18 @@
     "new-branch-and-pr": [
       "SKILL.md",
       "references/upstream.md"
+    ],
+    "nextjs-app-architecture": [
+      "SKILL.md",
+      "references/cache-components.md",
+      "references/components.md",
+      "references/example.md",
+      "references/feature-folders.md",
+      "references/pages-suspense.md",
+      "references/queries-actions.md",
+      "references/single-page-applications.md",
+      "references/upstream.md",
+      "references/ux-patterns.md"
     ],
     "nextjs-app-router": [
       "SKILL.md"

--- a/.agents/skills/find-skills/SKILL.md
+++ b/.agents/skills/find-skills/SKILL.md
@@ -80,6 +80,19 @@ workflows, and use `docs/ai/skills/inngest-setup/SKILL.md` only when explicitly
 adding product runtime Inngest. Refresh with `bun run skills:refresh-inngest`,
 then `bun run skills:sync` and `bun run skills:verify`.
 
+**Example — Next.js app architecture:** page composition, feature-folder UI
+layout, colocated Suspense skeletons, and leaf-client UX are covered by
+`docs/ai/skills/nextjs-app-architecture/SKILL.md`. Install or refresh from
+[`aurorascharff/nextjs-app-architecture-skill`](https://github.com/aurorascharff/nextjs-app-architecture-skill)
+with `npx skills add aurorascharff/nextjs-app-architecture-skill -y`, then
+restore the local overlay from `docs/ai/skills/nextjs-app-architecture/SKILL.md`
+and `docs/ai/skills/nextjs-app-architecture/references/upstream.md`, then
+`bun run skills:sync` and `bun run skills:verify`. Keep it subordinate to
+`docs/ai/rules/frontend.md`, `docs/ai/skills/nextjs-app-router/SKILL.md`,
+`docs/ai/skills/cache-components/SKILL.md`, and
+`docs/guides/architecture/data-access-boundary.md`. Do not move business
+queries or privileged mutations into app feature folders.
+
 ## How to Help Users Find Skills
 
 ### Step 1: Understand What They Need

--- a/.agents/skills/nextjs-app-architecture/LICENSE
+++ b/.agents/skills/nextjs-app-architecture/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aurora Scharff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/nextjs-app-architecture/README.md
+++ b/.agents/skills/nextjs-app-architecture/README.md
@@ -1,0 +1,65 @@
+# Next.js App Architecture Skill
+
+An agent skill for building or auditing Next.js 16+ App Router apps. It packages the patterns from [Component Architecture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/) and the [next-beats](https://github.com/vercel-labs/next-beats) reference app into a form AI coding agents can load and apply.
+
+## Install
+
+```bash
+npx skills add aurorascharff/nextjs-app-architecture-skill
+```
+
+## The six principles
+
+- **Pages are synchronous compositors.** They don't fetch, they compose.
+- **Async components fetch their own data.** Co-locate the read with the JSX.
+- **Route props stop at the page.** Components receive IDs, slugs, parsed filters, or records — not raw `params` / `searchParams`.
+- **Skeletons live next to their component.** Same file, exported alongside it.
+- **Suspense boundaries go at the page level.** The page designs the loading sequence.
+- **Client boundaries are leaf nodes.** Push `'use client'` as deep as it can go.
+
+## Prerequisite
+
+Before using the skill on a project, follow the [Next.js AI Coding Agents guide](https://preview.nextjs.org/docs/app/guides/ai-agents) so the agent reads version-matched Next.js docs from `AGENTS.md` / bundled docs instead of stale training data.
+
+## What it covers
+
+- **Feature folders** — domain ownership, cross-domain product experiences, merging sub-concepts into a parent, and file naming.
+- **Queries** — `import 'server-only'`, plain async reads by default, selective React `cache()` only for proven same-request dedup, and `'use cache'` + `cacheTag` + `cacheLife` for Cache Components.
+- **Actions** — `'use server'`, input validation, tag invalidation under Cache Components, calling from client components.
+- **Components** — async server components that receive IDs/parsed values, sibling skeletons, single-use helpers, the client boundary, the `use()` + promise-prop pattern, live data via polling.
+- **Pages** — sync page composition, `params.then()` for static-shell preservation, Suspense boundary placement, CLS prevention, error boundaries, audit smells.
+- **Cache Components** — when to opt in, the static-shell model, `'use cache'` variants, build constraints.
+- **UX patterns** — `useOptimistic`, toasts, pending state, destructive-action flows, the action-prop pattern, URL pagination.
+
+## References
+
+The `SKILL.md` overview is always loaded; references split into two zones so the agent pulls only what the task needs.
+
+**Core** (any RSC app):
+
+- [`references/feature-folders.md`](references/feature-folders.md) — folder layout, naming, merging sub-concepts, action/query file naming.
+- [`references/queries-actions.md`](references/queries-actions.md) — server-only queries, selective same-request dedup, server actions, validation, and cache/tag invalidation.
+- [`references/components.md`](references/components.md) — async server components, skeletons without alias wrappers, client boundary, promise + `use()`, single-use helpers, polling.
+- [`references/pages-suspense.md`](references/pages-suspense.md) — page composition, `PageProps` / `LayoutProps`, `params.then()`, Suspense placement, CLS prevention, error boundaries.
+- [`references/example.md`](references/example.md) — next-beats invariant map and supporting patterns.
+
+**Instant Apps** (opt-in, load only when optimizing for instant-feeling apps):
+
+- [`references/cache-components.md`](references/cache-components.md) — `cacheComponents: true`, the static shell, which reads to cache, `'use cache'` variants, `cacheTag` / `cacheLife`, `updateTag` / `revalidateTag`, and `io()` vs `connection()`.
+- [`references/single-page-applications.md`](references/single-page-applications.md) — SPA-style client caching and navigation patterns.
+- [`references/ux-patterns.md`](references/ux-patterns.md) — `useOptimistic`, toasts, pending state via `data-pending`, destructive flows, the action-prop pattern, URL pagination, `useFormStatus`.
+
+## Background reading
+
+- [Component Architeture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/)
+- [Server and Client Component Composition in Practice](https://aurorascharff.no/posts/server-client-component-composition-in-practice/)
+- [Building Design Components with Action Props using Async React](https://aurorascharff.no/posts/building-design-components-with-action-props-using-async-react/)
+- [Error Handling in Next.js with catchError](https://aurorascharff.no/posts/error-handling-in-nextjs-with-catch-error/)
+- [Avoiding Server Component Waterfall Fetching with React 19 cache()](https://aurorascharff.no/posts/avoiding-server-component-waterfall-fetching-with-react-19-cache/)
+- [next16-social-media](https://github.com/aurorascharff/next16-social-media) — demo app applying these patterns.
+
+**Companion skill:** [React View Transitions](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+
+## License
+
+MIT

--- a/.agents/skills/nextjs-app-architecture/SKILL.md
+++ b/.agents/skills/nextjs-app-architecture/SKILL.md
@@ -21,6 +21,12 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
 - Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+- Do not regenerate or expand the managed root `AGENTS.md`.
+
+**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+
+- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
 

--- a/.agents/skills/nextjs-app-architecture/SKILL.md
+++ b/.agents/skills/nextjs-app-architecture/SKILL.md
@@ -23,9 +23,9 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
 - Do not regenerate or expand the managed root `AGENTS.md`.
 
-**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+**Core remaps** — apply these at every numbered step. Upstream file-placement lines are vendor text, not permission to add a query layer.
 
-- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Feature-owned means UI composition only.** The feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` at all.
 - **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
@@ -34,7 +34,7 @@ Refresh: `references/upstream.md`.
 
 A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
 
-**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+**Follow the workflow below step by step** — apply the **Core remaps** at each step. Upstream `*-queries.ts` / `*-actions.ts` lines are vendor text: **CORE: skip file creation.** Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
 
 ## Prerequisite
 
@@ -46,7 +46,7 @@ Build pages that describe the loading experience, not pages that act like route 
 
 - `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
 - Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
-- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly. **(CORE: skip file creation. Import `@asym/api` or `@asym/database/hooks` from the feature component.)**
 - When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
 - Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
 
@@ -60,8 +60,8 @@ The non-negotiables. The workflow produces them; the final check verifies them.
 4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
 5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
 6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
-7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
-8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts. **(CORE: skip file creation. Call `@asym/api` from the feature component; do not add those files under `apps/*/features/`.)**
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions. **(CORE: "keeps its queries and actions" means `packages/api`, not a feature-local query file.)**
 9. **Client components import actions directly** — never receive a server action as a prop just to call it.
 10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
 11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
@@ -78,13 +78,13 @@ Run these in order for build-from-scratch, feature work, or audits. Each step na
 2. **Place the work.** Decide the feature folder before writing anything.
    → `references/feature-folders.md` (decision tree + merge rules).
    ✓ A real domain, a cross-domain product experience, or folded into the right parent.
-3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`. **(CORE: skip file creation. Import the existing `@asym/api` read, or `@asym/database/hooks` for an approved browser table.)**
    → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
    ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
-4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top. **(CORE: skip file creation. Import the existing `@asym/api` mutation.)**
    → `references/queries-actions.md`.
    ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
-5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves. **(CORE: "its own query" is an `@asym/api` or `@asym/database` call, not a new `*-queries.ts`.)**
    → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
    ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
 6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
@@ -105,10 +105,10 @@ Inspect the diff against every invariant — each is checkable by reading the ch
 - [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
 - [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
 - [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
-- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`. **(CORE: skip file creation. A new `*-queries.ts` / `*-actions.ts` under `apps/*/features/` means the change is wrong.)**
 - [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
 - [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
-- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions. **(CORE: skip file creation.)**
 - [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
 - [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
 - [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.

--- a/.agents/skills/nextjs-app-architecture/SKILL.md
+++ b/.agents/skills/nextjs-app-architecture/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: nextjs-app-architecture
+description: Build or audit Next.js 16 App Router apps using a next-beats-style React Server Components architecture. Use when scaffolding a new app, adding a feature, reviewing an existing app, refactoring route-loader-shaped pages into feature-owned async server components, deciding where queries/actions/components live, keeping pages synchronous with `params.then()`, placing Suspense boundaries, choosing the client/server boundary, designing skeletons, preventing CLS, or enabling Cache Components. Also use when the user asks about RSC composition, components receiving IDs instead of route params, `'use cache'`, `cacheTag`, `updateTag`, static-shell prerendering, or making an app easier for AI agents to modify.
+license: MIT
+metadata:
+  author: aurorascharff
+  version: "1.3.9"
+---
+
+## This repository (Asymmetric-al/core)
+
+Subordinate to installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`), **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/nextjs-app-router/SKILL.md`**, **`docs/ai/skills/cache-components/SKILL.md`**, and **`docs/guides/architecture/data-access-boundary.md`**.
+
+This skill is for page composition, Suspense placement, leaf client boundaries, and feature-owned UI. It is not a license to invent a new app folder scheme or move business database logic.
+
+**Repo mapping:**
+
+- Privileged reads, writes, payments, webhooks, and vendor calls stay in `packages/api`.
+- Browser-visible table data uses `@asym/database/hooks` when a collection exists.
+- Shared UI stays in `@asym/ui` / exact `base-maia`. Existing `apps/*/features/` directories are UI composition, not a new query layer.
+- All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
+- Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
+- Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+
+Refresh: `references/upstream.md`.
+
+# Next.js App Architecture
+
+A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
+
+**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+
+## Prerequisite
+
+Before changing a Next.js app, make sure the project is set up for AI agents to read version-matched docs. Follow the [AI Coding Agents guide](https://preview.nextjs.org/docs/app/guides/ai-agents): prefer the project's `AGENTS.md` / bundled docs, and create or refresh them when missing. Then use this skill for architecture decisions.
+
+## Architecture target
+
+Build pages that describe the loading experience, not pages that act like route loaders:
+
+- `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
+- Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
+- Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
+
+## Invariants (what every change must satisfy)
+
+The non-negotiables. The workflow produces them; the final check verifies them.
+
+1. **Pages compose, they never fetch.** A page/layout imports feature components and places `<Suspense>`. No queries or domain logic inline. Tiny route-local control-flow helpers are allowed only when they exist to place a boundary around `connection()`, `redirect()`, or a resolved route prop.
+2. **Pages stay synchronous.** Use `params.then()` / `searchParams.then()` or `Promise.all([params, searchParams]).then(...)`, never `await params` at the top — so chrome paints into the static shell and only data-dependent sections suspend.
+3. **Feature components receive IDs, not route props.** Resolve `params` / `searchParams` at the page boundary and pass plain values (`id`, `slug`, `query`) into features.
+4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
+5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
+6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+9. **Client components import actions directly** — never receive a server action as a prop just to call it.
+10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
+11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
+
+## Workflow
+
+Run these in order for build-from-scratch, feature work, or audits. Each step names the reference to consult and the check it must pass.
+
+1. **Choose mode.**
+   - **Build from scratch:** sketch routes, real domain nouns, static shell, and expected loading groups before writing code.
+   - **Audit/refactor:** scan current `app/` pages first; list every async page, page-level query import, route prop leak, missing Suspense boundary, and feature folder mismatch.
+     → `references/example.md` for the target shape; `references/feature-folders.md` for placement.
+     ✓ You know whether you are creating the architecture or converting loader-shaped code into it.
+2. **Place the work.** Decide the feature folder before writing anything.
+   → `references/feature-folders.md` (decision tree + merge rules).
+   ✓ A real domain, a cross-domain product experience, or folded into the right parent.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+   → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
+   ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+   → `references/queries-actions.md`.
+   ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+   → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
+   ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
+6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
+   → `references/pages-suspense.md`.
+   ✓ Route props become plain values; stable cards/sections wrap Suspense when they set layout; boundaries stay visible at the page.
+7. **Add interaction** (if any): optimistic updates, pending state, toasts, confirmation.
+   → `references/ux-patterns.md`.
+   ✓ Feedback isn't doubled; optimistic reducers/actions live with the feature; URL/search params own shareable state; client effects synchronize external systems, not derived React state.
+8. **Verify** against the checklist below before declaring done.
+
+## Verify before done
+
+Inspect the diff against every invariant — each is checkable by reading the changed files:
+
+- [ ] No page/layout imports a `*-queries` file or defines reusable domain UI inline; any inline helper is route-local control flow only.
+- [ ] Every page with params is synchronous and uses `params.then()` / `searchParams.then()` / `Promise.all([params, searchParams]).then(...)`.
+- [ ] Feature components receive plain IDs/handles/parsed filters or resolved records; no feature prop is named `params` or `searchParams`.
+- [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
+- [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
+- [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
+- [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
+- [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
+- [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.
+- [ ] Client leaves use `useOptimistic`, transitions, reducers, URL state, or form actions for interaction; they do not call `setState` in effects for derived React state.
+- [ ] Mutations validate their input and invalidate the affected data.
+
+## Reference index
+
+- **`references/feature-folders.md`** — where code goes: folder layout, cache contracts, naming, and merging sub-concepts.
+- **`references/queries-actions.md`** — query/action rules: server-only, dedup, validation, invalidation, return shape.
+- **`references/components.md`** — server/client boundary, skeletons, `use()`, single-use helpers, live data.
+- **`references/pages-suspense.md`** — page composition, `params.then()`, Suspense placement, CLS, error boundaries, prefetch.
+- **`references/cache-components.md`** — the `cacheComponents` decisions: which reads to cache, which directive to use, how to invalidate.
+- **`references/single-page-applications.md`** — client cache decisions: placement, server seeding, Cache Components coordination, hydration, and mutations.
+- **`references/ux-patterns.md`** — interaction decisions: optimistic vs pending vs inline error, toasts, action-prop, confirmations.
+- **`references/example.md`** — the next-beats reference app: invariant → file map, for seeing any rule in real code.

--- a/.agents/skills/nextjs-app-architecture/references/cache-components.md
+++ b/.agents/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,0 +1,80 @@
+# Cache Components
+
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+
+## When this reference applies
+
+Use this reference when an app already has `cacheComponents: true`, the user wants this architecture while enabling it, or you are reviewing/refactoring an app that targets Cache Components.
+
+If the project has not adopted Cache Components yet and the user asks to enable, migrate, or work through adoption blockers, use the `next-cache-components-adoption` skill first. It owns the route-by-route migration loop, opt-out strategy, and build/dev overlay workflow. Then return here for steady-state query/action/component architecture.
+
+If `cacheComponents` is not enabled and the task is ordinary feature work, follow the core references without adding cache directives. Do not recommend skipping Cache Components based on app category alone; adoption is a migration/project decision, not a per-feature shortcut.
+
+Adopting these in an existing app: follow [Migrating to Cache Components](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components) and [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) — they cover the incremental path (per-route `prefetch = 'partial'`, fixing dynamic-usage build errors) rather than a big-bang switch.
+
+## The model
+
+```ts
+// next.config.ts
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true, // prefetch the static shell of linked routes
+};
+```
+
+- **Static shell** — synchronous content, `'use cache'` output, and Suspense fallbacks prerender at build time.
+- **Dynamic holes** — async work without `'use cache'` streams in behind `<Suspense>` at request time.
+- **Build constraint** — any async work without `'use cache'` must sit inside `<Suspense>`, or the build fails (wrap it, or add `'use cache'`).
+
+`cacheComponents` implies Partial Prerendering — it replaced `experimental.ppr` / `dynamicIO` / `useCache`, so don't set those. See [caching](https://preview.nextjs.org/docs/app/getting-started/caching).
+
+With `cacheComponents: true`, the skill practice is **cache reusable reads**. Do not leave a database/API read dynamic just because Suspense makes the build pass. If a read has a stable key and a mutation can name what changed, give it a cache directive, tags, and a lifetime.
+
+Dynamic reads are the exception: use them for values that must be recomputed for every request or cannot be invalidated coherently. When you leave a read dynamic, note the reason in the surrounding code/review and invalidate its mutations with `refresh()` because there is no tag to update.
+
+## Decide what to cache
+
+| Data | Directive | Notes |
+| ---- | --------- | ----- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
+| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+
+Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
+
+## Keep a synchronous value out of the shell
+
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+
+Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
+
+## Decide how to invalidate
+
+- [`updateTag(tag)`](https://preview.nextjs.org/docs/app/api-reference/functions/updateTag) — in **server actions**, when the user should see the result immediately (read-your-own-writes). Requires the query to carry a matching `cacheTag`.
+- [`revalidateTag(tag, 'max')`](https://preview.nextjs.org/docs/app/api-reference/functions/revalidateTag) — in **route handlers** (webhooks, cron) for stale-while-revalidate. The single-arg `revalidateTag(tag)` form is deprecated.
+- [`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) — re-render the current route for the current user. Use it for deliberately dynamic reads with no tag; don't use it instead of `updateTag()` for cached reads.
+
+Tag, cache, invalidate: the `cacheTag` in the query and the `updateTag` in the action use the same string and live in the same feature folder.
+
+## Coordinate hydrated client data
+
+When cached server data seeds SWR, TanStack Query, or another browser cache, follow `references/single-page-applications.md`. Server and client freshness policies are independent; hydration adds library-specific constraints.
+
+## Build failure map
+
+When `next build` fails under Cache Components, map the error back to an architecture rule instead of patching locally:
+
+- Async work without `'use cache'` and without an ancestor `<Suspense>` → cache the reusable read, or wrap a justified dynamic read in a page-owned `<Suspense>`.
+- Request data inside `'use cache'` → switch to `'use cache: private'` when it is per-user cacheable, or keep it dynamic with a documented reason.
+- `await params` / `await searchParams` at the top of a page → keep the page synchronous and move the read into `params.then()` / `searchParams.then()`.
+- Sync request-time values (`new Date()`, `Math.random()`, sync storage reads) captured in the shell → cache stable values, or use [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) for per-request values.
+
+For adoption-wide blocker triage, use `next-cache-components-adoption`. For API-specific recipes, follow the [Migrating to Cache Components guide](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components).
+
+## Without Cache Components
+
+- Don't use `'use cache'` / `cacheTag` / `cacheLife` — they require the flag.
+- Use React `cache()` only for proven same-request dedup needs; plain `server-only` async queries are the default.
+- Invalidate with `refresh()` from server actions.
+- Pages still use `params.then()` in this architecture. Without Cache Components there is no build-time static shell to preserve, but keeping pages synchronous still lets chrome paint before route-specific data resolves and keeps the app consistent.

--- a/.agents/skills/nextjs-app-architecture/references/cache-components.md
+++ b/.agents/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,6 +1,6 @@
 # Cache Components
 
-Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about _which reads to cache, which directive to use, and how to invalidate_ — for the mechanics of each directive, follow the doc links.
 
 ## When this reference applies
 
@@ -34,18 +34,18 @@ Dynamic reads are the exception: use them for values that must be recomputed for
 
 ## Decide what to cache
 
-| Data | Directive | Notes |
-| ---- | --------- | ----- |
-| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
-| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
-| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
-| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+| Data                                                     | Directive                                                                                                | Notes                                                                                                                                                                                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache)                  | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session               | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server.                                                                                                                                          |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote)   | Protects against rate-limited third-party APIs.                                                                                                                                                                                  |
+| Genuinely dynamic per request                            | none                                                                                                     | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists.                                                                                                                                    |
 
 Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
 
 ## Keep a synchronous value out of the shell
 
-You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a _synchronous_ request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
 
 Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
 

--- a/.agents/skills/nextjs-app-architecture/references/components.md
+++ b/.agents/skills/nextjs-app-architecture/references/components.md
@@ -1,0 +1,243 @@
+# Components
+
+How to build server and client components inside a feature folder.
+
+## Default: async server component
+
+Server components await their own queries directly — no `useEffect`, no client-side fetching, no manual loading state. See the [Server Components docs](https://preview.nextjs.org/docs/app/getting-started/server-and-client-components) for the model.
+
+Prefer minimal, stable props: IDs, slugs, handles, parsed filters, or records the parent already fetched. Do not pass raw route `params` or `searchParams` into feature components. Pages resolve those promises and pass plain values.
+
+```tsx
+// features/notifications/components/notifications-badge.tsx
+import { getUnreadNotificationCount } from "@/features/notifications/notifications-queries";
+
+export async function NotificationsBadge() {
+  const count = await getUnreadNotificationCount();
+  if (count === 0) return null;
+  return <span aria-label={`${count} unread`}>{count}</span>;
+}
+```
+
+The page (not this file) wraps it in `<Suspense fallback={<NotificationsBadgeSkeleton />}>` — see `references/pages-suspense.md`.
+
+For parameterized routes, the page resolves `params` and the feature receives an ID:
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <PostDetail id={id} />
+  ))}
+</Suspense>
+```
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Skeletons live in the same file
+
+Export the main component and its skeleton from the same file. Pages import both. Define the skeleton **at the end of the file**, below the real component(s) — never above. Function declarations are hoisted, so a skeleton referenced by a component earlier in the file still works when defined last.
+
+```tsx
+export async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return (
+    <ul>
+      {posts.map((p) => (
+        <Post key={p.id} post={p} />
+      ))}
+    </ul>
+  );
+}
+
+export function FeedSkeleton() {
+  return (
+    <ul>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <li key={i}>
+          <Skeleton className="h-24" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Don't export a second skeleton whose whole job is to rename or preconfigure another skeleton:
+
+```tsx
+// Wrong — alias wrapper adds an import surface but no behavior
+export function CompactGridSkeleton() {
+  return <GridSkeleton dense />;
+}
+```
+
+Import the real skeleton and pass the prop inline at the `<Suspense>` boundary: `fallback={<GridSkeleton dense />}`.
+
+### Skeleton design checklist
+
+1. Match the real component's layout: flex direction, gaps, padding, breakpoints.
+2. Include all structural elements: avatar circles, action button placeholders, image squares.
+3. Responsive visibility must match (`hidden sm:block` in the real component → same in the skeleton).
+4. Show 2–5 placeholders for variable-length lists, not the real count.
+5. Don't include skeletons for inner Suspense content — those have their own boundaries.
+6. Reserve the right height. CLS comes from skeletons that are shorter than the real content.
+7. Dense placeholders should not animate. A grid of 28 shimmering covers reads as flicker rather than progress, so use a flat low-contrast fill when there are many items and keep the animated sweep for a handful of bars.
+
+## Group related components in one file
+
+A card and its grid live in the same file. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`. Variants should reuse that skeleton inline instead of exporting alias skeletons. Don't split shared UI primitives prematurely — wait until three call sites need the same shape before extracting.
+
+Two sidebar widgets that happen to look similar but render different data shapes are **not** the same component. The visuals diverge as soon as one needs an extra slot.
+
+### Single-use sub-components stay inlined
+
+For a metadata strip inside one card, a header used only by one detail view, a list item only rendered by its list — inline them as **non-exported** functions in the same file:
+
+```tsx
+export async function EventDetails({ slug }: { slug: string }) {
+  const event = await getEventBySlug(slug);
+  return (
+    <article>
+      <MetaStrip event={event} />
+      <Speaker speaker={event.speaker} />
+      <p>{event.description}</p>
+    </article>
+  );
+}
+
+function MetaStrip({ event }: { event: Event }) { ... }
+function Speaker({ speaker }: { speaker: string }) { ... }
+```
+
+Exports are for things other files will import. Internal structure is for readability inside one file.
+
+## The server/client boundary
+
+`'use client'` only when you need:
+
+- Hooks (`useState`, `useReducer`, `useOptimistic`, `useTransition`, `useEffect`)
+- Event handlers (`onClick`, `onChange`, `onSubmit`)
+- Browser APIs (`window`, `localStorage`, refs to DOM)
+
+If the component needs interactive pieces, keep the server component as the parent and render client leaves:
+
+```tsx
+async function PostDetail({ id }: { id: string }) {
+  const [post, userState] = await Promise.all([
+    getPost(id),
+    getPostUserState(id),
+  ]);
+  return (
+    <article>
+      <PostBody body={post.body} />
+      <PostActions userState={userState} /> {/* 'use client' leaf */}
+    </article>
+  );
+}
+```
+
+### Server content as children of client components
+
+Composition crosses the boundary. A client component can accept server-rendered JSX as children or props:
+
+```tsx
+<ComposerForm
+  avatar={
+    <Suspense fallback={<AvatarSkeleton />}>
+      <CurrentUserAvatar />
+    </Suspense>
+  }
+/>
+```
+
+`ComposerForm` is `'use client'`. It doesn't know where the avatar JSX came from. The Suspense boundary streams the avatar in without the form re-rendering.
+
+### Pass server children resolved values, not promises
+
+Prefer passing plain values (strings, IDs, resolved data) to a server child. A server component _can_ `await` a promise prop, but resolve route promises in the page instead — pass an unresolved promise down only to a _client_ component that reads it with `use()` (see below). When a parent already has the data from its own query, pass it as a prop instead of having the child refetch.
+
+```tsx
+// Right — parent fetches the list, passes each item
+async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return posts.map((post) => <Post key={post.id} post={post} />);
+}
+
+async function Post({ post }: { post: Post }) {
+  return <article>{post.body}</article>;
+}
+```
+
+```tsx
+// Wrong — child refetches what the parent already had
+async function Post({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Client components that own their loading state
+
+When a client component needs server data but should manage its own loading (a sidebar badge, a popover that opens on hover), pass an **unresolved promise** from the server and resolve it with [`use()`](https://react.dev/reference/react/use) on the client. Wrap the consumer in `<Suspense>`.
+
+```tsx
+// page: pass the unresolved promise, wrap in Suspense
+<Suspense fallback={<TagListSkeleton />}>
+  <TagPicker itemsPromise={getTags()} />
+</Suspense>
+```
+
+```tsx
+"use client";
+import { use } from "react";
+
+export function TagPicker({ itemsPromise }: { itemsPromise: Promise<Tag[]> }) {
+  const items = use(itemsPromise);
+  // render interactive UI from items
+}
+```
+
+The opinionated bit: name promise props with a `Promise` suffix (`itemsPromise`, `userPromise`) so the contract is obvious at the call site.
+
+### Client data libraries (SWR, TanStack Query)
+
+Follow `references/single-page-applications.md` when a feature uses a browser data cache or needs externally authored updates. It covers when to use a library, where its files live, server seeding, Cache Components coordination, hydration, and mutations.
+
+## Interactive async React shape
+
+Keep the server/client split even when the UI is highly interactive:
+
+- The server component reads durable data and renders the initial tree.
+- The client leaf owns only ephemeral interaction: open state, focused field, pending flag, optimistic draft, selected tab that is not shareable.
+- Shareable or bookmarkable state lives in the URL/search params, not mirrored in component state.
+- Client leaves import server actions directly and call them from form actions or event handlers.
+- Mutation feedback (`useOptimistic`, pending flags, rollback, toasts) follows `references/ux-patterns.md`.
+
+Avoid effects whose only job is to copy React state to React state:
+
+```tsx
+// Wrong — derived React state cascades through an effect
+useEffect(() => {
+  setSelectedItem(null);
+}, [filterKey]);
+```
+
+Prefer one of these shapes:
+
+- Key the interactive child by the value that resets it: `<SelectableList key={filterKey} filterKey={filterKey} />`.
+- Derive the value during render.
+- Put the value in the URL/search params if navigation should own it.
+- Use a reducer where the same event that changes `filterKey` also clears `selectedItem`.
+
+Effects are for external systems: DOM APIs, subscriptions, timers, browser storage, analytics, or imperative libraries. They are not a cleanup lane for state that React could derive or reset structurally.
+
+## Mutations
+
+For client-side reactions to a server mutation (instant feedback, pending state, success/error toasts), see `references/ux-patterns.md`. To cache rendered output across requests, see `references/cache-components.md`.

--- a/.agents/skills/nextjs-app-architecture/references/example.md
+++ b/.agents/skills/nextjs-app-architecture/references/example.md
@@ -6,29 +6,29 @@ For the reasoning behind this architecture, read [Component Architecture for Rea
 
 ## Invariant → where to see it
 
-| Invariant | File(s) |
-| --------- | ------- |
-| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
-| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
-| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
-| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
-| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
-| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
-| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
-| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
-| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+| Invariant                                                                         | File(s)                                                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Pages compose, never fetch                                                     | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries.                                                                                                   |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`)                   | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`.                                                                                                                              |
+| 3. Feature components receive IDs, not route props                                | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components.                                                                                                          |
+| 4. Async server component default; `'use client'` on leaves                       | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`.                                                                     |
+| 5. Page owns Suspense; feature owns skeleton                                      | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below).                                                                                                                      |
+| 6. Skeleton in the same file, at the end                                          | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`.                                                                                                      |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`.                                                                                                                                                    |
+| 8. Feature folders follow product ownership                                       | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly                                      | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly.                                                                                                                                          |
 
 ## Supporting patterns
 
-| Pattern | File |
-| ------- | ---- |
-| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
-| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
-| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
-| `useFormStatus` submit button | `components/ui/button.tsx` |
-| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
-| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
-| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
-| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+| Pattern                                                | File                                                                                         |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`)   | `components/ui/error-boundary.tsx`                                                           |
+| `useOptimistic` for an unlikely-to-fail toggle         | `features/track/components/track-interactions.tsx`                                           |
+| Action-prop / `*Action` convention + confirm dialog    | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button                          | `components/ui/button.tsx`                                                                   |
+| `useActionState` inline field errors                   | `features/user/components/sign-in-form.tsx`                                                  |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx`                           |
+| `use()` on an unresolved promise prop                  | `features/playlist/components/add-to-playlist-menu.tsx`                                      |
+| Purpose-named `components/scripts/` subfolder          | `components/scripts/`                                                                        |
 
 > The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/.agents/skills/nextjs-app-architecture/references/example.md
+++ b/.agents/skills/nextjs-app-architecture/references/example.md
@@ -1,0 +1,34 @@
+# Reference app: next-beats
+
+A working app that follows this architecture: **<https://github.com/vercel-labs/next-beats>** (Next.js 16, `cacheComponents` + `partialPrefetching`, a music player). Use it to see any invariant in real code rather than restating the code here. Paths are as of this writing — verify against the current repo.
+
+For the reasoning behind this architecture, read [Component Architecture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/). The skill's target is the same shape: pages describe layout and loading; feature components own server reads; route params become IDs before they reach components.
+
+## Invariant → where to see it
+
+| Invariant | File(s) |
+| --------- | ------- |
+| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
+| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
+| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
+| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
+| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
+| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+
+## Supporting patterns
+
+| Pattern | File |
+| ------- | ---- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
+| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
+| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button | `components/ui/button.tsx` |
+| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
+| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
+| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+
+> The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/.agents/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.agents/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,5 +1,7 @@
 # Feature folders
 
+> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+
 How to organize code under `features/` and `app/`.
 
 ## Folder layout

--- a/.agents/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.agents/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,6 +1,6 @@
 # Feature folders
 
-> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+> **Core:** Existing `apps/*/features/` folders are UI composition only. Do not add `*-queries.ts` or `*-actions.ts` at all. Call `@asym/api` or `@asym/database/hooks` from the feature component.
 
 How to organize code under `features/` and `app/`.
 

--- a/.agents/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.agents/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,0 +1,147 @@
+# Feature folders
+
+How to organize code under `features/` and `app/`.
+
+## Folder layout
+
+```
+features/<domain>/
+  <domain>-cache.ts     # Pure server tags + client query keys, when shared
+  <domain>-queries.ts   # Server-only queries, when this feature owns reads
+  <domain>-actions.ts   # Server actions, when this feature owns writes
+  <domain>-query-options.ts # Client data-library query definitions, when needed
+  components/           # Server + client components, each with its skeleton
+  types/                # Feature-local public types, when needed by multiple files
+  hooks/                # Actual feature-local React hooks and hook wrappers
+  providers/            # Feature-local providers, only when the provider belongs to this domain
+```
+
+The folder name identifies the domain or cohesive product experience. Query and action filenames match the owning domain folder when present.
+
+## How many features?
+
+Keep the feature list short. Use folders for **domains and cohesive product experiences a user would recognize**, not database tables or technical concerns.
+
+A new folder is justified in either of these cases:
+
+1. **Domain ownership:** it owns the queries, actions, and components for a real product entity.
+2. **Cross-domain composition:** it owns the route-level UI or client state for an experience that combines multiple domains. The underlying queries and actions remain with the domains whose data they read or mutate.
+
+If you find yourself making a feature folder with one query, one action, and one button, fold it into the parent feature instead.
+
+### Merge aggressively
+
+Concepts that exist only in service of a parent entity belong inside the parent's feature folder:
+
+- A `favorite` or `bookmark` concept that only attaches to one parent entity (events, posts) → inside that parent's folder.
+- A `like`, `repost`, `vote`, or `reaction` concept on a piece of content → with that content's feature.
+- `auth` / `session` / `current user` → a single `user` folder, not split.
+- A search query stays with the domain it searches (`searchTracks` in `features/track/`, `searchPlaylists` in `features/playlist/`). When one search experience combines several domains, `features/search/` may own the search form, result composition, and client state without taking ownership of those domain queries.
+
+Concrete example: `toggleFavorite` is a mutation about events ("I favorite an event"), not its own domain. It lives in `features/event/event-actions.ts`, not `features/favorite/favorite-actions.ts`.
+
+## File naming
+
+Filenames inside the folder always start with the folder name:
+
+```
+features/event/
+  event-queries.ts
+  event-actions.ts
+  components/
+    event-grid.tsx
+    event-details.tsx
+    favorite-button.tsx     ← OK: a component, not a "favorite" feature
+```
+
+- `<folder>-queries.ts` — even if the file has only one query.
+- `<folder>-actions.ts` — even if a mutation is about a sub-concept.
+- Don't create empty query or action files for a cross-domain UI feature that doesn't own data access.
+- Other `<folder>-*.ts` files are fine when the folder needs them (`playlist-constants.ts`, `<folder>-schema.ts`), as long as they keep the folder-name prefix. Don't put reusable domain types in a root `*-types.ts` file; use `features/<domain>/types/` once a type is imported by multiple files.
+- Component files use any descriptive name. The component (not the feature) is the unit here.
+
+## Local vs shared support folders
+
+Use a local support folder when the code belongs to one feature:
+
+```
+features/message/
+  message-cache.ts
+  message-query-options.ts
+  types/
+    message.ts
+  hooks/
+    use-message-mutations.ts
+    use-message-draft.ts
+  providers/
+    message-draft-provider.tsx
+```
+
+Feature-owned client coordination stays with the feature. Place each file by the shape it exports and the domain it belongs to:
+
+- Client data-library cache contracts and query definitions follow `references/single-page-applications.md`.
+- Mutation wrappers that export hooks live in `hooks/use-*.ts` (`use-message-mutations.ts` exporting `useSendMessage`).
+- Browser-only state helpers live in `hooks/` when their public API is a hook (`use-thread.ts`, `use-message-draft.ts`).
+- Client leaf components that coordinate a server write live in `components/` next to the UI they support (`mark-activity-read.tsx` posts read activity in the background while the current `/activity` tree stays stable).
+
+Keep the file prefix aligned with the feature folder when a file exports a grouped feature contract (`workspace-cache.ts` and `workspace-query-options.ts`, not `activity-cache.ts` in `features/workspace/`). Support code for a sub-concept still lives with the parent feature: reactions on messages belong in `features/message/`; unread activity chrome belongs in `features/workspace/`.
+
+Promote only when there are real cross-feature consumers:
+
+- `types/` at the project root — shared domain/application types imported across features.
+- `hooks/` at the project root — shared client hooks used across features.
+- `app/providers.tsx` or `components/*-provider.tsx` — app-shell providers that wrap the whole app.
+
+Avoid root-level miscellany like `message-types.ts`, `shared-hooks.ts`, or `common-provider.tsx`; the folder name should explain the scope.
+
+## What goes in `components/`
+
+Each component file exports the main component **plus its skeleton**:
+
+```tsx
+// features/event/components/event-grid.tsx
+export async function EventGrid(...) { ... }
+export function EventGridSkeleton() { ... }
+```
+
+Group related components in one file when they're always used together or one is a natural building block for another. A card and its grid live together. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`.
+
+Split into separate files only when:
+
+- A component is consumed by multiple sibling components (one shared use is not enough — wait until three call sites need it).
+- A component is `'use client'` and a sibling is a server component (the server/client boundary forbids sharing a file).
+
+See `references/components.md` for inlining rules and the skeleton design checklist.
+
+## What pages do
+
+Pages in `app/` compose feature components with Suspense and transition wrappers. They never:
+
+- Contain domain logic
+- Define new components except thin transition wrappers (e.g. `<ViewTransition>`)
+- Fetch data directly
+- Inline route-specific components — extract them into the feature folder
+
+See `references/pages-suspense.md` for page composition details.
+
+## Top-level layout
+
+```
+app/                  # Pages and layouts
+features/             # Domain folders
+components/           # UI primitives, theme, and app-shell singletons
+hooks/                # Shared client hooks used across features
+types/                # Shared cross-feature types only
+lib/                  # Utilities and cohesive non-domain subsystems
+```
+
+`lib/` holds flat helpers (`db.ts`, `utils.ts`) but may also group a cohesive non-domain subsystem in its own subfolder (e.g. `lib/audio/` for an audio engine). Cross-feature client hooks live in top-level `hooks/`; a hook used by a single feature co-locates in that feature's `hooks/`. Types follow the same rule: shared types at top-level `types/`, feature-only exported types in `features/<domain>/types/`.
+
+`components/` holds:
+
+- **`components/ui/`** — primitives. Low-level building blocks and action-prop components.
+- **`components/theme/`** — theme provider and toggle, paired.
+- **Top-level files** (`site-header.tsx`, `auth-gate.tsx`, `poller.tsx`) — app-shell singletons used once each. No `common/` folder — "common" is not a category. If a component is used everywhere it's a primitive (→ `ui/`); if it's used once it lives at the top level.
+- **Purpose-named subfolders** are fine when several files share a clear technical role — e.g. `components/scripts/` for pre-hydration inline `<script>` seed components. This is distinct from the rejected `common/`: a `scripts/` folder names _what the files are_, not "miscellaneous."
+
+Conventions for filenames and casing live in the project's `AGENTS.md`. This skill doesn't impose one.

--- a/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -1,0 +1,276 @@
+# Pages and Suspense
+
+How to compose pages, place Suspense boundaries, and prevent layout shift.
+
+## Pages are composition only
+
+Pages in `app/` import feature components and place `<Suspense>` boundaries. They never:
+
+- Fetch data directly (queries live in feature folders)
+- Define reusable UI components except thin transition wrappers (e.g. `<ViewTransition>`) or tiny route-local control-flow helpers
+- Inline route-specific UI (extract it into the feature folder)
+- Pass raw `params` / `searchParams` to features
+
+## Page function signatures
+
+Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
+
+```tsx
+export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+```
+
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+
+## Keep pages synchronous
+
+Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
+
+```tsx
+import { Suspense } from 'react';
+import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+
+export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+  return (
+    <div>
+      <h1>Post</h1>
+      <Suspense fallback={<PostDetailSkeleton />}>
+        {params.then(({ id }) => (
+          <PostDetail id={id} />
+        ))}
+      </Suspense>
+    </div>
+  );
+}
+```
+
+The `<h1>` sits **above** the `params.then()` so it paints instantly. The `Suspense` fallback covers only the dynamic section.
+
+Resolve route props to plain values at this boundary. Feature components receive `id`, `slug`, `query`, or parsed filter values — not `params`, `searchParams`, or unresolved server promises.
+
+### Implicit return inside `.then()`
+
+Use an implicit-return arrow function when the callback just renders JSX — e.g. `({ id }) => <PostDetail id={id} />`. Only switch to a block body with `return` when you need to do work first (destructure with defaults, parse a `searchParams` value, branch on a condition). This keeps the JSX-in-page shape readable and matches how the resolved tree will look.
+
+### `searchParams` and combined params
+
+```tsx
+// searchParams only
+export default function SearchPage({ searchParams }: PageProps<'/search'>) {
+  return searchParams.then(sp => {
+    const q = typeof sp.q === 'string' ? sp.q : '';
+    return q ? <SearchResults query={q} /> : <EmptyState />;
+  });
+}
+
+// Both params and searchParams
+export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+  return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
+    <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
+  ));
+}
+```
+
+Use `Promise.all([params, searchParams])` when both are needed. Avoid nested `.then()` calls that make the resolved tree hard to read and easy to wrap in the wrong boundary.
+
+### Metadata, static params, and `notFound()`
+
+- [`generateMetadata`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-metadata) runs before render, so `await params` is fine there — it's a separate async function, not the page body, so it doesn't make the page dynamic.
+- Export [`generateStaticParams`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-static-params) from a `[slug]` page/layout to pre-build a known set of slugs; with `cacheComponents` + `'use cache'` they land in the static shell. It does **not** change the page signature — `params` is still a Promise, still consumed with `params.then()`.
+- A query that can't find its resource calls [`notFound()`](https://preview.nextjs.org/docs/app/api-reference/functions/not-found), which bubbles to the nearest [`not-found.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/not-found). Don't try/catch it — use [`unstable_rethrow`](https://preview.nextjs.org/docs/app/api-reference/functions/unstable_rethrow) if you must catch nearby.
+
+## Prefer a page boundary over `loading.tsx`
+
+Put the boundary in the page next to the `params.then()` / `searchParams.then()` it covers, rather than adding a route-segment `loading.tsx`. A page boundary keeps the fallback beside the JSX it stands in for, lets sibling sections share one boundary or split into several, and can be wrapped in `<ViewTransition>` so the reveal animates. A `loading.tsx` renders outside the page's own tree, so a transition wrapper inside the page cannot animate the swap out of it, and one fallback has to cover the whole route.
+
+## The page owns the Suspense boundary
+
+The feature exports the async component **and** its skeleton. The page imports both and places the boundary. Don't pre-wrap inside the feature — that hides the boundary and prevents grouping siblings.
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) { ... }
+export function PostDetailSkeleton() { ... }
+```
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <>
+      <PostDetail id={id} />
+      <ErrorBoundary title="Replies didn't load">
+        <Suspense fallback={<RepliesSkeleton />}>
+          <Replies postId={id} />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  ))}
+</Suspense>
+```
+
+If a page uses a transition wrapper (e.g. `<ViewTransition>`), place it in the page next to the `<Suspense>` boundary. Feature components render content and skeletons, not transition wrappers.
+
+## Stable shell, suspending body
+
+Before designing a fallback, identify what is stable and what is data-dependent.
+
+- Stable: card/panel border, padding, icon, label, section heading, fixed action rail.
+- Data-dependent: title text, counts, form body, list rows, loaded choices.
+- Rule: stable shell outside Suspense; skeleton/crossfade inside the shell around the data body.
+
+```tsx
+<FeaturePanel>
+  <Suspense fallback={<FeaturePanelBodySkeleton />}>
+    <Crossfade>
+      <FeaturePanelBody id={id} />
+    </Crossfade>
+  </Suspense>
+</FeaturePanel>
+```
+
+Do not render `<FeaturePanel>` in both `fallback` and final content. That duplicates layout responsibility and makes the skeleton guess the panel size.
+
+Use the app's real domain noun at implementation time (`PostPanel`, `MessageList`, `GroupEditor`, `EventDetails`, etc.); the neutral names here describe the reusable shape, not a component to copy literally.
+
+When the top data section has unknown final height and pushes the sections below, either reserve that height in the stable wrapper or group the affected sections in one boundary. Do not create two independent crossfades if the first one changes the second one's starting position.
+
+## Audit smells
+
+When auditing an existing app, flag and fix these first:
+
+- `export default async function Page(...)` that only awaits `params`, `searchParams`, or page-level queries.
+- `import { getSomething } from '@/features/.../*-queries'` inside `app/**/page.tsx` or `layout.tsx`.
+- Feature components whose props are `params`, `searchParams`, or a route-shaped object.
+- Page-local components like `HomeContent`, `PostShell`, or `ResultsSection` that only exist to fetch data or group a Suspense fallback.
+- `<Suspense>` inside feature components that prevents the page from grouping reveal behavior.
+
+## Route-local control-flow helpers
+
+Small inline helpers are fine when their only job is route control flow that must live exactly where a boundary is placed:
+
+```tsx
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginRedirect />
+    </Suspense>
+  );
+}
+
+async function LoginRedirect() {
+  await connection();
+  await redirectIfAuthenticated('/dashboard');
+  return <LoginForm />;
+}
+```
+
+Do not move a helper like this into a feature folder just to satisfy a blanket "no inline components" rule. It is not domain UI and it is not a reusable feature component; extracting it creates noise. Keep the cookie/session read inside the data-access helper (`redirectIfAuthenticated`, `verifyAuth`, etc.) rather than importing a feature query into the page.
+
+## Don't create page-local wrapper components
+
+Avoid components whose only job is to group boundary content, like `HomeLists` or `HomeListsSkeleton`. Keep the resolved JSX and fallback JSX **inline in the page** so the loading shape, headings, and grouped reveal behavior are visible at the boundary.
+
+```tsx
+// Wrong — hides the structure behind a wrapper
+<Suspense fallback={<HomeListsSkeleton />}>
+  <HomeLists searchParams={searchParams} />
+</Suspense>
+```
+
+```tsx
+// Right — structure visible at the page level
+<Suspense
+  fallback={
+    <>
+      <FeaturedSkeleton />
+      <RecentSkeleton />
+    </>
+  }
+>
+  {searchParams.then(sp => (
+    <>
+      <Featured filter={sp.filter} />
+      <Recent filter={sp.filter} />
+    </>
+  ))}
+</Suspense>
+```
+
+The same applies to feature-level skeleton aliases. If a variant only passes props to a base skeleton, import the base skeleton and pass those props inline in `fallback={...}`.
+
+## Suspense boundary placement rules
+
+1. **First section gets its own Suspense** with a known-height skeleton fallback.
+2. **Section headings stay outside Suspense** when their final position is stable.
+3. **Stable wrappers stay outside Suspense.** If fallback and final content both render the same card or panel, lift that wrapper around the boundary.
+4. **Variable-height sections: group everything below them** in the same Suspense, including any headings that would otherwise paint in the wrong vertical position.
+5. **Fixed-height sections: own boundary is safe.**
+6. **Variable-length lists: show 2–5 skeleton items**, not the real count.
+7. **Inner Suspense content stays out of the outer skeleton.** Each boundary owns its own.
+8. **Never `fallback={null}` for visible UI.** If a boundary covers UI, give it a real shaped fallback, or group it with a sibling boundary that already has the correct fallback.
+9. **If the top section's final height is unknown, group the following sections** in the same boundary so they reveal together and don't jump underneath.
+
+## Error boundaries
+
+Wrap fallible sections in a Next.js-aware error boundary so one failure doesn't take down the page. Build it on [`catchError`](https://preview.nextjs.org/docs/app/api-reference/functions/catchError) from `next/error` (its `ErrorInfo` gives you a `retry()` that re-fetches server data) — it understands Next's control-flow throws (`notFound()`, `redirect()`, `unauthorized()`, `forbidden()`) and won't swallow them. Place the boundary around the suspending section, in the page:
+
+```tsx
+<ErrorBoundary title="Replies didn't load">
+  <Suspense fallback={<RepliesSkeleton />}>
+    <Replies postId={id} />
+  </Suspense>
+</ErrorBoundary>
+```
+
+Why not plain `react-error-boundary`? It catches Next's framework throws (so `notFound()` never reaches `not-found.tsx`), and its reset doesn't re-fetch server data. Background: [Error Handling in Next.js with catchError](https://aurorascharff.no/posts/error-handling-in-nextjs-with-catch-error/).
+
+Pair component-level boundaries with route-segment [`error.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/error) for unrecoverable errors; it also receives a `retry` callback.
+
+## Layout-level Suspense
+
+Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
+
+```tsx
+export default function RootLayout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>
+        <Suspense>
+          <AuthGate userPromise={getCurrentUser()} />
+        </Suspense>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}
+```
+
+`AuthGate` is a client component that resolves the promise with `use()` so the dialog can render conditionally without server-side branching.
+
+## CLS prevention
+
+Layout shift happens when:
+
+- A skeleton is shorter than the real content
+- A heading sits inside a Suspense boundary whose final height is unknown — it paints in the wrong place, then jumps
+- A variable-length list streams in without a fallback that reserves space
+
+Fixes:
+
+- Match skeleton height to the typical real content height.
+- Move headings **outside** boundaries when their position depends on data above them.
+- For unknown-height top sections, group everything below in one boundary so siblings stream together.
+
+To audit CLS, use React DevTools' Suspense panel to pin each boundary in its loading state and check vertical positions.
+
+## Optimizing prefetching for high-value routes
+
+With `cacheComponents` + [`partialPrefetching`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, a visible `<Link>` prefetches the destination's shared [App Shell](https://preview.nextjs.org/docs/app/glossary#app-shell) — enough to commit navigation instantly, with link-specific content streaming after. The default (`'auto'`) already does this; don't write `prefetch = 'auto'`.
+
+Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link data (`params`, `searchParams`, the full URL) at prefetch time. Each such link can wake the server for a prerender, so reserve it for routes users predictably visit next. See [Optimizing prefetching](https://preview.nextjs.org/docs/app/guides/optimizing-prefetching).
+
+Can't enable `partialPrefetching` app-wide yet? Opt in per route with `export const prefetch = 'partial'` on the destination, then drop the per-route exports once the global flag is on — see [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) for the incremental path and [prefetch config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for the options. To validate navigation feels instant, see the [`instant` config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant) and [Instant Navigation guide](https://preview.nextjs.org/docs/app/guides/instant-navigation).
+
+## Never wrap the entire page in a Suspense fallback
+
+Page chrome (header, nav, surrounding layout) should paint instantly. Only data-dependent sections suspend. If you find yourself wrapping `<div>` and everything in it with `<Suspense fallback={<FullPageSkeleton />}>`, restructure: pull static elements out, narrow the boundary to just the dynamic part.

--- a/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -16,20 +16,25 @@ Pages in `app/` import feature components and place `<Suspense>` boundaries. The
 Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
 
 ```tsx
-export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
+  /* ... */
+}
 ```
 
-Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a _separate_ feature (statically-typed `href`s), not the source of these helpers.
 
 ## Keep pages synchronous
 
 Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
 
 ```tsx
-import { Suspense } from 'react';
-import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+import { Suspense } from "react";
+import {
+  PostDetail,
+  PostDetailSkeleton,
+} from "@/features/post/components/post-detail";
 
-export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
   return (
     <div>
       <h1>Post</h1>
@@ -55,15 +60,18 @@ Use an implicit-return arrow function when the callback just renders JSX — e.g
 
 ```tsx
 // searchParams only
-export default function SearchPage({ searchParams }: PageProps<'/search'>) {
-  return searchParams.then(sp => {
-    const q = typeof sp.q === 'string' ? sp.q : '';
+export default function SearchPage({ searchParams }: PageProps<"/search">) {
+  return searchParams.then((sp) => {
+    const q = typeof sp.q === "string" ? sp.q : "";
     return q ? <SearchResults query={q} /> : <EmptyState />;
   });
 }
 
 // Both params and searchParams
-export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+export default function ProfilePage({
+  params,
+  searchParams,
+}: PageProps<"/u/[handle]">) {
   return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
     <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
   ));
@@ -159,7 +167,7 @@ export default function LoginPage() {
 
 async function LoginRedirect() {
   await connection();
-  await redirectIfAuthenticated('/dashboard');
+  await redirectIfAuthenticated("/dashboard");
   return <LoginForm />;
 }
 ```
@@ -187,7 +195,7 @@ Avoid components whose only job is to group boundary content, like `HomeLists` o
     </>
   }
 >
-  {searchParams.then(sp => (
+  {searchParams.then((sp) => (
     <>
       <Featured filter={sp.filter} />
       <Recent filter={sp.filter} />
@@ -231,7 +239,7 @@ Pair component-level boundaries with route-segment [`error.tsx`](https://preview
 Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
 
 ```tsx
-export default function RootLayout({ children }: LayoutProps<'/'>) {
+export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html>
       <body>

--- a/.agents/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.agents/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,6 +1,6 @@
 # Queries and actions
 
-> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables. The vendor procedure below is placement-only and must not be copied into `apps/*/features/`.
 
 The data layer. Every feature has both: queries to read, actions to write.
 

--- a/.agents/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.agents/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,5 +1,7 @@
 # Queries and actions
 
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+
 The data layer. Every feature has both: queries to read, actions to write.
 
 This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
@@ -15,7 +17,7 @@ Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` â
 Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
 
 ```ts
-import 'server-only';
+import "server-only";
 
 export async function getFeed(userId: string) {
   return db.post.findMany({ where: { userId } });
@@ -30,9 +32,13 @@ Take normalized primitives, not the params object:
 
 ```ts
 // features/book/book-queries.ts
-export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
-  'use cache';
-  cacheLife('hours');
+export async function getBooksPage(
+  page: number = 1,
+  search: string = "",
+  year: number = MAX_YEAR,
+) {
+  "use cache";
+  cacheLife("hours");
   // ...
 }
 ```
@@ -43,7 +49,7 @@ Normalize and clamp in the feature's own helper, **before** the call, not inside
 
 Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" â€” it adds indirection and can hide when data is intentionally dynamic.
 
-`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results _across_ requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
 
 ## Actions
 
@@ -56,13 +62,13 @@ Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the 
 5. Return a result (`{ ok }` or `{ error }`).
 
 ```tsx
-'use server';
+"use server";
 
-import { refresh } from 'next/cache';
+import { refresh } from "next/cache";
 
 export async function createPost(formData: FormData) {
   const user = await verifyUser();
-  const parsed = schema.safeParse({ body: formData.get('body') });
+  const parsed = schema.safeParse({ body: formData.get("body") });
   if (!parsed.success) {
     return { ok: false as const, error: parsed.error.issues[0].message };
   }
@@ -85,8 +91,8 @@ Client components import server actions directly. **Don't** pass an action as a 
 
 ```tsx
 // Right
-'use client';
-import { likePost } from '@/features/post/post-actions';
+"use client";
+import { likePost } from "@/features/post/post-actions";
 
 export function LikeButton({ postId }: { postId: string }) {
   return <button onClick={() => likePost(postId)}>Like</button>;
@@ -113,7 +119,9 @@ For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTran
 Return a discriminated union from actions that can fail:
 
 ```tsx
-export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+export type ActionResult<T = void> =
+  | { ok: true; data?: T }
+  | { ok: false; error: string };
 ```
 
 Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
@@ -126,7 +134,10 @@ If your DB rows have shapes you don't want to leak to components (extra columns,
 
 ```ts
 export async function getPost(id: string) {
-  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  const row = await db.post.findUnique({
+    where: { id },
+    include: { author: true },
+  });
   if (!row) notFound();
   return toPost(row);
 }

--- a/.agents/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.agents/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,0 +1,139 @@
+# Queries and actions
+
+The data layer. Every feature has both: queries to read, actions to write.
+
+This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
+
+## Cache identities
+
+When a server read also seeds a browser data cache, follow `references/single-page-applications.md` for the feature-local cache contract and client-library placement.
+
+## Queries
+
+Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` — that's the invariant. Default to plain async exports.
+
+Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
+
+```ts
+import 'server-only';
+
+export async function getFeed(userId: string) {
+  return db.post.findMany({ where: { userId } });
+}
+```
+
+## Cache keys are the arguments
+
+A `'use cache'` function's arguments are its cache key, so shape them deliberately.
+
+Take normalized primitives, not the params object:
+
+```ts
+// features/book/book-queries.ts
+export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
+  'use cache';
+  cacheLife('hours');
+  // ...
+}
+```
+
+Passing `searchParams` straight through keys the entry on an object carrying every param the route knows about, including the ones the caller left undefined, and the key then changes shape whenever the route gains a param.
+
+Normalize and clamp in the feature's own helper, **before** the call, not inside the cached function. `?yr=9999`, `?yr=2023`, and no `yr` at all describe the same result set, so they should resolve to the same arguments and share one entry. Clamping inside the cached function gives each spelling its own entry with identical contents.
+
+Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" — it adds indirection and can hide when data is intentionally dynamic.
+
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+
+## Actions
+
+Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the top. Always:
+
+1. Verify auth.
+2. Validate input with your schema validator.
+3. Run the mutation.
+4. Invalidate cached data so the next render sees the new state.
+5. Return a result (`{ ok }` or `{ error }`).
+
+```tsx
+'use server';
+
+import { refresh } from 'next/cache';
+
+export async function createPost(formData: FormData) {
+  const user = await verifyUser();
+  const parsed = schema.safeParse({ body: formData.get('body') });
+  if (!parsed.success) {
+    return { ok: false as const, error: parsed.error.issues[0].message };
+  }
+
+  await db.post.create({ data: { body: parsed.data.body, userId: user.id } });
+  refresh();
+  return { ok: true as const };
+}
+```
+
+[`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) re-renders the current route for the current user. Use it when the affected read is deliberately dynamic and has no tag. With Cache Components enabled, reusable reads should have matching `cacheTag()` calls, so server actions normally call `updateTag()` for read-your-own-writes. See `references/cache-components.md`.
+
+### Action file naming
+
+Actions for a feature always go in `<folder>-actions.ts`, matching the folder name — even when the mutation operates on a sub-concept. `toggleFavorite` in `features/event/` lives in `event-actions.ts`, not `favorite-actions.ts`. The folder is the source of truth for the name.
+
+## Calling actions from client components
+
+Client components import server actions directly. **Don't** pass an action as a prop just to call it:
+
+```tsx
+// Right
+'use client';
+import { likePost } from '@/features/post/post-actions';
+
+export function LikeButton({ postId }: { postId: string }) {
+  return <button onClick={() => likePost(postId)}>Like</button>;
+}
+```
+
+```tsx
+// Wrong — adds indirection with no benefit
+async function Post({ id }: { id: string }) {
+  return <LikeButton postId={id} onLike={likePost} />;
+}
+```
+
+Design components (`<BottomNav>`, `<ToggleGroup>`, `<SubmitButton>`) take this further with the **action-prop pattern** — `action` is a callback wrapped in `useTransition` / `useOptimistic` internally. See `references/ux-patterns.md`.
+
+## Form actions vs onClick handlers
+
+Prefer [`<form action={serverAction}>`](https://react.dev/reference/react-dom/components/form#action) for form mutations — React wraps the call in a transition and surfaces pending state automatically.
+
+For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTransition`](https://react.dev/reference/react/startTransition) if you need pending state.
+
+## Return shape
+
+Return a discriminated union from actions that can fail:
+
+```tsx
+export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+```
+
+Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
+
+A shared `ActionResult<T>` is optional — a per-action inline union is just as good, and often clearer when the payload has a natural name: `return { ok: true as const, playlist }` reads better than a generic `data`. What matters is that fallible actions return a discriminated union the client can narrow on, not that every action shares one type.
+
+## Mappers and domain types
+
+If your DB rows have shapes you don't want to leak to components (extra columns, ORM-specific types), write a mapper inside the query:
+
+```ts
+export async function getPost(id: string) {
+  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  if (!row) notFound();
+  return toPost(row);
+}
+
+function toPost(row: PostRow & { author: UserRow }): Post {
+  return { id: row.id, body: row.body, author: row.author.handle };
+}
+```
+
+Components see `Post`, not the ORM row. If that type is imported by multiple files in the feature, put it under `features/<domain>/types/` (for example `features/post/types/post.ts`). Promote it to top-level `types/` only when multiple features import it.

--- a/.agents/skills/nextjs-app-architecture/references/single-page-applications.md
+++ b/.agents/skills/nextjs-app-architecture/references/single-page-applications.md
@@ -1,0 +1,48 @@
+# Single-page application patterns
+
+Use this reference when a feature adds SWR, TanStack Query, or another browser data cache. For complete library APIs and runnable examples, follow the [Single-page applications guide](https://preview.nextjs.org/docs/app/guides/single-page-applications).
+
+## Decide whether a client cache is needed
+
+Use a client data library when the browser needs revalidation, optimistic mutations, request deduplication, or shared live data. If a Client Component only reads server data once, pass a Promise from its Server Component and unwrap it with `use()` instead.
+
+## Keep ownership with the feature
+
+```text
+features/<domain>/
+  <domain>-cache.ts          # Pure server tags + client keys
+  <domain>-queries.ts        # Server reads and cacheLife
+  <domain>-query-options.ts  # Client fetcher/query options
+  hooks/use-*.ts             # Client mutations and coordination
+  components/                # Async server owner + client leaves
+```
+
+The cache contract imports neither Next.js nor the client library. Queries, actions, route handlers, hydration code, query options, and hooks import identities from it. This prevents a key or tag spelling from drifting between a read and its invalidation.
+
+Keep behavior in the layer that owns it:
+
+- Server `cacheLife`, `cacheTag`, and database reads belong in `<domain>-queries.ts`.
+- Browser freshness and refetch behavior belong in `<domain>-query-options.ts` or the SWR hook.
+- Optimistic mutation behavior belongs in `hooks/use-*.ts`.
+- Tiny effect-only or interactive leaves belong in `components/`.
+
+## Seed from the server
+
+The async feature component owns the initial read and the library's hydration provider. The page remains a synchronous composition surface and owns the feature's Suspense boundary.
+
+- With SWR, seed the exact key read by `useSWR`. Use `preload` with `cacheData` when later `mutate(key)` calls must update the seeded entry itself.
+- With TanStack Query, seed the same query key read by the client query and render the client subtree inside `HydrationBoundary`.
+
+Do not move the initial read to the browser just because the feature also has a client cache.
+
+## Coordinate Cache Components
+
+The server cache and browser cache have independent freshness policies. Do not mirror `cacheLife` into `staleTime`, polling intervals, or SWR revalidation settings. Coordinate identities and invalidation, not durations.
+
+For tag-driven data, a mutation updates the client cache for immediate feedback and invalidates the same server tag used by the seeded read. For a time-driven server read, choose its `cacheLife` from the server data's freshness requirement.
+
+TanStack Query hydration adds one coupling: the hydration timestamp must advance whenever the seeded data advances. For tag-driven reads, cache the timestamp with the same tags as the data. For time-driven reads, derive the data and timestamp from the same cached snapshot. Do not cache a `QueryClient` or dehydrated payload.
+
+## Mutate without drift
+
+Let the client library own the optimistic browser update, rollback, and authoritative response. Let the write invalidate the server tag only after stored data changes. Do not add polling as a cache-coordination mechanism; add focus revalidation, intervals, SSE, or WebSockets only when the product actually needs external updates to appear automatically.

--- a/.agents/skills/nextjs-app-architecture/references/upstream.md
+++ b/.agents/skills/nextjs-app-architecture/references/upstream.md
@@ -1,0 +1,30 @@
+---
+source_name: aurorascharff/nextjs-app-architecture-skill (nextjs-app-architecture)
+source_url: https://github.com/aurorascharff/nextjs-app-architecture-skill
+source_type: github
+upstream_path: SKILL.md
+reviewed_commit: f2902b8538b25610da694394ecf88e69adf5f96a
+skills_lock_hash: 94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66
+license: MIT
+last_reviewed: 2026-08-28
+---
+
+# Upstream: nextjs-app-architecture
+
+Canonical copy in this repo: `docs/ai/skills/nextjs-app-architecture/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/aurorascharff/nextjs-app-architecture-skill
+- **Upstream path:** `SKILL.md` plus `references/{cache-components,components,example,feature-folders,pages-suspense,queries-actions,single-page-applications,ux-patterns}.md`
+- **License:** MIT; copyright Aurora Scharff (see the ecosystem `LICENSE` copied by the Skills CLI)
+- **Install via Skills CLI:** `npx skills add aurorascharff/nextjs-app-architecture-skill -y`
+
+The skill packages next-beats-style RSC composition for Next.js 16 App Router: synchronous pages, feature-owned async server components, colocated skeletons, and Cache Components practice. Inside Core it stays subordinate to installed Next.js docs, `docs/ai/rules/frontend.md`, and the data-access boundary.
+
+## Refresh from ecosystem
+
+1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
+2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
+3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+
+This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.agents/skills/nextjs-app-architecture/references/upstream.md
+++ b/.agents/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.agents/skills/nextjs-app-architecture/references/upstream.md
+++ b/.agents/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section, **Core remaps**, and in-place `CORE: skip file creation` annotations in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.agents/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/.agents/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -4,13 +4,13 @@ Interaction decisions on top of the architecture: which feedback mechanism to re
 
 ## Choose the feedback mechanism
 
-| Situation | Reach for | Key rule |
-| --------- | --------- | -------- |
-| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
-| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
-| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
-| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
-| One-shot result with no visible change | toast | See below. |
+| Situation                                          | Reach for                                                                           | Key rule                                                                                                                                                                                  |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic)                  | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters.                                |
+| No optimistic fit (filters, sort, navigation)      | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field")           | [`useActionState`](https://react.dev/reference/react/useActionState)                | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`.                                                                                                           |
+| Submit disable + spinner                           | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus)        | Call it from a child of `<form>`, not the form component itself.                                                                                                                          |
+| One-shot result with no visible change             | toast                                                                               | See below.                                                                                                                                                                                |
 
 ### Name the signal when a subtree has more than one pending source
 
@@ -29,10 +29,10 @@ For create/update/delete flows where the changed item is visible, prefer one fea
 
 ```tsx
 type OptimisticListAction<TItem> =
-  | { type: 'create'; item: TItem }
-  | { type: 'update'; item: TItem }
-  | { type: 'delete'; id: string }
-  | { type: 'rollback'; id: string };
+  | { type: "create"; item: TItem }
+  | { type: "update"; item: TItem }
+  | { type: "delete"; id: string }
+  | { type: "rollback"; id: string };
 
 const [items, dispatchOptimisticItem] = useOptimistic(
   initialItems,
@@ -61,7 +61,7 @@ Use a success page/state instead of a toast when the completed action changes th
 
 ## View transitions: portaled / floating UI
 
-Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a _named_ transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
 
 ## Destructive actions (delete / leave / unsubscribe)
 
@@ -72,14 +72,14 @@ Gate behind a confirmation dialog, and mind two edge cases:
 
 ## The action-prop pattern
 
-A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited _without_ a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
 
 ## URL-based pagination
 
 Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
 
 ```tsx
-import { Suspense } from 'react';
+import { Suspense } from "react";
 
 export function Feed({ page = 1 }: { page?: number }) {
   return (

--- a/.agents/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/.agents/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -1,0 +1,106 @@
+# UX patterns
+
+Interaction decisions on top of the architecture: which feedback mechanism to reach for, and the boundary edge-cases that trip agents up. Hook mechanics live in the React / Next docs — linked, not restated. The deeper end-to-end picture is the [Building interactive apps guide](https://preview.nextjs.org/docs/app/guides/interactive-apps).
+
+## Choose the feedback mechanism
+
+| Situation | Reach for | Key rule |
+| --------- | --------- | -------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
+| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
+| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
+| One-shot result with no visible change | toast | See below. |
+
+### Name the signal when a subtree has more than one pending source
+
+`data-pending` bubbles through CSS, so every descendant that sets it participates. `useLinkStatus` sets it on any pending link, which means `group-has-data-pending:` on a page wrapper also fires for ordinary navigation and dims content that is not being refetched. When a subtree can be pending for more than one reason, give the reason you are reacting to its own attribute (`data-filtering`, `data-saving`) and key the ancestor off that.
+
+### Two things to get right with `useOptimistic`
+
+- The value reverts as soon as its transition settles, so the work it predicts has to run **inside the same** `startTransition`. Setting the optimistic value in one transition and navigating in another snaps it back before the URL changes.
+- Derive the controls from the optimistic value and the surrounding chrome from the committed one. A slider thumb should follow the drag immediately, but a "Clear all filters" button keyed off that same optimistic value appears while the filter is still in flight.
+
+`useOptimistic(false)` also works as a transition-scoped **pending flag** that resets automatically when the transition settles — handy when you don't need the `data-pending` bubbling.
+
+## Optimistic mutations for interactive apps
+
+For create/update/delete flows where the changed item is visible, prefer one feature-owned optimistic reducer over hand-rolled pending state spread across the board, modal, and list.
+
+```tsx
+type OptimisticListAction<TItem> =
+  | { type: 'create'; item: TItem }
+  | { type: 'update'; item: TItem }
+  | { type: 'delete'; id: string }
+  | { type: 'rollback'; id: string };
+
+const [items, dispatchOptimisticItem] = useOptimistic(
+  initialItems,
+  optimisticListReducer,
+);
+```
+
+Use names that describe the app's domain (`dispatchOptimisticPost`, `messageReducer`, `groupReducer`, `eventReducer`) rather than implementation mechanics like `applyOptimisticAction`. The reducer owns the optimistic list shape; components dispatch intent.
+
+For modal creates, apply the optimistic item and close the modal immediately when the local form is valid. If the action fails, roll back and show an error toast. Keeping the modal open with a slow primary button makes the optimistic result feel broken.
+
+For deletes, remove optimistically, then roll back on failure. Do not wait for the server before the item disappears when the user's intent is clear.
+
+## Forms and validation
+
+Do local validation before submitting when the missing field is already available on the client. Show inline field errors without changing the modal or card's overall geometry. Reserve `useActionState` for server-validated errors or field errors that require the action result.
+
+Use a success page/state instead of a toast when the completed action changes the user's task. For example, after a reservation, checkout, or invite request succeeds, replace the form with a confirmation and a secondary "start another" action; a success toast is redundant.
+
+## Toasts
+
+- **Toast only on error** when an optimistic UI already shows the result — a success toast next to an optimistic checkmark/removal is double feedback, which is noise.
+- **Toast on success** only for non-visible side effects (email sent, link copied, file uploaded).
+- **Don't toast for routine navigation** — the page change is the feedback.
+- **Don't toast inside a server action.** Toasts are client-side; return a result and toast at the call site.
+
+## View transitions: portaled / floating UI
+
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+
+## Destructive actions (delete / leave / unsubscribe)
+
+Gate behind a confirmation dialog, and mind two edge cases:
+
+- **Don't `redirect()` inside the action.** It throws, which stops the client from toasting or closing the dialog. Return `{ ok: true }` and navigate with `router.push()`.
+- **Don't wrap the whole action call in `useTransition`** inside the dialog — with view transitions on, that animates the background UI behind the dialog. Track pending with `useState` / `useOptimistic(false)` and reserve `startTransition` for the post-success navigation only.
+
+## The action-prop pattern
+
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+
+## URL-based pagination
+
+Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
+
+```tsx
+import { Suspense } from 'react';
+
+export function Feed({ page = 1 }: { page?: number }) {
+  return (
+    <ul>
+      {Array.from({ length: page }).map((_, i) => {
+        const p = i + 1;
+        return p === 1 ? (
+          <FeedPage key={p} page={p} />
+        ) : (
+          <Suspense key={p} fallback={<FeedPageSkeleton />}>
+            <FeedPage page={p} />
+          </Suspense>
+        );
+      })}
+    </ul>
+  );
+}
+```
+
+The first page can render in the parent boundary; later pages get their own fallbacks so "load more" streams only the newly requested page. If the URL update should preserve scroll, use [`<Link scroll={false}>`](https://preview.nextjs.org/docs/app/api-reference/components/link).
+
+## Global client state
+
+For truly global client state (audio player, cart, system-reactive theme), wrap a [context provider](https://react.dev/reference/react/createContext) at the root; the provider is `'use client'` but `children` stays server-rendered, and only leaf components read the context. **Don't push server data into it** — server data stays in queries; client state is for ephemeral UI (open menus, playback position, optimistic drafts). See the live-data decision in `references/components.md`.

--- a/.claude/skills/.repo-canonical-skills.json
+++ b/.claude/skills/.repo-canonical-skills.json
@@ -58,6 +58,7 @@
     "moai-library-shadcn",
     "motion",
     "new-branch-and-pr",
+    "nextjs-app-architecture",
     "nextjs-app-router",
     "nextjs-supabase-auth",
     "npm-deps-cleanup",
@@ -468,6 +469,18 @@
     "new-branch-and-pr": [
       "SKILL.md",
       "references/upstream.md"
+    ],
+    "nextjs-app-architecture": [
+      "SKILL.md",
+      "references/cache-components.md",
+      "references/components.md",
+      "references/example.md",
+      "references/feature-folders.md",
+      "references/pages-suspense.md",
+      "references/queries-actions.md",
+      "references/single-page-applications.md",
+      "references/upstream.md",
+      "references/ux-patterns.md"
     ],
     "nextjs-app-router": [
       "SKILL.md"

--- a/.claude/skills/find-skills/SKILL.md
+++ b/.claude/skills/find-skills/SKILL.md
@@ -80,6 +80,19 @@ workflows, and use `docs/ai/skills/inngest-setup/SKILL.md` only when explicitly
 adding product runtime Inngest. Refresh with `bun run skills:refresh-inngest`,
 then `bun run skills:sync` and `bun run skills:verify`.
 
+**Example — Next.js app architecture:** page composition, feature-folder UI
+layout, colocated Suspense skeletons, and leaf-client UX are covered by
+`docs/ai/skills/nextjs-app-architecture/SKILL.md`. Install or refresh from
+[`aurorascharff/nextjs-app-architecture-skill`](https://github.com/aurorascharff/nextjs-app-architecture-skill)
+with `npx skills add aurorascharff/nextjs-app-architecture-skill -y`, then
+restore the local overlay from `docs/ai/skills/nextjs-app-architecture/SKILL.md`
+and `docs/ai/skills/nextjs-app-architecture/references/upstream.md`, then
+`bun run skills:sync` and `bun run skills:verify`. Keep it subordinate to
+`docs/ai/rules/frontend.md`, `docs/ai/skills/nextjs-app-router/SKILL.md`,
+`docs/ai/skills/cache-components/SKILL.md`, and
+`docs/guides/architecture/data-access-boundary.md`. Do not move business
+queries or privileged mutations into app feature folders.
+
 ## How to Help Users Find Skills
 
 ### Step 1: Understand What They Need

--- a/.claude/skills/nextjs-app-architecture/LICENSE
+++ b/.claude/skills/nextjs-app-architecture/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aurora Scharff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/nextjs-app-architecture/README.md
+++ b/.claude/skills/nextjs-app-architecture/README.md
@@ -1,0 +1,65 @@
+# Next.js App Architecture Skill
+
+An agent skill for building or auditing Next.js 16+ App Router apps. It packages the patterns from [Component Architecture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/) and the [next-beats](https://github.com/vercel-labs/next-beats) reference app into a form AI coding agents can load and apply.
+
+## Install
+
+```bash
+npx skills add aurorascharff/nextjs-app-architecture-skill
+```
+
+## The six principles
+
+- **Pages are synchronous compositors.** They don't fetch, they compose.
+- **Async components fetch their own data.** Co-locate the read with the JSX.
+- **Route props stop at the page.** Components receive IDs, slugs, parsed filters, or records — not raw `params` / `searchParams`.
+- **Skeletons live next to their component.** Same file, exported alongside it.
+- **Suspense boundaries go at the page level.** The page designs the loading sequence.
+- **Client boundaries are leaf nodes.** Push `'use client'` as deep as it can go.
+
+## Prerequisite
+
+Before using the skill on a project, follow the [Next.js AI Coding Agents guide](https://preview.nextjs.org/docs/app/guides/ai-agents) so the agent reads version-matched Next.js docs from `AGENTS.md` / bundled docs instead of stale training data.
+
+## What it covers
+
+- **Feature folders** — domain ownership, cross-domain product experiences, merging sub-concepts into a parent, and file naming.
+- **Queries** — `import 'server-only'`, plain async reads by default, selective React `cache()` only for proven same-request dedup, and `'use cache'` + `cacheTag` + `cacheLife` for Cache Components.
+- **Actions** — `'use server'`, input validation, tag invalidation under Cache Components, calling from client components.
+- **Components** — async server components that receive IDs/parsed values, sibling skeletons, single-use helpers, the client boundary, the `use()` + promise-prop pattern, live data via polling.
+- **Pages** — sync page composition, `params.then()` for static-shell preservation, Suspense boundary placement, CLS prevention, error boundaries, audit smells.
+- **Cache Components** — when to opt in, the static-shell model, `'use cache'` variants, build constraints.
+- **UX patterns** — `useOptimistic`, toasts, pending state, destructive-action flows, the action-prop pattern, URL pagination.
+
+## References
+
+The `SKILL.md` overview is always loaded; references split into two zones so the agent pulls only what the task needs.
+
+**Core** (any RSC app):
+
+- [`references/feature-folders.md`](references/feature-folders.md) — folder layout, naming, merging sub-concepts, action/query file naming.
+- [`references/queries-actions.md`](references/queries-actions.md) — server-only queries, selective same-request dedup, server actions, validation, and cache/tag invalidation.
+- [`references/components.md`](references/components.md) — async server components, skeletons without alias wrappers, client boundary, promise + `use()`, single-use helpers, polling.
+- [`references/pages-suspense.md`](references/pages-suspense.md) — page composition, `PageProps` / `LayoutProps`, `params.then()`, Suspense placement, CLS prevention, error boundaries.
+- [`references/example.md`](references/example.md) — next-beats invariant map and supporting patterns.
+
+**Instant Apps** (opt-in, load only when optimizing for instant-feeling apps):
+
+- [`references/cache-components.md`](references/cache-components.md) — `cacheComponents: true`, the static shell, which reads to cache, `'use cache'` variants, `cacheTag` / `cacheLife`, `updateTag` / `revalidateTag`, and `io()` vs `connection()`.
+- [`references/single-page-applications.md`](references/single-page-applications.md) — SPA-style client caching and navigation patterns.
+- [`references/ux-patterns.md`](references/ux-patterns.md) — `useOptimistic`, toasts, pending state via `data-pending`, destructive flows, the action-prop pattern, URL pagination, `useFormStatus`.
+
+## Background reading
+
+- [Component Architeture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/)
+- [Server and Client Component Composition in Practice](https://aurorascharff.no/posts/server-client-component-composition-in-practice/)
+- [Building Design Components with Action Props using Async React](https://aurorascharff.no/posts/building-design-components-with-action-props-using-async-react/)
+- [Error Handling in Next.js with catchError](https://aurorascharff.no/posts/error-handling-in-nextjs-with-catch-error/)
+- [Avoiding Server Component Waterfall Fetching with React 19 cache()](https://aurorascharff.no/posts/avoiding-server-component-waterfall-fetching-with-react-19-cache/)
+- [next16-social-media](https://github.com/aurorascharff/next16-social-media) — demo app applying these patterns.
+
+**Companion skill:** [React View Transitions](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+
+## License
+
+MIT

--- a/.claude/skills/nextjs-app-architecture/SKILL.md
+++ b/.claude/skills/nextjs-app-architecture/SKILL.md
@@ -21,6 +21,12 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
 - Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+- Do not regenerate or expand the managed root `AGENTS.md`.
+
+**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+
+- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
 

--- a/.claude/skills/nextjs-app-architecture/SKILL.md
+++ b/.claude/skills/nextjs-app-architecture/SKILL.md
@@ -23,9 +23,9 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
 - Do not regenerate or expand the managed root `AGENTS.md`.
 
-**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+**Core remaps** — apply these at every numbered step. Upstream file-placement lines are vendor text, not permission to add a query layer.
 
-- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Feature-owned means UI composition only.** The feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` at all.
 - **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
@@ -34,7 +34,7 @@ Refresh: `references/upstream.md`.
 
 A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
 
-**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+**Follow the workflow below step by step** — apply the **Core remaps** at each step. Upstream `*-queries.ts` / `*-actions.ts` lines are vendor text: **CORE: skip file creation.** Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
 
 ## Prerequisite
 
@@ -46,7 +46,7 @@ Build pages that describe the loading experience, not pages that act like route 
 
 - `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
 - Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
-- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly. **(CORE: skip file creation. Import `@asym/api` or `@asym/database/hooks` from the feature component.)**
 - When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
 - Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
 
@@ -60,8 +60,8 @@ The non-negotiables. The workflow produces them; the final check verifies them.
 4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
 5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
 6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
-7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
-8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts. **(CORE: skip file creation. Call `@asym/api` from the feature component; do not add those files under `apps/*/features/`.)**
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions. **(CORE: "keeps its queries and actions" means `packages/api`, not a feature-local query file.)**
 9. **Client components import actions directly** — never receive a server action as a prop just to call it.
 10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
 11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
@@ -78,13 +78,13 @@ Run these in order for build-from-scratch, feature work, or audits. Each step na
 2. **Place the work.** Decide the feature folder before writing anything.
    → `references/feature-folders.md` (decision tree + merge rules).
    ✓ A real domain, a cross-domain product experience, or folded into the right parent.
-3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`. **(CORE: skip file creation. Import the existing `@asym/api` read, or `@asym/database/hooks` for an approved browser table.)**
    → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
    ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
-4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top. **(CORE: skip file creation. Import the existing `@asym/api` mutation.)**
    → `references/queries-actions.md`.
    ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
-5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves. **(CORE: "its own query" is an `@asym/api` or `@asym/database` call, not a new `*-queries.ts`.)**
    → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
    ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
 6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
@@ -105,10 +105,10 @@ Inspect the diff against every invariant — each is checkable by reading the ch
 - [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
 - [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
 - [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
-- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`. **(CORE: skip file creation. A new `*-queries.ts` / `*-actions.ts` under `apps/*/features/` means the change is wrong.)**
 - [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
 - [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
-- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions. **(CORE: skip file creation.)**
 - [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
 - [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
 - [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.

--- a/.claude/skills/nextjs-app-architecture/SKILL.md
+++ b/.claude/skills/nextjs-app-architecture/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: nextjs-app-architecture
+description: Build or audit Next.js 16 App Router apps using a next-beats-style React Server Components architecture. Use when scaffolding a new app, adding a feature, reviewing an existing app, refactoring route-loader-shaped pages into feature-owned async server components, deciding where queries/actions/components live, keeping pages synchronous with `params.then()`, placing Suspense boundaries, choosing the client/server boundary, designing skeletons, preventing CLS, or enabling Cache Components. Also use when the user asks about RSC composition, components receiving IDs instead of route params, `'use cache'`, `cacheTag`, `updateTag`, static-shell prerendering, or making an app easier for AI agents to modify.
+license: MIT
+metadata:
+  author: aurorascharff
+  version: "1.3.9"
+---
+
+## This repository (Asymmetric-al/core)
+
+Subordinate to installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`), **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/nextjs-app-router/SKILL.md`**, **`docs/ai/skills/cache-components/SKILL.md`**, and **`docs/guides/architecture/data-access-boundary.md`**.
+
+This skill is for page composition, Suspense placement, leaf client boundaries, and feature-owned UI. It is not a license to invent a new app folder scheme or move business database logic.
+
+**Repo mapping:**
+
+- Privileged reads, writes, payments, webhooks, and vendor calls stay in `packages/api`.
+- Browser-visible table data uses `@asym/database/hooks` when a collection exists.
+- Shared UI stays in `@asym/ui` / exact `base-maia`. Existing `apps/*/features/` directories are UI composition, not a new query layer.
+- All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
+- Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
+- Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+
+Refresh: `references/upstream.md`.
+
+# Next.js App Architecture
+
+A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
+
+**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+
+## Prerequisite
+
+Before changing a Next.js app, make sure the project is set up for AI agents to read version-matched docs. Follow the [AI Coding Agents guide](https://preview.nextjs.org/docs/app/guides/ai-agents): prefer the project's `AGENTS.md` / bundled docs, and create or refresh them when missing. Then use this skill for architecture decisions.
+
+## Architecture target
+
+Build pages that describe the loading experience, not pages that act like route loaders:
+
+- `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
+- Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
+- Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
+
+## Invariants (what every change must satisfy)
+
+The non-negotiables. The workflow produces them; the final check verifies them.
+
+1. **Pages compose, they never fetch.** A page/layout imports feature components and places `<Suspense>`. No queries or domain logic inline. Tiny route-local control-flow helpers are allowed only when they exist to place a boundary around `connection()`, `redirect()`, or a resolved route prop.
+2. **Pages stay synchronous.** Use `params.then()` / `searchParams.then()` or `Promise.all([params, searchParams]).then(...)`, never `await params` at the top — so chrome paints into the static shell and only data-dependent sections suspend.
+3. **Feature components receive IDs, not route props.** Resolve `params` / `searchParams` at the page boundary and pass plain values (`id`, `slug`, `query`) into features.
+4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
+5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
+6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+9. **Client components import actions directly** — never receive a server action as a prop just to call it.
+10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
+11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
+
+## Workflow
+
+Run these in order for build-from-scratch, feature work, or audits. Each step names the reference to consult and the check it must pass.
+
+1. **Choose mode.**
+   - **Build from scratch:** sketch routes, real domain nouns, static shell, and expected loading groups before writing code.
+   - **Audit/refactor:** scan current `app/` pages first; list every async page, page-level query import, route prop leak, missing Suspense boundary, and feature folder mismatch.
+     → `references/example.md` for the target shape; `references/feature-folders.md` for placement.
+     ✓ You know whether you are creating the architecture or converting loader-shaped code into it.
+2. **Place the work.** Decide the feature folder before writing anything.
+   → `references/feature-folders.md` (decision tree + merge rules).
+   ✓ A real domain, a cross-domain product experience, or folded into the right parent.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+   → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
+   ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+   → `references/queries-actions.md`.
+   ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+   → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
+   ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
+6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
+   → `references/pages-suspense.md`.
+   ✓ Route props become plain values; stable cards/sections wrap Suspense when they set layout; boundaries stay visible at the page.
+7. **Add interaction** (if any): optimistic updates, pending state, toasts, confirmation.
+   → `references/ux-patterns.md`.
+   ✓ Feedback isn't doubled; optimistic reducers/actions live with the feature; URL/search params own shareable state; client effects synchronize external systems, not derived React state.
+8. **Verify** against the checklist below before declaring done.
+
+## Verify before done
+
+Inspect the diff against every invariant — each is checkable by reading the changed files:
+
+- [ ] No page/layout imports a `*-queries` file or defines reusable domain UI inline; any inline helper is route-local control flow only.
+- [ ] Every page with params is synchronous and uses `params.then()` / `searchParams.then()` / `Promise.all([params, searchParams]).then(...)`.
+- [ ] Feature components receive plain IDs/handles/parsed filters or resolved records; no feature prop is named `params` or `searchParams`.
+- [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
+- [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
+- [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
+- [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
+- [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
+- [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.
+- [ ] Client leaves use `useOptimistic`, transitions, reducers, URL state, or form actions for interaction; they do not call `setState` in effects for derived React state.
+- [ ] Mutations validate their input and invalidate the affected data.
+
+## Reference index
+
+- **`references/feature-folders.md`** — where code goes: folder layout, cache contracts, naming, and merging sub-concepts.
+- **`references/queries-actions.md`** — query/action rules: server-only, dedup, validation, invalidation, return shape.
+- **`references/components.md`** — server/client boundary, skeletons, `use()`, single-use helpers, live data.
+- **`references/pages-suspense.md`** — page composition, `params.then()`, Suspense placement, CLS, error boundaries, prefetch.
+- **`references/cache-components.md`** — the `cacheComponents` decisions: which reads to cache, which directive to use, how to invalidate.
+- **`references/single-page-applications.md`** — client cache decisions: placement, server seeding, Cache Components coordination, hydration, and mutations.
+- **`references/ux-patterns.md`** — interaction decisions: optimistic vs pending vs inline error, toasts, action-prop, confirmations.
+- **`references/example.md`** — the next-beats reference app: invariant → file map, for seeing any rule in real code.

--- a/.claude/skills/nextjs-app-architecture/references/cache-components.md
+++ b/.claude/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,0 +1,80 @@
+# Cache Components
+
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+
+## When this reference applies
+
+Use this reference when an app already has `cacheComponents: true`, the user wants this architecture while enabling it, or you are reviewing/refactoring an app that targets Cache Components.
+
+If the project has not adopted Cache Components yet and the user asks to enable, migrate, or work through adoption blockers, use the `next-cache-components-adoption` skill first. It owns the route-by-route migration loop, opt-out strategy, and build/dev overlay workflow. Then return here for steady-state query/action/component architecture.
+
+If `cacheComponents` is not enabled and the task is ordinary feature work, follow the core references without adding cache directives. Do not recommend skipping Cache Components based on app category alone; adoption is a migration/project decision, not a per-feature shortcut.
+
+Adopting these in an existing app: follow [Migrating to Cache Components](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components) and [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) — they cover the incremental path (per-route `prefetch = 'partial'`, fixing dynamic-usage build errors) rather than a big-bang switch.
+
+## The model
+
+```ts
+// next.config.ts
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true, // prefetch the static shell of linked routes
+};
+```
+
+- **Static shell** — synchronous content, `'use cache'` output, and Suspense fallbacks prerender at build time.
+- **Dynamic holes** — async work without `'use cache'` streams in behind `<Suspense>` at request time.
+- **Build constraint** — any async work without `'use cache'` must sit inside `<Suspense>`, or the build fails (wrap it, or add `'use cache'`).
+
+`cacheComponents` implies Partial Prerendering — it replaced `experimental.ppr` / `dynamicIO` / `useCache`, so don't set those. See [caching](https://preview.nextjs.org/docs/app/getting-started/caching).
+
+With `cacheComponents: true`, the skill practice is **cache reusable reads**. Do not leave a database/API read dynamic just because Suspense makes the build pass. If a read has a stable key and a mutation can name what changed, give it a cache directive, tags, and a lifetime.
+
+Dynamic reads are the exception: use them for values that must be recomputed for every request or cannot be invalidated coherently. When you leave a read dynamic, note the reason in the surrounding code/review and invalidate its mutations with `refresh()` because there is no tag to update.
+
+## Decide what to cache
+
+| Data | Directive | Notes |
+| ---- | --------- | ----- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
+| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+
+Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
+
+## Keep a synchronous value out of the shell
+
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+
+Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
+
+## Decide how to invalidate
+
+- [`updateTag(tag)`](https://preview.nextjs.org/docs/app/api-reference/functions/updateTag) — in **server actions**, when the user should see the result immediately (read-your-own-writes). Requires the query to carry a matching `cacheTag`.
+- [`revalidateTag(tag, 'max')`](https://preview.nextjs.org/docs/app/api-reference/functions/revalidateTag) — in **route handlers** (webhooks, cron) for stale-while-revalidate. The single-arg `revalidateTag(tag)` form is deprecated.
+- [`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) — re-render the current route for the current user. Use it for deliberately dynamic reads with no tag; don't use it instead of `updateTag()` for cached reads.
+
+Tag, cache, invalidate: the `cacheTag` in the query and the `updateTag` in the action use the same string and live in the same feature folder.
+
+## Coordinate hydrated client data
+
+When cached server data seeds SWR, TanStack Query, or another browser cache, follow `references/single-page-applications.md`. Server and client freshness policies are independent; hydration adds library-specific constraints.
+
+## Build failure map
+
+When `next build` fails under Cache Components, map the error back to an architecture rule instead of patching locally:
+
+- Async work without `'use cache'` and without an ancestor `<Suspense>` → cache the reusable read, or wrap a justified dynamic read in a page-owned `<Suspense>`.
+- Request data inside `'use cache'` → switch to `'use cache: private'` when it is per-user cacheable, or keep it dynamic with a documented reason.
+- `await params` / `await searchParams` at the top of a page → keep the page synchronous and move the read into `params.then()` / `searchParams.then()`.
+- Sync request-time values (`new Date()`, `Math.random()`, sync storage reads) captured in the shell → cache stable values, or use [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) for per-request values.
+
+For adoption-wide blocker triage, use `next-cache-components-adoption`. For API-specific recipes, follow the [Migrating to Cache Components guide](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components).
+
+## Without Cache Components
+
+- Don't use `'use cache'` / `cacheTag` / `cacheLife` — they require the flag.
+- Use React `cache()` only for proven same-request dedup needs; plain `server-only` async queries are the default.
+- Invalidate with `refresh()` from server actions.
+- Pages still use `params.then()` in this architecture. Without Cache Components there is no build-time static shell to preserve, but keeping pages synchronous still lets chrome paint before route-specific data resolves and keeps the app consistent.

--- a/.claude/skills/nextjs-app-architecture/references/cache-components.md
+++ b/.claude/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,6 +1,6 @@
 # Cache Components
 
-Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about _which reads to cache, which directive to use, and how to invalidate_ — for the mechanics of each directive, follow the doc links.
 
 ## When this reference applies
 
@@ -34,18 +34,18 @@ Dynamic reads are the exception: use them for values that must be recomputed for
 
 ## Decide what to cache
 
-| Data | Directive | Notes |
-| ---- | --------- | ----- |
-| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
-| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
-| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
-| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+| Data                                                     | Directive                                                                                                | Notes                                                                                                                                                                                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache)                  | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session               | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server.                                                                                                                                          |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote)   | Protects against rate-limited third-party APIs.                                                                                                                                                                                  |
+| Genuinely dynamic per request                            | none                                                                                                     | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists.                                                                                                                                    |
 
 Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
 
 ## Keep a synchronous value out of the shell
 
-You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a _synchronous_ request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
 
 Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
 

--- a/.claude/skills/nextjs-app-architecture/references/components.md
+++ b/.claude/skills/nextjs-app-architecture/references/components.md
@@ -1,0 +1,243 @@
+# Components
+
+How to build server and client components inside a feature folder.
+
+## Default: async server component
+
+Server components await their own queries directly — no `useEffect`, no client-side fetching, no manual loading state. See the [Server Components docs](https://preview.nextjs.org/docs/app/getting-started/server-and-client-components) for the model.
+
+Prefer minimal, stable props: IDs, slugs, handles, parsed filters, or records the parent already fetched. Do not pass raw route `params` or `searchParams` into feature components. Pages resolve those promises and pass plain values.
+
+```tsx
+// features/notifications/components/notifications-badge.tsx
+import { getUnreadNotificationCount } from "@/features/notifications/notifications-queries";
+
+export async function NotificationsBadge() {
+  const count = await getUnreadNotificationCount();
+  if (count === 0) return null;
+  return <span aria-label={`${count} unread`}>{count}</span>;
+}
+```
+
+The page (not this file) wraps it in `<Suspense fallback={<NotificationsBadgeSkeleton />}>` — see `references/pages-suspense.md`.
+
+For parameterized routes, the page resolves `params` and the feature receives an ID:
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <PostDetail id={id} />
+  ))}
+</Suspense>
+```
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Skeletons live in the same file
+
+Export the main component and its skeleton from the same file. Pages import both. Define the skeleton **at the end of the file**, below the real component(s) — never above. Function declarations are hoisted, so a skeleton referenced by a component earlier in the file still works when defined last.
+
+```tsx
+export async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return (
+    <ul>
+      {posts.map((p) => (
+        <Post key={p.id} post={p} />
+      ))}
+    </ul>
+  );
+}
+
+export function FeedSkeleton() {
+  return (
+    <ul>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <li key={i}>
+          <Skeleton className="h-24" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Don't export a second skeleton whose whole job is to rename or preconfigure another skeleton:
+
+```tsx
+// Wrong — alias wrapper adds an import surface but no behavior
+export function CompactGridSkeleton() {
+  return <GridSkeleton dense />;
+}
+```
+
+Import the real skeleton and pass the prop inline at the `<Suspense>` boundary: `fallback={<GridSkeleton dense />}`.
+
+### Skeleton design checklist
+
+1. Match the real component's layout: flex direction, gaps, padding, breakpoints.
+2. Include all structural elements: avatar circles, action button placeholders, image squares.
+3. Responsive visibility must match (`hidden sm:block` in the real component → same in the skeleton).
+4. Show 2–5 placeholders for variable-length lists, not the real count.
+5. Don't include skeletons for inner Suspense content — those have their own boundaries.
+6. Reserve the right height. CLS comes from skeletons that are shorter than the real content.
+7. Dense placeholders should not animate. A grid of 28 shimmering covers reads as flicker rather than progress, so use a flat low-contrast fill when there are many items and keep the animated sweep for a handful of bars.
+
+## Group related components in one file
+
+A card and its grid live in the same file. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`. Variants should reuse that skeleton inline instead of exporting alias skeletons. Don't split shared UI primitives prematurely — wait until three call sites need the same shape before extracting.
+
+Two sidebar widgets that happen to look similar but render different data shapes are **not** the same component. The visuals diverge as soon as one needs an extra slot.
+
+### Single-use sub-components stay inlined
+
+For a metadata strip inside one card, a header used only by one detail view, a list item only rendered by its list — inline them as **non-exported** functions in the same file:
+
+```tsx
+export async function EventDetails({ slug }: { slug: string }) {
+  const event = await getEventBySlug(slug);
+  return (
+    <article>
+      <MetaStrip event={event} />
+      <Speaker speaker={event.speaker} />
+      <p>{event.description}</p>
+    </article>
+  );
+}
+
+function MetaStrip({ event }: { event: Event }) { ... }
+function Speaker({ speaker }: { speaker: string }) { ... }
+```
+
+Exports are for things other files will import. Internal structure is for readability inside one file.
+
+## The server/client boundary
+
+`'use client'` only when you need:
+
+- Hooks (`useState`, `useReducer`, `useOptimistic`, `useTransition`, `useEffect`)
+- Event handlers (`onClick`, `onChange`, `onSubmit`)
+- Browser APIs (`window`, `localStorage`, refs to DOM)
+
+If the component needs interactive pieces, keep the server component as the parent and render client leaves:
+
+```tsx
+async function PostDetail({ id }: { id: string }) {
+  const [post, userState] = await Promise.all([
+    getPost(id),
+    getPostUserState(id),
+  ]);
+  return (
+    <article>
+      <PostBody body={post.body} />
+      <PostActions userState={userState} /> {/* 'use client' leaf */}
+    </article>
+  );
+}
+```
+
+### Server content as children of client components
+
+Composition crosses the boundary. A client component can accept server-rendered JSX as children or props:
+
+```tsx
+<ComposerForm
+  avatar={
+    <Suspense fallback={<AvatarSkeleton />}>
+      <CurrentUserAvatar />
+    </Suspense>
+  }
+/>
+```
+
+`ComposerForm` is `'use client'`. It doesn't know where the avatar JSX came from. The Suspense boundary streams the avatar in without the form re-rendering.
+
+### Pass server children resolved values, not promises
+
+Prefer passing plain values (strings, IDs, resolved data) to a server child. A server component _can_ `await` a promise prop, but resolve route promises in the page instead — pass an unresolved promise down only to a _client_ component that reads it with `use()` (see below). When a parent already has the data from its own query, pass it as a prop instead of having the child refetch.
+
+```tsx
+// Right — parent fetches the list, passes each item
+async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return posts.map((post) => <Post key={post.id} post={post} />);
+}
+
+async function Post({ post }: { post: Post }) {
+  return <article>{post.body}</article>;
+}
+```
+
+```tsx
+// Wrong — child refetches what the parent already had
+async function Post({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Client components that own their loading state
+
+When a client component needs server data but should manage its own loading (a sidebar badge, a popover that opens on hover), pass an **unresolved promise** from the server and resolve it with [`use()`](https://react.dev/reference/react/use) on the client. Wrap the consumer in `<Suspense>`.
+
+```tsx
+// page: pass the unresolved promise, wrap in Suspense
+<Suspense fallback={<TagListSkeleton />}>
+  <TagPicker itemsPromise={getTags()} />
+</Suspense>
+```
+
+```tsx
+"use client";
+import { use } from "react";
+
+export function TagPicker({ itemsPromise }: { itemsPromise: Promise<Tag[]> }) {
+  const items = use(itemsPromise);
+  // render interactive UI from items
+}
+```
+
+The opinionated bit: name promise props with a `Promise` suffix (`itemsPromise`, `userPromise`) so the contract is obvious at the call site.
+
+### Client data libraries (SWR, TanStack Query)
+
+Follow `references/single-page-applications.md` when a feature uses a browser data cache or needs externally authored updates. It covers when to use a library, where its files live, server seeding, Cache Components coordination, hydration, and mutations.
+
+## Interactive async React shape
+
+Keep the server/client split even when the UI is highly interactive:
+
+- The server component reads durable data and renders the initial tree.
+- The client leaf owns only ephemeral interaction: open state, focused field, pending flag, optimistic draft, selected tab that is not shareable.
+- Shareable or bookmarkable state lives in the URL/search params, not mirrored in component state.
+- Client leaves import server actions directly and call them from form actions or event handlers.
+- Mutation feedback (`useOptimistic`, pending flags, rollback, toasts) follows `references/ux-patterns.md`.
+
+Avoid effects whose only job is to copy React state to React state:
+
+```tsx
+// Wrong — derived React state cascades through an effect
+useEffect(() => {
+  setSelectedItem(null);
+}, [filterKey]);
+```
+
+Prefer one of these shapes:
+
+- Key the interactive child by the value that resets it: `<SelectableList key={filterKey} filterKey={filterKey} />`.
+- Derive the value during render.
+- Put the value in the URL/search params if navigation should own it.
+- Use a reducer where the same event that changes `filterKey` also clears `selectedItem`.
+
+Effects are for external systems: DOM APIs, subscriptions, timers, browser storage, analytics, or imperative libraries. They are not a cleanup lane for state that React could derive or reset structurally.
+
+## Mutations
+
+For client-side reactions to a server mutation (instant feedback, pending state, success/error toasts), see `references/ux-patterns.md`. To cache rendered output across requests, see `references/cache-components.md`.

--- a/.claude/skills/nextjs-app-architecture/references/example.md
+++ b/.claude/skills/nextjs-app-architecture/references/example.md
@@ -6,29 +6,29 @@ For the reasoning behind this architecture, read [Component Architecture for Rea
 
 ## Invariant → where to see it
 
-| Invariant | File(s) |
-| --------- | ------- |
-| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
-| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
-| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
-| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
-| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
-| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
-| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
-| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
-| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+| Invariant                                                                         | File(s)                                                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Pages compose, never fetch                                                     | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries.                                                                                                   |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`)                   | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`.                                                                                                                              |
+| 3. Feature components receive IDs, not route props                                | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components.                                                                                                          |
+| 4. Async server component default; `'use client'` on leaves                       | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`.                                                                     |
+| 5. Page owns Suspense; feature owns skeleton                                      | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below).                                                                                                                      |
+| 6. Skeleton in the same file, at the end                                          | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`.                                                                                                      |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`.                                                                                                                                                    |
+| 8. Feature folders follow product ownership                                       | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly                                      | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly.                                                                                                                                          |
 
 ## Supporting patterns
 
-| Pattern | File |
-| ------- | ---- |
-| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
-| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
-| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
-| `useFormStatus` submit button | `components/ui/button.tsx` |
-| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
-| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
-| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
-| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+| Pattern                                                | File                                                                                         |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`)   | `components/ui/error-boundary.tsx`                                                           |
+| `useOptimistic` for an unlikely-to-fail toggle         | `features/track/components/track-interactions.tsx`                                           |
+| Action-prop / `*Action` convention + confirm dialog    | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button                          | `components/ui/button.tsx`                                                                   |
+| `useActionState` inline field errors                   | `features/user/components/sign-in-form.tsx`                                                  |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx`                           |
+| `use()` on an unresolved promise prop                  | `features/playlist/components/add-to-playlist-menu.tsx`                                      |
+| Purpose-named `components/scripts/` subfolder          | `components/scripts/`                                                                        |
 
 > The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/.claude/skills/nextjs-app-architecture/references/example.md
+++ b/.claude/skills/nextjs-app-architecture/references/example.md
@@ -1,0 +1,34 @@
+# Reference app: next-beats
+
+A working app that follows this architecture: **<https://github.com/vercel-labs/next-beats>** (Next.js 16, `cacheComponents` + `partialPrefetching`, a music player). Use it to see any invariant in real code rather than restating the code here. Paths are as of this writing — verify against the current repo.
+
+For the reasoning behind this architecture, read [Component Architecture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/). The skill's target is the same shape: pages describe layout and loading; feature components own server reads; route params become IDs before they reach components.
+
+## Invariant → where to see it
+
+| Invariant | File(s) |
+| --------- | ------- |
+| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
+| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
+| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
+| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
+| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
+| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+
+## Supporting patterns
+
+| Pattern | File |
+| ------- | ---- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
+| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
+| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button | `components/ui/button.tsx` |
+| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
+| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
+| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+
+> The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/.claude/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.claude/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,5 +1,7 @@
 # Feature folders
 
+> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+
 How to organize code under `features/` and `app/`.
 
 ## Folder layout

--- a/.claude/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.claude/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,6 +1,6 @@
 # Feature folders
 
-> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+> **Core:** Existing `apps/*/features/` folders are UI composition only. Do not add `*-queries.ts` or `*-actions.ts` at all. Call `@asym/api` or `@asym/database/hooks` from the feature component.
 
 How to organize code under `features/` and `app/`.
 

--- a/.claude/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.claude/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,0 +1,147 @@
+# Feature folders
+
+How to organize code under `features/` and `app/`.
+
+## Folder layout
+
+```
+features/<domain>/
+  <domain>-cache.ts     # Pure server tags + client query keys, when shared
+  <domain>-queries.ts   # Server-only queries, when this feature owns reads
+  <domain>-actions.ts   # Server actions, when this feature owns writes
+  <domain>-query-options.ts # Client data-library query definitions, when needed
+  components/           # Server + client components, each with its skeleton
+  types/                # Feature-local public types, when needed by multiple files
+  hooks/                # Actual feature-local React hooks and hook wrappers
+  providers/            # Feature-local providers, only when the provider belongs to this domain
+```
+
+The folder name identifies the domain or cohesive product experience. Query and action filenames match the owning domain folder when present.
+
+## How many features?
+
+Keep the feature list short. Use folders for **domains and cohesive product experiences a user would recognize**, not database tables or technical concerns.
+
+A new folder is justified in either of these cases:
+
+1. **Domain ownership:** it owns the queries, actions, and components for a real product entity.
+2. **Cross-domain composition:** it owns the route-level UI or client state for an experience that combines multiple domains. The underlying queries and actions remain with the domains whose data they read or mutate.
+
+If you find yourself making a feature folder with one query, one action, and one button, fold it into the parent feature instead.
+
+### Merge aggressively
+
+Concepts that exist only in service of a parent entity belong inside the parent's feature folder:
+
+- A `favorite` or `bookmark` concept that only attaches to one parent entity (events, posts) → inside that parent's folder.
+- A `like`, `repost`, `vote`, or `reaction` concept on a piece of content → with that content's feature.
+- `auth` / `session` / `current user` → a single `user` folder, not split.
+- A search query stays with the domain it searches (`searchTracks` in `features/track/`, `searchPlaylists` in `features/playlist/`). When one search experience combines several domains, `features/search/` may own the search form, result composition, and client state without taking ownership of those domain queries.
+
+Concrete example: `toggleFavorite` is a mutation about events ("I favorite an event"), not its own domain. It lives in `features/event/event-actions.ts`, not `features/favorite/favorite-actions.ts`.
+
+## File naming
+
+Filenames inside the folder always start with the folder name:
+
+```
+features/event/
+  event-queries.ts
+  event-actions.ts
+  components/
+    event-grid.tsx
+    event-details.tsx
+    favorite-button.tsx     ← OK: a component, not a "favorite" feature
+```
+
+- `<folder>-queries.ts` — even if the file has only one query.
+- `<folder>-actions.ts` — even if a mutation is about a sub-concept.
+- Don't create empty query or action files for a cross-domain UI feature that doesn't own data access.
+- Other `<folder>-*.ts` files are fine when the folder needs them (`playlist-constants.ts`, `<folder>-schema.ts`), as long as they keep the folder-name prefix. Don't put reusable domain types in a root `*-types.ts` file; use `features/<domain>/types/` once a type is imported by multiple files.
+- Component files use any descriptive name. The component (not the feature) is the unit here.
+
+## Local vs shared support folders
+
+Use a local support folder when the code belongs to one feature:
+
+```
+features/message/
+  message-cache.ts
+  message-query-options.ts
+  types/
+    message.ts
+  hooks/
+    use-message-mutations.ts
+    use-message-draft.ts
+  providers/
+    message-draft-provider.tsx
+```
+
+Feature-owned client coordination stays with the feature. Place each file by the shape it exports and the domain it belongs to:
+
+- Client data-library cache contracts and query definitions follow `references/single-page-applications.md`.
+- Mutation wrappers that export hooks live in `hooks/use-*.ts` (`use-message-mutations.ts` exporting `useSendMessage`).
+- Browser-only state helpers live in `hooks/` when their public API is a hook (`use-thread.ts`, `use-message-draft.ts`).
+- Client leaf components that coordinate a server write live in `components/` next to the UI they support (`mark-activity-read.tsx` posts read activity in the background while the current `/activity` tree stays stable).
+
+Keep the file prefix aligned with the feature folder when a file exports a grouped feature contract (`workspace-cache.ts` and `workspace-query-options.ts`, not `activity-cache.ts` in `features/workspace/`). Support code for a sub-concept still lives with the parent feature: reactions on messages belong in `features/message/`; unread activity chrome belongs in `features/workspace/`.
+
+Promote only when there are real cross-feature consumers:
+
+- `types/` at the project root — shared domain/application types imported across features.
+- `hooks/` at the project root — shared client hooks used across features.
+- `app/providers.tsx` or `components/*-provider.tsx` — app-shell providers that wrap the whole app.
+
+Avoid root-level miscellany like `message-types.ts`, `shared-hooks.ts`, or `common-provider.tsx`; the folder name should explain the scope.
+
+## What goes in `components/`
+
+Each component file exports the main component **plus its skeleton**:
+
+```tsx
+// features/event/components/event-grid.tsx
+export async function EventGrid(...) { ... }
+export function EventGridSkeleton() { ... }
+```
+
+Group related components in one file when they're always used together or one is a natural building block for another. A card and its grid live together. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`.
+
+Split into separate files only when:
+
+- A component is consumed by multiple sibling components (one shared use is not enough — wait until three call sites need it).
+- A component is `'use client'` and a sibling is a server component (the server/client boundary forbids sharing a file).
+
+See `references/components.md` for inlining rules and the skeleton design checklist.
+
+## What pages do
+
+Pages in `app/` compose feature components with Suspense and transition wrappers. They never:
+
+- Contain domain logic
+- Define new components except thin transition wrappers (e.g. `<ViewTransition>`)
+- Fetch data directly
+- Inline route-specific components — extract them into the feature folder
+
+See `references/pages-suspense.md` for page composition details.
+
+## Top-level layout
+
+```
+app/                  # Pages and layouts
+features/             # Domain folders
+components/           # UI primitives, theme, and app-shell singletons
+hooks/                # Shared client hooks used across features
+types/                # Shared cross-feature types only
+lib/                  # Utilities and cohesive non-domain subsystems
+```
+
+`lib/` holds flat helpers (`db.ts`, `utils.ts`) but may also group a cohesive non-domain subsystem in its own subfolder (e.g. `lib/audio/` for an audio engine). Cross-feature client hooks live in top-level `hooks/`; a hook used by a single feature co-locates in that feature's `hooks/`. Types follow the same rule: shared types at top-level `types/`, feature-only exported types in `features/<domain>/types/`.
+
+`components/` holds:
+
+- **`components/ui/`** — primitives. Low-level building blocks and action-prop components.
+- **`components/theme/`** — theme provider and toggle, paired.
+- **Top-level files** (`site-header.tsx`, `auth-gate.tsx`, `poller.tsx`) — app-shell singletons used once each. No `common/` folder — "common" is not a category. If a component is used everywhere it's a primitive (→ `ui/`); if it's used once it lives at the top level.
+- **Purpose-named subfolders** are fine when several files share a clear technical role — e.g. `components/scripts/` for pre-hydration inline `<script>` seed components. This is distinct from the rejected `common/`: a `scripts/` folder names _what the files are_, not "miscellaneous."
+
+Conventions for filenames and casing live in the project's `AGENTS.md`. This skill doesn't impose one.

--- a/.claude/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.claude/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -1,0 +1,276 @@
+# Pages and Suspense
+
+How to compose pages, place Suspense boundaries, and prevent layout shift.
+
+## Pages are composition only
+
+Pages in `app/` import feature components and place `<Suspense>` boundaries. They never:
+
+- Fetch data directly (queries live in feature folders)
+- Define reusable UI components except thin transition wrappers (e.g. `<ViewTransition>`) or tiny route-local control-flow helpers
+- Inline route-specific UI (extract it into the feature folder)
+- Pass raw `params` / `searchParams` to features
+
+## Page function signatures
+
+Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
+
+```tsx
+export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+```
+
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+
+## Keep pages synchronous
+
+Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
+
+```tsx
+import { Suspense } from 'react';
+import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+
+export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+  return (
+    <div>
+      <h1>Post</h1>
+      <Suspense fallback={<PostDetailSkeleton />}>
+        {params.then(({ id }) => (
+          <PostDetail id={id} />
+        ))}
+      </Suspense>
+    </div>
+  );
+}
+```
+
+The `<h1>` sits **above** the `params.then()` so it paints instantly. The `Suspense` fallback covers only the dynamic section.
+
+Resolve route props to plain values at this boundary. Feature components receive `id`, `slug`, `query`, or parsed filter values — not `params`, `searchParams`, or unresolved server promises.
+
+### Implicit return inside `.then()`
+
+Use an implicit-return arrow function when the callback just renders JSX — e.g. `({ id }) => <PostDetail id={id} />`. Only switch to a block body with `return` when you need to do work first (destructure with defaults, parse a `searchParams` value, branch on a condition). This keeps the JSX-in-page shape readable and matches how the resolved tree will look.
+
+### `searchParams` and combined params
+
+```tsx
+// searchParams only
+export default function SearchPage({ searchParams }: PageProps<'/search'>) {
+  return searchParams.then(sp => {
+    const q = typeof sp.q === 'string' ? sp.q : '';
+    return q ? <SearchResults query={q} /> : <EmptyState />;
+  });
+}
+
+// Both params and searchParams
+export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+  return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
+    <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
+  ));
+}
+```
+
+Use `Promise.all([params, searchParams])` when both are needed. Avoid nested `.then()` calls that make the resolved tree hard to read and easy to wrap in the wrong boundary.
+
+### Metadata, static params, and `notFound()`
+
+- [`generateMetadata`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-metadata) runs before render, so `await params` is fine there — it's a separate async function, not the page body, so it doesn't make the page dynamic.
+- Export [`generateStaticParams`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-static-params) from a `[slug]` page/layout to pre-build a known set of slugs; with `cacheComponents` + `'use cache'` they land in the static shell. It does **not** change the page signature — `params` is still a Promise, still consumed with `params.then()`.
+- A query that can't find its resource calls [`notFound()`](https://preview.nextjs.org/docs/app/api-reference/functions/not-found), which bubbles to the nearest [`not-found.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/not-found). Don't try/catch it — use [`unstable_rethrow`](https://preview.nextjs.org/docs/app/api-reference/functions/unstable_rethrow) if you must catch nearby.
+
+## Prefer a page boundary over `loading.tsx`
+
+Put the boundary in the page next to the `params.then()` / `searchParams.then()` it covers, rather than adding a route-segment `loading.tsx`. A page boundary keeps the fallback beside the JSX it stands in for, lets sibling sections share one boundary or split into several, and can be wrapped in `<ViewTransition>` so the reveal animates. A `loading.tsx` renders outside the page's own tree, so a transition wrapper inside the page cannot animate the swap out of it, and one fallback has to cover the whole route.
+
+## The page owns the Suspense boundary
+
+The feature exports the async component **and** its skeleton. The page imports both and places the boundary. Don't pre-wrap inside the feature — that hides the boundary and prevents grouping siblings.
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) { ... }
+export function PostDetailSkeleton() { ... }
+```
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <>
+      <PostDetail id={id} />
+      <ErrorBoundary title="Replies didn't load">
+        <Suspense fallback={<RepliesSkeleton />}>
+          <Replies postId={id} />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  ))}
+</Suspense>
+```
+
+If a page uses a transition wrapper (e.g. `<ViewTransition>`), place it in the page next to the `<Suspense>` boundary. Feature components render content and skeletons, not transition wrappers.
+
+## Stable shell, suspending body
+
+Before designing a fallback, identify what is stable and what is data-dependent.
+
+- Stable: card/panel border, padding, icon, label, section heading, fixed action rail.
+- Data-dependent: title text, counts, form body, list rows, loaded choices.
+- Rule: stable shell outside Suspense; skeleton/crossfade inside the shell around the data body.
+
+```tsx
+<FeaturePanel>
+  <Suspense fallback={<FeaturePanelBodySkeleton />}>
+    <Crossfade>
+      <FeaturePanelBody id={id} />
+    </Crossfade>
+  </Suspense>
+</FeaturePanel>
+```
+
+Do not render `<FeaturePanel>` in both `fallback` and final content. That duplicates layout responsibility and makes the skeleton guess the panel size.
+
+Use the app's real domain noun at implementation time (`PostPanel`, `MessageList`, `GroupEditor`, `EventDetails`, etc.); the neutral names here describe the reusable shape, not a component to copy literally.
+
+When the top data section has unknown final height and pushes the sections below, either reserve that height in the stable wrapper or group the affected sections in one boundary. Do not create two independent crossfades if the first one changes the second one's starting position.
+
+## Audit smells
+
+When auditing an existing app, flag and fix these first:
+
+- `export default async function Page(...)` that only awaits `params`, `searchParams`, or page-level queries.
+- `import { getSomething } from '@/features/.../*-queries'` inside `app/**/page.tsx` or `layout.tsx`.
+- Feature components whose props are `params`, `searchParams`, or a route-shaped object.
+- Page-local components like `HomeContent`, `PostShell`, or `ResultsSection` that only exist to fetch data or group a Suspense fallback.
+- `<Suspense>` inside feature components that prevents the page from grouping reveal behavior.
+
+## Route-local control-flow helpers
+
+Small inline helpers are fine when their only job is route control flow that must live exactly where a boundary is placed:
+
+```tsx
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginRedirect />
+    </Suspense>
+  );
+}
+
+async function LoginRedirect() {
+  await connection();
+  await redirectIfAuthenticated('/dashboard');
+  return <LoginForm />;
+}
+```
+
+Do not move a helper like this into a feature folder just to satisfy a blanket "no inline components" rule. It is not domain UI and it is not a reusable feature component; extracting it creates noise. Keep the cookie/session read inside the data-access helper (`redirectIfAuthenticated`, `verifyAuth`, etc.) rather than importing a feature query into the page.
+
+## Don't create page-local wrapper components
+
+Avoid components whose only job is to group boundary content, like `HomeLists` or `HomeListsSkeleton`. Keep the resolved JSX and fallback JSX **inline in the page** so the loading shape, headings, and grouped reveal behavior are visible at the boundary.
+
+```tsx
+// Wrong — hides the structure behind a wrapper
+<Suspense fallback={<HomeListsSkeleton />}>
+  <HomeLists searchParams={searchParams} />
+</Suspense>
+```
+
+```tsx
+// Right — structure visible at the page level
+<Suspense
+  fallback={
+    <>
+      <FeaturedSkeleton />
+      <RecentSkeleton />
+    </>
+  }
+>
+  {searchParams.then(sp => (
+    <>
+      <Featured filter={sp.filter} />
+      <Recent filter={sp.filter} />
+    </>
+  ))}
+</Suspense>
+```
+
+The same applies to feature-level skeleton aliases. If a variant only passes props to a base skeleton, import the base skeleton and pass those props inline in `fallback={...}`.
+
+## Suspense boundary placement rules
+
+1. **First section gets its own Suspense** with a known-height skeleton fallback.
+2. **Section headings stay outside Suspense** when their final position is stable.
+3. **Stable wrappers stay outside Suspense.** If fallback and final content both render the same card or panel, lift that wrapper around the boundary.
+4. **Variable-height sections: group everything below them** in the same Suspense, including any headings that would otherwise paint in the wrong vertical position.
+5. **Fixed-height sections: own boundary is safe.**
+6. **Variable-length lists: show 2–5 skeleton items**, not the real count.
+7. **Inner Suspense content stays out of the outer skeleton.** Each boundary owns its own.
+8. **Never `fallback={null}` for visible UI.** If a boundary covers UI, give it a real shaped fallback, or group it with a sibling boundary that already has the correct fallback.
+9. **If the top section's final height is unknown, group the following sections** in the same boundary so they reveal together and don't jump underneath.
+
+## Error boundaries
+
+Wrap fallible sections in a Next.js-aware error boundary so one failure doesn't take down the page. Build it on [`catchError`](https://preview.nextjs.org/docs/app/api-reference/functions/catchError) from `next/error` (its `ErrorInfo` gives you a `retry()` that re-fetches server data) — it understands Next's control-flow throws (`notFound()`, `redirect()`, `unauthorized()`, `forbidden()`) and won't swallow them. Place the boundary around the suspending section, in the page:
+
+```tsx
+<ErrorBoundary title="Replies didn't load">
+  <Suspense fallback={<RepliesSkeleton />}>
+    <Replies postId={id} />
+  </Suspense>
+</ErrorBoundary>
+```
+
+Why not plain `react-error-boundary`? It catches Next's framework throws (so `notFound()` never reaches `not-found.tsx`), and its reset doesn't re-fetch server data. Background: [Error Handling in Next.js with catchError](https://aurorascharff.no/posts/error-handling-in-nextjs-with-catch-error/).
+
+Pair component-level boundaries with route-segment [`error.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/error) for unrecoverable errors; it also receives a `retry` callback.
+
+## Layout-level Suspense
+
+Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
+
+```tsx
+export default function RootLayout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>
+        <Suspense>
+          <AuthGate userPromise={getCurrentUser()} />
+        </Suspense>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}
+```
+
+`AuthGate` is a client component that resolves the promise with `use()` so the dialog can render conditionally without server-side branching.
+
+## CLS prevention
+
+Layout shift happens when:
+
+- A skeleton is shorter than the real content
+- A heading sits inside a Suspense boundary whose final height is unknown — it paints in the wrong place, then jumps
+- A variable-length list streams in without a fallback that reserves space
+
+Fixes:
+
+- Match skeleton height to the typical real content height.
+- Move headings **outside** boundaries when their position depends on data above them.
+- For unknown-height top sections, group everything below in one boundary so siblings stream together.
+
+To audit CLS, use React DevTools' Suspense panel to pin each boundary in its loading state and check vertical positions.
+
+## Optimizing prefetching for high-value routes
+
+With `cacheComponents` + [`partialPrefetching`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, a visible `<Link>` prefetches the destination's shared [App Shell](https://preview.nextjs.org/docs/app/glossary#app-shell) — enough to commit navigation instantly, with link-specific content streaming after. The default (`'auto'`) already does this; don't write `prefetch = 'auto'`.
+
+Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link data (`params`, `searchParams`, the full URL) at prefetch time. Each such link can wake the server for a prerender, so reserve it for routes users predictably visit next. See [Optimizing prefetching](https://preview.nextjs.org/docs/app/guides/optimizing-prefetching).
+
+Can't enable `partialPrefetching` app-wide yet? Opt in per route with `export const prefetch = 'partial'` on the destination, then drop the per-route exports once the global flag is on — see [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) for the incremental path and [prefetch config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for the options. To validate navigation feels instant, see the [`instant` config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant) and [Instant Navigation guide](https://preview.nextjs.org/docs/app/guides/instant-navigation).
+
+## Never wrap the entire page in a Suspense fallback
+
+Page chrome (header, nav, surrounding layout) should paint instantly. Only data-dependent sections suspend. If you find yourself wrapping `<div>` and everything in it with `<Suspense fallback={<FullPageSkeleton />}>`, restructure: pull static elements out, narrow the boundary to just the dynamic part.

--- a/.claude/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.claude/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -16,20 +16,25 @@ Pages in `app/` import feature components and place `<Suspense>` boundaries. The
 Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
 
 ```tsx
-export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
+  /* ... */
+}
 ```
 
-Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a _separate_ feature (statically-typed `href`s), not the source of these helpers.
 
 ## Keep pages synchronous
 
 Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
 
 ```tsx
-import { Suspense } from 'react';
-import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+import { Suspense } from "react";
+import {
+  PostDetail,
+  PostDetailSkeleton,
+} from "@/features/post/components/post-detail";
 
-export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
   return (
     <div>
       <h1>Post</h1>
@@ -55,15 +60,18 @@ Use an implicit-return arrow function when the callback just renders JSX — e.g
 
 ```tsx
 // searchParams only
-export default function SearchPage({ searchParams }: PageProps<'/search'>) {
-  return searchParams.then(sp => {
-    const q = typeof sp.q === 'string' ? sp.q : '';
+export default function SearchPage({ searchParams }: PageProps<"/search">) {
+  return searchParams.then((sp) => {
+    const q = typeof sp.q === "string" ? sp.q : "";
     return q ? <SearchResults query={q} /> : <EmptyState />;
   });
 }
 
 // Both params and searchParams
-export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+export default function ProfilePage({
+  params,
+  searchParams,
+}: PageProps<"/u/[handle]">) {
   return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
     <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
   ));
@@ -159,7 +167,7 @@ export default function LoginPage() {
 
 async function LoginRedirect() {
   await connection();
-  await redirectIfAuthenticated('/dashboard');
+  await redirectIfAuthenticated("/dashboard");
   return <LoginForm />;
 }
 ```
@@ -187,7 +195,7 @@ Avoid components whose only job is to group boundary content, like `HomeLists` o
     </>
   }
 >
-  {searchParams.then(sp => (
+  {searchParams.then((sp) => (
     <>
       <Featured filter={sp.filter} />
       <Recent filter={sp.filter} />
@@ -231,7 +239,7 @@ Pair component-level boundaries with route-segment [`error.tsx`](https://preview
 Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
 
 ```tsx
-export default function RootLayout({ children }: LayoutProps<'/'>) {
+export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html>
       <body>

--- a/.claude/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.claude/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,6 +1,6 @@
 # Queries and actions
 
-> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables. The vendor procedure below is placement-only and must not be copied into `apps/*/features/`.
 
 The data layer. Every feature has both: queries to read, actions to write.
 

--- a/.claude/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.claude/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,5 +1,7 @@
 # Queries and actions
 
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+
 The data layer. Every feature has both: queries to read, actions to write.
 
 This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
@@ -15,7 +17,7 @@ Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` â
 Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
 
 ```ts
-import 'server-only';
+import "server-only";
 
 export async function getFeed(userId: string) {
   return db.post.findMany({ where: { userId } });
@@ -30,9 +32,13 @@ Take normalized primitives, not the params object:
 
 ```ts
 // features/book/book-queries.ts
-export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
-  'use cache';
-  cacheLife('hours');
+export async function getBooksPage(
+  page: number = 1,
+  search: string = "",
+  year: number = MAX_YEAR,
+) {
+  "use cache";
+  cacheLife("hours");
   // ...
 }
 ```
@@ -43,7 +49,7 @@ Normalize and clamp in the feature's own helper, **before** the call, not inside
 
 Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" â€” it adds indirection and can hide when data is intentionally dynamic.
 
-`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results _across_ requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
 
 ## Actions
 
@@ -56,13 +62,13 @@ Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the 
 5. Return a result (`{ ok }` or `{ error }`).
 
 ```tsx
-'use server';
+"use server";
 
-import { refresh } from 'next/cache';
+import { refresh } from "next/cache";
 
 export async function createPost(formData: FormData) {
   const user = await verifyUser();
-  const parsed = schema.safeParse({ body: formData.get('body') });
+  const parsed = schema.safeParse({ body: formData.get("body") });
   if (!parsed.success) {
     return { ok: false as const, error: parsed.error.issues[0].message };
   }
@@ -85,8 +91,8 @@ Client components import server actions directly. **Don't** pass an action as a 
 
 ```tsx
 // Right
-'use client';
-import { likePost } from '@/features/post/post-actions';
+"use client";
+import { likePost } from "@/features/post/post-actions";
 
 export function LikeButton({ postId }: { postId: string }) {
   return <button onClick={() => likePost(postId)}>Like</button>;
@@ -113,7 +119,9 @@ For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTran
 Return a discriminated union from actions that can fail:
 
 ```tsx
-export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+export type ActionResult<T = void> =
+  | { ok: true; data?: T }
+  | { ok: false; error: string };
 ```
 
 Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
@@ -126,7 +134,10 @@ If your DB rows have shapes you don't want to leak to components (extra columns,
 
 ```ts
 export async function getPost(id: string) {
-  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  const row = await db.post.findUnique({
+    where: { id },
+    include: { author: true },
+  });
   if (!row) notFound();
   return toPost(row);
 }

--- a/.claude/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.claude/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,0 +1,139 @@
+# Queries and actions
+
+The data layer. Every feature has both: queries to read, actions to write.
+
+This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
+
+## Cache identities
+
+When a server read also seeds a browser data cache, follow `references/single-page-applications.md` for the feature-local cache contract and client-library placement.
+
+## Queries
+
+Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` — that's the invariant. Default to plain async exports.
+
+Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
+
+```ts
+import 'server-only';
+
+export async function getFeed(userId: string) {
+  return db.post.findMany({ where: { userId } });
+}
+```
+
+## Cache keys are the arguments
+
+A `'use cache'` function's arguments are its cache key, so shape them deliberately.
+
+Take normalized primitives, not the params object:
+
+```ts
+// features/book/book-queries.ts
+export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
+  'use cache';
+  cacheLife('hours');
+  // ...
+}
+```
+
+Passing `searchParams` straight through keys the entry on an object carrying every param the route knows about, including the ones the caller left undefined, and the key then changes shape whenever the route gains a param.
+
+Normalize and clamp in the feature's own helper, **before** the call, not inside the cached function. `?yr=9999`, `?yr=2023`, and no `yr` at all describe the same result set, so they should resolve to the same arguments and share one entry. Clamping inside the cached function gives each spelling its own entry with identical contents.
+
+Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" — it adds indirection and can hide when data is intentionally dynamic.
+
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+
+## Actions
+
+Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the top. Always:
+
+1. Verify auth.
+2. Validate input with your schema validator.
+3. Run the mutation.
+4. Invalidate cached data so the next render sees the new state.
+5. Return a result (`{ ok }` or `{ error }`).
+
+```tsx
+'use server';
+
+import { refresh } from 'next/cache';
+
+export async function createPost(formData: FormData) {
+  const user = await verifyUser();
+  const parsed = schema.safeParse({ body: formData.get('body') });
+  if (!parsed.success) {
+    return { ok: false as const, error: parsed.error.issues[0].message };
+  }
+
+  await db.post.create({ data: { body: parsed.data.body, userId: user.id } });
+  refresh();
+  return { ok: true as const };
+}
+```
+
+[`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) re-renders the current route for the current user. Use it when the affected read is deliberately dynamic and has no tag. With Cache Components enabled, reusable reads should have matching `cacheTag()` calls, so server actions normally call `updateTag()` for read-your-own-writes. See `references/cache-components.md`.
+
+### Action file naming
+
+Actions for a feature always go in `<folder>-actions.ts`, matching the folder name — even when the mutation operates on a sub-concept. `toggleFavorite` in `features/event/` lives in `event-actions.ts`, not `favorite-actions.ts`. The folder is the source of truth for the name.
+
+## Calling actions from client components
+
+Client components import server actions directly. **Don't** pass an action as a prop just to call it:
+
+```tsx
+// Right
+'use client';
+import { likePost } from '@/features/post/post-actions';
+
+export function LikeButton({ postId }: { postId: string }) {
+  return <button onClick={() => likePost(postId)}>Like</button>;
+}
+```
+
+```tsx
+// Wrong — adds indirection with no benefit
+async function Post({ id }: { id: string }) {
+  return <LikeButton postId={id} onLike={likePost} />;
+}
+```
+
+Design components (`<BottomNav>`, `<ToggleGroup>`, `<SubmitButton>`) take this further with the **action-prop pattern** — `action` is a callback wrapped in `useTransition` / `useOptimistic` internally. See `references/ux-patterns.md`.
+
+## Form actions vs onClick handlers
+
+Prefer [`<form action={serverAction}>`](https://react.dev/reference/react-dom/components/form#action) for form mutations — React wraps the call in a transition and surfaces pending state automatically.
+
+For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTransition`](https://react.dev/reference/react/startTransition) if you need pending state.
+
+## Return shape
+
+Return a discriminated union from actions that can fail:
+
+```tsx
+export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+```
+
+Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
+
+A shared `ActionResult<T>` is optional — a per-action inline union is just as good, and often clearer when the payload has a natural name: `return { ok: true as const, playlist }` reads better than a generic `data`. What matters is that fallible actions return a discriminated union the client can narrow on, not that every action shares one type.
+
+## Mappers and domain types
+
+If your DB rows have shapes you don't want to leak to components (extra columns, ORM-specific types), write a mapper inside the query:
+
+```ts
+export async function getPost(id: string) {
+  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  if (!row) notFound();
+  return toPost(row);
+}
+
+function toPost(row: PostRow & { author: UserRow }): Post {
+  return { id: row.id, body: row.body, author: row.author.handle };
+}
+```
+
+Components see `Post`, not the ORM row. If that type is imported by multiple files in the feature, put it under `features/<domain>/types/` (for example `features/post/types/post.ts`). Promote it to top-level `types/` only when multiple features import it.

--- a/.claude/skills/nextjs-app-architecture/references/single-page-applications.md
+++ b/.claude/skills/nextjs-app-architecture/references/single-page-applications.md
@@ -1,0 +1,48 @@
+# Single-page application patterns
+
+Use this reference when a feature adds SWR, TanStack Query, or another browser data cache. For complete library APIs and runnable examples, follow the [Single-page applications guide](https://preview.nextjs.org/docs/app/guides/single-page-applications).
+
+## Decide whether a client cache is needed
+
+Use a client data library when the browser needs revalidation, optimistic mutations, request deduplication, or shared live data. If a Client Component only reads server data once, pass a Promise from its Server Component and unwrap it with `use()` instead.
+
+## Keep ownership with the feature
+
+```text
+features/<domain>/
+  <domain>-cache.ts          # Pure server tags + client keys
+  <domain>-queries.ts        # Server reads and cacheLife
+  <domain>-query-options.ts  # Client fetcher/query options
+  hooks/use-*.ts             # Client mutations and coordination
+  components/                # Async server owner + client leaves
+```
+
+The cache contract imports neither Next.js nor the client library. Queries, actions, route handlers, hydration code, query options, and hooks import identities from it. This prevents a key or tag spelling from drifting between a read and its invalidation.
+
+Keep behavior in the layer that owns it:
+
+- Server `cacheLife`, `cacheTag`, and database reads belong in `<domain>-queries.ts`.
+- Browser freshness and refetch behavior belong in `<domain>-query-options.ts` or the SWR hook.
+- Optimistic mutation behavior belongs in `hooks/use-*.ts`.
+- Tiny effect-only or interactive leaves belong in `components/`.
+
+## Seed from the server
+
+The async feature component owns the initial read and the library's hydration provider. The page remains a synchronous composition surface and owns the feature's Suspense boundary.
+
+- With SWR, seed the exact key read by `useSWR`. Use `preload` with `cacheData` when later `mutate(key)` calls must update the seeded entry itself.
+- With TanStack Query, seed the same query key read by the client query and render the client subtree inside `HydrationBoundary`.
+
+Do not move the initial read to the browser just because the feature also has a client cache.
+
+## Coordinate Cache Components
+
+The server cache and browser cache have independent freshness policies. Do not mirror `cacheLife` into `staleTime`, polling intervals, or SWR revalidation settings. Coordinate identities and invalidation, not durations.
+
+For tag-driven data, a mutation updates the client cache for immediate feedback and invalidates the same server tag used by the seeded read. For a time-driven server read, choose its `cacheLife` from the server data's freshness requirement.
+
+TanStack Query hydration adds one coupling: the hydration timestamp must advance whenever the seeded data advances. For tag-driven reads, cache the timestamp with the same tags as the data. For time-driven reads, derive the data and timestamp from the same cached snapshot. Do not cache a `QueryClient` or dehydrated payload.
+
+## Mutate without drift
+
+Let the client library own the optimistic browser update, rollback, and authoritative response. Let the write invalidate the server tag only after stored data changes. Do not add polling as a cache-coordination mechanism; add focus revalidation, intervals, SSE, or WebSockets only when the product actually needs external updates to appear automatically.

--- a/.claude/skills/nextjs-app-architecture/references/upstream.md
+++ b/.claude/skills/nextjs-app-architecture/references/upstream.md
@@ -1,0 +1,30 @@
+---
+source_name: aurorascharff/nextjs-app-architecture-skill (nextjs-app-architecture)
+source_url: https://github.com/aurorascharff/nextjs-app-architecture-skill
+source_type: github
+upstream_path: SKILL.md
+reviewed_commit: f2902b8538b25610da694394ecf88e69adf5f96a
+skills_lock_hash: 94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66
+license: MIT
+last_reviewed: 2026-08-28
+---
+
+# Upstream: nextjs-app-architecture
+
+Canonical copy in this repo: `docs/ai/skills/nextjs-app-architecture/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/aurorascharff/nextjs-app-architecture-skill
+- **Upstream path:** `SKILL.md` plus `references/{cache-components,components,example,feature-folders,pages-suspense,queries-actions,single-page-applications,ux-patterns}.md`
+- **License:** MIT; copyright Aurora Scharff (see the ecosystem `LICENSE` copied by the Skills CLI)
+- **Install via Skills CLI:** `npx skills add aurorascharff/nextjs-app-architecture-skill -y`
+
+The skill packages next-beats-style RSC composition for Next.js 16 App Router: synchronous pages, feature-owned async server components, colocated skeletons, and Cache Components practice. Inside Core it stays subordinate to installed Next.js docs, `docs/ai/rules/frontend.md`, and the data-access boundary.
+
+## Refresh from ecosystem
+
+1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
+2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
+3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+
+This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.claude/skills/nextjs-app-architecture/references/upstream.md
+++ b/.claude/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.claude/skills/nextjs-app-architecture/references/upstream.md
+++ b/.claude/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section, **Core remaps**, and in-place `CORE: skip file creation` annotations in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.claude/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/.claude/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -4,13 +4,13 @@ Interaction decisions on top of the architecture: which feedback mechanism to re
 
 ## Choose the feedback mechanism
 
-| Situation | Reach for | Key rule |
-| --------- | --------- | -------- |
-| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
-| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
-| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
-| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
-| One-shot result with no visible change | toast | See below. |
+| Situation                                          | Reach for                                                                           | Key rule                                                                                                                                                                                  |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic)                  | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters.                                |
+| No optimistic fit (filters, sort, navigation)      | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field")           | [`useActionState`](https://react.dev/reference/react/useActionState)                | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`.                                                                                                           |
+| Submit disable + spinner                           | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus)        | Call it from a child of `<form>`, not the form component itself.                                                                                                                          |
+| One-shot result with no visible change             | toast                                                                               | See below.                                                                                                                                                                                |
 
 ### Name the signal when a subtree has more than one pending source
 
@@ -29,10 +29,10 @@ For create/update/delete flows where the changed item is visible, prefer one fea
 
 ```tsx
 type OptimisticListAction<TItem> =
-  | { type: 'create'; item: TItem }
-  | { type: 'update'; item: TItem }
-  | { type: 'delete'; id: string }
-  | { type: 'rollback'; id: string };
+  | { type: "create"; item: TItem }
+  | { type: "update"; item: TItem }
+  | { type: "delete"; id: string }
+  | { type: "rollback"; id: string };
 
 const [items, dispatchOptimisticItem] = useOptimistic(
   initialItems,
@@ -61,7 +61,7 @@ Use a success page/state instead of a toast when the completed action changes th
 
 ## View transitions: portaled / floating UI
 
-Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a _named_ transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
 
 ## Destructive actions (delete / leave / unsubscribe)
 
@@ -72,14 +72,14 @@ Gate behind a confirmation dialog, and mind two edge cases:
 
 ## The action-prop pattern
 
-A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited _without_ a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
 
 ## URL-based pagination
 
 Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
 
 ```tsx
-import { Suspense } from 'react';
+import { Suspense } from "react";
 
 export function Feed({ page = 1 }: { page?: number }) {
   return (

--- a/.claude/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/.claude/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -1,0 +1,106 @@
+# UX patterns
+
+Interaction decisions on top of the architecture: which feedback mechanism to reach for, and the boundary edge-cases that trip agents up. Hook mechanics live in the React / Next docs — linked, not restated. The deeper end-to-end picture is the [Building interactive apps guide](https://preview.nextjs.org/docs/app/guides/interactive-apps).
+
+## Choose the feedback mechanism
+
+| Situation | Reach for | Key rule |
+| --------- | --------- | -------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
+| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
+| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
+| One-shot result with no visible change | toast | See below. |
+
+### Name the signal when a subtree has more than one pending source
+
+`data-pending` bubbles through CSS, so every descendant that sets it participates. `useLinkStatus` sets it on any pending link, which means `group-has-data-pending:` on a page wrapper also fires for ordinary navigation and dims content that is not being refetched. When a subtree can be pending for more than one reason, give the reason you are reacting to its own attribute (`data-filtering`, `data-saving`) and key the ancestor off that.
+
+### Two things to get right with `useOptimistic`
+
+- The value reverts as soon as its transition settles, so the work it predicts has to run **inside the same** `startTransition`. Setting the optimistic value in one transition and navigating in another snaps it back before the URL changes.
+- Derive the controls from the optimistic value and the surrounding chrome from the committed one. A slider thumb should follow the drag immediately, but a "Clear all filters" button keyed off that same optimistic value appears while the filter is still in flight.
+
+`useOptimistic(false)` also works as a transition-scoped **pending flag** that resets automatically when the transition settles — handy when you don't need the `data-pending` bubbling.
+
+## Optimistic mutations for interactive apps
+
+For create/update/delete flows where the changed item is visible, prefer one feature-owned optimistic reducer over hand-rolled pending state spread across the board, modal, and list.
+
+```tsx
+type OptimisticListAction<TItem> =
+  | { type: 'create'; item: TItem }
+  | { type: 'update'; item: TItem }
+  | { type: 'delete'; id: string }
+  | { type: 'rollback'; id: string };
+
+const [items, dispatchOptimisticItem] = useOptimistic(
+  initialItems,
+  optimisticListReducer,
+);
+```
+
+Use names that describe the app's domain (`dispatchOptimisticPost`, `messageReducer`, `groupReducer`, `eventReducer`) rather than implementation mechanics like `applyOptimisticAction`. The reducer owns the optimistic list shape; components dispatch intent.
+
+For modal creates, apply the optimistic item and close the modal immediately when the local form is valid. If the action fails, roll back and show an error toast. Keeping the modal open with a slow primary button makes the optimistic result feel broken.
+
+For deletes, remove optimistically, then roll back on failure. Do not wait for the server before the item disappears when the user's intent is clear.
+
+## Forms and validation
+
+Do local validation before submitting when the missing field is already available on the client. Show inline field errors without changing the modal or card's overall geometry. Reserve `useActionState` for server-validated errors or field errors that require the action result.
+
+Use a success page/state instead of a toast when the completed action changes the user's task. For example, after a reservation, checkout, or invite request succeeds, replace the form with a confirmation and a secondary "start another" action; a success toast is redundant.
+
+## Toasts
+
+- **Toast only on error** when an optimistic UI already shows the result — a success toast next to an optimistic checkmark/removal is double feedback, which is noise.
+- **Toast on success** only for non-visible side effects (email sent, link copied, file uploaded).
+- **Don't toast for routine navigation** — the page change is the feedback.
+- **Don't toast inside a server action.** Toasts are client-side; return a result and toast at the call site.
+
+## View transitions: portaled / floating UI
+
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+
+## Destructive actions (delete / leave / unsubscribe)
+
+Gate behind a confirmation dialog, and mind two edge cases:
+
+- **Don't `redirect()` inside the action.** It throws, which stops the client from toasting or closing the dialog. Return `{ ok: true }` and navigate with `router.push()`.
+- **Don't wrap the whole action call in `useTransition`** inside the dialog — with view transitions on, that animates the background UI behind the dialog. Track pending with `useState` / `useOptimistic(false)` and reserve `startTransition` for the post-success navigation only.
+
+## The action-prop pattern
+
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+
+## URL-based pagination
+
+Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
+
+```tsx
+import { Suspense } from 'react';
+
+export function Feed({ page = 1 }: { page?: number }) {
+  return (
+    <ul>
+      {Array.from({ length: page }).map((_, i) => {
+        const p = i + 1;
+        return p === 1 ? (
+          <FeedPage key={p} page={p} />
+        ) : (
+          <Suspense key={p} fallback={<FeedPageSkeleton />}>
+            <FeedPage page={p} />
+          </Suspense>
+        );
+      })}
+    </ul>
+  );
+}
+```
+
+The first page can render in the parent boundary; later pages get their own fallbacks so "load more" streams only the newly requested page. If the URL update should preserve scroll, use [`<Link scroll={false}>`](https://preview.nextjs.org/docs/app/api-reference/components/link).
+
+## Global client state
+
+For truly global client state (audio player, cart, system-reactive theme), wrap a [context provider](https://react.dev/reference/react/createContext) at the root; the provider is `'use client'` but `children` stays server-rendered, and only leaf components read the context. **Don't push server data into it** — server data stays in queries; client state is for ephemeral UI (open menus, playback position, optimistic drafts). See the live-data decision in `references/components.md`.

--- a/.cursor/skills/.repo-canonical-skills.json
+++ b/.cursor/skills/.repo-canonical-skills.json
@@ -58,6 +58,7 @@
     "moai-library-shadcn",
     "motion",
     "new-branch-and-pr",
+    "nextjs-app-architecture",
     "nextjs-app-router",
     "nextjs-supabase-auth",
     "npm-deps-cleanup",
@@ -468,6 +469,18 @@
     "new-branch-and-pr": [
       "SKILL.md",
       "references/upstream.md"
+    ],
+    "nextjs-app-architecture": [
+      "SKILL.md",
+      "references/cache-components.md",
+      "references/components.md",
+      "references/example.md",
+      "references/feature-folders.md",
+      "references/pages-suspense.md",
+      "references/queries-actions.md",
+      "references/single-page-applications.md",
+      "references/upstream.md",
+      "references/ux-patterns.md"
     ],
     "nextjs-app-router": [
       "SKILL.md"

--- a/.cursor/skills/find-skills/SKILL.md
+++ b/.cursor/skills/find-skills/SKILL.md
@@ -80,6 +80,19 @@ workflows, and use `docs/ai/skills/inngest-setup/SKILL.md` only when explicitly
 adding product runtime Inngest. Refresh with `bun run skills:refresh-inngest`,
 then `bun run skills:sync` and `bun run skills:verify`.
 
+**Example — Next.js app architecture:** page composition, feature-folder UI
+layout, colocated Suspense skeletons, and leaf-client UX are covered by
+`docs/ai/skills/nextjs-app-architecture/SKILL.md`. Install or refresh from
+[`aurorascharff/nextjs-app-architecture-skill`](https://github.com/aurorascharff/nextjs-app-architecture-skill)
+with `npx skills add aurorascharff/nextjs-app-architecture-skill -y`, then
+restore the local overlay from `docs/ai/skills/nextjs-app-architecture/SKILL.md`
+and `docs/ai/skills/nextjs-app-architecture/references/upstream.md`, then
+`bun run skills:sync` and `bun run skills:verify`. Keep it subordinate to
+`docs/ai/rules/frontend.md`, `docs/ai/skills/nextjs-app-router/SKILL.md`,
+`docs/ai/skills/cache-components/SKILL.md`, and
+`docs/guides/architecture/data-access-boundary.md`. Do not move business
+queries or privileged mutations into app feature folders.
+
 ## How to Help Users Find Skills
 
 ### Step 1: Understand What They Need

--- a/.cursor/skills/nextjs-app-architecture/LICENSE
+++ b/.cursor/skills/nextjs-app-architecture/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aurora Scharff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.cursor/skills/nextjs-app-architecture/README.md
+++ b/.cursor/skills/nextjs-app-architecture/README.md
@@ -1,0 +1,65 @@
+# Next.js App Architecture Skill
+
+An agent skill for building or auditing Next.js 16+ App Router apps. It packages the patterns from [Component Architecture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/) and the [next-beats](https://github.com/vercel-labs/next-beats) reference app into a form AI coding agents can load and apply.
+
+## Install
+
+```bash
+npx skills add aurorascharff/nextjs-app-architecture-skill
+```
+
+## The six principles
+
+- **Pages are synchronous compositors.** They don't fetch, they compose.
+- **Async components fetch their own data.** Co-locate the read with the JSX.
+- **Route props stop at the page.** Components receive IDs, slugs, parsed filters, or records — not raw `params` / `searchParams`.
+- **Skeletons live next to their component.** Same file, exported alongside it.
+- **Suspense boundaries go at the page level.** The page designs the loading sequence.
+- **Client boundaries are leaf nodes.** Push `'use client'` as deep as it can go.
+
+## Prerequisite
+
+Before using the skill on a project, follow the [Next.js AI Coding Agents guide](https://preview.nextjs.org/docs/app/guides/ai-agents) so the agent reads version-matched Next.js docs from `AGENTS.md` / bundled docs instead of stale training data.
+
+## What it covers
+
+- **Feature folders** — domain ownership, cross-domain product experiences, merging sub-concepts into a parent, and file naming.
+- **Queries** — `import 'server-only'`, plain async reads by default, selective React `cache()` only for proven same-request dedup, and `'use cache'` + `cacheTag` + `cacheLife` for Cache Components.
+- **Actions** — `'use server'`, input validation, tag invalidation under Cache Components, calling from client components.
+- **Components** — async server components that receive IDs/parsed values, sibling skeletons, single-use helpers, the client boundary, the `use()` + promise-prop pattern, live data via polling.
+- **Pages** — sync page composition, `params.then()` for static-shell preservation, Suspense boundary placement, CLS prevention, error boundaries, audit smells.
+- **Cache Components** — when to opt in, the static-shell model, `'use cache'` variants, build constraints.
+- **UX patterns** — `useOptimistic`, toasts, pending state, destructive-action flows, the action-prop pattern, URL pagination.
+
+## References
+
+The `SKILL.md` overview is always loaded; references split into two zones so the agent pulls only what the task needs.
+
+**Core** (any RSC app):
+
+- [`references/feature-folders.md`](references/feature-folders.md) — folder layout, naming, merging sub-concepts, action/query file naming.
+- [`references/queries-actions.md`](references/queries-actions.md) — server-only queries, selective same-request dedup, server actions, validation, and cache/tag invalidation.
+- [`references/components.md`](references/components.md) — async server components, skeletons without alias wrappers, client boundary, promise + `use()`, single-use helpers, polling.
+- [`references/pages-suspense.md`](references/pages-suspense.md) — page composition, `PageProps` / `LayoutProps`, `params.then()`, Suspense placement, CLS prevention, error boundaries.
+- [`references/example.md`](references/example.md) — next-beats invariant map and supporting patterns.
+
+**Instant Apps** (opt-in, load only when optimizing for instant-feeling apps):
+
+- [`references/cache-components.md`](references/cache-components.md) — `cacheComponents: true`, the static shell, which reads to cache, `'use cache'` variants, `cacheTag` / `cacheLife`, `updateTag` / `revalidateTag`, and `io()` vs `connection()`.
+- [`references/single-page-applications.md`](references/single-page-applications.md) — SPA-style client caching and navigation patterns.
+- [`references/ux-patterns.md`](references/ux-patterns.md) — `useOptimistic`, toasts, pending state via `data-pending`, destructive flows, the action-prop pattern, URL pagination, `useFormStatus`.
+
+## Background reading
+
+- [Component Architeture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/)
+- [Server and Client Component Composition in Practice](https://aurorascharff.no/posts/server-client-component-composition-in-practice/)
+- [Building Design Components with Action Props using Async React](https://aurorascharff.no/posts/building-design-components-with-action-props-using-async-react/)
+- [Error Handling in Next.js with catchError](https://aurorascharff.no/posts/error-handling-in-nextjs-with-catch-error/)
+- [Avoiding Server Component Waterfall Fetching with React 19 cache()](https://aurorascharff.no/posts/avoiding-server-component-waterfall-fetching-with-react-19-cache/)
+- [next16-social-media](https://github.com/aurorascharff/next16-social-media) — demo app applying these patterns.
+
+**Companion skill:** [React View Transitions](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+
+## License
+
+MIT

--- a/.cursor/skills/nextjs-app-architecture/SKILL.md
+++ b/.cursor/skills/nextjs-app-architecture/SKILL.md
@@ -21,6 +21,12 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
 - Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+- Do not regenerate or expand the managed root `AGENTS.md`.
+
+**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+
+- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
 

--- a/.cursor/skills/nextjs-app-architecture/SKILL.md
+++ b/.cursor/skills/nextjs-app-architecture/SKILL.md
@@ -23,9 +23,9 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
 - Do not regenerate or expand the managed root `AGENTS.md`.
 
-**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+**Core remaps** — apply these at every numbered step. Upstream file-placement lines are vendor text, not permission to add a query layer.
 
-- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Feature-owned means UI composition only.** The feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` at all.
 - **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
@@ -34,7 +34,7 @@ Refresh: `references/upstream.md`.
 
 A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
 
-**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+**Follow the workflow below step by step** — apply the **Core remaps** at each step. Upstream `*-queries.ts` / `*-actions.ts` lines are vendor text: **CORE: skip file creation.** Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
 
 ## Prerequisite
 
@@ -46,7 +46,7 @@ Build pages that describe the loading experience, not pages that act like route 
 
 - `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
 - Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
-- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly. **(CORE: skip file creation. Import `@asym/api` or `@asym/database/hooks` from the feature component.)**
 - When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
 - Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
 
@@ -60,8 +60,8 @@ The non-negotiables. The workflow produces them; the final check verifies them.
 4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
 5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
 6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
-7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
-8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts. **(CORE: skip file creation. Call `@asym/api` from the feature component; do not add those files under `apps/*/features/`.)**
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions. **(CORE: "keeps its queries and actions" means `packages/api`, not a feature-local query file.)**
 9. **Client components import actions directly** — never receive a server action as a prop just to call it.
 10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
 11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
@@ -78,13 +78,13 @@ Run these in order for build-from-scratch, feature work, or audits. Each step na
 2. **Place the work.** Decide the feature folder before writing anything.
    → `references/feature-folders.md` (decision tree + merge rules).
    ✓ A real domain, a cross-domain product experience, or folded into the right parent.
-3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`. **(CORE: skip file creation. Import the existing `@asym/api` read, or `@asym/database/hooks` for an approved browser table.)**
    → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
    ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
-4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top. **(CORE: skip file creation. Import the existing `@asym/api` mutation.)**
    → `references/queries-actions.md`.
    ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
-5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves. **(CORE: "its own query" is an `@asym/api` or `@asym/database` call, not a new `*-queries.ts`.)**
    → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
    ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
 6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
@@ -105,10 +105,10 @@ Inspect the diff against every invariant — each is checkable by reading the ch
 - [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
 - [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
 - [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
-- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`. **(CORE: skip file creation. A new `*-queries.ts` / `*-actions.ts` under `apps/*/features/` means the change is wrong.)**
 - [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
 - [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
-- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions. **(CORE: skip file creation.)**
 - [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
 - [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
 - [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.

--- a/.cursor/skills/nextjs-app-architecture/SKILL.md
+++ b/.cursor/skills/nextjs-app-architecture/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: nextjs-app-architecture
+description: Build or audit Next.js 16 App Router apps using a next-beats-style React Server Components architecture. Use when scaffolding a new app, adding a feature, reviewing an existing app, refactoring route-loader-shaped pages into feature-owned async server components, deciding where queries/actions/components live, keeping pages synchronous with `params.then()`, placing Suspense boundaries, choosing the client/server boundary, designing skeletons, preventing CLS, or enabling Cache Components. Also use when the user asks about RSC composition, components receiving IDs instead of route params, `'use cache'`, `cacheTag`, `updateTag`, static-shell prerendering, or making an app easier for AI agents to modify.
+license: MIT
+metadata:
+  author: aurorascharff
+  version: "1.3.9"
+---
+
+## This repository (Asymmetric-al/core)
+
+Subordinate to installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`), **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/nextjs-app-router/SKILL.md`**, **`docs/ai/skills/cache-components/SKILL.md`**, and **`docs/guides/architecture/data-access-boundary.md`**.
+
+This skill is for page composition, Suspense placement, leaf client boundaries, and feature-owned UI. It is not a license to invent a new app folder scheme or move business database logic.
+
+**Repo mapping:**
+
+- Privileged reads, writes, payments, webhooks, and vendor calls stay in `packages/api`.
+- Browser-visible table data uses `@asym/database/hooks` when a collection exists.
+- Shared UI stays in `@asym/ui` / exact `base-maia`. Existing `apps/*/features/` directories are UI composition, not a new query layer.
+- All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
+- Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
+- Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+
+Refresh: `references/upstream.md`.
+
+# Next.js App Architecture
+
+A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
+
+**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+
+## Prerequisite
+
+Before changing a Next.js app, make sure the project is set up for AI agents to read version-matched docs. Follow the [AI Coding Agents guide](https://preview.nextjs.org/docs/app/guides/ai-agents): prefer the project's `AGENTS.md` / bundled docs, and create or refresh them when missing. Then use this skill for architecture decisions.
+
+## Architecture target
+
+Build pages that describe the loading experience, not pages that act like route loaders:
+
+- `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
+- Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
+- Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
+
+## Invariants (what every change must satisfy)
+
+The non-negotiables. The workflow produces them; the final check verifies them.
+
+1. **Pages compose, they never fetch.** A page/layout imports feature components and places `<Suspense>`. No queries or domain logic inline. Tiny route-local control-flow helpers are allowed only when they exist to place a boundary around `connection()`, `redirect()`, or a resolved route prop.
+2. **Pages stay synchronous.** Use `params.then()` / `searchParams.then()` or `Promise.all([params, searchParams]).then(...)`, never `await params` at the top — so chrome paints into the static shell and only data-dependent sections suspend.
+3. **Feature components receive IDs, not route props.** Resolve `params` / `searchParams` at the page boundary and pass plain values (`id`, `slug`, `query`) into features.
+4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
+5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
+6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+9. **Client components import actions directly** — never receive a server action as a prop just to call it.
+10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
+11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
+
+## Workflow
+
+Run these in order for build-from-scratch, feature work, or audits. Each step names the reference to consult and the check it must pass.
+
+1. **Choose mode.**
+   - **Build from scratch:** sketch routes, real domain nouns, static shell, and expected loading groups before writing code.
+   - **Audit/refactor:** scan current `app/` pages first; list every async page, page-level query import, route prop leak, missing Suspense boundary, and feature folder mismatch.
+     → `references/example.md` for the target shape; `references/feature-folders.md` for placement.
+     ✓ You know whether you are creating the architecture or converting loader-shaped code into it.
+2. **Place the work.** Decide the feature folder before writing anything.
+   → `references/feature-folders.md` (decision tree + merge rules).
+   ✓ A real domain, a cross-domain product experience, or folded into the right parent.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+   → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
+   ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+   → `references/queries-actions.md`.
+   ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+   → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
+   ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
+6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
+   → `references/pages-suspense.md`.
+   ✓ Route props become plain values; stable cards/sections wrap Suspense when they set layout; boundaries stay visible at the page.
+7. **Add interaction** (if any): optimistic updates, pending state, toasts, confirmation.
+   → `references/ux-patterns.md`.
+   ✓ Feedback isn't doubled; optimistic reducers/actions live with the feature; URL/search params own shareable state; client effects synchronize external systems, not derived React state.
+8. **Verify** against the checklist below before declaring done.
+
+## Verify before done
+
+Inspect the diff against every invariant — each is checkable by reading the changed files:
+
+- [ ] No page/layout imports a `*-queries` file or defines reusable domain UI inline; any inline helper is route-local control flow only.
+- [ ] Every page with params is synchronous and uses `params.then()` / `searchParams.then()` / `Promise.all([params, searchParams]).then(...)`.
+- [ ] Feature components receive plain IDs/handles/parsed filters or resolved records; no feature prop is named `params` or `searchParams`.
+- [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
+- [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
+- [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
+- [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
+- [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
+- [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.
+- [ ] Client leaves use `useOptimistic`, transitions, reducers, URL state, or form actions for interaction; they do not call `setState` in effects for derived React state.
+- [ ] Mutations validate their input and invalidate the affected data.
+
+## Reference index
+
+- **`references/feature-folders.md`** — where code goes: folder layout, cache contracts, naming, and merging sub-concepts.
+- **`references/queries-actions.md`** — query/action rules: server-only, dedup, validation, invalidation, return shape.
+- **`references/components.md`** — server/client boundary, skeletons, `use()`, single-use helpers, live data.
+- **`references/pages-suspense.md`** — page composition, `params.then()`, Suspense placement, CLS, error boundaries, prefetch.
+- **`references/cache-components.md`** — the `cacheComponents` decisions: which reads to cache, which directive to use, how to invalidate.
+- **`references/single-page-applications.md`** — client cache decisions: placement, server seeding, Cache Components coordination, hydration, and mutations.
+- **`references/ux-patterns.md`** — interaction decisions: optimistic vs pending vs inline error, toasts, action-prop, confirmations.
+- **`references/example.md`** — the next-beats reference app: invariant → file map, for seeing any rule in real code.

--- a/.cursor/skills/nextjs-app-architecture/references/cache-components.md
+++ b/.cursor/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,0 +1,80 @@
+# Cache Components
+
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+
+## When this reference applies
+
+Use this reference when an app already has `cacheComponents: true`, the user wants this architecture while enabling it, or you are reviewing/refactoring an app that targets Cache Components.
+
+If the project has not adopted Cache Components yet and the user asks to enable, migrate, or work through adoption blockers, use the `next-cache-components-adoption` skill first. It owns the route-by-route migration loop, opt-out strategy, and build/dev overlay workflow. Then return here for steady-state query/action/component architecture.
+
+If `cacheComponents` is not enabled and the task is ordinary feature work, follow the core references without adding cache directives. Do not recommend skipping Cache Components based on app category alone; adoption is a migration/project decision, not a per-feature shortcut.
+
+Adopting these in an existing app: follow [Migrating to Cache Components](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components) and [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) — they cover the incremental path (per-route `prefetch = 'partial'`, fixing dynamic-usage build errors) rather than a big-bang switch.
+
+## The model
+
+```ts
+// next.config.ts
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true, // prefetch the static shell of linked routes
+};
+```
+
+- **Static shell** — synchronous content, `'use cache'` output, and Suspense fallbacks prerender at build time.
+- **Dynamic holes** — async work without `'use cache'` streams in behind `<Suspense>` at request time.
+- **Build constraint** — any async work without `'use cache'` must sit inside `<Suspense>`, or the build fails (wrap it, or add `'use cache'`).
+
+`cacheComponents` implies Partial Prerendering — it replaced `experimental.ppr` / `dynamicIO` / `useCache`, so don't set those. See [caching](https://preview.nextjs.org/docs/app/getting-started/caching).
+
+With `cacheComponents: true`, the skill practice is **cache reusable reads**. Do not leave a database/API read dynamic just because Suspense makes the build pass. If a read has a stable key and a mutation can name what changed, give it a cache directive, tags, and a lifetime.
+
+Dynamic reads are the exception: use them for values that must be recomputed for every request or cannot be invalidated coherently. When you leave a read dynamic, note the reason in the surrounding code/review and invalidate its mutations with `refresh()` because there is no tag to update.
+
+## Decide what to cache
+
+| Data | Directive | Notes |
+| ---- | --------- | ----- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
+| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+
+Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
+
+## Keep a synchronous value out of the shell
+
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+
+Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
+
+## Decide how to invalidate
+
+- [`updateTag(tag)`](https://preview.nextjs.org/docs/app/api-reference/functions/updateTag) — in **server actions**, when the user should see the result immediately (read-your-own-writes). Requires the query to carry a matching `cacheTag`.
+- [`revalidateTag(tag, 'max')`](https://preview.nextjs.org/docs/app/api-reference/functions/revalidateTag) — in **route handlers** (webhooks, cron) for stale-while-revalidate. The single-arg `revalidateTag(tag)` form is deprecated.
+- [`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) — re-render the current route for the current user. Use it for deliberately dynamic reads with no tag; don't use it instead of `updateTag()` for cached reads.
+
+Tag, cache, invalidate: the `cacheTag` in the query and the `updateTag` in the action use the same string and live in the same feature folder.
+
+## Coordinate hydrated client data
+
+When cached server data seeds SWR, TanStack Query, or another browser cache, follow `references/single-page-applications.md`. Server and client freshness policies are independent; hydration adds library-specific constraints.
+
+## Build failure map
+
+When `next build` fails under Cache Components, map the error back to an architecture rule instead of patching locally:
+
+- Async work without `'use cache'` and without an ancestor `<Suspense>` → cache the reusable read, or wrap a justified dynamic read in a page-owned `<Suspense>`.
+- Request data inside `'use cache'` → switch to `'use cache: private'` when it is per-user cacheable, or keep it dynamic with a documented reason.
+- `await params` / `await searchParams` at the top of a page → keep the page synchronous and move the read into `params.then()` / `searchParams.then()`.
+- Sync request-time values (`new Date()`, `Math.random()`, sync storage reads) captured in the shell → cache stable values, or use [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) for per-request values.
+
+For adoption-wide blocker triage, use `next-cache-components-adoption`. For API-specific recipes, follow the [Migrating to Cache Components guide](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components).
+
+## Without Cache Components
+
+- Don't use `'use cache'` / `cacheTag` / `cacheLife` — they require the flag.
+- Use React `cache()` only for proven same-request dedup needs; plain `server-only` async queries are the default.
+- Invalidate with `refresh()` from server actions.
+- Pages still use `params.then()` in this architecture. Without Cache Components there is no build-time static shell to preserve, but keeping pages synchronous still lets chrome paint before route-specific data resolves and keeps the app consistent.

--- a/.cursor/skills/nextjs-app-architecture/references/cache-components.md
+++ b/.cursor/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,6 +1,6 @@
 # Cache Components
 
-Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about _which reads to cache, which directive to use, and how to invalidate_ — for the mechanics of each directive, follow the doc links.
 
 ## When this reference applies
 
@@ -34,18 +34,18 @@ Dynamic reads are the exception: use them for values that must be recomputed for
 
 ## Decide what to cache
 
-| Data | Directive | Notes |
-| ---- | --------- | ----- |
-| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
-| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
-| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
-| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+| Data                                                     | Directive                                                                                                | Notes                                                                                                                                                                                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache)                  | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session               | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server.                                                                                                                                          |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote)   | Protects against rate-limited third-party APIs.                                                                                                                                                                                  |
+| Genuinely dynamic per request                            | none                                                                                                     | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists.                                                                                                                                    |
 
 Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
 
 ## Keep a synchronous value out of the shell
 
-You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a _synchronous_ request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
 
 Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
 

--- a/.cursor/skills/nextjs-app-architecture/references/components.md
+++ b/.cursor/skills/nextjs-app-architecture/references/components.md
@@ -1,0 +1,243 @@
+# Components
+
+How to build server and client components inside a feature folder.
+
+## Default: async server component
+
+Server components await their own queries directly — no `useEffect`, no client-side fetching, no manual loading state. See the [Server Components docs](https://preview.nextjs.org/docs/app/getting-started/server-and-client-components) for the model.
+
+Prefer minimal, stable props: IDs, slugs, handles, parsed filters, or records the parent already fetched. Do not pass raw route `params` or `searchParams` into feature components. Pages resolve those promises and pass plain values.
+
+```tsx
+// features/notifications/components/notifications-badge.tsx
+import { getUnreadNotificationCount } from "@/features/notifications/notifications-queries";
+
+export async function NotificationsBadge() {
+  const count = await getUnreadNotificationCount();
+  if (count === 0) return null;
+  return <span aria-label={`${count} unread`}>{count}</span>;
+}
+```
+
+The page (not this file) wraps it in `<Suspense fallback={<NotificationsBadgeSkeleton />}>` — see `references/pages-suspense.md`.
+
+For parameterized routes, the page resolves `params` and the feature receives an ID:
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <PostDetail id={id} />
+  ))}
+</Suspense>
+```
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Skeletons live in the same file
+
+Export the main component and its skeleton from the same file. Pages import both. Define the skeleton **at the end of the file**, below the real component(s) — never above. Function declarations are hoisted, so a skeleton referenced by a component earlier in the file still works when defined last.
+
+```tsx
+export async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return (
+    <ul>
+      {posts.map((p) => (
+        <Post key={p.id} post={p} />
+      ))}
+    </ul>
+  );
+}
+
+export function FeedSkeleton() {
+  return (
+    <ul>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <li key={i}>
+          <Skeleton className="h-24" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Don't export a second skeleton whose whole job is to rename or preconfigure another skeleton:
+
+```tsx
+// Wrong — alias wrapper adds an import surface but no behavior
+export function CompactGridSkeleton() {
+  return <GridSkeleton dense />;
+}
+```
+
+Import the real skeleton and pass the prop inline at the `<Suspense>` boundary: `fallback={<GridSkeleton dense />}`.
+
+### Skeleton design checklist
+
+1. Match the real component's layout: flex direction, gaps, padding, breakpoints.
+2. Include all structural elements: avatar circles, action button placeholders, image squares.
+3. Responsive visibility must match (`hidden sm:block` in the real component → same in the skeleton).
+4. Show 2–5 placeholders for variable-length lists, not the real count.
+5. Don't include skeletons for inner Suspense content — those have their own boundaries.
+6. Reserve the right height. CLS comes from skeletons that are shorter than the real content.
+7. Dense placeholders should not animate. A grid of 28 shimmering covers reads as flicker rather than progress, so use a flat low-contrast fill when there are many items and keep the animated sweep for a handful of bars.
+
+## Group related components in one file
+
+A card and its grid live in the same file. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`. Variants should reuse that skeleton inline instead of exporting alias skeletons. Don't split shared UI primitives prematurely — wait until three call sites need the same shape before extracting.
+
+Two sidebar widgets that happen to look similar but render different data shapes are **not** the same component. The visuals diverge as soon as one needs an extra slot.
+
+### Single-use sub-components stay inlined
+
+For a metadata strip inside one card, a header used only by one detail view, a list item only rendered by its list — inline them as **non-exported** functions in the same file:
+
+```tsx
+export async function EventDetails({ slug }: { slug: string }) {
+  const event = await getEventBySlug(slug);
+  return (
+    <article>
+      <MetaStrip event={event} />
+      <Speaker speaker={event.speaker} />
+      <p>{event.description}</p>
+    </article>
+  );
+}
+
+function MetaStrip({ event }: { event: Event }) { ... }
+function Speaker({ speaker }: { speaker: string }) { ... }
+```
+
+Exports are for things other files will import. Internal structure is for readability inside one file.
+
+## The server/client boundary
+
+`'use client'` only when you need:
+
+- Hooks (`useState`, `useReducer`, `useOptimistic`, `useTransition`, `useEffect`)
+- Event handlers (`onClick`, `onChange`, `onSubmit`)
+- Browser APIs (`window`, `localStorage`, refs to DOM)
+
+If the component needs interactive pieces, keep the server component as the parent and render client leaves:
+
+```tsx
+async function PostDetail({ id }: { id: string }) {
+  const [post, userState] = await Promise.all([
+    getPost(id),
+    getPostUserState(id),
+  ]);
+  return (
+    <article>
+      <PostBody body={post.body} />
+      <PostActions userState={userState} /> {/* 'use client' leaf */}
+    </article>
+  );
+}
+```
+
+### Server content as children of client components
+
+Composition crosses the boundary. A client component can accept server-rendered JSX as children or props:
+
+```tsx
+<ComposerForm
+  avatar={
+    <Suspense fallback={<AvatarSkeleton />}>
+      <CurrentUserAvatar />
+    </Suspense>
+  }
+/>
+```
+
+`ComposerForm` is `'use client'`. It doesn't know where the avatar JSX came from. The Suspense boundary streams the avatar in without the form re-rendering.
+
+### Pass server children resolved values, not promises
+
+Prefer passing plain values (strings, IDs, resolved data) to a server child. A server component _can_ `await` a promise prop, but resolve route promises in the page instead — pass an unresolved promise down only to a _client_ component that reads it with `use()` (see below). When a parent already has the data from its own query, pass it as a prop instead of having the child refetch.
+
+```tsx
+// Right — parent fetches the list, passes each item
+async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return posts.map((post) => <Post key={post.id} post={post} />);
+}
+
+async function Post({ post }: { post: Post }) {
+  return <article>{post.body}</article>;
+}
+```
+
+```tsx
+// Wrong — child refetches what the parent already had
+async function Post({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Client components that own their loading state
+
+When a client component needs server data but should manage its own loading (a sidebar badge, a popover that opens on hover), pass an **unresolved promise** from the server and resolve it with [`use()`](https://react.dev/reference/react/use) on the client. Wrap the consumer in `<Suspense>`.
+
+```tsx
+// page: pass the unresolved promise, wrap in Suspense
+<Suspense fallback={<TagListSkeleton />}>
+  <TagPicker itemsPromise={getTags()} />
+</Suspense>
+```
+
+```tsx
+"use client";
+import { use } from "react";
+
+export function TagPicker({ itemsPromise }: { itemsPromise: Promise<Tag[]> }) {
+  const items = use(itemsPromise);
+  // render interactive UI from items
+}
+```
+
+The opinionated bit: name promise props with a `Promise` suffix (`itemsPromise`, `userPromise`) so the contract is obvious at the call site.
+
+### Client data libraries (SWR, TanStack Query)
+
+Follow `references/single-page-applications.md` when a feature uses a browser data cache or needs externally authored updates. It covers when to use a library, where its files live, server seeding, Cache Components coordination, hydration, and mutations.
+
+## Interactive async React shape
+
+Keep the server/client split even when the UI is highly interactive:
+
+- The server component reads durable data and renders the initial tree.
+- The client leaf owns only ephemeral interaction: open state, focused field, pending flag, optimistic draft, selected tab that is not shareable.
+- Shareable or bookmarkable state lives in the URL/search params, not mirrored in component state.
+- Client leaves import server actions directly and call them from form actions or event handlers.
+- Mutation feedback (`useOptimistic`, pending flags, rollback, toasts) follows `references/ux-patterns.md`.
+
+Avoid effects whose only job is to copy React state to React state:
+
+```tsx
+// Wrong — derived React state cascades through an effect
+useEffect(() => {
+  setSelectedItem(null);
+}, [filterKey]);
+```
+
+Prefer one of these shapes:
+
+- Key the interactive child by the value that resets it: `<SelectableList key={filterKey} filterKey={filterKey} />`.
+- Derive the value during render.
+- Put the value in the URL/search params if navigation should own it.
+- Use a reducer where the same event that changes `filterKey` also clears `selectedItem`.
+
+Effects are for external systems: DOM APIs, subscriptions, timers, browser storage, analytics, or imperative libraries. They are not a cleanup lane for state that React could derive or reset structurally.
+
+## Mutations
+
+For client-side reactions to a server mutation (instant feedback, pending state, success/error toasts), see `references/ux-patterns.md`. To cache rendered output across requests, see `references/cache-components.md`.

--- a/.cursor/skills/nextjs-app-architecture/references/example.md
+++ b/.cursor/skills/nextjs-app-architecture/references/example.md
@@ -6,29 +6,29 @@ For the reasoning behind this architecture, read [Component Architecture for Rea
 
 ## Invariant → where to see it
 
-| Invariant | File(s) |
-| --------- | ------- |
-| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
-| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
-| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
-| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
-| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
-| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
-| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
-| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
-| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+| Invariant                                                                         | File(s)                                                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Pages compose, never fetch                                                     | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries.                                                                                                   |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`)                   | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`.                                                                                                                              |
+| 3. Feature components receive IDs, not route props                                | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components.                                                                                                          |
+| 4. Async server component default; `'use client'` on leaves                       | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`.                                                                     |
+| 5. Page owns Suspense; feature owns skeleton                                      | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below).                                                                                                                      |
+| 6. Skeleton in the same file, at the end                                          | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`.                                                                                                      |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`.                                                                                                                                                    |
+| 8. Feature folders follow product ownership                                       | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly                                      | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly.                                                                                                                                          |
 
 ## Supporting patterns
 
-| Pattern | File |
-| ------- | ---- |
-| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
-| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
-| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
-| `useFormStatus` submit button | `components/ui/button.tsx` |
-| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
-| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
-| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
-| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+| Pattern                                                | File                                                                                         |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`)   | `components/ui/error-boundary.tsx`                                                           |
+| `useOptimistic` for an unlikely-to-fail toggle         | `features/track/components/track-interactions.tsx`                                           |
+| Action-prop / `*Action` convention + confirm dialog    | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button                          | `components/ui/button.tsx`                                                                   |
+| `useActionState` inline field errors                   | `features/user/components/sign-in-form.tsx`                                                  |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx`                           |
+| `use()` on an unresolved promise prop                  | `features/playlist/components/add-to-playlist-menu.tsx`                                      |
+| Purpose-named `components/scripts/` subfolder          | `components/scripts/`                                                                        |
 
 > The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/.cursor/skills/nextjs-app-architecture/references/example.md
+++ b/.cursor/skills/nextjs-app-architecture/references/example.md
@@ -1,0 +1,34 @@
+# Reference app: next-beats
+
+A working app that follows this architecture: **<https://github.com/vercel-labs/next-beats>** (Next.js 16, `cacheComponents` + `partialPrefetching`, a music player). Use it to see any invariant in real code rather than restating the code here. Paths are as of this writing — verify against the current repo.
+
+For the reasoning behind this architecture, read [Component Architecture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/). The skill's target is the same shape: pages describe layout and loading; feature components own server reads; route params become IDs before they reach components.
+
+## Invariant → where to see it
+
+| Invariant | File(s) |
+| --------- | ------- |
+| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
+| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
+| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
+| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
+| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
+| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+
+## Supporting patterns
+
+| Pattern | File |
+| ------- | ---- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
+| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
+| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button | `components/ui/button.tsx` |
+| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
+| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
+| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+
+> The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/.cursor/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.cursor/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,5 +1,7 @@
 # Feature folders
 
+> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+
 How to organize code under `features/` and `app/`.
 
 ## Folder layout

--- a/.cursor/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.cursor/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,6 +1,6 @@
 # Feature folders
 
-> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+> **Core:** Existing `apps/*/features/` folders are UI composition only. Do not add `*-queries.ts` or `*-actions.ts` at all. Call `@asym/api` or `@asym/database/hooks` from the feature component.
 
 How to organize code under `features/` and `app/`.
 

--- a/.cursor/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/.cursor/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,0 +1,147 @@
+# Feature folders
+
+How to organize code under `features/` and `app/`.
+
+## Folder layout
+
+```
+features/<domain>/
+  <domain>-cache.ts     # Pure server tags + client query keys, when shared
+  <domain>-queries.ts   # Server-only queries, when this feature owns reads
+  <domain>-actions.ts   # Server actions, when this feature owns writes
+  <domain>-query-options.ts # Client data-library query definitions, when needed
+  components/           # Server + client components, each with its skeleton
+  types/                # Feature-local public types, when needed by multiple files
+  hooks/                # Actual feature-local React hooks and hook wrappers
+  providers/            # Feature-local providers, only when the provider belongs to this domain
+```
+
+The folder name identifies the domain or cohesive product experience. Query and action filenames match the owning domain folder when present.
+
+## How many features?
+
+Keep the feature list short. Use folders for **domains and cohesive product experiences a user would recognize**, not database tables or technical concerns.
+
+A new folder is justified in either of these cases:
+
+1. **Domain ownership:** it owns the queries, actions, and components for a real product entity.
+2. **Cross-domain composition:** it owns the route-level UI or client state for an experience that combines multiple domains. The underlying queries and actions remain with the domains whose data they read or mutate.
+
+If you find yourself making a feature folder with one query, one action, and one button, fold it into the parent feature instead.
+
+### Merge aggressively
+
+Concepts that exist only in service of a parent entity belong inside the parent's feature folder:
+
+- A `favorite` or `bookmark` concept that only attaches to one parent entity (events, posts) → inside that parent's folder.
+- A `like`, `repost`, `vote`, or `reaction` concept on a piece of content → with that content's feature.
+- `auth` / `session` / `current user` → a single `user` folder, not split.
+- A search query stays with the domain it searches (`searchTracks` in `features/track/`, `searchPlaylists` in `features/playlist/`). When one search experience combines several domains, `features/search/` may own the search form, result composition, and client state without taking ownership of those domain queries.
+
+Concrete example: `toggleFavorite` is a mutation about events ("I favorite an event"), not its own domain. It lives in `features/event/event-actions.ts`, not `features/favorite/favorite-actions.ts`.
+
+## File naming
+
+Filenames inside the folder always start with the folder name:
+
+```
+features/event/
+  event-queries.ts
+  event-actions.ts
+  components/
+    event-grid.tsx
+    event-details.tsx
+    favorite-button.tsx     ← OK: a component, not a "favorite" feature
+```
+
+- `<folder>-queries.ts` — even if the file has only one query.
+- `<folder>-actions.ts` — even if a mutation is about a sub-concept.
+- Don't create empty query or action files for a cross-domain UI feature that doesn't own data access.
+- Other `<folder>-*.ts` files are fine when the folder needs them (`playlist-constants.ts`, `<folder>-schema.ts`), as long as they keep the folder-name prefix. Don't put reusable domain types in a root `*-types.ts` file; use `features/<domain>/types/` once a type is imported by multiple files.
+- Component files use any descriptive name. The component (not the feature) is the unit here.
+
+## Local vs shared support folders
+
+Use a local support folder when the code belongs to one feature:
+
+```
+features/message/
+  message-cache.ts
+  message-query-options.ts
+  types/
+    message.ts
+  hooks/
+    use-message-mutations.ts
+    use-message-draft.ts
+  providers/
+    message-draft-provider.tsx
+```
+
+Feature-owned client coordination stays with the feature. Place each file by the shape it exports and the domain it belongs to:
+
+- Client data-library cache contracts and query definitions follow `references/single-page-applications.md`.
+- Mutation wrappers that export hooks live in `hooks/use-*.ts` (`use-message-mutations.ts` exporting `useSendMessage`).
+- Browser-only state helpers live in `hooks/` when their public API is a hook (`use-thread.ts`, `use-message-draft.ts`).
+- Client leaf components that coordinate a server write live in `components/` next to the UI they support (`mark-activity-read.tsx` posts read activity in the background while the current `/activity` tree stays stable).
+
+Keep the file prefix aligned with the feature folder when a file exports a grouped feature contract (`workspace-cache.ts` and `workspace-query-options.ts`, not `activity-cache.ts` in `features/workspace/`). Support code for a sub-concept still lives with the parent feature: reactions on messages belong in `features/message/`; unread activity chrome belongs in `features/workspace/`.
+
+Promote only when there are real cross-feature consumers:
+
+- `types/` at the project root — shared domain/application types imported across features.
+- `hooks/` at the project root — shared client hooks used across features.
+- `app/providers.tsx` or `components/*-provider.tsx` — app-shell providers that wrap the whole app.
+
+Avoid root-level miscellany like `message-types.ts`, `shared-hooks.ts`, or `common-provider.tsx`; the folder name should explain the scope.
+
+## What goes in `components/`
+
+Each component file exports the main component **plus its skeleton**:
+
+```tsx
+// features/event/components/event-grid.tsx
+export async function EventGrid(...) { ... }
+export function EventGridSkeleton() { ... }
+```
+
+Group related components in one file when they're always used together or one is a natural building block for another. A card and its grid live together. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`.
+
+Split into separate files only when:
+
+- A component is consumed by multiple sibling components (one shared use is not enough — wait until three call sites need it).
+- A component is `'use client'` and a sibling is a server component (the server/client boundary forbids sharing a file).
+
+See `references/components.md` for inlining rules and the skeleton design checklist.
+
+## What pages do
+
+Pages in `app/` compose feature components with Suspense and transition wrappers. They never:
+
+- Contain domain logic
+- Define new components except thin transition wrappers (e.g. `<ViewTransition>`)
+- Fetch data directly
+- Inline route-specific components — extract them into the feature folder
+
+See `references/pages-suspense.md` for page composition details.
+
+## Top-level layout
+
+```
+app/                  # Pages and layouts
+features/             # Domain folders
+components/           # UI primitives, theme, and app-shell singletons
+hooks/                # Shared client hooks used across features
+types/                # Shared cross-feature types only
+lib/                  # Utilities and cohesive non-domain subsystems
+```
+
+`lib/` holds flat helpers (`db.ts`, `utils.ts`) but may also group a cohesive non-domain subsystem in its own subfolder (e.g. `lib/audio/` for an audio engine). Cross-feature client hooks live in top-level `hooks/`; a hook used by a single feature co-locates in that feature's `hooks/`. Types follow the same rule: shared types at top-level `types/`, feature-only exported types in `features/<domain>/types/`.
+
+`components/` holds:
+
+- **`components/ui/`** — primitives. Low-level building blocks and action-prop components.
+- **`components/theme/`** — theme provider and toggle, paired.
+- **Top-level files** (`site-header.tsx`, `auth-gate.tsx`, `poller.tsx`) — app-shell singletons used once each. No `common/` folder — "common" is not a category. If a component is used everywhere it's a primitive (→ `ui/`); if it's used once it lives at the top level.
+- **Purpose-named subfolders** are fine when several files share a clear technical role — e.g. `components/scripts/` for pre-hydration inline `<script>` seed components. This is distinct from the rejected `common/`: a `scripts/` folder names _what the files are_, not "miscellaneous."
+
+Conventions for filenames and casing live in the project's `AGENTS.md`. This skill doesn't impose one.

--- a/.cursor/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.cursor/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -1,0 +1,276 @@
+# Pages and Suspense
+
+How to compose pages, place Suspense boundaries, and prevent layout shift.
+
+## Pages are composition only
+
+Pages in `app/` import feature components and place `<Suspense>` boundaries. They never:
+
+- Fetch data directly (queries live in feature folders)
+- Define reusable UI components except thin transition wrappers (e.g. `<ViewTransition>`) or tiny route-local control-flow helpers
+- Inline route-specific UI (extract it into the feature folder)
+- Pass raw `params` / `searchParams` to features
+
+## Page function signatures
+
+Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
+
+```tsx
+export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+```
+
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+
+## Keep pages synchronous
+
+Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
+
+```tsx
+import { Suspense } from 'react';
+import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+
+export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+  return (
+    <div>
+      <h1>Post</h1>
+      <Suspense fallback={<PostDetailSkeleton />}>
+        {params.then(({ id }) => (
+          <PostDetail id={id} />
+        ))}
+      </Suspense>
+    </div>
+  );
+}
+```
+
+The `<h1>` sits **above** the `params.then()` so it paints instantly. The `Suspense` fallback covers only the dynamic section.
+
+Resolve route props to plain values at this boundary. Feature components receive `id`, `slug`, `query`, or parsed filter values — not `params`, `searchParams`, or unresolved server promises.
+
+### Implicit return inside `.then()`
+
+Use an implicit-return arrow function when the callback just renders JSX — e.g. `({ id }) => <PostDetail id={id} />`. Only switch to a block body with `return` when you need to do work first (destructure with defaults, parse a `searchParams` value, branch on a condition). This keeps the JSX-in-page shape readable and matches how the resolved tree will look.
+
+### `searchParams` and combined params
+
+```tsx
+// searchParams only
+export default function SearchPage({ searchParams }: PageProps<'/search'>) {
+  return searchParams.then(sp => {
+    const q = typeof sp.q === 'string' ? sp.q : '';
+    return q ? <SearchResults query={q} /> : <EmptyState />;
+  });
+}
+
+// Both params and searchParams
+export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+  return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
+    <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
+  ));
+}
+```
+
+Use `Promise.all([params, searchParams])` when both are needed. Avoid nested `.then()` calls that make the resolved tree hard to read and easy to wrap in the wrong boundary.
+
+### Metadata, static params, and `notFound()`
+
+- [`generateMetadata`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-metadata) runs before render, so `await params` is fine there — it's a separate async function, not the page body, so it doesn't make the page dynamic.
+- Export [`generateStaticParams`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-static-params) from a `[slug]` page/layout to pre-build a known set of slugs; with `cacheComponents` + `'use cache'` they land in the static shell. It does **not** change the page signature — `params` is still a Promise, still consumed with `params.then()`.
+- A query that can't find its resource calls [`notFound()`](https://preview.nextjs.org/docs/app/api-reference/functions/not-found), which bubbles to the nearest [`not-found.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/not-found). Don't try/catch it — use [`unstable_rethrow`](https://preview.nextjs.org/docs/app/api-reference/functions/unstable_rethrow) if you must catch nearby.
+
+## Prefer a page boundary over `loading.tsx`
+
+Put the boundary in the page next to the `params.then()` / `searchParams.then()` it covers, rather than adding a route-segment `loading.tsx`. A page boundary keeps the fallback beside the JSX it stands in for, lets sibling sections share one boundary or split into several, and can be wrapped in `<ViewTransition>` so the reveal animates. A `loading.tsx` renders outside the page's own tree, so a transition wrapper inside the page cannot animate the swap out of it, and one fallback has to cover the whole route.
+
+## The page owns the Suspense boundary
+
+The feature exports the async component **and** its skeleton. The page imports both and places the boundary. Don't pre-wrap inside the feature — that hides the boundary and prevents grouping siblings.
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) { ... }
+export function PostDetailSkeleton() { ... }
+```
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <>
+      <PostDetail id={id} />
+      <ErrorBoundary title="Replies didn't load">
+        <Suspense fallback={<RepliesSkeleton />}>
+          <Replies postId={id} />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  ))}
+</Suspense>
+```
+
+If a page uses a transition wrapper (e.g. `<ViewTransition>`), place it in the page next to the `<Suspense>` boundary. Feature components render content and skeletons, not transition wrappers.
+
+## Stable shell, suspending body
+
+Before designing a fallback, identify what is stable and what is data-dependent.
+
+- Stable: card/panel border, padding, icon, label, section heading, fixed action rail.
+- Data-dependent: title text, counts, form body, list rows, loaded choices.
+- Rule: stable shell outside Suspense; skeleton/crossfade inside the shell around the data body.
+
+```tsx
+<FeaturePanel>
+  <Suspense fallback={<FeaturePanelBodySkeleton />}>
+    <Crossfade>
+      <FeaturePanelBody id={id} />
+    </Crossfade>
+  </Suspense>
+</FeaturePanel>
+```
+
+Do not render `<FeaturePanel>` in both `fallback` and final content. That duplicates layout responsibility and makes the skeleton guess the panel size.
+
+Use the app's real domain noun at implementation time (`PostPanel`, `MessageList`, `GroupEditor`, `EventDetails`, etc.); the neutral names here describe the reusable shape, not a component to copy literally.
+
+When the top data section has unknown final height and pushes the sections below, either reserve that height in the stable wrapper or group the affected sections in one boundary. Do not create two independent crossfades if the first one changes the second one's starting position.
+
+## Audit smells
+
+When auditing an existing app, flag and fix these first:
+
+- `export default async function Page(...)` that only awaits `params`, `searchParams`, or page-level queries.
+- `import { getSomething } from '@/features/.../*-queries'` inside `app/**/page.tsx` or `layout.tsx`.
+- Feature components whose props are `params`, `searchParams`, or a route-shaped object.
+- Page-local components like `HomeContent`, `PostShell`, or `ResultsSection` that only exist to fetch data or group a Suspense fallback.
+- `<Suspense>` inside feature components that prevents the page from grouping reveal behavior.
+
+## Route-local control-flow helpers
+
+Small inline helpers are fine when their only job is route control flow that must live exactly where a boundary is placed:
+
+```tsx
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginRedirect />
+    </Suspense>
+  );
+}
+
+async function LoginRedirect() {
+  await connection();
+  await redirectIfAuthenticated('/dashboard');
+  return <LoginForm />;
+}
+```
+
+Do not move a helper like this into a feature folder just to satisfy a blanket "no inline components" rule. It is not domain UI and it is not a reusable feature component; extracting it creates noise. Keep the cookie/session read inside the data-access helper (`redirectIfAuthenticated`, `verifyAuth`, etc.) rather than importing a feature query into the page.
+
+## Don't create page-local wrapper components
+
+Avoid components whose only job is to group boundary content, like `HomeLists` or `HomeListsSkeleton`. Keep the resolved JSX and fallback JSX **inline in the page** so the loading shape, headings, and grouped reveal behavior are visible at the boundary.
+
+```tsx
+// Wrong — hides the structure behind a wrapper
+<Suspense fallback={<HomeListsSkeleton />}>
+  <HomeLists searchParams={searchParams} />
+</Suspense>
+```
+
+```tsx
+// Right — structure visible at the page level
+<Suspense
+  fallback={
+    <>
+      <FeaturedSkeleton />
+      <RecentSkeleton />
+    </>
+  }
+>
+  {searchParams.then(sp => (
+    <>
+      <Featured filter={sp.filter} />
+      <Recent filter={sp.filter} />
+    </>
+  ))}
+</Suspense>
+```
+
+The same applies to feature-level skeleton aliases. If a variant only passes props to a base skeleton, import the base skeleton and pass those props inline in `fallback={...}`.
+
+## Suspense boundary placement rules
+
+1. **First section gets its own Suspense** with a known-height skeleton fallback.
+2. **Section headings stay outside Suspense** when their final position is stable.
+3. **Stable wrappers stay outside Suspense.** If fallback and final content both render the same card or panel, lift that wrapper around the boundary.
+4. **Variable-height sections: group everything below them** in the same Suspense, including any headings that would otherwise paint in the wrong vertical position.
+5. **Fixed-height sections: own boundary is safe.**
+6. **Variable-length lists: show 2–5 skeleton items**, not the real count.
+7. **Inner Suspense content stays out of the outer skeleton.** Each boundary owns its own.
+8. **Never `fallback={null}` for visible UI.** If a boundary covers UI, give it a real shaped fallback, or group it with a sibling boundary that already has the correct fallback.
+9. **If the top section's final height is unknown, group the following sections** in the same boundary so they reveal together and don't jump underneath.
+
+## Error boundaries
+
+Wrap fallible sections in a Next.js-aware error boundary so one failure doesn't take down the page. Build it on [`catchError`](https://preview.nextjs.org/docs/app/api-reference/functions/catchError) from `next/error` (its `ErrorInfo` gives you a `retry()` that re-fetches server data) — it understands Next's control-flow throws (`notFound()`, `redirect()`, `unauthorized()`, `forbidden()`) and won't swallow them. Place the boundary around the suspending section, in the page:
+
+```tsx
+<ErrorBoundary title="Replies didn't load">
+  <Suspense fallback={<RepliesSkeleton />}>
+    <Replies postId={id} />
+  </Suspense>
+</ErrorBoundary>
+```
+
+Why not plain `react-error-boundary`? It catches Next's framework throws (so `notFound()` never reaches `not-found.tsx`), and its reset doesn't re-fetch server data. Background: [Error Handling in Next.js with catchError](https://aurorascharff.no/posts/error-handling-in-nextjs-with-catch-error/).
+
+Pair component-level boundaries with route-segment [`error.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/error) for unrecoverable errors; it also receives a `retry` callback.
+
+## Layout-level Suspense
+
+Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
+
+```tsx
+export default function RootLayout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>
+        <Suspense>
+          <AuthGate userPromise={getCurrentUser()} />
+        </Suspense>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}
+```
+
+`AuthGate` is a client component that resolves the promise with `use()` so the dialog can render conditionally without server-side branching.
+
+## CLS prevention
+
+Layout shift happens when:
+
+- A skeleton is shorter than the real content
+- A heading sits inside a Suspense boundary whose final height is unknown — it paints in the wrong place, then jumps
+- A variable-length list streams in without a fallback that reserves space
+
+Fixes:
+
+- Match skeleton height to the typical real content height.
+- Move headings **outside** boundaries when their position depends on data above them.
+- For unknown-height top sections, group everything below in one boundary so siblings stream together.
+
+To audit CLS, use React DevTools' Suspense panel to pin each boundary in its loading state and check vertical positions.
+
+## Optimizing prefetching for high-value routes
+
+With `cacheComponents` + [`partialPrefetching`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, a visible `<Link>` prefetches the destination's shared [App Shell](https://preview.nextjs.org/docs/app/glossary#app-shell) — enough to commit navigation instantly, with link-specific content streaming after. The default (`'auto'`) already does this; don't write `prefetch = 'auto'`.
+
+Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link data (`params`, `searchParams`, the full URL) at prefetch time. Each such link can wake the server for a prerender, so reserve it for routes users predictably visit next. See [Optimizing prefetching](https://preview.nextjs.org/docs/app/guides/optimizing-prefetching).
+
+Can't enable `partialPrefetching` app-wide yet? Opt in per route with `export const prefetch = 'partial'` on the destination, then drop the per-route exports once the global flag is on — see [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) for the incremental path and [prefetch config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for the options. To validate navigation feels instant, see the [`instant` config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant) and [Instant Navigation guide](https://preview.nextjs.org/docs/app/guides/instant-navigation).
+
+## Never wrap the entire page in a Suspense fallback
+
+Page chrome (header, nav, surrounding layout) should paint instantly. Only data-dependent sections suspend. If you find yourself wrapping `<div>` and everything in it with `<Suspense fallback={<FullPageSkeleton />}>`, restructure: pull static elements out, narrow the boundary to just the dynamic part.

--- a/.cursor/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.cursor/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -16,20 +16,25 @@ Pages in `app/` import feature components and place `<Suspense>` boundaries. The
 Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
 
 ```tsx
-export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
+  /* ... */
+}
 ```
 
-Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a _separate_ feature (statically-typed `href`s), not the source of these helpers.
 
 ## Keep pages synchronous
 
 Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
 
 ```tsx
-import { Suspense } from 'react';
-import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+import { Suspense } from "react";
+import {
+  PostDetail,
+  PostDetailSkeleton,
+} from "@/features/post/components/post-detail";
 
-export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
   return (
     <div>
       <h1>Post</h1>
@@ -55,15 +60,18 @@ Use an implicit-return arrow function when the callback just renders JSX — e.g
 
 ```tsx
 // searchParams only
-export default function SearchPage({ searchParams }: PageProps<'/search'>) {
-  return searchParams.then(sp => {
-    const q = typeof sp.q === 'string' ? sp.q : '';
+export default function SearchPage({ searchParams }: PageProps<"/search">) {
+  return searchParams.then((sp) => {
+    const q = typeof sp.q === "string" ? sp.q : "";
     return q ? <SearchResults query={q} /> : <EmptyState />;
   });
 }
 
 // Both params and searchParams
-export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+export default function ProfilePage({
+  params,
+  searchParams,
+}: PageProps<"/u/[handle]">) {
   return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
     <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
   ));
@@ -159,7 +167,7 @@ export default function LoginPage() {
 
 async function LoginRedirect() {
   await connection();
-  await redirectIfAuthenticated('/dashboard');
+  await redirectIfAuthenticated("/dashboard");
   return <LoginForm />;
 }
 ```
@@ -187,7 +195,7 @@ Avoid components whose only job is to group boundary content, like `HomeLists` o
     </>
   }
 >
-  {searchParams.then(sp => (
+  {searchParams.then((sp) => (
     <>
       <Featured filter={sp.filter} />
       <Recent filter={sp.filter} />
@@ -231,7 +239,7 @@ Pair component-level boundaries with route-segment [`error.tsx`](https://preview
 Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
 
 ```tsx
-export default function RootLayout({ children }: LayoutProps<'/'>) {
+export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html>
       <body>

--- a/.cursor/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.cursor/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,6 +1,6 @@
 # Queries and actions
 
-> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables. The vendor procedure below is placement-only and must not be copied into `apps/*/features/`.
 
 The data layer. Every feature has both: queries to read, actions to write.
 

--- a/.cursor/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.cursor/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,5 +1,7 @@
 # Queries and actions
 
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+
 The data layer. Every feature has both: queries to read, actions to write.
 
 This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
@@ -15,7 +17,7 @@ Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` â
 Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
 
 ```ts
-import 'server-only';
+import "server-only";
 
 export async function getFeed(userId: string) {
   return db.post.findMany({ where: { userId } });
@@ -30,9 +32,13 @@ Take normalized primitives, not the params object:
 
 ```ts
 // features/book/book-queries.ts
-export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
-  'use cache';
-  cacheLife('hours');
+export async function getBooksPage(
+  page: number = 1,
+  search: string = "",
+  year: number = MAX_YEAR,
+) {
+  "use cache";
+  cacheLife("hours");
   // ...
 }
 ```
@@ -43,7 +49,7 @@ Normalize and clamp in the feature's own helper, **before** the call, not inside
 
 Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" â€” it adds indirection and can hide when data is intentionally dynamic.
 
-`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results _across_ requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
 
 ## Actions
 
@@ -56,13 +62,13 @@ Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the 
 5. Return a result (`{ ok }` or `{ error }`).
 
 ```tsx
-'use server';
+"use server";
 
-import { refresh } from 'next/cache';
+import { refresh } from "next/cache";
 
 export async function createPost(formData: FormData) {
   const user = await verifyUser();
-  const parsed = schema.safeParse({ body: formData.get('body') });
+  const parsed = schema.safeParse({ body: formData.get("body") });
   if (!parsed.success) {
     return { ok: false as const, error: parsed.error.issues[0].message };
   }
@@ -85,8 +91,8 @@ Client components import server actions directly. **Don't** pass an action as a 
 
 ```tsx
 // Right
-'use client';
-import { likePost } from '@/features/post/post-actions';
+"use client";
+import { likePost } from "@/features/post/post-actions";
 
 export function LikeButton({ postId }: { postId: string }) {
   return <button onClick={() => likePost(postId)}>Like</button>;
@@ -113,7 +119,9 @@ For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTran
 Return a discriminated union from actions that can fail:
 
 ```tsx
-export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+export type ActionResult<T = void> =
+  | { ok: true; data?: T }
+  | { ok: false; error: string };
 ```
 
 Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
@@ -126,7 +134,10 @@ If your DB rows have shapes you don't want to leak to components (extra columns,
 
 ```ts
 export async function getPost(id: string) {
-  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  const row = await db.post.findUnique({
+    where: { id },
+    include: { author: true },
+  });
   if (!row) notFound();
   return toPost(row);
 }

--- a/.cursor/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/.cursor/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,0 +1,139 @@
+# Queries and actions
+
+The data layer. Every feature has both: queries to read, actions to write.
+
+This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
+
+## Cache identities
+
+When a server read also seeds a browser data cache, follow `references/single-page-applications.md` for the feature-local cache contract and client-library placement.
+
+## Queries
+
+Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` — that's the invariant. Default to plain async exports.
+
+Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
+
+```ts
+import 'server-only';
+
+export async function getFeed(userId: string) {
+  return db.post.findMany({ where: { userId } });
+}
+```
+
+## Cache keys are the arguments
+
+A `'use cache'` function's arguments are its cache key, so shape them deliberately.
+
+Take normalized primitives, not the params object:
+
+```ts
+// features/book/book-queries.ts
+export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
+  'use cache';
+  cacheLife('hours');
+  // ...
+}
+```
+
+Passing `searchParams` straight through keys the entry on an object carrying every param the route knows about, including the ones the caller left undefined, and the key then changes shape whenever the route gains a param.
+
+Normalize and clamp in the feature's own helper, **before** the call, not inside the cached function. `?yr=9999`, `?yr=2023`, and no `yr` at all describe the same result set, so they should resolve to the same arguments and share one entry. Clamping inside the cached function gives each spelling its own entry with identical contents.
+
+Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" — it adds indirection and can hide when data is intentionally dynamic.
+
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+
+## Actions
+
+Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the top. Always:
+
+1. Verify auth.
+2. Validate input with your schema validator.
+3. Run the mutation.
+4. Invalidate cached data so the next render sees the new state.
+5. Return a result (`{ ok }` or `{ error }`).
+
+```tsx
+'use server';
+
+import { refresh } from 'next/cache';
+
+export async function createPost(formData: FormData) {
+  const user = await verifyUser();
+  const parsed = schema.safeParse({ body: formData.get('body') });
+  if (!parsed.success) {
+    return { ok: false as const, error: parsed.error.issues[0].message };
+  }
+
+  await db.post.create({ data: { body: parsed.data.body, userId: user.id } });
+  refresh();
+  return { ok: true as const };
+}
+```
+
+[`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) re-renders the current route for the current user. Use it when the affected read is deliberately dynamic and has no tag. With Cache Components enabled, reusable reads should have matching `cacheTag()` calls, so server actions normally call `updateTag()` for read-your-own-writes. See `references/cache-components.md`.
+
+### Action file naming
+
+Actions for a feature always go in `<folder>-actions.ts`, matching the folder name — even when the mutation operates on a sub-concept. `toggleFavorite` in `features/event/` lives in `event-actions.ts`, not `favorite-actions.ts`. The folder is the source of truth for the name.
+
+## Calling actions from client components
+
+Client components import server actions directly. **Don't** pass an action as a prop just to call it:
+
+```tsx
+// Right
+'use client';
+import { likePost } from '@/features/post/post-actions';
+
+export function LikeButton({ postId }: { postId: string }) {
+  return <button onClick={() => likePost(postId)}>Like</button>;
+}
+```
+
+```tsx
+// Wrong — adds indirection with no benefit
+async function Post({ id }: { id: string }) {
+  return <LikeButton postId={id} onLike={likePost} />;
+}
+```
+
+Design components (`<BottomNav>`, `<ToggleGroup>`, `<SubmitButton>`) take this further with the **action-prop pattern** — `action` is a callback wrapped in `useTransition` / `useOptimistic` internally. See `references/ux-patterns.md`.
+
+## Form actions vs onClick handlers
+
+Prefer [`<form action={serverAction}>`](https://react.dev/reference/react-dom/components/form#action) for form mutations — React wraps the call in a transition and surfaces pending state automatically.
+
+For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTransition`](https://react.dev/reference/react/startTransition) if you need pending state.
+
+## Return shape
+
+Return a discriminated union from actions that can fail:
+
+```tsx
+export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+```
+
+Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
+
+A shared `ActionResult<T>` is optional — a per-action inline union is just as good, and often clearer when the payload has a natural name: `return { ok: true as const, playlist }` reads better than a generic `data`. What matters is that fallible actions return a discriminated union the client can narrow on, not that every action shares one type.
+
+## Mappers and domain types
+
+If your DB rows have shapes you don't want to leak to components (extra columns, ORM-specific types), write a mapper inside the query:
+
+```ts
+export async function getPost(id: string) {
+  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  if (!row) notFound();
+  return toPost(row);
+}
+
+function toPost(row: PostRow & { author: UserRow }): Post {
+  return { id: row.id, body: row.body, author: row.author.handle };
+}
+```
+
+Components see `Post`, not the ORM row. If that type is imported by multiple files in the feature, put it under `features/<domain>/types/` (for example `features/post/types/post.ts`). Promote it to top-level `types/` only when multiple features import it.

--- a/.cursor/skills/nextjs-app-architecture/references/single-page-applications.md
+++ b/.cursor/skills/nextjs-app-architecture/references/single-page-applications.md
@@ -1,0 +1,48 @@
+# Single-page application patterns
+
+Use this reference when a feature adds SWR, TanStack Query, or another browser data cache. For complete library APIs and runnable examples, follow the [Single-page applications guide](https://preview.nextjs.org/docs/app/guides/single-page-applications).
+
+## Decide whether a client cache is needed
+
+Use a client data library when the browser needs revalidation, optimistic mutations, request deduplication, or shared live data. If a Client Component only reads server data once, pass a Promise from its Server Component and unwrap it with `use()` instead.
+
+## Keep ownership with the feature
+
+```text
+features/<domain>/
+  <domain>-cache.ts          # Pure server tags + client keys
+  <domain>-queries.ts        # Server reads and cacheLife
+  <domain>-query-options.ts  # Client fetcher/query options
+  hooks/use-*.ts             # Client mutations and coordination
+  components/                # Async server owner + client leaves
+```
+
+The cache contract imports neither Next.js nor the client library. Queries, actions, route handlers, hydration code, query options, and hooks import identities from it. This prevents a key or tag spelling from drifting between a read and its invalidation.
+
+Keep behavior in the layer that owns it:
+
+- Server `cacheLife`, `cacheTag`, and database reads belong in `<domain>-queries.ts`.
+- Browser freshness and refetch behavior belong in `<domain>-query-options.ts` or the SWR hook.
+- Optimistic mutation behavior belongs in `hooks/use-*.ts`.
+- Tiny effect-only or interactive leaves belong in `components/`.
+
+## Seed from the server
+
+The async feature component owns the initial read and the library's hydration provider. The page remains a synchronous composition surface and owns the feature's Suspense boundary.
+
+- With SWR, seed the exact key read by `useSWR`. Use `preload` with `cacheData` when later `mutate(key)` calls must update the seeded entry itself.
+- With TanStack Query, seed the same query key read by the client query and render the client subtree inside `HydrationBoundary`.
+
+Do not move the initial read to the browser just because the feature also has a client cache.
+
+## Coordinate Cache Components
+
+The server cache and browser cache have independent freshness policies. Do not mirror `cacheLife` into `staleTime`, polling intervals, or SWR revalidation settings. Coordinate identities and invalidation, not durations.
+
+For tag-driven data, a mutation updates the client cache for immediate feedback and invalidates the same server tag used by the seeded read. For a time-driven server read, choose its `cacheLife` from the server data's freshness requirement.
+
+TanStack Query hydration adds one coupling: the hydration timestamp must advance whenever the seeded data advances. For tag-driven reads, cache the timestamp with the same tags as the data. For time-driven reads, derive the data and timestamp from the same cached snapshot. Do not cache a `QueryClient` or dehydrated payload.
+
+## Mutate without drift
+
+Let the client library own the optimistic browser update, rollback, and authoritative response. Let the write invalidate the server tag only after stored data changes. Do not add polling as a cache-coordination mechanism; add focus revalidation, intervals, SSE, or WebSockets only when the product actually needs external updates to appear automatically.

--- a/.cursor/skills/nextjs-app-architecture/references/upstream.md
+++ b/.cursor/skills/nextjs-app-architecture/references/upstream.md
@@ -1,0 +1,30 @@
+---
+source_name: aurorascharff/nextjs-app-architecture-skill (nextjs-app-architecture)
+source_url: https://github.com/aurorascharff/nextjs-app-architecture-skill
+source_type: github
+upstream_path: SKILL.md
+reviewed_commit: f2902b8538b25610da694394ecf88e69adf5f96a
+skills_lock_hash: 94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66
+license: MIT
+last_reviewed: 2026-08-28
+---
+
+# Upstream: nextjs-app-architecture
+
+Canonical copy in this repo: `docs/ai/skills/nextjs-app-architecture/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/aurorascharff/nextjs-app-architecture-skill
+- **Upstream path:** `SKILL.md` plus `references/{cache-components,components,example,feature-folders,pages-suspense,queries-actions,single-page-applications,ux-patterns}.md`
+- **License:** MIT; copyright Aurora Scharff (see the ecosystem `LICENSE` copied by the Skills CLI)
+- **Install via Skills CLI:** `npx skills add aurorascharff/nextjs-app-architecture-skill -y`
+
+The skill packages next-beats-style RSC composition for Next.js 16 App Router: synchronous pages, feature-owned async server components, colocated skeletons, and Cache Components practice. Inside Core it stays subordinate to installed Next.js docs, `docs/ai/rules/frontend.md`, and the data-access boundary.
+
+## Refresh from ecosystem
+
+1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
+2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
+3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+
+This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.cursor/skills/nextjs-app-architecture/references/upstream.md
+++ b/.cursor/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.cursor/skills/nextjs-app-architecture/references/upstream.md
+++ b/.cursor/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section, **Core remaps**, and in-place `CORE: skip file creation` annotations in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/.cursor/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/.cursor/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -4,13 +4,13 @@ Interaction decisions on top of the architecture: which feedback mechanism to re
 
 ## Choose the feedback mechanism
 
-| Situation | Reach for | Key rule |
-| --------- | --------- | -------- |
-| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
-| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
-| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
-| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
-| One-shot result with no visible change | toast | See below. |
+| Situation                                          | Reach for                                                                           | Key rule                                                                                                                                                                                  |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic)                  | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters.                                |
+| No optimistic fit (filters, sort, navigation)      | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field")           | [`useActionState`](https://react.dev/reference/react/useActionState)                | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`.                                                                                                           |
+| Submit disable + spinner                           | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus)        | Call it from a child of `<form>`, not the form component itself.                                                                                                                          |
+| One-shot result with no visible change             | toast                                                                               | See below.                                                                                                                                                                                |
 
 ### Name the signal when a subtree has more than one pending source
 
@@ -29,10 +29,10 @@ For create/update/delete flows where the changed item is visible, prefer one fea
 
 ```tsx
 type OptimisticListAction<TItem> =
-  | { type: 'create'; item: TItem }
-  | { type: 'update'; item: TItem }
-  | { type: 'delete'; id: string }
-  | { type: 'rollback'; id: string };
+  | { type: "create"; item: TItem }
+  | { type: "update"; item: TItem }
+  | { type: "delete"; id: string }
+  | { type: "rollback"; id: string };
 
 const [items, dispatchOptimisticItem] = useOptimistic(
   initialItems,
@@ -61,7 +61,7 @@ Use a success page/state instead of a toast when the completed action changes th
 
 ## View transitions: portaled / floating UI
 
-Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a _named_ transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
 
 ## Destructive actions (delete / leave / unsubscribe)
 
@@ -72,14 +72,14 @@ Gate behind a confirmation dialog, and mind two edge cases:
 
 ## The action-prop pattern
 
-A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited _without_ a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
 
 ## URL-based pagination
 
 Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
 
 ```tsx
-import { Suspense } from 'react';
+import { Suspense } from "react";
 
 export function Feed({ page = 1 }: { page?: number }) {
   return (

--- a/.cursor/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/.cursor/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -1,0 +1,106 @@
+# UX patterns
+
+Interaction decisions on top of the architecture: which feedback mechanism to reach for, and the boundary edge-cases that trip agents up. Hook mechanics live in the React / Next docs — linked, not restated. The deeper end-to-end picture is the [Building interactive apps guide](https://preview.nextjs.org/docs/app/guides/interactive-apps).
+
+## Choose the feedback mechanism
+
+| Situation | Reach for | Key rule |
+| --------- | --------- | -------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
+| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
+| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
+| One-shot result with no visible change | toast | See below. |
+
+### Name the signal when a subtree has more than one pending source
+
+`data-pending` bubbles through CSS, so every descendant that sets it participates. `useLinkStatus` sets it on any pending link, which means `group-has-data-pending:` on a page wrapper also fires for ordinary navigation and dims content that is not being refetched. When a subtree can be pending for more than one reason, give the reason you are reacting to its own attribute (`data-filtering`, `data-saving`) and key the ancestor off that.
+
+### Two things to get right with `useOptimistic`
+
+- The value reverts as soon as its transition settles, so the work it predicts has to run **inside the same** `startTransition`. Setting the optimistic value in one transition and navigating in another snaps it back before the URL changes.
+- Derive the controls from the optimistic value and the surrounding chrome from the committed one. A slider thumb should follow the drag immediately, but a "Clear all filters" button keyed off that same optimistic value appears while the filter is still in flight.
+
+`useOptimistic(false)` also works as a transition-scoped **pending flag** that resets automatically when the transition settles — handy when you don't need the `data-pending` bubbling.
+
+## Optimistic mutations for interactive apps
+
+For create/update/delete flows where the changed item is visible, prefer one feature-owned optimistic reducer over hand-rolled pending state spread across the board, modal, and list.
+
+```tsx
+type OptimisticListAction<TItem> =
+  | { type: 'create'; item: TItem }
+  | { type: 'update'; item: TItem }
+  | { type: 'delete'; id: string }
+  | { type: 'rollback'; id: string };
+
+const [items, dispatchOptimisticItem] = useOptimistic(
+  initialItems,
+  optimisticListReducer,
+);
+```
+
+Use names that describe the app's domain (`dispatchOptimisticPost`, `messageReducer`, `groupReducer`, `eventReducer`) rather than implementation mechanics like `applyOptimisticAction`. The reducer owns the optimistic list shape; components dispatch intent.
+
+For modal creates, apply the optimistic item and close the modal immediately when the local form is valid. If the action fails, roll back and show an error toast. Keeping the modal open with a slow primary button makes the optimistic result feel broken.
+
+For deletes, remove optimistically, then roll back on failure. Do not wait for the server before the item disappears when the user's intent is clear.
+
+## Forms and validation
+
+Do local validation before submitting when the missing field is already available on the client. Show inline field errors without changing the modal or card's overall geometry. Reserve `useActionState` for server-validated errors or field errors that require the action result.
+
+Use a success page/state instead of a toast when the completed action changes the user's task. For example, after a reservation, checkout, or invite request succeeds, replace the form with a confirmation and a secondary "start another" action; a success toast is redundant.
+
+## Toasts
+
+- **Toast only on error** when an optimistic UI already shows the result — a success toast next to an optimistic checkmark/removal is double feedback, which is noise.
+- **Toast on success** only for non-visible side effects (email sent, link copied, file uploaded).
+- **Don't toast for routine navigation** — the page change is the feedback.
+- **Don't toast inside a server action.** Toasts are client-side; return a result and toast at the call site.
+
+## View transitions: portaled / floating UI
+
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+
+## Destructive actions (delete / leave / unsubscribe)
+
+Gate behind a confirmation dialog, and mind two edge cases:
+
+- **Don't `redirect()` inside the action.** It throws, which stops the client from toasting or closing the dialog. Return `{ ok: true }` and navigate with `router.push()`.
+- **Don't wrap the whole action call in `useTransition`** inside the dialog — with view transitions on, that animates the background UI behind the dialog. Track pending with `useState` / `useOptimistic(false)` and reserve `startTransition` for the post-success navigation only.
+
+## The action-prop pattern
+
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+
+## URL-based pagination
+
+Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
+
+```tsx
+import { Suspense } from 'react';
+
+export function Feed({ page = 1 }: { page?: number }) {
+  return (
+    <ul>
+      {Array.from({ length: page }).map((_, i) => {
+        const p = i + 1;
+        return p === 1 ? (
+          <FeedPage key={p} page={p} />
+        ) : (
+          <Suspense key={p} fallback={<FeedPageSkeleton />}>
+            <FeedPage page={p} />
+          </Suspense>
+        );
+      })}
+    </ul>
+  );
+}
+```
+
+The first page can render in the parent boundary; later pages get their own fallbacks so "load more" streams only the newly requested page. If the URL update should preserve scroll, use [`<Link scroll={false}>`](https://preview.nextjs.org/docs/app/api-reference/components/link).
+
+## Global client state
+
+For truly global client state (audio player, cart, system-reactive theme), wrap a [context provider](https://react.dev/reference/react/createContext) at the root; the provider is `'use client'` but `children` stays server-rendered, and only leaf components read the context. **Don't push server data into it** — server data stays in queries; client state is for ephemeral UI (open menus, playback position, optimistic drafts). See the live-data decision in `references/components.md`.

--- a/docs/ai/rules/agent-skill-routing.md
+++ b/docs/ai/rules/agent-skill-routing.md
@@ -12,7 +12,7 @@
 
 - The agent needs to choose a canonical skill under `docs/ai/skills/`
 - The agent needs to restore ecosystem skills from `skills-lock.json`
-- The agent needs Core-specific notes for a vendor skill (Supabase, Resend CLI, Emil Kowalski, Matt Pocock, Inngest, shadcn, TDD)
+- The agent needs Core-specific notes for a vendor skill (Supabase, Resend CLI, Emil Kowalski, Matt Pocock, Inngest, shadcn, TDD, Next.js app architecture)
 - Root `AGENTS.md` points here when discovered skill metadata is insufficient
   or skill maintenance is requested
 
@@ -74,6 +74,8 @@ To **pull newer upstream** content for Supabase: `npx skills add supabase/agent-
 
 **`improve`** ([`shadcn/improve`](https://github.com/shadcn/improve)) is in `docs/ai/skills/improve/`. Refresh via `npx skills add shadcn/improve -y`, then **delete any project-level `.claude/skills/improve` symlink the CLI creates** (this repo routes Claude Code through `docs/ai/skills/` + this file, not `.claude/skills/`), reconcile into `docs/ai/skills/improve/` if needed, then `bun run skills:sync` and `bun run skills:verify`. See `docs/ai/skills/improve/references/upstream.md`; **not** updated by `bun run skills:refresh-upstream` today.
 
+**`nextjs-app-architecture`** ([`aurorascharff/nextjs-app-architecture-skill`](https://github.com/aurorascharff/nextjs-app-architecture-skill)) is in `docs/ai/skills/nextjs-app-architecture/`. Refresh via `npx skills add aurorascharff/nextjs-app-architecture-skill -y`, then **delete any project-level `.claude/skills/nextjs-app-architecture` symlink the CLI creates** (this repo routes Claude Code through `docs/ai/skills/` + this file, not `.claude/skills/`), reconcile into `docs/ai/skills/nextjs-app-architecture/` if needed, then `bun run skills:sync` and `bun run skills:verify`. See `docs/ai/skills/nextjs-app-architecture/references/upstream.md`; **not** updated by `bun run skills:refresh-upstream` today.
+
 **Official Inngest agent skills** (`docs/ai/skills/inngest-*`) are vendored from [`inngest/inngest-skills`](https://github.com/inngest/inngest-skills) and [`inngest/inngest-codex-plugin`](https://github.com/inngest/inngest-codex-plugin). Refresh them with `bun run skills:refresh-inngest`, then `bun run skills:sync` and `bun run skills:verify`; source SHAs and licenses are documented in `docs/ai/skills/inngest/references/upstream.md`. These skills are agent tooling for integration work, not evidence of product runtime adoption. Use `docs/ai/skills/inngest/SKILL.md` as the router when unsure which Inngest skill applies.
 
 **`eve`**, **`create-agent`**, **`impeccable`**, and **`playwright-best-practices`** are vendored under `docs/ai/skills/` with refresh steps in each skill's `references/upstream.md`; **not** updated by `bun run skills:refresh-upstream` today. Upstream CLI id for Impeccable is **`impeccable`** (not `critique`).
@@ -82,6 +84,7 @@ To **pull newer upstream** content for Supabase: `npx skills add supabase/agent-
 
 - **Next.js App Router structure, rendering, data fetching:** `docs/ai/skills/nextjs-app-router/SKILL.md`
 - **Cache Components / PPR / cacheTag & invalidation:** `docs/ai/skills/cache-components/SKILL.md`
+- **Next.js 16 page composition, feature-folder UI layout, colocated Suspense skeletons, and leaf-client UX:** `docs/ai/skills/nextjs-app-architecture/SKILL.md` (subordinate to `docs/ai/rules/frontend.md`, `nextjs-app-router`, `cache-components`, and `docs/guides/architecture/data-access-boundary.md`; do not move business queries or privileged mutations into app feature folders)
 - **Verify Next.js runtime behavior after edits (running dev server + browser + React tree):** `next-dev-loop` (first-party `vercel/next.js` skill; ecosystem install under `.agents/skills/`, mirrored to `.claude/skills/` and `.cursor/skills/`; requires `agent-browser` ≥0.27)
 - **Adopt Cache Components on existing routes (feature-by-feature):** `next-cache-components-adoption` (first-party `vercel/next.js` skill; ecosystem install)
 - **Grow a route's static shell / make navigations instant:** `next-cache-components-optimizer` (first-party `vercel/next.js` skill; ecosystem install) — see **Instant Navigation (Next.js 16.3)** in `docs/ai/rules/frontend.md`

--- a/docs/ai/rules/frontend.md
+++ b/docs/ai/rules/frontend.md
@@ -120,7 +120,7 @@ implementation task.
 
 ## Workflow
 
-1. Identify if the change is Server or Client and apply `skills/nextjs-app-router/SKILL.md` when relevant.
+1. Identify if the change is Server or Client and apply `skills/nextjs-app-router/SKILL.md` when relevant. For page composition, feature-folder UI layout, colocated Suspense skeletons, or leaf-client UX, also load `skills/nextjs-app-architecture/SKILL.md`. Keep business queries and privileged mutations in `packages/api`.
 2. For Tiptap / rich text editor work, apply `skills/tiptap/SKILL.md`.
 3. Reuse shared primitives from `@asym/ui` before creating new UI.
 4. Keep Tailwind usage token-based and consistent with Maia/Zinc.

--- a/docs/ai/skills/find-skills/SKILL.md
+++ b/docs/ai/skills/find-skills/SKILL.md
@@ -80,6 +80,19 @@ workflows, and use `docs/ai/skills/inngest-setup/SKILL.md` only when explicitly
 adding product runtime Inngest. Refresh with `bun run skills:refresh-inngest`,
 then `bun run skills:sync` and `bun run skills:verify`.
 
+**Example — Next.js app architecture:** page composition, feature-folder UI
+layout, colocated Suspense skeletons, and leaf-client UX are covered by
+`docs/ai/skills/nextjs-app-architecture/SKILL.md`. Install or refresh from
+[`aurorascharff/nextjs-app-architecture-skill`](https://github.com/aurorascharff/nextjs-app-architecture-skill)
+with `npx skills add aurorascharff/nextjs-app-architecture-skill -y`, then
+restore the local overlay from `docs/ai/skills/nextjs-app-architecture/SKILL.md`
+and `docs/ai/skills/nextjs-app-architecture/references/upstream.md`, then
+`bun run skills:sync` and `bun run skills:verify`. Keep it subordinate to
+`docs/ai/rules/frontend.md`, `docs/ai/skills/nextjs-app-router/SKILL.md`,
+`docs/ai/skills/cache-components/SKILL.md`, and
+`docs/guides/architecture/data-access-boundary.md`. Do not move business
+queries or privileged mutations into app feature folders.
+
 ## How to Help Users Find Skills
 
 ### Step 1: Understand What They Need

--- a/docs/ai/skills/nextjs-app-architecture/SKILL.md
+++ b/docs/ai/skills/nextjs-app-architecture/SKILL.md
@@ -21,6 +21,12 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
 - Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+- Do not regenerate or expand the managed root `AGENTS.md`.
+
+**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+
+- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
 

--- a/docs/ai/skills/nextjs-app-architecture/SKILL.md
+++ b/docs/ai/skills/nextjs-app-architecture/SKILL.md
@@ -23,9 +23,9 @@ This skill is for page composition, Suspense placement, leaf client boundaries, 
 - Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
 - Do not regenerate or expand the managed root `AGENTS.md`.
 
-**Core remaps** — follow the numbered workflow, but replace these upstream lines:
+**Core remaps** — apply these at every numbered step. Upstream file-placement lines are vendor text, not permission to add a query layer.
 
-- **Invariant 7 and workflow steps 3–4:** "Feature-owned" means the feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` for business or privileged data. Those reads and mutations stay in `packages/api`.
+- **Feature-owned means UI composition only.** The feature component owns _when_ it reads and _which_ `@asym/api` function or `@asym/database` hook it calls. Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` at all.
 - **Prerequisite:** Prefer the project's installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`). Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.
 
 Refresh: `references/upstream.md`.
@@ -34,7 +34,7 @@ Refresh: `references/upstream.md`.
 
 A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
 
-**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+**Follow the workflow below step by step** — apply the **Core remaps** at each step. Upstream `*-queries.ts` / `*-actions.ts` lines are vendor text: **CORE: skip file creation.** Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
 
 ## Prerequisite
 
@@ -46,7 +46,7 @@ Build pages that describe the loading experience, not pages that act like route 
 
 - `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
 - Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
-- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly. **(CORE: skip file creation. Import `@asym/api` or `@asym/database/hooks` from the feature component.)**
 - When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
 - Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
 
@@ -60,8 +60,8 @@ The non-negotiables. The workflow produces them; the final check verifies them.
 4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
 5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
 6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
-7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
-8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts. **(CORE: skip file creation. Call `@asym/api` from the feature component; do not add those files under `apps/*/features/`.)**
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions. **(CORE: "keeps its queries and actions" means `packages/api`, not a feature-local query file.)**
 9. **Client components import actions directly** — never receive a server action as a prop just to call it.
 10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
 11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
@@ -78,13 +78,13 @@ Run these in order for build-from-scratch, feature work, or audits. Each step na
 2. **Place the work.** Decide the feature folder before writing anything.
    → `references/feature-folders.md` (decision tree + merge rules).
    ✓ A real domain, a cross-domain product experience, or folded into the right parent.
-3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`. **(CORE: skip file creation. Import the existing `@asym/api` read, or `@asym/database/hooks` for an approved browser table.)**
    → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
    ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
-4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top. **(CORE: skip file creation. Import the existing `@asym/api` mutation.)**
    → `references/queries-actions.md`.
    ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
-5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves. **(CORE: "its own query" is an `@asym/api` or `@asym/database` call, not a new `*-queries.ts`.)**
    → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
    ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
 6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
@@ -105,10 +105,10 @@ Inspect the diff against every invariant — each is checkable by reading the ch
 - [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
 - [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
 - [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
-- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`. **(CORE: skip file creation. A new `*-queries.ts` / `*-actions.ts` under `apps/*/features/` means the change is wrong.)**
 - [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
 - [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
-- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions. **(CORE: skip file creation.)**
 - [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
 - [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
 - [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.

--- a/docs/ai/skills/nextjs-app-architecture/SKILL.md
+++ b/docs/ai/skills/nextjs-app-architecture/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: nextjs-app-architecture
+description: Build or audit Next.js 16 App Router apps using a next-beats-style React Server Components architecture. Use when scaffolding a new app, adding a feature, reviewing an existing app, refactoring route-loader-shaped pages into feature-owned async server components, deciding where queries/actions/components live, keeping pages synchronous with `params.then()`, placing Suspense boundaries, choosing the client/server boundary, designing skeletons, preventing CLS, or enabling Cache Components. Also use when the user asks about RSC composition, components receiving IDs instead of route params, `'use cache'`, `cacheTag`, `updateTag`, static-shell prerendering, or making an app easier for AI agents to modify.
+license: MIT
+metadata:
+  author: aurorascharff
+  version: "1.3.9"
+---
+
+## This repository (Asymmetric-al/core)
+
+Subordinate to installed Next.js docs (`apps/<app>/node_modules/next/dist/docs/` or `.next-docs/`), **`docs/ai/rules/frontend.md`**, **`docs/ai/skills/nextjs-app-router/SKILL.md`**, **`docs/ai/skills/cache-components/SKILL.md`**, and **`docs/guides/architecture/data-access-boundary.md`**.
+
+This skill is for page composition, Suspense placement, leaf client boundaries, and feature-owned UI. It is not a license to invent a new app folder scheme or move business database logic.
+
+**Repo mapping:**
+
+- Privileged reads, writes, payments, webhooks, and vendor calls stay in `packages/api`.
+- Browser-visible table data uses `@asym/database/hooks` when a collection exists.
+- Shared UI stays in `@asym/ui` / exact `base-maia`. Existing `apps/*/features/` directories are UI composition, not a new query layer.
+- All apps already run `cacheComponents: true` and `partialPrefetching: true`. Do not "enable Cache Components." Follow Instant Navigation (Stream / Cache / explicit Block) in `docs/ai/rules/frontend.md`.
+- Get API mechanics from the installed Next.js docs, not `preview.nextjs.org` or remembered APIs.
+- Do not add Zustand. Use the installed TanStack Query / TanStack DB patterns from `docs/ai/rules/frontend.md`.
+
+Refresh: `references/upstream.md`.
+
+# Next.js App Architecture
+
+A workflow for building and auditing Next.js 16+ App Router apps so they follow one consistent, feature-sliced RSC architecture like `next-beats`.
+
+**Follow the workflow below step by step** — it produces the invariants by construction. Load the reference a step names for the decision it depends on. Get framework _mechanics_ (API signatures, config options, hook contracts) from the linked docs — don't restate or improvise them.
+
+## Prerequisite
+
+Before changing a Next.js app, make sure the project is set up for AI agents to read version-matched docs. Follow the [AI Coding Agents guide](https://preview.nextjs.org/docs/app/guides/ai-agents): prefer the project's `AGENTS.md` / bundled docs, and create or refresh them when missing. Then use this skill for architecture decisions.
+
+## Architecture target
+
+Build pages that describe the loading experience, not pages that act like route loaders:
+
+- `app/**/page.tsx` and `layout.tsx` are synchronous composition surfaces: static chrome, section headings, `<Suspense>` boundaries, error boundaries, and transition wrappers.
+- Feature components own their reads on the server. They receive minimal stable inputs (`id`, `slug`, `handle`, parsed filter values) or already-fetched records, never raw `params` / `searchParams`.
+- Queries and actions live in the feature folder. Components import queries; client leaves import actions directly.
+- When server tags and client query keys describe the same feature data, a pure feature-local cache contract owns those identities.
+- Stable chrome, wrappers, and skeletons preserve layout: cards/panels stay outside Suspense, and fallbacks swap only the data-dependent body.
+
+## Invariants (what every change must satisfy)
+
+The non-negotiables. The workflow produces them; the final check verifies them.
+
+1. **Pages compose, they never fetch.** A page/layout imports feature components and places `<Suspense>`. No queries or domain logic inline. Tiny route-local control-flow helpers are allowed only when they exist to place a boundary around `connection()`, `redirect()`, or a resolved route prop.
+2. **Pages stay synchronous.** Use `params.then()` / `searchParams.then()` or `Promise.all([params, searchParams]).then(...)`, never `await params` at the top — so chrome paints into the static shell and only data-dependent sections suspend.
+3. **Feature components receive IDs, not route props.** Resolve `params` / `searchParams` at the page boundary and pass plain values (`id`, `slug`, `query`) into features.
+4. **Async server component is the default.** `'use client'` only for hooks, event handlers, or browser APIs — and only on leaves, never on parents of server content.
+5. **The page owns the Suspense boundary; the feature owns the skeleton.** Features never pre-wrap themselves in `<Suspense>`; stable wrappers/cards/chrome wrap the boundary instead of being duplicated in fallback and final content.
+6. **Skeletons live in the same file as the component**, exported alongside it, defined at the end. `Feed` and `FeedSkeleton` are siblings.
+7. **Queries live in `<domain>-queries.ts`** (`import 'server-only'`); **actions live in `<domain>-actions.ts`** (`'use server'`). The file name matches the folder, even for sub-concepts.
+8. **Feature folders follow product ownership.** Entity-owned sub-concepts (favorite, like, vote, bookmark) fold into their parent. A route-level experience that composes multiple domains may own its UI and state in a separate feature while each domain keeps its queries and actions.
+9. **Client components import actions directly** — never receive a server action as a prop just to call it.
+10. **Feature-local cache coordination stays with its domain.** Put pure tags/keys in `<domain>-cache.ts`, client query definitions in `<domain>-query-options.ts`, hook wrappers in `hooks/use-*.ts`, and tiny client leaves in `components/`; promote support code only after real cross-feature reuse.
+11. **Interactive async UI keeps server data on the server and client state local to the interaction.** Use `useOptimistic`, `useTransition`, reducers, URL/search params, and form actions instead of mirrored prop state, derived-state effects, or hand-rolled pending arrays.
+
+## Workflow
+
+Run these in order for build-from-scratch, feature work, or audits. Each step names the reference to consult and the check it must pass.
+
+1. **Choose mode.**
+   - **Build from scratch:** sketch routes, real domain nouns, static shell, and expected loading groups before writing code.
+   - **Audit/refactor:** scan current `app/` pages first; list every async page, page-level query import, route prop leak, missing Suspense boundary, and feature folder mismatch.
+     → `references/example.md` for the target shape; `references/feature-folders.md` for placement.
+     ✓ You know whether you are creating the architecture or converting loader-shaped code into it.
+2. **Place the work.** Decide the feature folder before writing anything.
+   → `references/feature-folders.md` (decision tree + merge rules).
+   ✓ A real domain, a cross-domain product experience, or folded into the right parent.
+3. **Write the query and, when a client cache shares its data, the cache contract.** Put server reads in `<domain>-queries.ts` with `import 'server-only'`; keep shared tag/key identities in a pure `<domain>-cache.ts`.
+   → `references/queries-actions.md`; for SWR/TanStack Query → `references/single-page-applications.md`; with `cacheComponents: true`, also → `references/cache-components.md`.
+   ✓ Cache identities are defined once; server reads are server-only, cached/tagged/lifetimed under Cache Components, and return domain types rather than ORM rows.
+4. **Write the action** (if there's a mutation). `features/<domain>/<domain>-actions.ts`, `'use server'` at the top.
+   → `references/queries-actions.md`.
+   ✓ Re-checks auth, validates input, invalidates matching cache tags under Cache Components (`refresh()` only for justified dynamic reads), returns a discriminated union.
+5. **Build the component + skeleton.** `features/<domain>/components/<name>.tsx`: an async server component that awaits its own query from minimal props; `'use client'` only on interactive leaves.
+   → `references/components.md`; for a client data library or strict-SPA/CSR feature → `references/single-page-applications.md`.
+   ✓ Component receives IDs/handles/parsed filters or already-resolved records, not `params`; skeleton is a sibling export at the end; no alias skeleton wrappers.
+6. **Compose the page.** `app/<route>/page.tsx`: synchronous, `params.then()` / `Promise.all(...).then(...)`, place Suspense around data bodies, and wrap fallible sections in an error boundary.
+   → `references/pages-suspense.md`.
+   ✓ Route props become plain values; stable cards/sections wrap Suspense when they set layout; boundaries stay visible at the page.
+7. **Add interaction** (if any): optimistic updates, pending state, toasts, confirmation.
+   → `references/ux-patterns.md`.
+   ✓ Feedback isn't doubled; optimistic reducers/actions live with the feature; URL/search params own shareable state; client effects synchronize external systems, not derived React state.
+8. **Verify** against the checklist below before declaring done.
+
+## Verify before done
+
+Inspect the diff against every invariant — each is checkable by reading the changed files:
+
+- [ ] No page/layout imports a `*-queries` file or defines reusable domain UI inline; any inline helper is route-local control flow only.
+- [ ] Every page with params is synchronous and uses `params.then()` / `searchParams.then()` / `Promise.all([params, searchParams]).then(...)`.
+- [ ] Feature components receive plain IDs/handles/parsed filters or resolved records; no feature prop is named `params` or `searchParams`.
+- [ ] Every `<Suspense>` for page data sits in the page; no feature pre-wraps itself.
+- [ ] Stable wrappers/cards/chrome sit outside Suspense; fallback and final content do not duplicate the same outer card.
+- [ ] Every component has its real `*Skeleton` in the same file, at the end; no tiny skeleton aliases just to pass props.
+- [ ] Every `*-queries.ts` starts with `import 'server-only'`; every `*-actions.ts` with `'use server'`.
+- [ ] With `cacheComponents: true`, reusable reads use `'use cache'` / `cacheTag` / `cacheLife`, or `'use cache: private'` / `'use cache: remote'` when appropriate; any dynamic read is intentional and justified.
+- [ ] Mutations touching cached reads call `updateTag()` / `revalidateTag(..., 'max')` for the matching tags; `refresh()` is not a substitute for tag invalidation.
+- [ ] Action files are named `<folder>-actions.ts`; no entity-owned sub-concept spawned its own folder, and cross-domain product features do not take ownership of entity queries/actions.
+- [ ] Features with both server tags and client query keys define them once in a pure `<domain>-cache.ts`; queries, actions, hydration, query options, and hooks import from it.
+- [ ] Feature-local client-support files sit in the smallest fitting place: query options at the feature root, `use-*` hook wrappers in `hooks/`, leaf components in `components/`, and shared support only after real cross-feature reuse.
+- [ ] `'use client'` components are leaves — they import actions/hooks/providers, not async server components.
+- [ ] Client leaves use `useOptimistic`, transitions, reducers, URL state, or form actions for interaction; they do not call `setState` in effects for derived React state.
+- [ ] Mutations validate their input and invalidate the affected data.
+
+## Reference index
+
+- **`references/feature-folders.md`** — where code goes: folder layout, cache contracts, naming, and merging sub-concepts.
+- **`references/queries-actions.md`** — query/action rules: server-only, dedup, validation, invalidation, return shape.
+- **`references/components.md`** — server/client boundary, skeletons, `use()`, single-use helpers, live data.
+- **`references/pages-suspense.md`** — page composition, `params.then()`, Suspense placement, CLS, error boundaries, prefetch.
+- **`references/cache-components.md`** — the `cacheComponents` decisions: which reads to cache, which directive to use, how to invalidate.
+- **`references/single-page-applications.md`** — client cache decisions: placement, server seeding, Cache Components coordination, hydration, and mutations.
+- **`references/ux-patterns.md`** — interaction decisions: optimistic vs pending vs inline error, toasts, action-prop, confirmations.
+- **`references/example.md`** — the next-beats reference app: invariant → file map, for seeing any rule in real code.

--- a/docs/ai/skills/nextjs-app-architecture/references/cache-components.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,0 +1,80 @@
+# Cache Components
+
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+
+## When this reference applies
+
+Use this reference when an app already has `cacheComponents: true`, the user wants this architecture while enabling it, or you are reviewing/refactoring an app that targets Cache Components.
+
+If the project has not adopted Cache Components yet and the user asks to enable, migrate, or work through adoption blockers, use the `next-cache-components-adoption` skill first. It owns the route-by-route migration loop, opt-out strategy, and build/dev overlay workflow. Then return here for steady-state query/action/component architecture.
+
+If `cacheComponents` is not enabled and the task is ordinary feature work, follow the core references without adding cache directives. Do not recommend skipping Cache Components based on app category alone; adoption is a migration/project decision, not a per-feature shortcut.
+
+Adopting these in an existing app: follow [Migrating to Cache Components](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components) and [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) — they cover the incremental path (per-route `prefetch = 'partial'`, fixing dynamic-usage build errors) rather than a big-bang switch.
+
+## The model
+
+```ts
+// next.config.ts
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true, // prefetch the static shell of linked routes
+};
+```
+
+- **Static shell** — synchronous content, `'use cache'` output, and Suspense fallbacks prerender at build time.
+- **Dynamic holes** — async work without `'use cache'` streams in behind `<Suspense>` at request time.
+- **Build constraint** — any async work without `'use cache'` must sit inside `<Suspense>`, or the build fails (wrap it, or add `'use cache'`).
+
+`cacheComponents` implies Partial Prerendering — it replaced `experimental.ppr` / `dynamicIO` / `useCache`, so don't set those. See [caching](https://preview.nextjs.org/docs/app/getting-started/caching).
+
+With `cacheComponents: true`, the skill practice is **cache reusable reads**. Do not leave a database/API read dynamic just because Suspense makes the build pass. If a read has a stable key and a mutation can name what changed, give it a cache directive, tags, and a lifetime.
+
+Dynamic reads are the exception: use them for values that must be recomputed for every request or cannot be invalidated coherently. When you leave a read dynamic, note the reason in the surrounding code/review and invalidate its mutations with `refresh()` because there is no tag to update.
+
+## Decide what to cache
+
+| Data | Directive | Notes |
+| ---- | --------- | ----- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
+| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+
+Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
+
+## Keep a synchronous value out of the shell
+
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+
+Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
+
+## Decide how to invalidate
+
+- [`updateTag(tag)`](https://preview.nextjs.org/docs/app/api-reference/functions/updateTag) — in **server actions**, when the user should see the result immediately (read-your-own-writes). Requires the query to carry a matching `cacheTag`.
+- [`revalidateTag(tag, 'max')`](https://preview.nextjs.org/docs/app/api-reference/functions/revalidateTag) — in **route handlers** (webhooks, cron) for stale-while-revalidate. The single-arg `revalidateTag(tag)` form is deprecated.
+- [`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) — re-render the current route for the current user. Use it for deliberately dynamic reads with no tag; don't use it instead of `updateTag()` for cached reads.
+
+Tag, cache, invalidate: the `cacheTag` in the query and the `updateTag` in the action use the same string and live in the same feature folder.
+
+## Coordinate hydrated client data
+
+When cached server data seeds SWR, TanStack Query, or another browser cache, follow `references/single-page-applications.md`. Server and client freshness policies are independent; hydration adds library-specific constraints.
+
+## Build failure map
+
+When `next build` fails under Cache Components, map the error back to an architecture rule instead of patching locally:
+
+- Async work without `'use cache'` and without an ancestor `<Suspense>` → cache the reusable read, or wrap a justified dynamic read in a page-owned `<Suspense>`.
+- Request data inside `'use cache'` → switch to `'use cache: private'` when it is per-user cacheable, or keep it dynamic with a documented reason.
+- `await params` / `await searchParams` at the top of a page → keep the page synchronous and move the read into `params.then()` / `searchParams.then()`.
+- Sync request-time values (`new Date()`, `Math.random()`, sync storage reads) captured in the shell → cache stable values, or use [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) for per-request values.
+
+For adoption-wide blocker triage, use `next-cache-components-adoption`. For API-specific recipes, follow the [Migrating to Cache Components guide](https://preview.nextjs.org/docs/app/guides/migrating-to-cache-components).
+
+## Without Cache Components
+
+- Don't use `'use cache'` / `cacheTag` / `cacheLife` — they require the flag.
+- Use React `cache()` only for proven same-request dedup needs; plain `server-only` async queries are the default.
+- Invalidate with `refresh()` from server actions.
+- Pages still use `params.then()` in this architecture. Without Cache Components there is no build-time static shell to preserve, but keeping pages synchronous still lets chrome paint before route-specific data resolves and keeps the app consistent.

--- a/docs/ai/skills/nextjs-app-architecture/references/cache-components.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/cache-components.md
@@ -1,6 +1,6 @@
 # Cache Components
 
-Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about *which reads to cache, which directive to use, and how to invalidate* — for the mechanics of each directive, follow the doc links.
+Decisions for when [`cacheComponents: true`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) is set in `next.config.ts`. This file is about _which reads to cache, which directive to use, and how to invalidate_ — for the mechanics of each directive, follow the doc links.
 
 ## When this reference applies
 
@@ -34,18 +34,18 @@ Dynamic reads are the exception: use them for values that must be recomputed for
 
 ## Decide what to cache
 
-| Data | Directive | Notes |
-| ---- | --------- | ----- |
-| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache) | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
-| Per-user / reads cookies, headers, session | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server. |
-| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote) | Protects against rate-limited third-party APIs. |
-| Genuinely dynamic per request | none | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists. |
+| Data                                                     | Directive                                                                                                | Notes                                                                                                                                                                                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cacheable across users (public listings, computed pages) | [`'use cache'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache)                  | Add [`cacheTag`](https://preview.nextjs.org/docs/app/api-reference/functions/cacheTag) (a global + a scoped tag) and a [`cacheLife`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/cacheLife) profile. |
+| Per-user / reads cookies, headers, session               | [`'use cache: private'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-private) | Cached in the browser only, doesn't persist across reloads; never stored on the server.                                                                                                                                          |
+| Remote service, safe across users, worth durable storage | [`'use cache: remote'`](https://preview.nextjs.org/docs/app/api-reference/directives/use-cache-remote)   | Protects against rate-limited third-party APIs.                                                                                                                                                                                  |
+| Genuinely dynamic per request                            | none                                                                                                     | Must be justified. Read inside `<Suspense>`; mutations use `refresh()` because no tag exists.                                                                                                                                    |
 
 Cache the **query** when its result should be reused across requests. Cache the **component** when rendering is expensive and props are stable (a nav, a trending sidebar). Don't `'use cache'` a component that already calls a `'use cache'` query — double-caching, no benefit.
 
 ## Keep a synchronous value out of the shell
 
-You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a *synchronous* request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
+You usually don't need this. A query that reads `cookies()`/`headers()` or awaits a DB/`fetch` inside `<Suspense>` already stays out of the shell on its own. Only a _synchronous_ request-time read (`new Date()`, `Math.random()`, a sync sqlite read) needs help: `await` [`io()`](https://preview.nextjs.org/docs/app/api-reference/functions/io) before it, with the caller inside `<Suspense>`.
 
 Prefer `io()` over [`connection()`](https://preview.nextjs.org/docs/app/api-reference/functions/connection): both exclude what follows from the shell, but `connection()` blocks prefetches while `io()` stays prefetchable. Reach for `connection()` only when rendering must wait for a real user request.
 

--- a/docs/ai/skills/nextjs-app-architecture/references/components.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/components.md
@@ -1,0 +1,243 @@
+# Components
+
+How to build server and client components inside a feature folder.
+
+## Default: async server component
+
+Server components await their own queries directly — no `useEffect`, no client-side fetching, no manual loading state. See the [Server Components docs](https://preview.nextjs.org/docs/app/getting-started/server-and-client-components) for the model.
+
+Prefer minimal, stable props: IDs, slugs, handles, parsed filters, or records the parent already fetched. Do not pass raw route `params` or `searchParams` into feature components. Pages resolve those promises and pass plain values.
+
+```tsx
+// features/notifications/components/notifications-badge.tsx
+import { getUnreadNotificationCount } from "@/features/notifications/notifications-queries";
+
+export async function NotificationsBadge() {
+  const count = await getUnreadNotificationCount();
+  if (count === 0) return null;
+  return <span aria-label={`${count} unread`}>{count}</span>;
+}
+```
+
+The page (not this file) wraps it in `<Suspense fallback={<NotificationsBadgeSkeleton />}>` — see `references/pages-suspense.md`.
+
+For parameterized routes, the page resolves `params` and the feature receives an ID:
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <PostDetail id={id} />
+  ))}
+</Suspense>
+```
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Skeletons live in the same file
+
+Export the main component and its skeleton from the same file. Pages import both. Define the skeleton **at the end of the file**, below the real component(s) — never above. Function declarations are hoisted, so a skeleton referenced by a component earlier in the file still works when defined last.
+
+```tsx
+export async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return (
+    <ul>
+      {posts.map((p) => (
+        <Post key={p.id} post={p} />
+      ))}
+    </ul>
+  );
+}
+
+export function FeedSkeleton() {
+  return (
+    <ul>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <li key={i}>
+          <Skeleton className="h-24" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Don't export a second skeleton whose whole job is to rename or preconfigure another skeleton:
+
+```tsx
+// Wrong — alias wrapper adds an import surface but no behavior
+export function CompactGridSkeleton() {
+  return <GridSkeleton dense />;
+}
+```
+
+Import the real skeleton and pass the prop inline at the `<Suspense>` boundary: `fallback={<GridSkeleton dense />}`.
+
+### Skeleton design checklist
+
+1. Match the real component's layout: flex direction, gaps, padding, breakpoints.
+2. Include all structural elements: avatar circles, action button placeholders, image squares.
+3. Responsive visibility must match (`hidden sm:block` in the real component → same in the skeleton).
+4. Show 2–5 placeholders for variable-length lists, not the real count.
+5. Don't include skeletons for inner Suspense content — those have their own boundaries.
+6. Reserve the right height. CLS comes from skeletons that are shorter than the real content.
+7. Dense placeholders should not animate. A grid of 28 shimmering covers reads as flicker rather than progress, so use a flat low-contrast fill when there are many items and keep the animated sweep for a handful of bars.
+
+## Group related components in one file
+
+A card and its grid live in the same file. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`. Variants should reuse that skeleton inline instead of exporting alias skeletons. Don't split shared UI primitives prematurely — wait until three call sites need the same shape before extracting.
+
+Two sidebar widgets that happen to look similar but render different data shapes are **not** the same component. The visuals diverge as soon as one needs an extra slot.
+
+### Single-use sub-components stay inlined
+
+For a metadata strip inside one card, a header used only by one detail view, a list item only rendered by its list — inline them as **non-exported** functions in the same file:
+
+```tsx
+export async function EventDetails({ slug }: { slug: string }) {
+  const event = await getEventBySlug(slug);
+  return (
+    <article>
+      <MetaStrip event={event} />
+      <Speaker speaker={event.speaker} />
+      <p>{event.description}</p>
+    </article>
+  );
+}
+
+function MetaStrip({ event }: { event: Event }) { ... }
+function Speaker({ speaker }: { speaker: string }) { ... }
+```
+
+Exports are for things other files will import. Internal structure is for readability inside one file.
+
+## The server/client boundary
+
+`'use client'` only when you need:
+
+- Hooks (`useState`, `useReducer`, `useOptimistic`, `useTransition`, `useEffect`)
+- Event handlers (`onClick`, `onChange`, `onSubmit`)
+- Browser APIs (`window`, `localStorage`, refs to DOM)
+
+If the component needs interactive pieces, keep the server component as the parent and render client leaves:
+
+```tsx
+async function PostDetail({ id }: { id: string }) {
+  const [post, userState] = await Promise.all([
+    getPost(id),
+    getPostUserState(id),
+  ]);
+  return (
+    <article>
+      <PostBody body={post.body} />
+      <PostActions userState={userState} /> {/* 'use client' leaf */}
+    </article>
+  );
+}
+```
+
+### Server content as children of client components
+
+Composition crosses the boundary. A client component can accept server-rendered JSX as children or props:
+
+```tsx
+<ComposerForm
+  avatar={
+    <Suspense fallback={<AvatarSkeleton />}>
+      <CurrentUserAvatar />
+    </Suspense>
+  }
+/>
+```
+
+`ComposerForm` is `'use client'`. It doesn't know where the avatar JSX came from. The Suspense boundary streams the avatar in without the form re-rendering.
+
+### Pass server children resolved values, not promises
+
+Prefer passing plain values (strings, IDs, resolved data) to a server child. A server component _can_ `await` a promise prop, but resolve route promises in the page instead — pass an unresolved promise down only to a _client_ component that reads it with `use()` (see below). When a parent already has the data from its own query, pass it as a prop instead of having the child refetch.
+
+```tsx
+// Right — parent fetches the list, passes each item
+async function Feed({ userId }: { userId: string }) {
+  const posts = await getFeed(userId);
+  return posts.map((post) => <Post key={post.id} post={post} />);
+}
+
+async function Post({ post }: { post: Post }) {
+  return <article>{post.body}</article>;
+}
+```
+
+```tsx
+// Wrong — child refetches what the parent already had
+async function Post({ id }: { id: string }) {
+  const post = await getPost(id);
+  return <article>{post.body}</article>;
+}
+```
+
+## Client components that own their loading state
+
+When a client component needs server data but should manage its own loading (a sidebar badge, a popover that opens on hover), pass an **unresolved promise** from the server and resolve it with [`use()`](https://react.dev/reference/react/use) on the client. Wrap the consumer in `<Suspense>`.
+
+```tsx
+// page: pass the unresolved promise, wrap in Suspense
+<Suspense fallback={<TagListSkeleton />}>
+  <TagPicker itemsPromise={getTags()} />
+</Suspense>
+```
+
+```tsx
+"use client";
+import { use } from "react";
+
+export function TagPicker({ itemsPromise }: { itemsPromise: Promise<Tag[]> }) {
+  const items = use(itemsPromise);
+  // render interactive UI from items
+}
+```
+
+The opinionated bit: name promise props with a `Promise` suffix (`itemsPromise`, `userPromise`) so the contract is obvious at the call site.
+
+### Client data libraries (SWR, TanStack Query)
+
+Follow `references/single-page-applications.md` when a feature uses a browser data cache or needs externally authored updates. It covers when to use a library, where its files live, server seeding, Cache Components coordination, hydration, and mutations.
+
+## Interactive async React shape
+
+Keep the server/client split even when the UI is highly interactive:
+
+- The server component reads durable data and renders the initial tree.
+- The client leaf owns only ephemeral interaction: open state, focused field, pending flag, optimistic draft, selected tab that is not shareable.
+- Shareable or bookmarkable state lives in the URL/search params, not mirrored in component state.
+- Client leaves import server actions directly and call them from form actions or event handlers.
+- Mutation feedback (`useOptimistic`, pending flags, rollback, toasts) follows `references/ux-patterns.md`.
+
+Avoid effects whose only job is to copy React state to React state:
+
+```tsx
+// Wrong — derived React state cascades through an effect
+useEffect(() => {
+  setSelectedItem(null);
+}, [filterKey]);
+```
+
+Prefer one of these shapes:
+
+- Key the interactive child by the value that resets it: `<SelectableList key={filterKey} filterKey={filterKey} />`.
+- Derive the value during render.
+- Put the value in the URL/search params if navigation should own it.
+- Use a reducer where the same event that changes `filterKey` also clears `selectedItem`.
+
+Effects are for external systems: DOM APIs, subscriptions, timers, browser storage, analytics, or imperative libraries. They are not a cleanup lane for state that React could derive or reset structurally.
+
+## Mutations
+
+For client-side reactions to a server mutation (instant feedback, pending state, success/error toasts), see `references/ux-patterns.md`. To cache rendered output across requests, see `references/cache-components.md`.

--- a/docs/ai/skills/nextjs-app-architecture/references/example.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/example.md
@@ -6,29 +6,29 @@ For the reasoning behind this architecture, read [Component Architecture for Rea
 
 ## Invariant → where to see it
 
-| Invariant | File(s) |
-| --------- | ------- |
-| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
-| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
-| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
-| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
-| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
-| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
-| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
-| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
-| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+| Invariant                                                                         | File(s)                                                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Pages compose, never fetch                                                     | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries.                                                                                                   |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`)                   | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`.                                                                                                                              |
+| 3. Feature components receive IDs, not route props                                | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components.                                                                                                          |
+| 4. Async server component default; `'use client'` on leaves                       | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`.                                                                     |
+| 5. Page owns Suspense; feature owns skeleton                                      | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below).                                                                                                                      |
+| 6. Skeleton in the same file, at the end                                          | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`.                                                                                                      |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`.                                                                                                                                                    |
+| 8. Feature folders follow product ownership                                       | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly                                      | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly.                                                                                                                                          |
 
 ## Supporting patterns
 
-| Pattern | File |
-| ------- | ---- |
-| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
-| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
-| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
-| `useFormStatus` submit button | `components/ui/button.tsx` |
-| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
-| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
-| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
-| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+| Pattern                                                | File                                                                                         |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`)   | `components/ui/error-boundary.tsx`                                                           |
+| `useOptimistic` for an unlikely-to-fail toggle         | `features/track/components/track-interactions.tsx`                                           |
+| Action-prop / `*Action` convention + confirm dialog    | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button                          | `components/ui/button.tsx`                                                                   |
+| `useActionState` inline field errors                   | `features/user/components/sign-in-form.tsx`                                                  |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx`                           |
+| `use()` on an unresolved promise prop                  | `features/playlist/components/add-to-playlist-menu.tsx`                                      |
+| Purpose-named `components/scripts/` subfolder          | `components/scripts/`                                                                        |
 
 > The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/docs/ai/skills/nextjs-app-architecture/references/example.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/example.md
@@ -1,0 +1,34 @@
+# Reference app: next-beats
+
+A working app that follows this architecture: **<https://github.com/vercel-labs/next-beats>** (Next.js 16, `cacheComponents` + `partialPrefetching`, a music player). Use it to see any invariant in real code rather than restating the code here. Paths are as of this writing — verify against the current repo.
+
+For the reasoning behind this architecture, read [Component Architecture for React Server Components](https://aurorascharff.no/posts/component-architecture-for-react-server-components/). The skill's target is the same shape: pages describe layout and loading; feature components own server reads; route params become IDs before they reach components.
+
+## Invariant → where to see it
+
+| Invariant | File(s) |
+| --------- | ------- |
+| 1. Pages compose, never fetch | `app/(app)/search/page.tsx`, `app/(app)/genre/[genre]/page.tsx` — import feature components, place `<Suspense>`, no queries. |
+| 2. Pages stay synchronous (`params.then` / `searchParams.then`) | `app/(app)/track/[id]/page.tsx`, `app/(app)/genre/[genre]/page.tsx`, `app/(app)/search/page.tsx`. |
+| 3. Feature components receive IDs, not route props | Track/genre pages resolve `params` / `searchParams` and pass `id`, `genre`, or parsed values into feature components. |
+| 4. Async server component default; `'use client'` on leaves | Server: `features/track/components/discover.tsx`, `most-played.tsx`. Client leaves: `features/track/components/track-interactions.tsx`, `play-button.tsx`. |
+| 5. Page owns Suspense; feature owns skeleton | Pages place the boundary (e.g. `app/(app)/genre/[genre]/page.tsx`); features export the skeleton (below). |
+| 6. Skeleton in the same file, at the end | `features/track/components/track-row.tsx` (`TrackRow` … `TrackListSkeleton`), `features/genre/components/genre-card.tsx`. |
+| 7. `<domain>-queries.ts` (`server-only`) / `<domain>-actions.ts` (`'use server'`) | `features/track/track-queries.ts`, `features/playlist/playlist-actions.ts`. |
+| 8. Feature folders follow product ownership | `toggleFavorite` stays in `features/track/track-actions.ts`; entity queries such as `searchTracks` and `searchPlaylists` stay with their domains, while `features/search/components/` owns the cross-domain search experience. |
+| 9. Client components import actions directly | `features/track/components/track-interactions.tsx` imports `toggleFavorite` directly. |
+
+## Supporting patterns
+
+| Pattern | File |
+| ------- | ---- |
+| Error boundary on `catchError` (`ErrorInfo` `retry`) | `components/ui/error-boundary.tsx` |
+| `useOptimistic` for an unlikely-to-fail toggle | `features/track/components/track-interactions.tsx` |
+| Action-prop / `*Action` convention + confirm dialog | `features/playlist/components/playlist-interactions.tsx`, `components/ui/confirm-dialog.tsx` |
+| `useFormStatus` submit button | `components/ui/button.tsx` |
+| `useActionState` inline field errors | `features/user/components/sign-in-form.tsx` |
+| Client-owned live data via a provider (not `<Poller>`) | `providers/player-provider.tsx` → `components/now-playing-bar.tsx` |
+| `use()` on an unresolved promise prop | `features/playlist/components/add-to-playlist-menu.tsx` |
+| Purpose-named `components/scripts/` subfolder | `components/scripts/` |
+
+> The repo is a live app, not a golden reference — spots may drift from the invariants (a page may fetch inline, a route `error.tsx` may lag an API rename). When the app and the invariants disagree, the invariants win; treat the mismatch as a fix for the app.

--- a/docs/ai/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,5 +1,7 @@
 # Feature folders
 
+> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+
 How to organize code under `features/` and `app/`.
 
 ## Folder layout

--- a/docs/ai/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,6 +1,6 @@
 # Feature folders
 
-> **Core:** Existing `apps/*/features/` folders are UI composition. Do not add `*-queries.ts` or `*-actions.ts` as a new data layer. Business and privileged queries stay in `packages/api`.
+> **Core:** Existing `apps/*/features/` folders are UI composition only. Do not add `*-queries.ts` or `*-actions.ts` at all. Call `@asym/api` or `@asym/database/hooks` from the feature component.
 
 How to organize code under `features/` and `app/`.
 

--- a/docs/ai/skills/nextjs-app-architecture/references/feature-folders.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/feature-folders.md
@@ -1,0 +1,147 @@
+# Feature folders
+
+How to organize code under `features/` and `app/`.
+
+## Folder layout
+
+```
+features/<domain>/
+  <domain>-cache.ts     # Pure server tags + client query keys, when shared
+  <domain>-queries.ts   # Server-only queries, when this feature owns reads
+  <domain>-actions.ts   # Server actions, when this feature owns writes
+  <domain>-query-options.ts # Client data-library query definitions, when needed
+  components/           # Server + client components, each with its skeleton
+  types/                # Feature-local public types, when needed by multiple files
+  hooks/                # Actual feature-local React hooks and hook wrappers
+  providers/            # Feature-local providers, only when the provider belongs to this domain
+```
+
+The folder name identifies the domain or cohesive product experience. Query and action filenames match the owning domain folder when present.
+
+## How many features?
+
+Keep the feature list short. Use folders for **domains and cohesive product experiences a user would recognize**, not database tables or technical concerns.
+
+A new folder is justified in either of these cases:
+
+1. **Domain ownership:** it owns the queries, actions, and components for a real product entity.
+2. **Cross-domain composition:** it owns the route-level UI or client state for an experience that combines multiple domains. The underlying queries and actions remain with the domains whose data they read or mutate.
+
+If you find yourself making a feature folder with one query, one action, and one button, fold it into the parent feature instead.
+
+### Merge aggressively
+
+Concepts that exist only in service of a parent entity belong inside the parent's feature folder:
+
+- A `favorite` or `bookmark` concept that only attaches to one parent entity (events, posts) → inside that parent's folder.
+- A `like`, `repost`, `vote`, or `reaction` concept on a piece of content → with that content's feature.
+- `auth` / `session` / `current user` → a single `user` folder, not split.
+- A search query stays with the domain it searches (`searchTracks` in `features/track/`, `searchPlaylists` in `features/playlist/`). When one search experience combines several domains, `features/search/` may own the search form, result composition, and client state without taking ownership of those domain queries.
+
+Concrete example: `toggleFavorite` is a mutation about events ("I favorite an event"), not its own domain. It lives in `features/event/event-actions.ts`, not `features/favorite/favorite-actions.ts`.
+
+## File naming
+
+Filenames inside the folder always start with the folder name:
+
+```
+features/event/
+  event-queries.ts
+  event-actions.ts
+  components/
+    event-grid.tsx
+    event-details.tsx
+    favorite-button.tsx     ← OK: a component, not a "favorite" feature
+```
+
+- `<folder>-queries.ts` — even if the file has only one query.
+- `<folder>-actions.ts` — even if a mutation is about a sub-concept.
+- Don't create empty query or action files for a cross-domain UI feature that doesn't own data access.
+- Other `<folder>-*.ts` files are fine when the folder needs them (`playlist-constants.ts`, `<folder>-schema.ts`), as long as they keep the folder-name prefix. Don't put reusable domain types in a root `*-types.ts` file; use `features/<domain>/types/` once a type is imported by multiple files.
+- Component files use any descriptive name. The component (not the feature) is the unit here.
+
+## Local vs shared support folders
+
+Use a local support folder when the code belongs to one feature:
+
+```
+features/message/
+  message-cache.ts
+  message-query-options.ts
+  types/
+    message.ts
+  hooks/
+    use-message-mutations.ts
+    use-message-draft.ts
+  providers/
+    message-draft-provider.tsx
+```
+
+Feature-owned client coordination stays with the feature. Place each file by the shape it exports and the domain it belongs to:
+
+- Client data-library cache contracts and query definitions follow `references/single-page-applications.md`.
+- Mutation wrappers that export hooks live in `hooks/use-*.ts` (`use-message-mutations.ts` exporting `useSendMessage`).
+- Browser-only state helpers live in `hooks/` when their public API is a hook (`use-thread.ts`, `use-message-draft.ts`).
+- Client leaf components that coordinate a server write live in `components/` next to the UI they support (`mark-activity-read.tsx` posts read activity in the background while the current `/activity` tree stays stable).
+
+Keep the file prefix aligned with the feature folder when a file exports a grouped feature contract (`workspace-cache.ts` and `workspace-query-options.ts`, not `activity-cache.ts` in `features/workspace/`). Support code for a sub-concept still lives with the parent feature: reactions on messages belong in `features/message/`; unread activity chrome belongs in `features/workspace/`.
+
+Promote only when there are real cross-feature consumers:
+
+- `types/` at the project root — shared domain/application types imported across features.
+- `hooks/` at the project root — shared client hooks used across features.
+- `app/providers.tsx` or `components/*-provider.tsx` — app-shell providers that wrap the whole app.
+
+Avoid root-level miscellany like `message-types.ts`, `shared-hooks.ts`, or `common-provider.tsx`; the folder name should explain the scope.
+
+## What goes in `components/`
+
+Each component file exports the main component **plus its skeleton**:
+
+```tsx
+// features/event/components/event-grid.tsx
+export async function EventGrid(...) { ... }
+export function EventGridSkeleton() { ... }
+```
+
+Group related components in one file when they're always used together or one is a natural building block for another. A card and its grid live together. For example, `genre-card.tsx` exports `GenrePill`, `GenreCard`, `GenreGrid`, `GenreGridSkeleton`.
+
+Split into separate files only when:
+
+- A component is consumed by multiple sibling components (one shared use is not enough — wait until three call sites need it).
+- A component is `'use client'` and a sibling is a server component (the server/client boundary forbids sharing a file).
+
+See `references/components.md` for inlining rules and the skeleton design checklist.
+
+## What pages do
+
+Pages in `app/` compose feature components with Suspense and transition wrappers. They never:
+
+- Contain domain logic
+- Define new components except thin transition wrappers (e.g. `<ViewTransition>`)
+- Fetch data directly
+- Inline route-specific components — extract them into the feature folder
+
+See `references/pages-suspense.md` for page composition details.
+
+## Top-level layout
+
+```
+app/                  # Pages and layouts
+features/             # Domain folders
+components/           # UI primitives, theme, and app-shell singletons
+hooks/                # Shared client hooks used across features
+types/                # Shared cross-feature types only
+lib/                  # Utilities and cohesive non-domain subsystems
+```
+
+`lib/` holds flat helpers (`db.ts`, `utils.ts`) but may also group a cohesive non-domain subsystem in its own subfolder (e.g. `lib/audio/` for an audio engine). Cross-feature client hooks live in top-level `hooks/`; a hook used by a single feature co-locates in that feature's `hooks/`. Types follow the same rule: shared types at top-level `types/`, feature-only exported types in `features/<domain>/types/`.
+
+`components/` holds:
+
+- **`components/ui/`** — primitives. Low-level building blocks and action-prop components.
+- **`components/theme/`** — theme provider and toggle, paired.
+- **Top-level files** (`site-header.tsx`, `auth-gate.tsx`, `poller.tsx`) — app-shell singletons used once each. No `common/` folder — "common" is not a category. If a component is used everywhere it's a primitive (→ `ui/`); if it's used once it lives at the top level.
+- **Purpose-named subfolders** are fine when several files share a clear technical role — e.g. `components/scripts/` for pre-hydration inline `<script>` seed components. This is distinct from the rejected `common/`: a `scripts/` folder names _what the files are_, not "miscellaneous."
+
+Conventions for filenames and casing live in the project's `AGENTS.md`. This skill doesn't impose one.

--- a/docs/ai/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -1,0 +1,276 @@
+# Pages and Suspense
+
+How to compose pages, place Suspense boundaries, and prevent layout shift.
+
+## Pages are composition only
+
+Pages in `app/` import feature components and place `<Suspense>` boundaries. They never:
+
+- Fetch data directly (queries live in feature folders)
+- Define reusable UI components except thin transition wrappers (e.g. `<ViewTransition>`) or tiny route-local control-flow helpers
+- Inline route-specific UI (extract it into the feature folder)
+- Pass raw `params` / `searchParams` to features
+
+## Page function signatures
+
+Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
+
+```tsx
+export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+```
+
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+
+## Keep pages synchronous
+
+Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
+
+```tsx
+import { Suspense } from 'react';
+import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+
+export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+  return (
+    <div>
+      <h1>Post</h1>
+      <Suspense fallback={<PostDetailSkeleton />}>
+        {params.then(({ id }) => (
+          <PostDetail id={id} />
+        ))}
+      </Suspense>
+    </div>
+  );
+}
+```
+
+The `<h1>` sits **above** the `params.then()` so it paints instantly. The `Suspense` fallback covers only the dynamic section.
+
+Resolve route props to plain values at this boundary. Feature components receive `id`, `slug`, `query`, or parsed filter values — not `params`, `searchParams`, or unresolved server promises.
+
+### Implicit return inside `.then()`
+
+Use an implicit-return arrow function when the callback just renders JSX — e.g. `({ id }) => <PostDetail id={id} />`. Only switch to a block body with `return` when you need to do work first (destructure with defaults, parse a `searchParams` value, branch on a condition). This keeps the JSX-in-page shape readable and matches how the resolved tree will look.
+
+### `searchParams` and combined params
+
+```tsx
+// searchParams only
+export default function SearchPage({ searchParams }: PageProps<'/search'>) {
+  return searchParams.then(sp => {
+    const q = typeof sp.q === 'string' ? sp.q : '';
+    return q ? <SearchResults query={q} /> : <EmptyState />;
+  });
+}
+
+// Both params and searchParams
+export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+  return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
+    <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
+  ));
+}
+```
+
+Use `Promise.all([params, searchParams])` when both are needed. Avoid nested `.then()` calls that make the resolved tree hard to read and easy to wrap in the wrong boundary.
+
+### Metadata, static params, and `notFound()`
+
+- [`generateMetadata`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-metadata) runs before render, so `await params` is fine there — it's a separate async function, not the page body, so it doesn't make the page dynamic.
+- Export [`generateStaticParams`](https://preview.nextjs.org/docs/app/api-reference/functions/generate-static-params) from a `[slug]` page/layout to pre-build a known set of slugs; with `cacheComponents` + `'use cache'` they land in the static shell. It does **not** change the page signature — `params` is still a Promise, still consumed with `params.then()`.
+- A query that can't find its resource calls [`notFound()`](https://preview.nextjs.org/docs/app/api-reference/functions/not-found), which bubbles to the nearest [`not-found.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/not-found). Don't try/catch it — use [`unstable_rethrow`](https://preview.nextjs.org/docs/app/api-reference/functions/unstable_rethrow) if you must catch nearby.
+
+## Prefer a page boundary over `loading.tsx`
+
+Put the boundary in the page next to the `params.then()` / `searchParams.then()` it covers, rather than adding a route-segment `loading.tsx`. A page boundary keeps the fallback beside the JSX it stands in for, lets sibling sections share one boundary or split into several, and can be wrapped in `<ViewTransition>` so the reveal animates. A `loading.tsx` renders outside the page's own tree, so a transition wrapper inside the page cannot animate the swap out of it, and one fallback has to cover the whole route.
+
+## The page owns the Suspense boundary
+
+The feature exports the async component **and** its skeleton. The page imports both and places the boundary. Don't pre-wrap inside the feature — that hides the boundary and prevents grouping siblings.
+
+```tsx
+// features/post/components/post-detail.tsx
+export async function PostDetail({ id }: { id: string }) { ... }
+export function PostDetailSkeleton() { ... }
+```
+
+```tsx
+// app/post/[id]/page.tsx
+<Suspense fallback={<PostDetailSkeleton />}>
+  {params.then(({ id }) => (
+    <>
+      <PostDetail id={id} />
+      <ErrorBoundary title="Replies didn't load">
+        <Suspense fallback={<RepliesSkeleton />}>
+          <Replies postId={id} />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  ))}
+</Suspense>
+```
+
+If a page uses a transition wrapper (e.g. `<ViewTransition>`), place it in the page next to the `<Suspense>` boundary. Feature components render content and skeletons, not transition wrappers.
+
+## Stable shell, suspending body
+
+Before designing a fallback, identify what is stable and what is data-dependent.
+
+- Stable: card/panel border, padding, icon, label, section heading, fixed action rail.
+- Data-dependent: title text, counts, form body, list rows, loaded choices.
+- Rule: stable shell outside Suspense; skeleton/crossfade inside the shell around the data body.
+
+```tsx
+<FeaturePanel>
+  <Suspense fallback={<FeaturePanelBodySkeleton />}>
+    <Crossfade>
+      <FeaturePanelBody id={id} />
+    </Crossfade>
+  </Suspense>
+</FeaturePanel>
+```
+
+Do not render `<FeaturePanel>` in both `fallback` and final content. That duplicates layout responsibility and makes the skeleton guess the panel size.
+
+Use the app's real domain noun at implementation time (`PostPanel`, `MessageList`, `GroupEditor`, `EventDetails`, etc.); the neutral names here describe the reusable shape, not a component to copy literally.
+
+When the top data section has unknown final height and pushes the sections below, either reserve that height in the stable wrapper or group the affected sections in one boundary. Do not create two independent crossfades if the first one changes the second one's starting position.
+
+## Audit smells
+
+When auditing an existing app, flag and fix these first:
+
+- `export default async function Page(...)` that only awaits `params`, `searchParams`, or page-level queries.
+- `import { getSomething } from '@/features/.../*-queries'` inside `app/**/page.tsx` or `layout.tsx`.
+- Feature components whose props are `params`, `searchParams`, or a route-shaped object.
+- Page-local components like `HomeContent`, `PostShell`, or `ResultsSection` that only exist to fetch data or group a Suspense fallback.
+- `<Suspense>` inside feature components that prevents the page from grouping reveal behavior.
+
+## Route-local control-flow helpers
+
+Small inline helpers are fine when their only job is route control flow that must live exactly where a boundary is placed:
+
+```tsx
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginRedirect />
+    </Suspense>
+  );
+}
+
+async function LoginRedirect() {
+  await connection();
+  await redirectIfAuthenticated('/dashboard');
+  return <LoginForm />;
+}
+```
+
+Do not move a helper like this into a feature folder just to satisfy a blanket "no inline components" rule. It is not domain UI and it is not a reusable feature component; extracting it creates noise. Keep the cookie/session read inside the data-access helper (`redirectIfAuthenticated`, `verifyAuth`, etc.) rather than importing a feature query into the page.
+
+## Don't create page-local wrapper components
+
+Avoid components whose only job is to group boundary content, like `HomeLists` or `HomeListsSkeleton`. Keep the resolved JSX and fallback JSX **inline in the page** so the loading shape, headings, and grouped reveal behavior are visible at the boundary.
+
+```tsx
+// Wrong — hides the structure behind a wrapper
+<Suspense fallback={<HomeListsSkeleton />}>
+  <HomeLists searchParams={searchParams} />
+</Suspense>
+```
+
+```tsx
+// Right — structure visible at the page level
+<Suspense
+  fallback={
+    <>
+      <FeaturedSkeleton />
+      <RecentSkeleton />
+    </>
+  }
+>
+  {searchParams.then(sp => (
+    <>
+      <Featured filter={sp.filter} />
+      <Recent filter={sp.filter} />
+    </>
+  ))}
+</Suspense>
+```
+
+The same applies to feature-level skeleton aliases. If a variant only passes props to a base skeleton, import the base skeleton and pass those props inline in `fallback={...}`.
+
+## Suspense boundary placement rules
+
+1. **First section gets its own Suspense** with a known-height skeleton fallback.
+2. **Section headings stay outside Suspense** when their final position is stable.
+3. **Stable wrappers stay outside Suspense.** If fallback and final content both render the same card or panel, lift that wrapper around the boundary.
+4. **Variable-height sections: group everything below them** in the same Suspense, including any headings that would otherwise paint in the wrong vertical position.
+5. **Fixed-height sections: own boundary is safe.**
+6. **Variable-length lists: show 2–5 skeleton items**, not the real count.
+7. **Inner Suspense content stays out of the outer skeleton.** Each boundary owns its own.
+8. **Never `fallback={null}` for visible UI.** If a boundary covers UI, give it a real shaped fallback, or group it with a sibling boundary that already has the correct fallback.
+9. **If the top section's final height is unknown, group the following sections** in the same boundary so they reveal together and don't jump underneath.
+
+## Error boundaries
+
+Wrap fallible sections in a Next.js-aware error boundary so one failure doesn't take down the page. Build it on [`catchError`](https://preview.nextjs.org/docs/app/api-reference/functions/catchError) from `next/error` (its `ErrorInfo` gives you a `retry()` that re-fetches server data) — it understands Next's control-flow throws (`notFound()`, `redirect()`, `unauthorized()`, `forbidden()`) and won't swallow them. Place the boundary around the suspending section, in the page:
+
+```tsx
+<ErrorBoundary title="Replies didn't load">
+  <Suspense fallback={<RepliesSkeleton />}>
+    <Replies postId={id} />
+  </Suspense>
+</ErrorBoundary>
+```
+
+Why not plain `react-error-boundary`? It catches Next's framework throws (so `notFound()` never reaches `not-found.tsx`), and its reset doesn't re-fetch server data. Background: [Error Handling in Next.js with catchError](https://aurorascharff.no/posts/error-handling-in-nextjs-with-catch-error/).
+
+Pair component-level boundaries with route-segment [`error.tsx`](https://preview.nextjs.org/docs/app/api-reference/file-conventions/error) for unrecoverable errors; it also receives a `retry` callback.
+
+## Layout-level Suspense
+
+Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
+
+```tsx
+export default function RootLayout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>
+        <Suspense>
+          <AuthGate userPromise={getCurrentUser()} />
+        </Suspense>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}
+```
+
+`AuthGate` is a client component that resolves the promise with `use()` so the dialog can render conditionally without server-side branching.
+
+## CLS prevention
+
+Layout shift happens when:
+
+- A skeleton is shorter than the real content
+- A heading sits inside a Suspense boundary whose final height is unknown — it paints in the wrong place, then jumps
+- A variable-length list streams in without a fallback that reserves space
+
+Fixes:
+
+- Match skeleton height to the typical real content height.
+- Move headings **outside** boundaries when their position depends on data above them.
+- For unknown-height top sections, group everything below in one boundary so siblings stream together.
+
+To audit CLS, use React DevTools' Suspense panel to pin each boundary in its loading state and check vertical positions.
+
+## Optimizing prefetching for high-value routes
+
+With `cacheComponents` + [`partialPrefetching`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, a visible `<Link>` prefetches the destination's shared [App Shell](https://preview.nextjs.org/docs/app/glossary#app-shell) — enough to commit navigation instantly, with link-specific content streaming after. The default (`'auto'`) already does this; don't write `prefetch = 'auto'`.
+
+Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link data (`params`, `searchParams`, the full URL) at prefetch time. Each such link can wake the server for a prerender, so reserve it for routes users predictably visit next. See [Optimizing prefetching](https://preview.nextjs.org/docs/app/guides/optimizing-prefetching).
+
+Can't enable `partialPrefetching` app-wide yet? Opt in per route with `export const prefetch = 'partial'` on the destination, then drop the per-route exports once the global flag is on — see [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) for the incremental path and [prefetch config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for the options. To validate navigation feels instant, see the [`instant` config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant) and [Instant Navigation guide](https://preview.nextjs.org/docs/app/guides/instant-navigation).
+
+## Never wrap the entire page in a Suspense fallback
+
+Page chrome (header, nav, surrounding layout) should paint instantly. Only data-dependent sections suspend. If you find yourself wrapping `<div>` and everything in it with `<Suspense fallback={<FullPageSkeleton />}>`, restructure: pull static elements out, narrow the boundary to just the dynamic part.

--- a/docs/ai/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -16,20 +16,25 @@ Pages in `app/` import feature components and place `<Suspense>` boundaries. The
 Type page and layout functions with the auto-generated `PageProps<'/route'>` / `LayoutProps<'/route'>` helpers — no import, regenerated on `next dev` / `next build` / `next typegen`. See [route type helpers](https://preview.nextjs.org/docs/app/api-reference/config/typescript#route-type-helpers).
 
 ```tsx
-export default function PostPage({ params }: PageProps<'/post/[id]'>) { /* ... */ }
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
+  /* ... */
+}
 ```
 
-Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a *separate* feature (statically-typed `href`s), not the source of these helpers.
+Don't hand-write `{ params: Promise<{ id: string }> }` — the generated types stay in sync with the route (catch-all, optional segments). Route handlers use `RouteContext<'/api/...'>`. `typedRoutes: true` is a _separate_ feature (statically-typed `href`s), not the source of these helpers.
 
 ## Keep pages synchronous
 
 Use `params.then()` instead of `await params`. Content above the `.then()` pre-renders into the static shell; content inside it suspends.
 
 ```tsx
-import { Suspense } from 'react';
-import { PostDetail, PostDetailSkeleton } from '@/features/post/components/post-detail';
+import { Suspense } from "react";
+import {
+  PostDetail,
+  PostDetailSkeleton,
+} from "@/features/post/components/post-detail";
 
-export default function PostPage({ params }: PageProps<'/post/[id]'>) {
+export default function PostPage({ params }: PageProps<"/post/[id]">) {
   return (
     <div>
       <h1>Post</h1>
@@ -55,15 +60,18 @@ Use an implicit-return arrow function when the callback just renders JSX — e.g
 
 ```tsx
 // searchParams only
-export default function SearchPage({ searchParams }: PageProps<'/search'>) {
-  return searchParams.then(sp => {
-    const q = typeof sp.q === 'string' ? sp.q : '';
+export default function SearchPage({ searchParams }: PageProps<"/search">) {
+  return searchParams.then((sp) => {
+    const q = typeof sp.q === "string" ? sp.q : "";
     return q ? <SearchResults query={q} /> : <EmptyState />;
   });
 }
 
 // Both params and searchParams
-export default function ProfilePage({ params, searchParams }: PageProps<'/u/[handle]'>) {
+export default function ProfilePage({
+  params,
+  searchParams,
+}: PageProps<"/u/[handle]">) {
   return Promise.all([params, searchParams]).then(([{ handle }, sp]) => (
     <ProfileFeed handle={handle} tab={parseTab(sp.tab)} />
   ));
@@ -159,7 +167,7 @@ export default function LoginPage() {
 
 async function LoginRedirect() {
   await connection();
-  await redirectIfAuthenticated('/dashboard');
+  await redirectIfAuthenticated("/dashboard");
   return <LoginForm />;
 }
 ```
@@ -187,7 +195,7 @@ Avoid components whose only job is to group boundary content, like `HomeLists` o
     </>
   }
 >
-  {searchParams.then(sp => (
+  {searchParams.then((sp) => (
     <>
       <Featured filter={sp.filter} />
       <Recent filter={sp.filter} />
@@ -231,7 +239,7 @@ Pair component-level boundaries with route-segment [`error.tsx`](https://preview
 Layouts compose feature components the same way pages do. Use `<Suspense>` for slots that fetch data (auth badge, sidebar):
 
 ```tsx
-export default function RootLayout({ children }: LayoutProps<'/'>) {
+export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html>
       <body>

--- a/docs/ai/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,6 +1,6 @@
 # Queries and actions
 
-> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables. The vendor procedure below is placement-only and must not be copied into `apps/*/features/`.
 
 The data layer. Every feature has both: queries to read, actions to write.
 

--- a/docs/ai/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,5 +1,7 @@
 # Queries and actions
 
+> **Core:** Vendor next-beats placement. In this repo, do not copy `db.*` into `features/<domain>/*-queries.ts` or `*-actions.ts`. Privileged reads and writes stay in `packages/api`. Feature components import those APIs, or `@asym/database/hooks` for approved browser tables.
+
 The data layer. Every feature has both: queries to read, actions to write.
 
 This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
@@ -15,7 +17,7 @@ Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` â
 Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
 
 ```ts
-import 'server-only';
+import "server-only";
 
 export async function getFeed(userId: string) {
   return db.post.findMany({ where: { userId } });
@@ -30,9 +32,13 @@ Take normalized primitives, not the params object:
 
 ```ts
 // features/book/book-queries.ts
-export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
-  'use cache';
-  cacheLife('hours');
+export async function getBooksPage(
+  page: number = 1,
+  search: string = "",
+  year: number = MAX_YEAR,
+) {
+  "use cache";
+  cacheLife("hours");
   // ...
 }
 ```
@@ -43,7 +49,7 @@ Normalize and clamp in the feature's own helper, **before** the call, not inside
 
 Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" â€” it adds indirection and can hide when data is intentionally dynamic.
 
-`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results _across_ requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
 
 ## Actions
 
@@ -56,13 +62,13 @@ Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the 
 5. Return a result (`{ ok }` or `{ error }`).
 
 ```tsx
-'use server';
+"use server";
 
-import { refresh } from 'next/cache';
+import { refresh } from "next/cache";
 
 export async function createPost(formData: FormData) {
   const user = await verifyUser();
-  const parsed = schema.safeParse({ body: formData.get('body') });
+  const parsed = schema.safeParse({ body: formData.get("body") });
   if (!parsed.success) {
     return { ok: false as const, error: parsed.error.issues[0].message };
   }
@@ -85,8 +91,8 @@ Client components import server actions directly. **Don't** pass an action as a 
 
 ```tsx
 // Right
-'use client';
-import { likePost } from '@/features/post/post-actions';
+"use client";
+import { likePost } from "@/features/post/post-actions";
 
 export function LikeButton({ postId }: { postId: string }) {
   return <button onClick={() => likePost(postId)}>Like</button>;
@@ -113,7 +119,9 @@ For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTran
 Return a discriminated union from actions that can fail:
 
 ```tsx
-export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+export type ActionResult<T = void> =
+  | { ok: true; data?: T }
+  | { ok: false; error: string };
 ```
 
 Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
@@ -126,7 +134,10 @@ If your DB rows have shapes you don't want to leak to components (extra columns,
 
 ```ts
 export async function getPost(id: string) {
-  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  const row = await db.post.findUnique({
+    where: { id },
+    include: { author: true },
+  });
   if (!row) notFound();
   return toPost(row);
 }

--- a/docs/ai/skills/nextjs-app-architecture/references/queries-actions.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/queries-actions.md
@@ -1,0 +1,139 @@
+# Queries and actions
+
+The data layer. Every feature has both: queries to read, actions to write.
+
+This page covers the universal data layer that applies to every Next.js App Router app. When `cacheComponents: true` is enabled, follow `references/cache-components.md`: reusable reads are cached/tagged/lifetimed, and mutations update matching tags.
+
+## Cache identities
+
+When a server read also seeds a browser data cache, follow `references/single-page-applications.md` for the feature-local cache contract and client-library placement.
+
+## Queries
+
+Create `features/<domain>/<domain>-queries.ts`. Mark it `import 'server-only'` — that's the invariant. Default to plain async exports.
+
+Resource queries own `notFound()` when a requested record is absent. Route pages only compose the feature and pass route values down; they do not perform data lookups or decide resource existence.
+
+```ts
+import 'server-only';
+
+export async function getFeed(userId: string) {
+  return db.post.findMany({ where: { userId } });
+}
+```
+
+## Cache keys are the arguments
+
+A `'use cache'` function's arguments are its cache key, so shape them deliberately.
+
+Take normalized primitives, not the params object:
+
+```ts
+// features/book/book-queries.ts
+export async function getBooksPage(page: number = 1, search: string = '', year: number = MAX_YEAR) {
+  'use cache';
+  cacheLife('hours');
+  // ...
+}
+```
+
+Passing `searchParams` straight through keys the entry on an object carrying every param the route knows about, including the ones the caller left undefined, and the key then changes shape whenever the route gains a param.
+
+Normalize and clamp in the feature's own helper, **before** the call, not inside the cached function. `?yr=9999`, `?yr=2023`, and no `yr` at all describe the same result set, so they should resolve to the same arguments and share one entry. Clamping inside the cached function gives each spelling its own entry with identical contents.
+
+Use [`cache()`](https://react.dev/reference/react/cache) from React only for **request-level deduplication** when the same dynamic query is called multiple times with the same arguments in one render. Highest-value cases: a session/user lookup used by many queries, or a shared expensive read used by metadata + page sections. Don't wrap every query "just in case" — it adds indirection and can hide when data is intentionally dynamic.
+
+`cache()` dedups within a request; `'use cache'` + `cacheTag` (Cache Components) shares results *across* requests. Don't add React `cache()` to a function only because it already uses `'use cache'`; that is double-caching unless you have a separate, proven same-request duplication problem. See `references/cache-components.md`.
+
+## Actions
+
+Create `features/<domain>/<domain>-actions.ts`. Mark with `'use server'` at the top. Always:
+
+1. Verify auth.
+2. Validate input with your schema validator.
+3. Run the mutation.
+4. Invalidate cached data so the next render sees the new state.
+5. Return a result (`{ ok }` or `{ error }`).
+
+```tsx
+'use server';
+
+import { refresh } from 'next/cache';
+
+export async function createPost(formData: FormData) {
+  const user = await verifyUser();
+  const parsed = schema.safeParse({ body: formData.get('body') });
+  if (!parsed.success) {
+    return { ok: false as const, error: parsed.error.issues[0].message };
+  }
+
+  await db.post.create({ data: { body: parsed.data.body, userId: user.id } });
+  refresh();
+  return { ok: true as const };
+}
+```
+
+[`refresh()`](https://preview.nextjs.org/docs/app/api-reference/functions/refresh) re-renders the current route for the current user. Use it when the affected read is deliberately dynamic and has no tag. With Cache Components enabled, reusable reads should have matching `cacheTag()` calls, so server actions normally call `updateTag()` for read-your-own-writes. See `references/cache-components.md`.
+
+### Action file naming
+
+Actions for a feature always go in `<folder>-actions.ts`, matching the folder name — even when the mutation operates on a sub-concept. `toggleFavorite` in `features/event/` lives in `event-actions.ts`, not `favorite-actions.ts`. The folder is the source of truth for the name.
+
+## Calling actions from client components
+
+Client components import server actions directly. **Don't** pass an action as a prop just to call it:
+
+```tsx
+// Right
+'use client';
+import { likePost } from '@/features/post/post-actions';
+
+export function LikeButton({ postId }: { postId: string }) {
+  return <button onClick={() => likePost(postId)}>Like</button>;
+}
+```
+
+```tsx
+// Wrong — adds indirection with no benefit
+async function Post({ id }: { id: string }) {
+  return <LikeButton postId={id} onLike={likePost} />;
+}
+```
+
+Design components (`<BottomNav>`, `<ToggleGroup>`, `<SubmitButton>`) take this further with the **action-prop pattern** — `action` is a callback wrapped in `useTransition` / `useOptimistic` internally. See `references/ux-patterns.md`.
+
+## Form actions vs onClick handlers
+
+Prefer [`<form action={serverAction}>`](https://react.dev/reference/react-dom/components/form#action) for form mutations — React wraps the call in a transition and surfaces pending state automatically.
+
+For one-off buttons, `onClick={() => action(args)}` is fine. Wrap in [`startTransition`](https://react.dev/reference/react/startTransition) if you need pending state.
+
+## Return shape
+
+Return a discriminated union from actions that can fail:
+
+```tsx
+export type ActionResult<T = void> = { ok: true; data?: T } | { ok: false; error: string };
+```
+
+Toast on `ok: false` from the client. Skip success toasts when an optimistic UI already shows the result.
+
+A shared `ActionResult<T>` is optional — a per-action inline union is just as good, and often clearer when the payload has a natural name: `return { ok: true as const, playlist }` reads better than a generic `data`. What matters is that fallible actions return a discriminated union the client can narrow on, not that every action shares one type.
+
+## Mappers and domain types
+
+If your DB rows have shapes you don't want to leak to components (extra columns, ORM-specific types), write a mapper inside the query:
+
+```ts
+export async function getPost(id: string) {
+  const row = await db.post.findUnique({ where: { id }, include: { author: true } });
+  if (!row) notFound();
+  return toPost(row);
+}
+
+function toPost(row: PostRow & { author: UserRow }): Post {
+  return { id: row.id, body: row.body, author: row.author.handle };
+}
+```
+
+Components see `Post`, not the ORM row. If that type is imported by multiple files in the feature, put it under `features/<domain>/types/` (for example `features/post/types/post.ts`). Promote it to top-level `types/` only when multiple features import it.

--- a/docs/ai/skills/nextjs-app-architecture/references/single-page-applications.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/single-page-applications.md
@@ -1,0 +1,48 @@
+# Single-page application patterns
+
+Use this reference when a feature adds SWR, TanStack Query, or another browser data cache. For complete library APIs and runnable examples, follow the [Single-page applications guide](https://preview.nextjs.org/docs/app/guides/single-page-applications).
+
+## Decide whether a client cache is needed
+
+Use a client data library when the browser needs revalidation, optimistic mutations, request deduplication, or shared live data. If a Client Component only reads server data once, pass a Promise from its Server Component and unwrap it with `use()` instead.
+
+## Keep ownership with the feature
+
+```text
+features/<domain>/
+  <domain>-cache.ts          # Pure server tags + client keys
+  <domain>-queries.ts        # Server reads and cacheLife
+  <domain>-query-options.ts  # Client fetcher/query options
+  hooks/use-*.ts             # Client mutations and coordination
+  components/                # Async server owner + client leaves
+```
+
+The cache contract imports neither Next.js nor the client library. Queries, actions, route handlers, hydration code, query options, and hooks import identities from it. This prevents a key or tag spelling from drifting between a read and its invalidation.
+
+Keep behavior in the layer that owns it:
+
+- Server `cacheLife`, `cacheTag`, and database reads belong in `<domain>-queries.ts`.
+- Browser freshness and refetch behavior belong in `<domain>-query-options.ts` or the SWR hook.
+- Optimistic mutation behavior belongs in `hooks/use-*.ts`.
+- Tiny effect-only or interactive leaves belong in `components/`.
+
+## Seed from the server
+
+The async feature component owns the initial read and the library's hydration provider. The page remains a synchronous composition surface and owns the feature's Suspense boundary.
+
+- With SWR, seed the exact key read by `useSWR`. Use `preload` with `cacheData` when later `mutate(key)` calls must update the seeded entry itself.
+- With TanStack Query, seed the same query key read by the client query and render the client subtree inside `HydrationBoundary`.
+
+Do not move the initial read to the browser just because the feature also has a client cache.
+
+## Coordinate Cache Components
+
+The server cache and browser cache have independent freshness policies. Do not mirror `cacheLife` into `staleTime`, polling intervals, or SWR revalidation settings. Coordinate identities and invalidation, not durations.
+
+For tag-driven data, a mutation updates the client cache for immediate feedback and invalidates the same server tag used by the seeded read. For a time-driven server read, choose its `cacheLife` from the server data's freshness requirement.
+
+TanStack Query hydration adds one coupling: the hydration timestamp must advance whenever the seeded data advances. For tag-driven reads, cache the timestamp with the same tags as the data. For time-driven reads, derive the data and timestamp from the same cached snapshot. Do not cache a `QueryClient` or dehydrated payload.
+
+## Mutate without drift
+
+Let the client library own the optimistic browser update, rollback, and authoritative response. Let the write invalidate the server tag only after stored data changes. Do not add polling as a cache-coordination mechanism; add focus revalidation, intervals, SSE, or WebSockets only when the product actually needs external updates to appear automatically.

--- a/docs/ai/skills/nextjs-app-architecture/references/upstream.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/upstream.md
@@ -1,0 +1,30 @@
+---
+source_name: aurorascharff/nextjs-app-architecture-skill (nextjs-app-architecture)
+source_url: https://github.com/aurorascharff/nextjs-app-architecture-skill
+source_type: github
+upstream_path: SKILL.md
+reviewed_commit: f2902b8538b25610da694394ecf88e69adf5f96a
+skills_lock_hash: 94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66
+license: MIT
+last_reviewed: 2026-08-28
+---
+
+# Upstream: nextjs-app-architecture
+
+Canonical copy in this repo: `docs/ai/skills/nextjs-app-architecture/` (mirrored to `.agents/skills/`, `.cursor/skills/`, and `.claude/skills/` via `bun run skills:sync`).
+
+- **Repository:** https://github.com/aurorascharff/nextjs-app-architecture-skill
+- **Upstream path:** `SKILL.md` plus `references/{cache-components,components,example,feature-folders,pages-suspense,queries-actions,single-page-applications,ux-patterns}.md`
+- **License:** MIT; copyright Aurora Scharff (see the ecosystem `LICENSE` copied by the Skills CLI)
+- **Install via Skills CLI:** `npx skills add aurorascharff/nextjs-app-architecture-skill -y`
+
+The skill packages next-beats-style RSC composition for Next.js 16 App Router: synchronous pages, feature-owned async server components, colocated skeletons, and Cache Components practice. Inside Core it stays subordinate to installed Next.js docs, `docs/ai/rules/frontend.md`, and the data-access boundary.
+
+## Refresh from ecosystem
+
+1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
+2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
+3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+4. Run `bun run skills:sync` and `bun run skills:verify`.
+
+This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/docs/ai/skills/nextjs-app-architecture/references/upstream.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file and the **This repository** section in `SKILL.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/docs/ai/skills/nextjs-app-architecture/references/upstream.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/upstream.md
@@ -24,7 +24,7 @@ The skill packages next-beats-style RSC composition for Next.js 16 App Router: s
 
 1. `npx skills add aurorascharff/nextjs-app-architecture-skill -y` updates `.agents/skills/nextjs-app-architecture/` and `skills-lock.json`. On Claude Code it may also create a project-level `.claude/skills/nextjs-app-architecture` symlink — delete it; this repo routes Claude Code through `docs/ai/skills/` + `AGENTS.md`, not `.claude/skills/`.
 2. Copy the skill tree (`SKILL.md` + `references/*`, excluding this file) into `docs/ai/skills/nextjs-app-architecture/` if the canonical copy needs updating.
-3. Preserve this `references/upstream.md` file, the **This repository** section and **Core remaps** in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
+3. Preserve this `references/upstream.md` file, the **This repository** section, **Core remaps**, and in-place `CORE: skip file creation` annotations in `SKILL.md`, and the **Core** notes at the top of `references/queries-actions.md` and `references/feature-folders.md`.
 4. Run `bun run skills:sync` and `bun run skills:verify`.
 
 This skill is **not** updated by `bun run skills:refresh-upstream` today.

--- a/docs/ai/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -4,13 +4,13 @@ Interaction decisions on top of the architecture: which feedback mechanism to re
 
 ## Choose the feedback mechanism
 
-| Situation | Reach for | Key rule |
-| --------- | --------- | -------- |
-| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
-| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
-| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
-| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
-| One-shot result with no visible change | toast | See below. |
+| Situation                                          | Reach for                                                                           | Key rule                                                                                                                                                                                  |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic)                  | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters.                                |
+| No optimistic fit (filters, sort, navigation)      | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field")           | [`useActionState`](https://react.dev/reference/react/useActionState)                | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`.                                                                                                           |
+| Submit disable + spinner                           | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus)        | Call it from a child of `<form>`, not the form component itself.                                                                                                                          |
+| One-shot result with no visible change             | toast                                                                               | See below.                                                                                                                                                                                |
 
 ### Name the signal when a subtree has more than one pending source
 
@@ -29,10 +29,10 @@ For create/update/delete flows where the changed item is visible, prefer one fea
 
 ```tsx
 type OptimisticListAction<TItem> =
-  | { type: 'create'; item: TItem }
-  | { type: 'update'; item: TItem }
-  | { type: 'delete'; id: string }
-  | { type: 'rollback'; id: string };
+  | { type: "create"; item: TItem }
+  | { type: "update"; item: TItem }
+  | { type: "delete"; id: string }
+  | { type: "rollback"; id: string };
 
 const [items, dispatchOptimisticItem] = useOptimistic(
   initialItems,
@@ -61,7 +61,7 @@ Use a success page/state instead of a toast when the completed action changes th
 
 ## View transitions: portaled / floating UI
 
-Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a _named_ transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
 
 ## Destructive actions (delete / leave / unsubscribe)
 
@@ -72,14 +72,14 @@ Gate behind a confirmation dialog, and mind two edge cases:
 
 ## The action-prop pattern
 
-A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited _without_ a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
 
 ## URL-based pagination
 
 Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
 
 ```tsx
-import { Suspense } from 'react';
+import { Suspense } from "react";
 
 export function Feed({ page = 1 }: { page?: number }) {
   return (

--- a/docs/ai/skills/nextjs-app-architecture/references/ux-patterns.md
+++ b/docs/ai/skills/nextjs-app-architecture/references/ux-patterns.md
@@ -1,0 +1,106 @@
+# UX patterns
+
+Interaction decisions on top of the architecture: which feedback mechanism to reach for, and the boundary edge-cases that trip agents up. Hook mechanics live in the React / Next docs — linked, not restated. The deeper end-to-end picture is the [Building interactive apps guide](https://preview.nextjs.org/docs/app/guides/interactive-apps).
+
+## Choose the feedback mechanism
+
+| Situation | Reach for | Key rule |
+| --------- | --------- | -------- |
+| Mutation unlikely to fail (favorite, vote, follow) | [`useOptimistic`](https://react.dev/reference/react/useOptimistic) | Update immediately, roll back on throw. Set it inside a transition; inside `<form action>` React opens the transition for you. Use a reducer for counters. |
+| No optimistic fit (filters, sort, navigation) | [`useTransition`](https://react.dev/reference/react/useTransition) + `data-pending` | Put `data-pending` on the pending node; let ancestors react with CSS (`has-data-pending:` for a direct parent, `group-has-data-pending:` further up) so it bubbles without prop drilling. |
+| Form field validation ("fix this field") | [`useActionState`](https://react.dev/reference/react/useActionState) | Action returns `{ error }`; render inline with `aria-invalid` + `role="alert"`. |
+| Submit disable + spinner | [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) | Call it from a child of `<form>`, not the form component itself. |
+| One-shot result with no visible change | toast | See below. |
+
+### Name the signal when a subtree has more than one pending source
+
+`data-pending` bubbles through CSS, so every descendant that sets it participates. `useLinkStatus` sets it on any pending link, which means `group-has-data-pending:` on a page wrapper also fires for ordinary navigation and dims content that is not being refetched. When a subtree can be pending for more than one reason, give the reason you are reacting to its own attribute (`data-filtering`, `data-saving`) and key the ancestor off that.
+
+### Two things to get right with `useOptimistic`
+
+- The value reverts as soon as its transition settles, so the work it predicts has to run **inside the same** `startTransition`. Setting the optimistic value in one transition and navigating in another snaps it back before the URL changes.
+- Derive the controls from the optimistic value and the surrounding chrome from the committed one. A slider thumb should follow the drag immediately, but a "Clear all filters" button keyed off that same optimistic value appears while the filter is still in flight.
+
+`useOptimistic(false)` also works as a transition-scoped **pending flag** that resets automatically when the transition settles — handy when you don't need the `data-pending` bubbling.
+
+## Optimistic mutations for interactive apps
+
+For create/update/delete flows where the changed item is visible, prefer one feature-owned optimistic reducer over hand-rolled pending state spread across the board, modal, and list.
+
+```tsx
+type OptimisticListAction<TItem> =
+  | { type: 'create'; item: TItem }
+  | { type: 'update'; item: TItem }
+  | { type: 'delete'; id: string }
+  | { type: 'rollback'; id: string };
+
+const [items, dispatchOptimisticItem] = useOptimistic(
+  initialItems,
+  optimisticListReducer,
+);
+```
+
+Use names that describe the app's domain (`dispatchOptimisticPost`, `messageReducer`, `groupReducer`, `eventReducer`) rather than implementation mechanics like `applyOptimisticAction`. The reducer owns the optimistic list shape; components dispatch intent.
+
+For modal creates, apply the optimistic item and close the modal immediately when the local form is valid. If the action fails, roll back and show an error toast. Keeping the modal open with a slow primary button makes the optimistic result feel broken.
+
+For deletes, remove optimistically, then roll back on failure. Do not wait for the server before the item disappears when the user's intent is clear.
+
+## Forms and validation
+
+Do local validation before submitting when the missing field is already available on the client. Show inline field errors without changing the modal or card's overall geometry. Reserve `useActionState` for server-validated errors or field errors that require the action result.
+
+Use a success page/state instead of a toast when the completed action changes the user's task. For example, after a reservation, checkout, or invite request succeeds, replace the form with a confirmation and a secondary "start another" action; a success toast is redundant.
+
+## Toasts
+
+- **Toast only on error** when an optimistic UI already shows the result — a success toast next to an optimistic checkmark/removal is double feedback, which is noise.
+- **Toast on success** only for non-visible side effects (email sent, link copied, file uploaded).
+- **Don't toast for routine navigation** — the page change is the feedback.
+- **Don't toast inside a server action.** Toasts are client-side; return a result and toast at the call site.
+
+## View transitions: portaled / floating UI
+
+Portaled elements (toasts, dialogs, popovers, dropdowns, tooltips) flicker during route transitions unless excluded. Apply `viewTransitionName: 'none'` to the portal root. When the portal also needs stacking control (z-index) or has translucent layers (backdrop-blur), give it a *named* transition and neutralize it in CSS instead — `::view-transition-group(name) { animation: none; z-index: … }` can do things `'none'` can't. See the [React View Transitions skill](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions).
+
+## Destructive actions (delete / leave / unsubscribe)
+
+Gate behind a confirmation dialog, and mind two edge cases:
+
+- **Don't `redirect()` inside the action.** It throws, which stops the client from toasting or closing the dialog. Return `{ ok: true }` and navigate with `router.push()`.
+- **Don't wrap the whole action call in `useTransition`** inside the dialog — with view transitions on, that animates the background UI behind the dialog. Track pending with `useState` / `useOptimistic(false)` and reserve `startTransition` for the post-success navigation only.
+
+## The action-prop pattern
+
+A reusable design component (`<ToggleGroup>`, `<BottomNav>`, `<SubmitButton>`) can take an action-style prop and own the async coordination (optimistic update, pending, dimming) so consumers pass a plain callback. Convention: an `action` / `*Action` prop signals "triggers a mutation this component coordinates," versus a plain `onChange` / `onClick` — renaming between them is a contract change. Not every such prop is transition-wrapped: a destructive `confirmAction` is awaited *without* a transition (see above). Transition-wrapping is the default for optimistic/navigation actions, not a rule tied to the name.
+
+## URL-based pagination
+
+Drive the page number through `searchParams`, render each page as its own `<Suspense>` boundary so pages stream independently, and add "load more" with `<Link scroll={false}>`. See [linking and navigating](https://preview.nextjs.org/docs/app/getting-started/linking-and-navigating).
+
+```tsx
+import { Suspense } from 'react';
+
+export function Feed({ page = 1 }: { page?: number }) {
+  return (
+    <ul>
+      {Array.from({ length: page }).map((_, i) => {
+        const p = i + 1;
+        return p === 1 ? (
+          <FeedPage key={p} page={p} />
+        ) : (
+          <Suspense key={p} fallback={<FeedPageSkeleton />}>
+            <FeedPage page={p} />
+          </Suspense>
+        );
+      })}
+    </ul>
+  );
+}
+```
+
+The first page can render in the parent boundary; later pages get their own fallbacks so "load more" streams only the newly requested page. If the URL update should preserve scroll, use [`<Link scroll={false}>`](https://preview.nextjs.org/docs/app/api-reference/components/link).
+
+## Global client state
+
+For truly global client state (audio player, cart, system-reactive theme), wrap a [context provider](https://react.dev/reference/react/createContext) at the root; the provider is `'use client'` but `children` stays server-rendered, and only leaf components read the context. **Don't push server data into it** — server data stays in queries; client state is for ephemeral UI (open menus, playback position, optimistic drafts). See the live-data decision in `references/components.md`.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -300,6 +300,12 @@
       "skillPath": "skills/next-dev-loop/SKILL.md",
       "computedHash": "aad97b32ba6efd31e92d063ec77120a694fe0d4a9401daf9af4c205cd5e21b07"
     },
+    "nextjs-app-architecture": {
+      "source": "aurorascharff/nextjs-app-architecture-skill",
+      "sourceType": "github",
+      "skillPath": "SKILL.md",
+      "computedHash": "94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66"
+    },
     "npm-deps-cleanup": {
       "source": "anthonyshew/dotfiles",
       "sourceType": "github",

--- a/tests/unit/docs/agent-instruction-routing.test.ts
+++ b/tests/unit/docs/agent-instruction-routing.test.ts
@@ -265,6 +265,9 @@ describe("agent instruction routing fixtures", () => {
     expect(skillRouting).toContain(
       "docs/ai/skills/idempotency-handling/SKILL.md",
     );
+    expect(skillRouting).toContain(
+      "docs/ai/skills/nextjs-app-architecture/SKILL.md",
+    );
     expect(skillRouting).toContain("docs/ai/skills/resend-cli/SKILL.md");
     expect(skillRouting).toContain("docs/ai/skills/eve/SKILL.md");
     expect(agents).toContain("openspec/project.md");

--- a/tests/unit/docs/nextjs-app-architecture-skill.test.ts
+++ b/tests/unit/docs/nextjs-app-architecture-skill.test.ts
@@ -71,7 +71,10 @@ describe("nextjs-app-architecture skill", () => {
 
   it("keeps the Core overlay, provenance, and data-access boundary", () => {
     const skill = readSkillFile("docs/ai/skills", "SKILL.md");
-    const provenance = readSkillFile("docs/ai/skills", "references/upstream.md");
+    const provenance = readSkillFile(
+      "docs/ai/skills",
+      "references/upstream.md",
+    );
 
     expect(skill).toContain("\nname: nextjs-app-architecture\n");
     expect(skill).toContain('version: "1.3.9"');
@@ -81,12 +84,16 @@ describe("nextjs-app-architecture skill", () => {
     expect(skill).toContain("Do not add Zustand");
     expect(skill).toContain('Do not "enable Cache Components."');
     expect(skill).toContain("not `preview.nextjs.org`");
-    expect(skill).toContain("Existing `apps/*/features/` directories are UI composition");
+    expect(skill).toContain(
+      "Existing `apps/*/features/` directories are UI composition",
+    );
     expect(provenance).toContain("f2902b8538b25610da694394ecf88e69adf5f96a");
     expect(provenance).toContain(
       "94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66",
     );
-    expect(provenance).toContain("not** updated by `bun run skills:refresh-upstream`");
+    expect(provenance).toContain(
+      "not** updated by `bun run skills:refresh-upstream`",
+    );
     expect(provenance).toContain(
       "npx skills add aurorascharff/nextjs-app-architecture-skill -y",
     );
@@ -113,10 +120,14 @@ describe("nextjs-app-architecture skill", () => {
       "docs/ai/skills/nextjs-app-architecture/SKILL.md",
     );
     expect(frontend).toContain("skills/nextjs-app-architecture/SKILL.md");
-    expect(frontend).toContain("Keep business queries and privileged mutations in `packages/api`.");
-    expect(agents).not.toContain("docs/ai/skills/nextjs-app-architecture/SKILL.md");
+    expect(frontend).toContain(
+      "Keep business queries and privileged mutations in `packages/api`.",
+    );
+    expect(agents).not.toContain(
+      "docs/ai/skills/nextjs-app-architecture/SKILL.md",
+    );
     expect(qualityGate).toContain(
-      'const fullyManagedCanonicalSkills = new Set([',
+      "const fullyManagedCanonicalSkills = new Set([",
     );
     expect(qualityGate).not.toMatch(
       /fullyManagedCanonicalSkills = new Set\(\[[^\]]*nextjs-app-architecture/,

--- a/tests/unit/docs/nextjs-app-architecture-skill.test.ts
+++ b/tests/unit/docs/nextjs-app-architecture-skill.test.ts
@@ -87,6 +87,38 @@ describe("nextjs-app-architecture skill", () => {
     expect(skill).toContain(
       "Existing `apps/*/features/` directories are UI composition",
     );
+    expect(skill).toContain("**Core remaps**");
+    expect(skill).toContain("**Invariant 7 and workflow steps 3–4:**");
+    expect(skill).toContain(
+      "Do **not** create `features/<domain>/<domain>-queries.ts`",
+    );
+    expect(skill).toContain(
+      "Do not regenerate or expand the managed root `AGENTS.md`.",
+    );
+    expect(skill).toContain(
+      "Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.",
+    );
+
+    const queriesActions = readSkillFile(
+      "docs/ai/skills",
+      "references/queries-actions.md",
+    );
+    const featureFolders = readSkillFile(
+      "docs/ai/skills",
+      "references/feature-folders.md",
+    );
+
+    expect(queriesActions).toContain("> **Core:**");
+    expect(queriesActions).toContain(
+      "do not copy `db.*` into `features/<domain>/*-queries.ts`",
+    );
+    expect(queriesActions).toContain(
+      "Privileged reads and writes stay in `packages/api`",
+    );
+    expect(featureFolders).toContain("> **Core:**");
+    expect(featureFolders).toContain(
+      "Do not add `*-queries.ts` or `*-actions.ts` as a new data layer",
+    );
     expect(provenance).toContain("f2902b8538b25610da694394ecf88e69adf5f96a");
     expect(provenance).toContain(
       "94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66",

--- a/tests/unit/docs/nextjs-app-architecture-skill.test.ts
+++ b/tests/unit/docs/nextjs-app-architecture-skill.test.ts
@@ -1,0 +1,155 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const skillName = "nextjs-app-architecture";
+const runtimeRoots = [
+  "docs/ai/skills",
+  ".agents/skills",
+  ".cursor/skills",
+  ".claude/skills",
+] as const;
+const ecosystemExtraFiles = ["LICENSE", "README.md"] as const;
+const sharedSkillFiles = [
+  "SKILL.md",
+  "references/upstream.md",
+  "references/cache-components.md",
+  "references/components.md",
+  "references/example.md",
+  "references/feature-folders.md",
+  "references/pages-suspense.md",
+  "references/queries-actions.md",
+  "references/single-page-applications.md",
+  "references/ux-patterns.md",
+] as const;
+
+function readRepoFile(relativePath: string) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function listFiles(root: string, relativeRoot = ""): string[] {
+  const directory = path.join(root, relativeRoot);
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const relativePath = path.join(relativeRoot, entry.name);
+    return entry.isDirectory()
+      ? listFiles(root, relativePath)
+      : [relativePath.replaceAll("\\", "/")];
+  });
+}
+
+function readSkillFile(
+  runtimeRoot: (typeof runtimeRoots)[number],
+  relativePath: string,
+) {
+  return readRepoFile(path.join(runtimeRoot, skillName, relativePath));
+}
+
+describe("nextjs-app-architecture skill", () => {
+  it("pins the Skills CLI source and reviewed hash", () => {
+    const lock = JSON.parse(readRepoFile("skills-lock.json")) as {
+      skills: Record<
+        string,
+        {
+          source?: string;
+          sourceType?: string;
+          skillPath?: string;
+          computedHash?: string;
+        }
+      >;
+    };
+
+    expect(lock.skills[skillName]).toEqual({
+      source: "aurorascharff/nextjs-app-architecture-skill",
+      sourceType: "github",
+      skillPath: "SKILL.md",
+      computedHash:
+        "94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66",
+    });
+  });
+
+  it("keeps the Core overlay, provenance, and data-access boundary", () => {
+    const skill = readSkillFile("docs/ai/skills", "SKILL.md");
+    const provenance = readSkillFile("docs/ai/skills", "references/upstream.md");
+
+    expect(skill).toContain("\nname: nextjs-app-architecture\n");
+    expect(skill).toContain('version: "1.3.9"');
+    expect(skill).toContain("## This repository (Asymmetric-al/core)");
+    expect(skill).toContain("docs/guides/architecture/data-access-boundary.md");
+    expect(skill).toContain("packages/api");
+    expect(skill).toContain("Do not add Zustand");
+    expect(skill).toContain('Do not "enable Cache Components."');
+    expect(skill).toContain("not `preview.nextjs.org`");
+    expect(skill).toContain("Existing `apps/*/features/` directories are UI composition");
+    expect(provenance).toContain("f2902b8538b25610da694394ecf88e69adf5f96a");
+    expect(provenance).toContain(
+      "94f700fb57aef401e135ddbb0d13a2986d6416820ee4e1b2bf1fd8e17fae0d66",
+    );
+    expect(provenance).toContain("not** updated by `bun run skills:refresh-upstream`");
+    expect(provenance).toContain(
+      "npx skills add aurorascharff/nextjs-app-architecture-skill -y",
+    );
+  });
+
+  it("routes the skill without bloating root AGENTS.md", () => {
+    const skillRouting = readRepoFile("docs/ai/rules/agent-skill-routing.md");
+    const findSkills = readRepoFile("docs/ai/skills/find-skills/SKILL.md");
+    const frontend = readRepoFile("docs/ai/rules/frontend.md");
+    const agents = readRepoFile("AGENTS.md");
+    const qualityGate = readRepoFile("scripts/sync-agent-skills.mjs");
+
+    expect(skillRouting).toContain(
+      "docs/ai/skills/nextjs-app-architecture/SKILL.md",
+    );
+    expect(skillRouting).toContain(
+      "npx skills add aurorascharff/nextjs-app-architecture-skill -y",
+    );
+    expect(skillRouting).toContain(
+      "do not move business queries or privileged mutations",
+    );
+    expect(findSkills).toContain("**Example — Next.js app architecture:**");
+    expect(findSkills).toContain(
+      "docs/ai/skills/nextjs-app-architecture/SKILL.md",
+    );
+    expect(frontend).toContain("skills/nextjs-app-architecture/SKILL.md");
+    expect(frontend).toContain("Keep business queries and privileged mutations in `packages/api`.");
+    expect(agents).not.toContain("docs/ai/skills/nextjs-app-architecture/SKILL.md");
+    expect(qualityGate).toContain(
+      'const fullyManagedCanonicalSkills = new Set([',
+    );
+    expect(qualityGate).not.toMatch(
+      /fullyManagedCanonicalSkills = new Set\(\[[^\]]*nextjs-app-architecture/,
+    );
+  });
+
+  it("keeps shared skill files byte-identical across runtime mirrors", () => {
+    const canonicalFiles = listFiles(
+      path.join(repoRoot, "docs/ai/skills", skillName),
+    ).sort();
+
+    expect(canonicalFiles).toEqual([...sharedSkillFiles].sort());
+
+    for (const extra of ecosystemExtraFiles) {
+      expect(
+        existsSync(path.join(repoRoot, "docs/ai/skills", skillName, extra)),
+      ).toBe(false);
+    }
+
+    for (const runtimeRoot of runtimeRoots.slice(1)) {
+      for (const relativePath of sharedSkillFiles) {
+        expect(
+          readSkillFile(runtimeRoot, relativePath),
+          `${runtimeRoot}/${skillName}/${relativePath}`,
+        ).toBe(readSkillFile("docs/ai/skills", relativePath));
+      }
+
+      for (const extra of ecosystemExtraFiles) {
+        expect(
+          existsSync(path.join(repoRoot, runtimeRoot, skillName, extra)),
+          `${runtimeRoot}/${skillName}/${extra}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/unit/docs/nextjs-app-architecture-skill.test.ts
+++ b/tests/unit/docs/nextjs-app-architecture-skill.test.ts
@@ -88,16 +88,45 @@ describe("nextjs-app-architecture skill", () => {
       "Existing `apps/*/features/` directories are UI composition",
     );
     expect(skill).toContain("**Core remaps**");
-    expect(skill).toContain("**Invariant 7 and workflow steps 3–4:**");
+    expect(skill).toContain("**Feature-owned means UI composition only.**");
     expect(skill).toContain(
-      "Do **not** create `features/<domain>/<domain>-queries.ts`",
+      "Do **not** create `features/<domain>/<domain>-queries.ts` or `features/<domain>/<domain>-actions.ts` at all.",
     );
+    expect(skill).not.toContain("for business or privileged data");
+    expect(skill).toContain("CORE: skip file creation");
     expect(skill).toContain(
       "Do not regenerate or expand the managed root `AGENTS.md`.",
     );
     expect(skill).toContain(
       "Do not create or refresh root `AGENTS.md` from `preview.nextjs.org`.",
     );
+
+    const invariant7 = skill.slice(
+      skill.indexOf("7. **Queries live in `<domain>-queries.ts`**"),
+    );
+    expect(invariant7).toMatch(/CORE: skip file creation/);
+
+    const step3 = skill.slice(
+      skill.indexOf(
+        "3. **Write the query and, when a client cache shares its data",
+      ),
+    );
+    expect(step3).toMatch(/CORE: skip file creation/);
+
+    const step4 = skill.slice(
+      skill.indexOf("4. **Write the action** (if there's a mutation)"),
+    );
+    expect(step4).toMatch(/CORE: skip file creation/);
+
+    const architectureTarget = skill.slice(
+      skill.indexOf("Queries and actions live in the feature folder."),
+    );
+    expect(architectureTarget).toMatch(/CORE: skip file creation/);
+
+    const verifyQueries = skill.slice(
+      skill.indexOf("Every `*-queries.ts` starts with `import 'server-only'`"),
+    );
+    expect(verifyQueries).toMatch(/CORE: skip file creation/);
 
     const queriesActions = readSkillFile(
       "docs/ai/skills",
@@ -113,11 +142,12 @@ describe("nextjs-app-architecture skill", () => {
       "do not copy `db.*` into `features/<domain>/*-queries.ts`",
     );
     expect(queriesActions).toContain(
-      "Privileged reads and writes stay in `packages/api`",
+      "must not be copied into `apps/*/features/`",
     );
     expect(featureFolders).toContain("> **Core:**");
+    expect(featureFolders).toContain("UI composition only");
     expect(featureFolders).toContain(
-      "Do not add `*-queries.ts` or `*-actions.ts` as a new data layer",
+      "Do not add `*-queries.ts` or `*-actions.ts` at all",
     );
     expect(provenance).toContain("f2902b8538b25610da694394ecf88e69adf5f96a");
     expect(provenance).toContain(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Deploy Checklist (for PRs to `production` or `develop`)

- [x] CI passes (local `skills:verify` + focused unit tests)
- [x] Base branch confirmed: `develop`
- [x] `bun run verify:deployment-discipline` passes if deployment controls changed (N/A)
- [x] Migrations reviewed (or N/A)
- [x] Migrations tested on development (or N/A)
- [x] New env vars added to all 3 Vercel projects (or N/A)
- [x] Rollback plan reviewed (revert the skill tree + routing + tests)
- [x] Production release will use `bun run release:production` (or N/A)
- [x] Post-deploy smoke tests planned (N/A — instruction-system only)

## Summary

Adds the `aurorascharff/nextjs-app-architecture-skill` as a routed Core skill with a data-access overlay.

- Canonical: `docs/ai/skills/nextjs-app-architecture/`
- Lockfile pin: `aurorascharff/nextjs-app-architecture-skill` at hash `94f700fb…`
- Mirrors via `bun run skills:sync` into `.agents`, `.cursor`, and `.claude` (real directory, not a CLI symlink)
- Routed from `docs/ai/rules/agent-skill-routing.md`, `docs/ai/rules/frontend.md`, and `docs/ai/skills/find-skills/SKILL.md`
- Root `AGENTS.md` is not bloated with a catalog entry
- Not added to `fullyManagedCanonicalSkills` or `skills:refresh-upstream`

**Core remaps:** feature folders are UI composition only. Do not create `features/<domain>/*-queries.ts` or `*-actions.ts` at all. In-place `CORE: skip file creation` notes sit on the architecture target, invariant 7, workflow steps 3–5, and the verify checklist so the numbered vendor procedure cannot stand alone. Matching Core notes sit on `references/queries-actions.md` and `references/feature-folders.md`. Overlay also forbids regenerating root `AGENTS.md` from `preview.nextjs.org`.

## Test plan

- `bun run skills:verify`
- `bunx vitest run tests/unit/docs/nextjs-app-architecture-skill.test.ts tests/unit/docs/agent-instruction-routing.test.ts tests/unit/docs/skill-quality-gate.test.ts`

## Verification

[nextjs_app_architecture_core_skip_annotations.log](https://cursor.com/artifacts/c/art-f2f3699f-2bf2-4fe6-b042-267f475c6e17)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1068df74-d23f-4640-b813-dcac4553129b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1068df74-d23f-4640-b813-dcac4553129b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>









<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=57901857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

No blocking failure remains.

What we checked:
- Compared isolated checkouts of the base revision and the PR head to verify consistency of the canonical skill and its mirrors. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Ran the repository skill-mirror verifier in both checkouts; each exited successfully and reported Skill mirrors match canonical sources. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Ran the focused Next.js app architecture skill tests in both checkouts; all 4 tests passed in each. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Verified the verifier consistently reported Skill mirrors match canonical sources before and after; the focused Vitest suite passed 4/4 before and after; no authored test script was needed; only repository commands were executed. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

Adds repository-specific Next.js application-architecture guidance, including routing for page composition, Suspense boundaries, feature-owned UI, and leaf client components. The canonical skill remains synchronized with the supported agent-runtime mirrors.

<sub>Reviews (4) · Last reviewed commit: ["style(skills): format nextjs-app-archite..."](https://github.com/asymmetric-al/core/commit/92f9414ddd9078506dd7623c09eb360b0b4a039d)</sub>

<!-- /greptile_comment -->